### PR TITLE
fix(hack): explicitly set umask in generate-controller-registration.sh

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -130,6 +130,9 @@ function cleanup {
 }
 trap cleanup EXIT ERR INT TERM
 
+# The umask could differ depending on the system/distro where the script is run. Therefore we explicitly set it to a sensible value
+umask 0022
+
 export HELM_HOME="$temp_helm_home"
 [ "$(helm version --client --template "{{.Version}}" | head -c2 | tail -c1)" = "3" ] || helm init --client-only > /dev/null 2>&1
 helm package "$CHART_DIR" --destination "$temp_dir" > /dev/null


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Explicitly sets the `umask` to `0022`.

We've noticed that the default umask is different between macOS (`0022`) and ubuntu (`0002`), thus resulting in different permissions on directories in the `tar.gz` of the helmchart:

```diff
diff $(tar -tvf bad/out.tar | psub) $(tar -tvf good/out.tar | psub)
1c1
< drwxrwxr-x root/root         0 2019-01-01 01:00 gardener-extension-provider-stackit/
---
> drwxr-xr-x root/root         0 2019-01-01 01:00 gardener-extension-provider-stackit/
3c3
< drwxrwxr-x root/root         0 2019-01-01 01:00 gardener-extension-provider-stackit/templates/
---
> drwxr-xr-x root/root         0 2019-01-01 01:00 gardener-extension-provider-stackit/templates/
```