### PR TITLE
Fix updates to CA annotation on `MachineDeployment` upon change in worker specific options

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -245,7 +245,11 @@ func deployMachineDeployments(
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, cl, machineDeployment, func() error {
 			metav1.SetMetaDataLabel(&machineDeployment.ObjectMeta, v1beta1constants.LabelWorkerPool, deployment.PoolName)
 			for k, v := range deployment.ClusterAutoscalerAnnotations {
-				metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
+				if v == "" {
+					delete(machineDeployment.ObjectMeta.GetAnnotations(), k)
+				} else {
+					metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
+				}
 			}
 			machineDeployment.Spec = machinev1alpha1.MachineDeploymentSpec{
 				Replicas:             replicas,

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -246,7 +246,7 @@ func deployMachineDeployments(
 			metav1.SetMetaDataLabel(&machineDeployment.ObjectMeta, v1beta1constants.LabelWorkerPool, deployment.PoolName)
 			for k, v := range deployment.ClusterAutoscalerAnnotations {
 				if v == "" {
-					delete(machineDeployment.ObjectMeta.GetAnnotations(), k)
+					delete(machineDeployment.GetAnnotations(), k)
 				} else {
 					metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
 				}

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ActuatorReconcile", func() {
 			testDeployment             *machinev1alpha1.MachineDeployment
 			returnedDeployment         machinev1alpha1.MachineDeployment
 			wantedMachineDeployments   extensionsworkercontroller.MachineDeployments
-			caUsed                     bool = true
+			caUsed                     bool
 		)
 
 		BeforeEach(func() {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -82,13 +82,13 @@ var _ = Describe("ActuatorReconcile", func() {
 			}
 
 			Expect(seedClient.Create(ctx, testDeployment)).To(Succeed())
-			dep := extensionsworkercontroller.MachineDeployment{
+			wantedMachineDeployment := extensionsworkercontroller.MachineDeployment{
 				Name:                         testDeployment.Name,
 				PoolName:                     testDeployment.Labels["worker.gardener.cloud/pool"],
 				Labels:                       testDeployment.Labels,
 				ClusterAutoscalerAnnotations: testDeployment.Annotations,
 			}
-			wantedMachineDeployments = []extensionsworkercontroller.MachineDeployment{dep}
+			wantedMachineDeployments = []extensionsworkercontroller.MachineDeployment{wantedMachineDeployment}
 
 			DeferCleanup(func() {
 				Expect(seedClient.Delete(ctx, worker)).To(Succeed())

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,12 +17,146 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 var _ = Describe("ActuatorReconcile", func() {
+	Describe("#deployMachineDeployments", func() {
+		var (
+			ctx                        context.Context
+			log                        logr.Logger
+			seedClient                 client.Client
+			cluster                    *extensionscontroller.Cluster
+			worker                     *extensionsv1alpha1.Worker
+			existingMachineDeployments machinev1alpha1.MachineDeploymentList
+			testDeployment             *machinev1alpha1.MachineDeployment
+			returnedDeployment         machinev1alpha1.MachineDeployment
+			wantedMachineDeployments   extensionsworkercontroller.MachineDeployments
+			caUsed                     bool = true
+		)
+
+		BeforeEach(func() {
+			seedClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.SeedScheme).
+				WithStatusSubresource(&extensionsv1alpha1.Worker{}, &machinev1alpha1.MachineDeployment{}).
+				Build()
+
+			ctx = context.Background()
+
+			worker = &extensionsv1alpha1.Worker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker",
+					Namespace: "namespace",
+				},
+				Spec: extensionsv1alpha1.WorkerSpec{
+					Pools: []extensionsv1alpha1.WorkerPool{
+						{
+							Name:              "pool1",
+							UpdateStrategy:    ptr.To(gardencorev1beta1.AutoInPlaceUpdate),
+							KubernetesVersion: ptr.To("1.32.0"),
+						},
+					},
+				},
+			}
+			Expect(seedClient.Create(ctx, worker)).To(Succeed())
+
+			testDeployment = &machinev1alpha1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-deployment1",
+					Namespace: worker.Namespace,
+					Labels: map[string]string{
+						"worker.gardener.cloud/name": worker.Name,
+						"worker.gardener.cloud/pool": "pool1",
+					},
+					Annotations: map[string]string{
+						"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "0.3",
+						"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+						"autoscaler.gardener.cloud/scale-down-unneeded-time":             "10m",
+						"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+						"autoscaler.gardener.cloud/max-node-provision-time":              "",
+					},
+				},
+			}
+
+			Expect(seedClient.Create(ctx, testDeployment)).To(Succeed())
+			dep := extensionsworkercontroller.MachineDeployment{
+				Name:                         testDeployment.Name,
+				PoolName:                     testDeployment.Labels["worker.gardener.cloud/pool"],
+				Labels:                       testDeployment.Labels,
+				ClusterAutoscalerAnnotations: testDeployment.Annotations,
+			}
+			wantedMachineDeployments = []extensionsworkercontroller.MachineDeployment{dep}
+
+			DeferCleanup(func() {
+				Expect(seedClient.Delete(ctx, worker)).To(Succeed())
+				Expect(seedClient.Delete(ctx, testDeployment)).To(Succeed())
+			})
+
+			cluster = &extensionscontroller.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Shoot: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{},
+				},
+			}
+		})
+		It("should remove cluster autoscaler annotations with no values", func() {
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Annotations).To(Equal(map[string]string{
+				"autoscaler.gardener.cloud/scale-down-utilization-threshold": "0.3",
+				"autoscaler.gardener.cloud/scale-down-unneeded-time":         "10m",
+			}))
+		})
+
+		It("should remove all cluster autoscaler annotations", func() {
+			testDeployment.Annotations = map[string]string{
+				"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
+				"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+				"autoscaler.gardener.cloud/scale-down-unneeded-time":             "",
+				"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+				"autoscaler.gardener.cloud/max-node-provision-time":              "",
+			}
+			wantedMachineDeployments[0].ClusterAutoscalerAnnotations = testDeployment.Annotations
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Annotations).To(BeNil())
+		})
+
+		It("should not remove non-CA annotation and update CA annotations", func() {
+			// Set non CA annotation
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			metav1.SetMetaDataAnnotation(&returnedDeployment.ObjectMeta, "non-ca-annotation", "")
+			Expect(seedClient.Update(ctx, &returnedDeployment)).To(Succeed())
+			// Update existing CA annotation value and remove another CA annotation
+			wantedMachineDeployments[0].ClusterAutoscalerAnnotations = map[string]string{
+				"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
+				"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+				"autoscaler.gardener.cloud/scale-down-unneeded-time":             "20m",
+				"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+				"autoscaler.gardener.cloud/max-node-provision-time":              "",
+			}
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.ObjectMeta.Annotations).To(Equal(map[string]string{
+				"non-ca-annotation": "",
+				"autoscaler.gardener.cloud/scale-down-unneeded-time": "20m",
+			}))
+		})
+	})
 	Describe("#updateWorkerStatusInPlaceUpdateWorkerPoolHash", func() {
 		var (
 			ctx        context.Context

--- a/pkg/apis/extensions/v1alpha1/helper/worker.go
+++ b/pkg/apis/extensions/v1alpha1/helper/worker.go
@@ -21,18 +21,14 @@ func ClusterAutoscalerRequired(pools []extensionsv1alpha1.WorkerPool) bool {
 
 // GetMachineDeploymentClusterAutoscalerAnnotations returns a map of annotations with values intended to be used as cluster-autoscaler options for the worker group
 func GetMachineDeploymentClusterAutoscalerAnnotations(caOptions *extensionsv1alpha1.ClusterAutoscalerOptions) map[string]string {
-	annotations := make(map[string]string)
-	caAnnotationsKeys := []string{
-		extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation,
-		extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation,
-		extensionsv1alpha1.ScaleDownUnneededTimeAnnotation,
-		extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation,
-		extensionsv1alpha1.MaxNodeProvisionTimeAnnotation,
-	}
 	// Setting all the annotations to empty value which is used
 	// to check which options are explicitly set
-	for _, key := range caAnnotationsKeys {
-		annotations[key] = ""
+	annotations := map[string]string{
+		extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation:    "",
+		extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation: "",
+		extensionsv1alpha1.ScaleDownUnneededTimeAnnotation:            "",
+		extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation:             "",
+		extensionsv1alpha1.MaxNodeProvisionTimeAnnotation:             "",
 	}
 	if caOptions != nil {
 		if caOptions.ScaleDownUtilizationThreshold != nil {

--- a/pkg/apis/extensions/v1alpha1/helper/worker.go
+++ b/pkg/apis/extensions/v1alpha1/helper/worker.go
@@ -21,9 +21,20 @@ func ClusterAutoscalerRequired(pools []extensionsv1alpha1.WorkerPool) bool {
 
 // GetMachineDeploymentClusterAutoscalerAnnotations returns a map of annotations with values intended to be used as cluster-autoscaler options for the worker group
 func GetMachineDeploymentClusterAutoscalerAnnotations(caOptions *extensionsv1alpha1.ClusterAutoscalerOptions) map[string]string {
-	var annotations map[string]string
+	annotations := make(map[string]string)
+	caAnnotationsKeys := []string{
+		extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation,
+		extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation,
+		extensionsv1alpha1.ScaleDownUnneededTimeAnnotation,
+		extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation,
+		extensionsv1alpha1.MaxNodeProvisionTimeAnnotation,
+	}
+	// Setting all the annotations to empty value which is used
+	// to check which options are explicitly set
+	for _, key := range caAnnotationsKeys {
+		annotations[key] = ""
+	}
 	if caOptions != nil {
-		annotations = map[string]string{}
 		if caOptions.ScaleDownUtilizationThreshold != nil {
 			annotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation] = *caOptions.ScaleDownUtilizationThreshold
 		}

--- a/pkg/apis/extensions/v1alpha1/helper/worker_test.go
+++ b/pkg/apis/extensions/v1alpha1/helper/worker_test.go
@@ -34,12 +34,26 @@ var _ = Describe("Helper", func() {
 	)
 
 	Describe("#GetMachineDeploymentClusterAutoscalerAnnotations", func() {
-		It("should return nil when options passed is nil", func() {
-			Expect(GetMachineDeploymentClusterAutoscalerAnnotations(nil)).To(BeNil())
+		It("should return annotations with value \"\" when options passed is nil", func() {
+			expectedValues := map[string]string{
+				extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation:    "",
+				extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation: "",
+				extensionsv1alpha1.ScaleDownUnneededTimeAnnotation:            "",
+				extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation:             "",
+				extensionsv1alpha1.MaxNodeProvisionTimeAnnotation:             "",
+			}
+			Expect(GetMachineDeploymentClusterAutoscalerAnnotations(nil)).To(Equal(expectedValues))
 		})
 
-		It("should return empty map when an empty map is passed", func() {
-			Expect(GetMachineDeploymentClusterAutoscalerAnnotations(ptr.To(extensionsv1alpha1.ClusterAutoscalerOptions{}))).To(Equal(map[string]string{}))
+		It("should return annotations with value \"\" when an empty map is passed", func() {
+			expectedValues := map[string]string{
+				extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation:    "",
+				extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation: "",
+				extensionsv1alpha1.ScaleDownUnneededTimeAnnotation:            "",
+				extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation:             "",
+				extensionsv1alpha1.MaxNodeProvisionTimeAnnotation:             "",
+			}
+			Expect(GetMachineDeploymentClusterAutoscalerAnnotations(ptr.To(extensionsv1alpha1.ClusterAutoscalerOptions{}))).To(Equal(expectedValues))
 		})
 
 		It("should return correctly populated map when all options are passed", func() {
@@ -66,8 +80,11 @@ var _ = Describe("Helper", func() {
 				ScaleDownUnneededTime:            ptr.To(metav1.Duration{Duration: time.Minute}),
 			}
 			expectedValues := map[string]string{
+				extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation:    "",
 				extensionsv1alpha1.ScaleDownGpuUtilizationThresholdAnnotation: "0.6",
 				extensionsv1alpha1.ScaleDownUnneededTimeAnnotation:            "1m0s",
+				extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation:             "",
+				extensionsv1alpha1.MaxNodeProvisionTimeAnnotation:             "",
 			}
 			Expect(GetMachineDeploymentClusterAutoscalerAnnotations(caOptions)).To(Equal(expectedValues))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
This PR allows for removal/updates of `cluster-autoscaler` annotations on `MachineDeployment` in accordance with the changes to worker pool cluster-autoscaler options.

Presently when the worker specific CA options are removed, the annotations corresponding to them persist on the MachineDeployment.

By initializing the annotations with a default `""` (empty) value and explicit declaration of the worker pool specific options, when updating the deployment annotations a check is performed and the CA annotations for options that are no longer set are removed. 

**Which issue(s) this PR fixes**:
Fixes #12547 

**Special notes for your reviewer**:
/cc @aaronfern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix cluster-autoscaler specific annotations on machine deployment upon update in worker specific cluster autoscaler options.
```
