### PR TITLE
Extract a script which can be used to re-add loopback IP addresses for kind containers

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -60,6 +60,17 @@ With this, mirrored images don't have to be pulled again after recreating the cl
 The command also deploys a default [calico](https://github.com/projectcalico/calico) installation as the cluster's CNI implementation with `NetworkPolicy` support (the default `kindnet` CNI doesn't provide `NetworkPolicy` support).
 Furthermore, it deploys the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) in order to support HPA and VPA on the seed cluster.
 
+After a restart of your host, the loopback IP addresses that were created for the kind cluster could be removed.
+To avoid recreating the cluster, there is a script that can be used to easily bring back the addresses.
+```bash
+./hack/kind-setup-loopback-devices.sh --cluster-name gardener-local
+```
+
+> Depending on the cluster you are using for your local dev setup you might have to:
+>  - Replace the value for `--cluster-name` with the name of the kind cluster you are using for your local dev setup.
+>  - Add the `--ip-family <ipv4|ipv6|dual>` flag if you want to setup `ipv6` or `dual` stack IPs (`ipv4` is the default value).
+>  - Add the `--multi-zonal` flag if you want to setup IPs for a multi-zonal cluster.
+
 ## Setting Up IPv6 Single-Stack Networking (optional)
 
 First, ensure that your `/etc/hosts` file contains an entry resolving `garden.local.gardener.cloud` to the IPv6 loopback address:

--- a/hack/kind-extensions-up.sh
+++ b/hack/kind-extensions-up.sh
@@ -8,8 +8,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ -n "$(docker ps -aq -f name=gardener-extensions-control-plane)" ]]; then 
+if [[ -n "$(docker ps -aq -f name=gardener-extensions-control-plane)" ]]; then
+    # After a reboot of the host machine, the ip addresses required for the port mappings of the
+    # gardener-extensions-control-plane container are removed. Re-add them here, in case they are missing.
+    ./hack/kind-setup-loopback-devices.sh --cluster-name gardener-extensions
     docker start gardener-extensions-control-plane
-else 
+else
     ./hack/kind-up.sh --cluster-name gardener-extensions --path-kubeconfig "${REPO_ROOT}/example/provider-extensions/garden/kubeconfig" --path-cluster-values "${REPO_ROOT}/example/gardener-local/kind/extensions/values.yaml"
 fi

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 
 set -o errexit
 set -o nounset

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
 set -o errexit
 set -o nounset
 
@@ -36,8 +35,6 @@ parse_flags() {
 
 parse_flags "$@"
 
-
-
 LOOPBACK_IP_ADDRESSES=(172.18.255.1)
 if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
   LOOPBACK_IP_ADDRESSES+=(::1)
@@ -69,7 +66,6 @@ elif [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-loc
   fi
 fi
 
-
 if ! command -v ip &>/dev/null; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "'ip' command not found. Please install 'ip' command, refer https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#installing-iproute2" 1>&2
@@ -78,6 +74,7 @@ if ! command -v ip &>/dev/null; then
   echo "Skipping loopback device setup because 'ip' command is not available..."
   return
 fi
+
 LOOPBACK_DEVICE=$(ip address | grep LOOPBACK | sed "s/^[0-9]\+: //g" | awk '{print $1}' | sed "s/:$//g")
 echo "Checking loopback device ${LOOPBACK_DEVICE}..."
 for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+MULTI_ZONAL="false"
+CLUSTER_NAME=""
+IPFAMILY="ipv4"
+
+SUDO=""
+if [[ "$(id -u)" != "0" ]]; then
+  SUDO="sudo "
+fi
+
+parse_flags() {
+  while test $# -gt 0; do
+    case "$1" in
+    --cluster-name)
+      shift; CLUSTER_NAME="${1}"
+      ;;
+    --ip-family)
+      shift; IPFAMILY="${1}"
+      ;;
+    --multi-zonal)
+      MULTI_ZONAL=true
+      ;;
+    esac
+
+    shift
+  done
+}
+
+parse_flags "$@"
+
+
+
+LOOPBACK_IP_ADDRESSES=(172.18.255.1)
+if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+  LOOPBACK_IP_ADDRESSES+=(::1)
+fi
+
+if [[ "$MULTI_ZONAL" == "true" ]]; then
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.10 172.18.255.11 172.18.255.12)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
+  fi
+fi
+
+if [[ "$CLUSTER_NAME" != "*local2*" ]] ; then
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.22)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::22)
+  fi
+fi
+
+if [[ "$CLUSTER_NAME" == "gardener-operator-local" ]]; then
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.3)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::3)
+  fi
+elif [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-local-multi-node2" ]]; then
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.2)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::2)
+  fi
+fi
+
+
+if ! command -v ip &>/dev/null; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "'ip' command not found. Please install 'ip' command, refer https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#installing-iproute2" 1>&2
+    exit 1
+  fi
+  echo "Skipping loopback device setup because 'ip' command is not available..."
+  return
+fi
+LOOPBACK_DEVICE=$(ip address | grep LOOPBACK | sed "s/^[0-9]\+: //g" | awk '{print $1}' | sed "s/:$//g")
+echo "Checking loopback device ${LOOPBACK_DEVICE}..."
+for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do
+  if ip address show dev ${LOOPBACK_DEVICE} | grep -q $address/; then
+    echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
+  else
+    echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
+    ${SUDO}ip address add "$address" dev "${LOOPBACK_DEVICE}"
+  fi
+done
+echo "Setting up loopback device ${LOOPBACK_DEVICE} completed."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR extracts the code which creates loopback devices for the local setup in a separate script - `hack/kind-setup-loopback-devices.sh`.

The main reason this was done is for the [local setup with extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md). When the setup is paused by calling `make kind-extensions-down` and the user's host is restarted, the loopback IPs are removed from the local device. When a developer then calls `make kind-extensions-up` again the loopback IPs are not recreated and the container for the kind cluster could fail to start. With this PR the loopback IPs are recreated in this case.

Additionally, the `hack/kind-setup-loopback-devices.sh` script can be used for the [local dev](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md) setup so that loopback IPs are created after a host restart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
