### PR TITLE
Use semver version comparison for OS during in-place update

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -3,6 +3,7 @@ run:
   concurrency: 4
 linters:
   enable:
+    - embeddedstructfieldcheck
     - ginkgolinter
     - importas
     - logcheck
@@ -12,7 +13,6 @@ linters:
     - unconvert
     - unparam
     - whitespace
-    - embeddedstructfieldcheck
   settings:
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -186,26 +186,7 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 			return nil, fmt.Errorf("failed to check if kubelet config has changed: %w", err)
 		}
 
-		if newOSC.Spec.InPlaceUpdates.CredentialsRotation != nil {
-			// Rotation is triggered for the first time
-			if oldOSC.Spec.InPlaceUpdates.CredentialsRotation == nil {
-				caRotation := newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil && newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime != nil
-				changes.InPlaceUpdates.CertificateAuthoritiesRotation.Kubelet = caRotation
-				changes.InPlaceUpdates.CertificateAuthoritiesRotation.NodeAgent = caRotation && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer)
-
-				changes.InPlaceUpdates.ServiceAccountKeyRotation = newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil && newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime != nil
-			} else {
-				caRotation := oldOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil &&
-					newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil &&
-					!oldOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime.Equal(newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime)
-				changes.InPlaceUpdates.CertificateAuthoritiesRotation.Kubelet = caRotation
-				changes.InPlaceUpdates.CertificateAuthoritiesRotation.NodeAgent = caRotation && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer)
-
-				changes.InPlaceUpdates.ServiceAccountKeyRotation = oldOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil &&
-					newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil &&
-					!oldOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime.Equal(newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime)
-			}
-		}
+		changes.InPlaceUpdates.CertificateAuthoritiesRotation.Kubelet, changes.InPlaceUpdates.CertificateAuthoritiesRotation.NodeAgent, changes.InPlaceUpdates.ServiceAccountKeyRotation = ComputeCredentialsRotationChanges(oldOSC, newOSC)
 	}
 
 	var (
@@ -249,6 +230,44 @@ func IsOsVersionUpToDate(currentOSVersion *string, newOSC *extensionsv1alpha1.Op
 	}
 
 	return osVersionUpToDate, nil
+}
+
+// ComputeCredentialsRotationChanges computes if the credentials rotation has changed between the old and new OSC.
+func ComputeCredentialsRotationChanges(oldOSC, newOSC *extensionsv1alpha1.OperatingSystemConfig) (bool, bool, bool) {
+	var (
+		kubeletCARotation,
+		nodeAgentCARotation,
+		serviceAccountKeyRotation bool
+	)
+
+	if newOSC.Spec.InPlaceUpdates.CredentialsRotation == nil {
+		return false, false, false
+	}
+
+	// Rotation is triggered for the first time
+	if oldOSC.Spec.InPlaceUpdates.CredentialsRotation == nil {
+		caRotation := newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil && newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime != nil
+
+		kubeletCARotation = caRotation
+		nodeAgentCARotation = caRotation && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer)
+
+		serviceAccountKeyRotation = newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil && newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime != nil
+
+		return kubeletCARotation, nodeAgentCARotation, serviceAccountKeyRotation
+	}
+
+	caRotation := oldOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil &&
+		newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities != nil &&
+		!oldOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime.Equal(newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime)
+
+	kubeletCARotation = caRotation
+	nodeAgentCARotation = caRotation && features.DefaultFeatureGate.Enabled(features.NodeAgentAuthorizer)
+
+	serviceAccountKeyRotation = oldOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil &&
+		newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey != nil &&
+		!oldOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime.Equal(newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime)
+
+	return kubeletCARotation, nodeAgentCARotation, serviceAccountKeyRotation
 }
 
 func getKubeletConfig(osc *extensionsv1alpha1.OperatingSystemConfig) (*kubeletconfigv1beta1.KubeletConfiguration, error) {

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -9,7 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/utils/ptr"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
 )
 
@@ -66,4 +68,66 @@ var _ = Describe("Changes", func() {
 		Entry("changed evictionHard nodefs.inodesFree", &kubeletconfigv1beta1.KubeletConfiguration{EvictionHard: map[string]string{"nodefs.inodesFree": "1k"}}, &kubeletconfigv1beta1.KubeletConfiguration{EvictionHard: map[string]string{"nodefs.inodesFree": "2k"}}, false, true, BeNil()),
 		Entry("some other field changed in evictionHard", &kubeletconfigv1beta1.KubeletConfiguration{EvictionHard: map[string]string{"foo": "bar"}}, &kubeletconfigv1beta1.KubeletConfiguration{EvictionHard: map[string]string{"foo": "baz"}}, false, false, BeNil()),
 	)
+
+	Describe("#IsOsVersionUpToDate", func() {
+		var (
+			currentOSVersion *string
+			newOSC           *extensionsv1alpha1.OperatingSystemConfig
+		)
+		BeforeEach(func() {
+			currentOSVersion = nil
+			newOSC = &extensionsv1alpha1.OperatingSystemConfig{
+				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+					InPlaceUpdates: &extensionsv1alpha1.InPlaceUpdates{
+						OperatingSystemVersion: "1.2.0",
+					},
+				},
+			}
+		})
+
+		It("should return false if current OS version is nil", func() {
+			changed, err := IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).To(MatchError(ContainSubstring("current OS version is nil")))
+			Expect(changed).To(BeFalse())
+		})
+
+		It("should return true if the OS version is up to date", func() {
+			currentOSVersion = ptr.To("1.2")
+			changed, err := IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			currentOSVersion = ptr.To("1.2.0")
+			changed, err = IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			currentOSVersion = ptr.To("1.2.0-foo.12")
+			newOSC.Spec.InPlaceUpdates.OperatingSystemVersion = "1.2.0"
+			changed, err = IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+		})
+
+		It("should return false if the OS version is not up to date", func() {
+			currentOSVersion = ptr.To("1.1.0")
+			changed, err := IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeFalse())
+
+			currentOSVersion = ptr.To("1.2.0")
+			newOSC.Spec.InPlaceUpdates.OperatingSystemVersion = "1.2.1"
+			changed, err = IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeFalse())
+		})
+
+		It("should return an error if the OS version in the new OSC is invalid", func() {
+			newOSC.Spec.InPlaceUpdates.OperatingSystemVersion = "invalid"
+			currentOSVersion = ptr.To("1.2.0")
+			changed, err := IsOsVersionUpToDate(currentOSVersion, newOSC)
+			Expect(err).To(MatchError(ContainSubstring("failed comparing current OS version")))
+			Expect(changed).To(BeFalse())
+		})
+	})
 })

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -5,9 +5,12 @@
 package operatingsystemconfig_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/utils/ptr"
 
@@ -128,6 +131,69 @@ var _ = Describe("Changes", func() {
 			changed, err := IsOsVersionUpToDate(currentOSVersion, newOSC)
 			Expect(err).To(MatchError(ContainSubstring("failed comparing current OS version")))
 			Expect(changed).To(BeFalse())
+		})
+	})
+
+	Describe("ComputeCredentialsRotationChanges", func() {
+		var (
+			oldOSC, newOSC *extensionsv1alpha1.OperatingSystemConfig
+			timeNow        = time.Now().UTC()
+		)
+
+		BeforeEach(func() {
+			oldOSC = &extensionsv1alpha1.OperatingSystemConfig{
+				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+					InPlaceUpdates: &extensionsv1alpha1.InPlaceUpdates{
+						CredentialsRotation: &extensionsv1alpha1.CredentialsRotation{
+							CertificateAuthorities: &extensionsv1alpha1.CARotation{
+								LastInitiationTime: &metav1.Time{Time: timeNow.Add(-time.Hour)},
+							},
+							ServiceAccountKey: &extensionsv1alpha1.ServiceAccountKeyRotation{
+								LastInitiationTime: &metav1.Time{Time: timeNow.Add(-time.Hour)},
+							},
+						},
+					},
+				},
+			}
+
+			newOSC = oldOSC.DeepCopy()
+			newOSC.Spec.InPlaceUpdates.CredentialsRotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: timeNow}
+			newOSC.Spec.InPlaceUpdates.CredentialsRotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: timeNow}
+		})
+
+		It("should return false if CredentialsRotation is nil in the new OSC", func() {
+			oldOSC.Spec.InPlaceUpdates.CredentialsRotation = nil
+			newOSC.Spec.InPlaceUpdates.CredentialsRotation = nil
+
+			kubeletCARotation, nodeAgentCARotation, saKeyRotation := ComputeCredentialsRotationChanges(oldOSC, newOSC)
+			Expect(kubeletCARotation).To(BeFalse())
+			Expect(nodeAgentCARotation).To(BeFalse())
+			Expect(saKeyRotation).To(BeFalse())
+		})
+
+		It("should return true if the CredentialsRotation is nil in the old OSC", func() {
+			oldOSC.Spec.InPlaceUpdates.CredentialsRotation = nil
+
+			kubeletCARotation, nodeAgentCARotation, saKeyRotation := ComputeCredentialsRotationChanges(oldOSC, newOSC)
+			Expect(kubeletCARotation).To(BeTrue())
+			Expect(nodeAgentCARotation).To(BeTrue())
+			Expect(saKeyRotation).To(BeTrue())
+		})
+
+		It("should return true if the lastInitiationTimes of rotations are changed", func() {
+			kubeletCARotation, nodeAgentCARotation, saKeyRotation := ComputeCredentialsRotationChanges(oldOSC, newOSC)
+			Expect(kubeletCARotation).To(BeTrue())
+			Expect(nodeAgentCARotation).To(BeTrue())
+			Expect(saKeyRotation).To(BeTrue())
+		})
+
+		It("should return false if the lastInitiationTimes of rotations are not changed", func() {
+			oldOSC = newOSC.DeepCopy()
+
+			kubeletCARotation, nodeAgentCARotation, saKeyRotation := ComputeCredentialsRotationChanges(oldOSC, newOSC)
+			Expect(kubeletCARotation).To(BeFalse())
+			Expect(nodeAgentCARotation).To(BeFalse())
+			Expect(saKeyRotation).To(BeFalse())
 		})
 	})
 })

--- a/pkg/nodeagent/controller/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -9,9 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/nodeagent/features"
 )
 
 func TestOperatingSystemConfig(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "NodeAgent Controller OperatingSystemConfig Suite")
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -721,11 +721,7 @@ func (r *Reconciler) performInPlaceUpdate(ctx context.Context, log logr.Logger, 
 		return fmt.Errorf("failed to update OS in-place: %w", err)
 	}
 
-	if err := r.performCredentialsRotationInPlace(ctx, log, oscChanges, node); err != nil {
-		return fmt.Errorf("failed to perform certificate rotation in-place: %w", err)
-	}
-
-	if (nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions) && !kubernetesutils.HasMetaDataLabel(node, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful)) || kubernetesutils.HasMetaDataLabel(node, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateFailed) {
+	if oscChanges.InPlaceUpdates.OperatingSystem {
 		// It can so happen that the updateOSInPlace function returns nil error, because calling the update command succeeded,
 		// but the OS is not yet rebooted. We should not proceed the reconciliation until the node-agent is restarted after the OS update.
 		currentOSVersion, err := GetOSVersion(osc.Spec.InPlaceUpdates, r.FS)
@@ -736,9 +732,15 @@ func (r *Reconciler) performInPlaceUpdate(ctx context.Context, log logr.Logger, 
 		if osVersionUpToDate, err := IsOsVersionUpToDate(currentOSVersion, osc); err != nil {
 			return err
 		} else if !osVersionUpToDate {
-			return reconcile.TerminalError(fmt.Errorf("stopping reconciliation until gardener-node-agent is restarted after the OS update"))
+			return reconcile.TerminalError(fmt.Errorf("stopping reconciliation until gardener-node-agent is restarted after the OS update. Current version: %q, Desired version: %q", *currentOSVersion, osc.Spec.InPlaceUpdates.OperatingSystemVersion))
 		}
+	}
 
+	if err := r.performCredentialsRotationInPlace(ctx, log, oscChanges, node); err != nil {
+		return fmt.Errorf("failed to perform certificate rotation in-place: %w", err)
+	}
+
+	if (nodeHasInPlaceUpdateConditionWithReasonReadyForUpdate(node.Status.Conditions) && !kubernetesutils.HasMetaDataLabel(node, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful)) || kubernetesutils.HasMetaDataLabel(node, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateFailed) {
 		if err := r.deleteRemainingPods(ctx, log, node); err != nil {
 			return fmt.Errorf("failed to delete remaining pods: %w", err)
 		}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -989,15 +989,14 @@ func (r *Reconciler) updateOSInPlace(ctx context.Context, log logr.Logger, oscCh
 	patch := client.MergeFrom(node.DeepCopy())
 	metav1.SetMetaDataAnnotation(&node.ObjectMeta, annotationUpdatingOperatingSystemVersion, osc.Spec.InPlaceUpdates.OperatingSystemVersion)
 	if err := r.Client.Patch(ctx, node, patch); err != nil {
-		log.Error(err, "Failed to patch node with annotation for OS update", "node", node.Name)
-		return err
+		return fmt.Errorf("failed to patch node with annotation for OS update: %w", err)
 	}
 
+	log.Info("Executing update script", "command", osc.Status.InPlaceUpdates.OSUpdate.Command, "args", strings.Join(osc.Status.InPlaceUpdates.OSUpdate.Args, " "))
 	if err := retryutils.UntilTimeout(ctx, OSUpdateRetryInterval, OSUpdateRetryTimeout, func(ctx context.Context) (bool, error) {
-		log.Info("Executing update script", "command", osc.Status.InPlaceUpdates.OSUpdate.Command, "args", strings.Join(osc.Status.InPlaceUpdates.OSUpdate.Args, " "))
-
 		if output, err2 := ExecCommandCombinedOutput(ctx, osc.Status.InPlaceUpdates.OSUpdate.Command, osc.Status.InPlaceUpdates.OSUpdate.Args...); err2 != nil {
 			if retriableErrorPatternRegex.MatchString(string(output)) {
+				log.Error(err2, "Retriable error detected while executing OS update command: retrying", "output", strings.ReplaceAll(string(output), "\n", " "))
 				return retryutils.MinorError(fmt.Errorf("retriable error detected: %w, output: %s", err2, string(output)))
 			} else if nonRetriableErrorPatternRegex.MatchString(string(output)) {
 				return retryutils.SevereError(fmt.Errorf("non-retriable error detected: %w, output: %s", err2, string(output)))
@@ -1033,7 +1032,7 @@ func (r *Reconciler) patchNodeUpdateSuccessful(ctx context.Context, log logr.Log
 }
 
 func (r *Reconciler) patchNodeUpdateFailed(ctx context.Context, log logr.Logger, node *corev1.Node, reason string) error {
-	log.Info("Marking the node with in-place update failed label", "node", node.Name, "reason", reason)
+	log.Info("Marking the node with in-place update failed label", "node", node.Name, "reason", strings.ReplaceAll(reason, "\n", " "))
 
 	patch := client.MergeFrom(node.DeepCopy())
 	metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateFailed)

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -170,9 +171,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// If the node-agent has restarted after OS update, we need to persist the change in oscChanges.
-	if osc.Spec.InPlaceUpdates != nil && ptr.Deref(osVersion, "") == osc.Spec.InPlaceUpdates.OperatingSystemVersion {
-		if err := oscChanges.completeOSUpdate(); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed completing OS update: %w", err)
+	if osc.Spec.InPlaceUpdates != nil {
+		if osVersionUpToDate, err := IsOsVersionUpToDate(osVersion, osc); err != nil {
+			return reconcile.Result{}, err
+		} else if osVersionUpToDate {
+			if err := oscChanges.completeOSUpdate(); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed completing OS update: %w", err)
+			}
 		}
 	}
 
@@ -680,22 +685,31 @@ func (r *Reconciler) performInPlaceUpdate(ctx context.Context, log logr.Logger, 
 		return nil
 	}
 
-	// This means that the OS was not updated in-place and it rolled back to the previous version but a newer version is not yet applied.
-	if lastAttemptedUpdateVersion, osUpdateAnnotationExists := node.Annotations[annotationUpdatingOperatingSystemVersion]; osUpdateAnnotationExists &&
-		osc.Spec.InPlaceUpdates != nil && osVersion != nil && osc.Spec.InPlaceUpdates.OperatingSystemVersion != *osVersion &&
-		lastAttemptedUpdateVersion == osc.Spec.InPlaceUpdates.OperatingSystemVersion {
-		reason, ok := node.Annotations[machinev1alpha1.AnnotationKeyMachineUpdateFailedReason]
-		// If there is already a annotatoin with the update failed reason, don't overwrite it.
-		if !ok {
-			if err := r.patchNodeUpdateFailed(ctx, log, node, fmt.Sprintf("OS update might have failed and rolled back to the previous version. Desired version: %q, Current version: %q", osc.Spec.InPlaceUpdates.OperatingSystemVersion, *osVersion)); err != nil {
-				return err
-			}
+	if osc.Spec.InPlaceUpdates == nil {
+		return nil
+	}
 
-			// No point in requeuing the node for the same version, wait for the newer version to be applied.
-			return reconcile.TerminalError(fmt.Errorf("OS update might have failed and rolled back to the previous version. Desired version: %q, Current version: %q", osc.Spec.InPlaceUpdates.OperatingSystemVersion, *osVersion))
+	// This means that the OS was not updated in-place and it rolled back to the previous version but a newer version is not yet applied.
+	if lastAttemptedUpdateVersion, osUpdateAnnotationExists := node.Annotations[annotationUpdatingOperatingSystemVersion]; osUpdateAnnotationExists && oscChanges.InPlaceUpdates.OperatingSystem {
+		lastAttemptedUpdateVersionIsSameAsDesired, err := versionutils.CompareVersions(lastAttemptedUpdateVersion, "=", osc.Spec.InPlaceUpdates.OperatingSystemVersion)
+		if err != nil {
+			return fmt.Errorf("failed comparing last attempted update version %q with desired OS version %q: %w", lastAttemptedUpdateVersion, osc.Spec.InPlaceUpdates.OperatingSystemVersion, err)
 		}
 
-		return reconcile.TerminalError(fmt.Errorf("OS update has failed with error: %s", reason))
+		if lastAttemptedUpdateVersionIsSameAsDesired {
+			reason, ok := node.Annotations[machinev1alpha1.AnnotationKeyMachineUpdateFailedReason]
+			// If there is already a annotation with the update failed reason, don't overwrite it.
+			if !ok {
+				if err := r.patchNodeUpdateFailed(ctx, log, node, fmt.Sprintf("OS update might have failed and rolled back to the previous version. Desired version: %q, Current version: %q", osc.Spec.InPlaceUpdates.OperatingSystemVersion, *osVersion)); err != nil {
+					return err
+				}
+
+				// No point in requeuing the node for the same version, wait for the newer version to be applied.
+				return reconcile.TerminalError(fmt.Errorf("OS update might have failed and rolled back to the previous version. Desired version: %q, Current version: %q", osc.Spec.InPlaceUpdates.OperatingSystemVersion, *osVersion))
+			}
+
+			return reconcile.TerminalError(fmt.Errorf("OS update has failed with error: %s", reason))
+		}
 	}
 
 	if err := r.updateOSInPlace(ctx, log, oscChanges, osc, node); err != nil {

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -378,6 +378,7 @@ PRETTY_NAME="Garden Linux 1592Foo"
 		It("should set the node to update-failed if the lastAttempted version is equal to the osc.Spec.InPlaceUpdates.OperatingSystemVersion", func() {
 			node.Annotations = map[string]string{"node-agent.gardener.cloud/updating-operating-system-version": "1.2.4"}
 			osc.Spec.InPlaceUpdates.OperatingSystemVersion = "1.2.4"
+			oscChanges.InPlaceUpdates.OperatingSystem = true
 
 			err := reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osVersion)
 			Expect(err).To(MatchError(ContainSubstring("OS update might have failed and rolled back to the previous version")))
@@ -394,6 +395,7 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			node.Annotations[machinev1alpha1.AnnotationKeyMachineUpdateFailedReason] = "previous error"
 			node.Labels = map[string]string{machinev1alpha1.LabelKeyNodeUpdateResult: machinev1alpha1.LabelValueNodeUpdateFailed}
 			Expect(c.Update(ctx, node)).To(Succeed())
+			oscChanges.InPlaceUpdates.OperatingSystem = true
 
 			err := reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osVersion)
 			Expect(err).To(MatchError(ContainSubstring("OS update has failed with error")))

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -368,6 +369,9 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			DeferCleanup(test.WithVars(
 				&OSUpdateRetryInterval, 1*time.Millisecond,
 				&OSUpdateRetryTimeout, 10*time.Millisecond,
+				&GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) {
+					return ptr.To(osVersion), nil
+				},
 			))
 		})
 
@@ -517,7 +521,7 @@ PRETTY_NAME="Garden Linux 1592Foo"
 				Expect(c.DeleteAllOf(ctx, &corev1.Pod{})).To(Or(Succeed(), BeNotFoundError()))
 			})
 
-			Expect(reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osVersion)).To(Succeed())
+			Expect(reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osc.Spec.InPlaceUpdates.OperatingSystemVersion)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
 			Expect(node.Labels).To(HaveKeyWithValue(machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful))
@@ -558,7 +562,7 @@ PRETTY_NAME="Garden Linux 1592Foo"
 				Expect(c.DeleteAllOf(ctx, &corev1.Pod{})).To(Or(Succeed(), BeNotFoundError()))
 			})
 
-			Expect(reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osVersion)).To(Succeed())
+			Expect(reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, &osc.Spec.InPlaceUpdates.OperatingSystemVersion)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
 			Expect(node.Labels).To(HaveKeyWithValue(machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateSuccessful))
@@ -566,6 +570,46 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			podList := &corev1.PodList{}
 			Expect(c.List(ctx, podList)).To(Succeed())
 			Expect(podList.Items).To(BeEmpty())
+		})
+
+		It("should not patch the node as update successful and delete the pods if the OS is not up-to-date", func() {
+			DeferCleanup(test.WithVar(&GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) {
+				return ptr.To("1.1.0"), nil
+			}))
+
+			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateFailed)
+			Expect(c.Update(ctx, node)).To(Succeed())
+
+			pods := []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-2",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+					},
+				},
+			}
+
+			for _, pod := range pods {
+				Expect(c.Create(ctx, pod)).To(Succeed())
+			}
+
+			DeferCleanup(func() {
+				Expect(c.DeleteAllOf(ctx, &corev1.Pod{})).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			err := reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, ptr.To("1.1.0"))
+			Expect(err).To(MatchError(ContainSubstring("stopping reconciliation until gardener-node-agent is restarted after the OS update")))
+			Expect(err).To(MatchError(reconcile.TerminalError(nil)))
 		})
 	})
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -577,6 +577,8 @@ PRETTY_NAME="Garden Linux 1592Foo"
 				return ptr.To("1.1.0"), nil
 			}))
 
+			oscChanges.InPlaceUpdates.OperatingSystem = true
+
 			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeUpdateResult, machinev1alpha1.LabelValueNodeUpdateFailed)
 			Expect(c.Update(ctx, node)).To(Succeed())
 
@@ -608,7 +610,7 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			})
 
 			err := reconciler.performInPlaceUpdate(ctx, log, osc, oscChanges, node, ptr.To("1.1.0"))
-			Expect(err).To(MatchError(ContainSubstring("stopping reconciliation until gardener-node-agent is restarted after the OS update")))
+			Expect(err).To(MatchError(ContainSubstring("stopping reconciliation until gardener-node-agent is restarted after the OS update. Current version: \"1.1.0\", Desired version: \"1.2.3\"")))
 			Expect(err).To(MatchError(reconcile.TerminalError(nil)))
 		})
 	})

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -1033,6 +1033,10 @@ kind: NodeAgentConfiguration
 			}
 
 			DeferCleanup(test.WithVar(&operatingsystemconfig.ExecCommandCombinedOutput, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+				// Simulate a successful OS update by returning the new OS version in GetOSVersion.
+				DeferCleanup(test.WithVars(
+					&operatingsystemconfig.GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) { return ptr.To("1.2.4"), nil },
+				))
 				return []byte("OS update successful"), nil
 			}))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality usability
/kind bugfix

**What this PR does / why we need it**:
- This PR uses semver comparison for OS version instead of string comparisons during in-place update. This is need to work with OS versions which use only `MAJOR.MINOR` format but the cloudprofile still contains `MAJOR.MINOR.PATCH` (patch is 0, which is discarded by semver).
- We also now use higher context timeouts in case of in-place updates. Previous timeout of `3` minutes was not enough in case of OS updates which implement retry with a `5` minute timeout.
- Some code improvements.

**Which issue(s) this PR fixes**:
Part of #10219 

**Special notes for your reviewer**:
/cc @acumino @ary1992 @Roncossek 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in which `gardener-node-agent` was not able to in-place update OS versions that specify only `MAJOR.MINOR` in the `os-release` but `MAJOR.MINOR.PATCH` in the cloud profile is now fixed.
```
