### PR TITLE
`gardener-resource-manager`: Explicitly filter for `kube-system` namespace when listing `Pod`s

### DIFF
--- a/pkg/resourcemanager/controller/node/criticalcomponents/reconciler.go
+++ b/pkg/resourcemanager/controller/node/criticalcomponents/reconciler.go
@@ -64,12 +64,12 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	// prep for checks: list all DaemonSets and all node-critical pods on the given node
 	daemonSetList := &appsv1.DaemonSetList{}
-	if err := r.TargetClient.List(ctx, daemonSetList, client.MatchingLabels{v1beta1constants.LabelNodeCriticalComponent: "true"}); err != nil {
+	if err := r.TargetClient.List(ctx, daemonSetList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{v1beta1constants.LabelNodeCriticalComponent: "true"}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed listing node-critical DaemonSets on node: %w", err)
 	}
 
 	podList := &corev1.PodList{}
-	if err := r.TargetClient.List(ctx, podList, client.MatchingFields{indexer.PodNodeName: node.Name}, client.MatchingLabels{v1beta1constants.LabelNodeCriticalComponent: "true"}); err != nil {
+	if err := r.TargetClient.List(ctx, podList, client.InNamespace(metav1.NamespaceSystem), client.MatchingFields{indexer.PodNodeName: node.Name}, client.MatchingLabels{v1beta1constants.LabelNodeCriticalComponent: "true"}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed listing node-critical Pods on node: %w", err)
 	}
 

--- a/test/integration/resourcemanager/node/criticalcomponents/criticalcomponents_suite_test.go
+++ b/test/integration/resourcemanager/node/criticalcomponents/criticalcomponents_suite_test.go
@@ -31,7 +31,6 @@ import (
 	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/resourcemanager/apis/config/v1alpha1"
 	resourcemanagerclient "github.com/gardener/gardener/pkg/resourcemanager/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/node/criticalcomponents"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 func TestCriticalComponents(t *testing.T) {
@@ -78,18 +77,12 @@ var _ = BeforeSuite(func() {
 	By("Create test Namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
-			GenerateName: testID + "-",
+			Name: "kube-system",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
-	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+	Expect(testClient.Get(ctx, client.ObjectKeyFromObject(testNamespace), testNamespace)).To(Succeed())
+	log.Info("Using Namespace for test", "namespaceName", testNamespace.Name)
 	testRunID = testNamespace.Name
-
-	DeferCleanup(func() {
-		By("Delete test Namespace")
-		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
-	})
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/11718 explicitly added https://github.com/gardener/gardener/blob/0e32da885b322c5815851c5538abbc6e2807ed24/cmd/gardener-resource-manager/app/app.go#L181-L186
This leads to the fact that `gardener-resource-manager`s cache now contained `Pod`s from all namespaces in the shoot clusters. Previously, only pods in the namespaces configured in the `TargetClientConnection` where considered: https://github.com/gardener/gardener/blob/0e32da885b322c5815851c5538abbc6e2807ed24/cmd/gardener-resource-manager/app/app.go#L188 https://github.com/gardener/gardener/blob/0e32da885b322c5815851c5538abbc6e2807ed24/pkg/gardenlet/operation/botanist/resource_manager.go#L55

This suddenly considered `Pods` labeled with `node.gardener.cloud/critical-component=true` from namespaces other than those (i.e., user namespaces).

**Special notes for your reviewer**:
/cc @oliver-goetz @vpnachev 
FYI @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused `Pod`s from namespaces other than `kube-system` and labeled with `node.gardener.cloud/critical-component=true` to be considered by `gardener-resource-manager`.
```
