### PR TITLE
Promote Feature Gate `NewWorkerPoolHash` to `Beta`  and default to `true`

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -12,7 +12,6 @@ spec:
     kind: GardenletConfiguration
     featureGates:
       DefaultSeccompProfile: true
-      NewWorkerPoolHash: true
       IstioTLSTermination: true
     controllers:
       shoot:

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,7 +25,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile                | `true`  | `Beta`  | `1.112` |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
-| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
+| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.123` |
 | NewWorkerPoolHash                        | `true`  | `Beta`  | `1.124` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,8 +25,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile                | `true`  | `Beta`  | `1.112` |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
-| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.123` |
-| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.124` |         |
+| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.124` |
+| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.125` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,8 +25,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile                | `true`  | `Beta`  | `1.112` |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
-| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.124` |
-| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.125` |         |
+| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.125` |
+| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.126` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,6 +26,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
+| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.124` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,7 +41,7 @@ const (
 	// to support this feature first.
 	// owner: @MichaelEischer
 	// alpha: v1.98.0
-	// beta: v1.124.0
+	// beta: v1.125.0
 	NewWorkerPoolHash featuregate.Feature = "NewWorkerPoolHash"
 
 	// NewVPN enables the new implementation of the VPN (go rewrite) using an IPv6 transfer network.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,7 +41,7 @@ const (
 	// to support this feature first.
 	// owner: @MichaelEischer
 	// alpha: v1.98.0
-	// beta: v1.125.0
+	// beta: v1.126.0
 	NewWorkerPoolHash featuregate.Feature = "NewWorkerPoolHash"
 
 	// NewVPN enables the new implementation of the VPN (go rewrite) using an IPv6 transfer network.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,6 +41,7 @@ const (
 	// to support this feature first.
 	// owner: @MichaelEischer
 	// alpha: v1.98.0
+	// beta: v1.124.0
 	NewWorkerPoolHash featuregate.Feature = "NewWorkerPoolHash"
 
 	// NewVPN enables the new implementation of the VPN (go rewrite) using an IPv6 transfer network.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -121,7 +121,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:                    {Default: false, PreRelease: featuregate.Alpha},
 	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.Beta},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
-	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
+	NewWorkerPoolHash:                        {Default: true, PreRelease: featuregate.Beta},
 	NewVPN:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	NodeAgentAuthorizer:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the feature gate `NewWorkerPoolHash` to `Beta` status.
Now that we had the feature gate in alpha for 27 versions, we are confident this can go `Beta`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9699

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ The `NewWorkerPoolHash` feature gate has been promoted to beta and is now enabled by default. When the feature gate is enabled, changes to `kubeReserved`, `systemReserved`, `evictionHard` or `cpuManagerPolicy` in the `kubelet` of the `Shoot` will trigger a node-roll. All provider extensions must be upgraded to a version which includes Gardener `v1.98.0` first to support this feature.
```
