### PR TITLE
[WIP] Remove and replace usages of deprecated `reconcile.Result{Requeue: true}`

### DIFF
--- a/pkg/controller/tokenrequestor/reconciler.go
+++ b/pkg/controller/tokenrequestor/reconciler.go
@@ -78,7 +78,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 	if mustRequeue {
 		log.Info("No need to generate new token, renewal is scheduled", "after", requeueAfter)
-		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	log.Info("Requesting new token")
@@ -105,7 +105,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 
 	log.Info("Successfully requested token and scheduled renewal", "after", renewDuration)
-	return reconcile.Result{Requeue: true, RequeueAfter: renewDuration}, nil
+	return reconcile.Result{RequeueAfter: renewDuration}, nil
 }
 
 func (r *Reconciler) reconcileServiceAccount(ctx context.Context, secret *corev1.Secret) (*corev1.ServiceAccount, error) {

--- a/pkg/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/controller/tokenrequestor/reconciler_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -145,7 +145,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -166,7 +166,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -186,7 +186,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -208,7 +208,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -237,7 +237,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -256,7 +256,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err = ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			targetSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -284,7 +284,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -302,7 +302,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -331,7 +331,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: time.Hour}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: time.Hour}))
 			})
 		})
 
@@ -356,7 +356,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should detect if the caBundle is incorrect (token case)", func() {
@@ -371,7 +371,7 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -388,7 +388,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should detect if the caBundle is incorrect (kubeconfig case)", func() {
@@ -400,7 +400,7 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("kubeconfig", newKubeconfigRaw(token, []byte("fake-ca-bundle"))))
@@ -417,7 +417,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -432,7 +432,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -461,7 +461,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
@@ -476,7 +476,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 		})
 
 		Context("error", func() {
@@ -514,7 +514,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))

--- a/pkg/controllermanager/controller/project/project/add.go
+++ b/pkg/controllermanager/controller/project/project/add.go
@@ -14,9 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+	"github.com/gardener/gardener/third_party/mock/client-go/util/workqueue"
 )
 
 // ControllerName is the name of this controller.
@@ -29,6 +31,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
+	}
+	if r.RateLimiter == nil {
+		r.RateLimiter = workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]()
 	}
 
 	return builder.

--- a/pkg/controllerutils/reconciler/reconcile.go
+++ b/pkg/controllerutils/reconciler/reconcile.go
@@ -12,7 +12,7 @@ import (
 // RequeueAfterError or not.
 func ReconcileErr(err error) (reconcile.Result, error) {
 	if requeueAfter, ok := err.(*RequeueAfterError); ok {
-		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter.RequeueAfter}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter.RequeueAfter}, nil
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/controllerutils/reconciler/reconcile_test.go
+++ b/pkg/controllerutils/reconciler/reconcile_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Reconcile", func() {
 		It("should return the correct result if it's a RequeueAfterError", func() {
 			res, err := ReconcileErr(requeueAfterError)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}))
+			Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 		})
 	})
 

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 	if mustRequeue {
 		log.Info("No need to generate new token, renewal is scheduled", "after", requeueAfter)
-		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
 	log.Info("Requesting new token")
@@ -100,7 +100,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 	}
 
 	log.Info("Successfully requested token and scheduled renewal", "after", renewDuration)
-	return reconcile.Result{Requeue: true, RequeueAfter: renewDuration}, nil
+	return reconcile.Result{RequeueAfter: renewDuration}, nil
 }
 
 func (r *Reconciler) reconcileSecret(ctx context.Context, log logr.Logger, secret *corev1.Secret, token string, renewDuration time.Duration) error {

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -161,7 +161,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -178,7 +178,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should issue a new token since the renew timestamp is in the past", func() {
@@ -193,7 +193,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -223,7 +223,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 		})
 
 		Context("error", func() {

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -161,7 +161,7 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 		}
 	}
 
-	return reconcile.Result{Requeue: true, RequeueAfter: r.Config.SyncPeriod.Duration}, errorList.ErrorOrNil()
+	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, errorList.ErrorOrNil()
 }
 
 type objectId struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity open-source
/kind cleanup

**What this PR does / why we need it**:
With version `v0.21.0` of controller-runtime the `sigs.k8s.io/controller-runtime/pkg/reconcile.Result.Requeue` field was deprecated.

To adapt to the deprecation, this PR does the following:
- Directly removes the field `Requeue: true` in places where it was used together with `RequeueAfter: <some-duration>`. In such cases setting `Requeue: true` had no effect before the deprecation.
- Replace `Requeue: true` with `RequeueAfter` and a rate limiter which will return the time after which the request has to be requeued so that the old behaviour of `Requeue: true` is preserved, [ref](https://github.com/kubernetes-sigs/controller-runtime/blob/1dce6213f6c078f3170921b3a774304d066d5bd4/pkg/internal/controller/controller.go#L363-L366)  To this end, the rate limiter is also shared between the reconciler and controller.

**Which issue(s) this PR fixes**:
Fixes #12210

**Special notes for your reviewer**:
Still WIP so that I can finish:
   - [ ] Fully testing the newly added rate limiters
   - [ ] Checking whether it makes sense for all the new rate limiters to be overwritten for integration tests.
   - [ ] Potentially adding short dev guide if someone wants to use the old `Requeue: true` behaviour.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
