### PR TITLE
Update wording in the `Shoot Kubernetes Minor Version Upgrades` guide

### DIFF
--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -11,14 +11,14 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 
 ## Upgrading to Kubernetes `v1.34`
 
-- The `Shoot`'s field `.spec.cloudProfileName` is forbidden. `Shoot` owners must migrate their `CloudProfile` reference to the new `spec.cloudProfile.name` field.
+- The `Shoot`'s `.spec.cloudProfileName` field is forbidden. `Shoot` owners must migrate their `CloudProfile` reference to the new `spec.cloudProfile.name` field.
 
 ## Upgrading to Kubernetes `v1.33`
 
 - A new `deny-all` `NetworkPolicy` is deployed into the `kube-system` namespace of the `Shoot` cluster. `Shoot` owners that run workloads in the `kube-system` namespace are required to explicitly allow their expected `Ingress` and `Egress` traffic in `kube-system` via `NetworkPolicies`.
-- The `Shoot`'s field `.spec.kubernetes.kubeControllerManager.podEvictionTimeout` is forbidden. `Shoot` owners should use the `.spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and `.spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds` fields.
-- The `Shoot`'s field `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` is forbidden. `Shoot` owners should use the `.spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism` field.
-- The `Shoot`'s field `.spec.cloudProfileName` is deprecated. `Shoot` owners should migrate their `CloudProfile` reference to the new `.spec.cloudProfile.name` field.
+- The `Shoot`'s `.spec.kubernetes.kubeControllerManager.podEvictionTimeout` field is forbidden. `Shoot` owners should use the `.spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and `.spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds` fields.
+- The `Shoot`'s `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` field is forbidden. `Shoot` owners should use the `.spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism` field.
+- The `Shoot`'s `.spec.cloudProfileName` field is deprecated. `Shoot` owners should migrate their `CloudProfile` reference to the new `.spec.cloudProfile.name` field.
 
 ## Upgrading to Kubernetes `v1.32`
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Right now, half of the statements use:
> - The `Shoot`'s field `.spec.foo.bar` is forbidden.

The other half:
> - The `Shoot`'s `.spec.foo.bar` field is forbidden.

This PR unifies the wording.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
