### PR TITLE
Improve validations for worker related fields in the shoot spec

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -141,6 +141,8 @@ spec:
     #   machineHealthTimeout: 10m
     #   machineCreationTimeout: 20m
     #   maxEvictRetries: 10
+    #   inPlaceUpdateTimeout: 20m (only relevant for in-place update strategy)
+    #   disableHealthTimeout: true (only relevant for in-place update strategy)
     #   nodeConditions:
     #   - ReadonlyFilesystem
     #   - KernelDeadlock

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1938,8 +1938,8 @@ func ValidateMachineControllerManagerSettingsOptions(mcmOptions *core.MachineCon
 	allErrs = append(allErrs, ValidatePositiveDuration(mcmOptions.MachineHealthTimeout, fldPath.Child("machineHealthTimeout"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(mcmOptions.MachineCreationTimeout, fldPath.Child("machineCreationTimeout"))...)
 
-	if maxEvictRetries := mcmOptions.MaxEvictRetries; ptr.Deref(mcmOptions.MaxEvictRetries, 0) < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxEvictRetries"), *maxEvictRetries, "can not be negative"))
+	if mcmOptions.MaxEvictRetries != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*mcmOptions.MaxEvictRetries), fldPath.Child("maxEvictRetries"))...)
 	}
 
 	allErrs = append(allErrs, ValidatePositiveDuration(mcmOptions.MachineInPlaceUpdateTimeout, fldPath.Child("machineInPlaceUpdateTimeout"))...)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -7002,6 +7002,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, fldPath, false)
 				Expect(errList).To(BeEmpty())
 			})
+
 			It("should forbid setting MachineDrainTimeout to a negative value", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					MachineDrainTimeout: &metav1.Duration{Duration: time.Minute * -2},
@@ -7014,6 +7015,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Detail": Equal("must be non-negative"),
 				}))))
 			})
+
 			It("should forbid setting MachineHealthTimeout to a negative value", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					MachineHealthTimeout: &metav1.Duration{Duration: time.Minute * -2},
@@ -7026,6 +7028,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Detail": Equal("must be non-negative"),
 				}))))
 			})
+
 			It("should forbid setting MachineCreationTimeout to a negative value", func() {
 				worker.MachineControllerManagerSettings = &core.MachineControllerManagerSettings{
 					MachineCreationTimeout: &metav1.Duration{Duration: time.Minute * -2},
@@ -7051,6 +7054,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Detail": Equal("can only be set when the update strategy is `AutoInPlaceUpdate` or `ManualInPlaceUpdate`"),
 				}))))
 			})
+
 			It("should allow setting MachineInPlaceUpdateTimeout to positive value for update strategy AutoInPlaceUpdate", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				worker.UpdateStrategy = ptr.To(core.AutoInPlaceUpdate)
@@ -7061,6 +7065,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, fldPath, false)
 				Expect(errList).To(BeEmpty())
 			})
+			
 			It("should forbid setting MachineInPlaceUpdateTimeout to negative value for update strategy AutoInPlaceUpdate", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				worker.UpdateStrategy = ptr.To(core.AutoInPlaceUpdate)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -7096,7 +7096,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Machine: core.Machine{
 					Type: "xlarge",
 				},
-				Priority: ptr.To(int32(-2)),
+				MaxUnavailable: ptr.To(intstr.FromInt(1)),
+				Priority:       ptr.To(int32(-2)),
 			}
 
 			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, nil, false)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -7056,11 +7056,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}
 
 				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, fldPath, false)
-				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("workers[0].machineControllerManagerSettings.maxEvictRetries"),
-					"Detail": Equal("can not be negative"),
-				}))))
+				Expect(errList).To(ConsistOf(field.Invalid(field.NewPath("workers[0].machineControllerManagerSettings.maxEvictRetries"), int64(-2), "must be greater than or equal to 0").WithOrigin("minimum")))
 			})
 		})
 		It("should fail when priority is set to value less than -1", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3027,13 +3027,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_28, BeEmpty()),
 				Entry("invalid with negative maxNodeProvisionTime", core.ClusterAutoscaler{
 					MaxNodeProvisionTime: &negativeDuration,
-				}, version_1_28, ConsistOf(field.Invalid(field.NewPath("maxNodeProvisionTime"), negativeDuration, "can not be negative"))),
+				}, version_1_28, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("maxNodeProvisionTime"),
+					"Detail": Equal("must be non-negative"),
+				})))),
 				Entry("valid with maxGracefulTerminationSeconds", core.ClusterAutoscaler{
 					MaxGracefulTerminationSeconds: &positiveInteger,
 				}, version_1_28, BeEmpty()),
 				Entry("invalid with negative maxGracefulTerminationSeconds", core.ClusterAutoscaler{
 					MaxGracefulTerminationSeconds: &negativeInteger,
-				}, version_1_28, ConsistOf(field.Invalid(field.NewPath("maxGracefulTerminationSeconds"), negativeInteger, "can not be negative"))),
+				}, version_1_28, ConsistOf(field.Invalid(field.NewPath("maxGracefulTerminationSeconds"), int64(negativeInteger), "must be greater than or equal to 0").WithOrigin("minimum"))),
 				Entry("valid with expander least waste", core.ClusterAutoscaler{
 					Expander: &expanderLeastWaste,
 				}, version_1_28, BeEmpty()),
@@ -3124,7 +3128,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_28, BeEmpty()),
 				Entry("invalid with negative newPodScaleUpDelay", core.ClusterAutoscaler{
 					NewPodScaleUpDelay: &negativeDuration,
-				}, version_1_28, ConsistOf(field.Invalid(field.NewPath("newPodScaleUpDelay"), negativeDuration, "can not be negative"))),
+				}, version_1_28, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("newPodScaleUpDelay"),
+					"Detail": Equal("must be non-negative"),
+				})))),
 				Entry("valid with maxEmptyBulkDelete", core.ClusterAutoscaler{
 					MaxEmptyBulkDelete: &positiveInteger,
 				}, version_1_28, BeEmpty()),
@@ -3145,7 +3153,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_32, BeEmpty()),
 				Entry("invalid with negative maxScaleDownParallelism", core.ClusterAutoscaler{
 					MaxScaleDownParallelism: &negativeInteger,
-				}, version_1_32, ConsistOf(field.Invalid(field.NewPath("maxScaleDownParallelism"), negativeInteger, "can not be negative"))),
+				}, version_1_32, ConsistOf(field.Invalid(field.NewPath("maxScaleDownParallelism"), int64(negativeInteger), "must be greater than or equal to 0").WithOrigin("minimum"))),
 				Entry("valid with maxDrainParallelism", core.ClusterAutoscaler{
 					MaxDrainParallelism: &positiveInteger,
 				}, version_1_32, BeEmpty()),
@@ -3155,7 +3163,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_32, BeEmpty()),
 				Entry("invalid with negative maxDrainParallelism", core.ClusterAutoscaler{
 					MaxDrainParallelism: &negativeInteger,
-				}, version_1_32, ConsistOf(field.Invalid(field.NewPath("maxDrainParallelism"), negativeInteger, "can not be negative"))),
+				}, version_1_32, ConsistOf(field.Invalid(field.NewPath("maxDrainParallelism"), int64(negativeInteger), "must be greater than or equal to 0").WithOrigin("minimum"))),
 				Entry("invalid with both maxEmptyBulkDelete and maxScaleDownParallelism set to different values", core.ClusterAutoscaler{
 					MaxEmptyBulkDelete:      ptr.To(positiveInteger + 10),
 					MaxScaleDownParallelism: &positiveInteger,
@@ -3170,35 +3178,35 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("scaleDownDelayAfterAdd"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				})))),
 				Entry("invalid with negative ScaleDownDelayAfterDelete", core.ClusterAutoscaler{
 					ScaleDownDelayAfterDelete: &metav1.Duration{Duration: -2 * time.Minute},
 				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("scaleDownDelayAfterDelete"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				})))),
 				Entry("invalid with negative ScaleDownDelayAfterFailure", core.ClusterAutoscaler{
 					ScaleDownDelayAfterFailure: &metav1.Duration{Duration: -2 * time.Minute},
 				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("scaleDownDelayAfterFailure"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				})))),
 				Entry("invalid with negative ScaleDownUnneededTime", core.ClusterAutoscaler{
 					ScaleDownUnneededTime: &metav1.Duration{Duration: -2 * time.Minute},
 				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("scaleDownUnneededTime"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				})))),
 				Entry("invalid with negative ScanInterval", core.ClusterAutoscaler{
 					ScanInterval: &metav1.Duration{Duration: -2 * time.Minute},
 				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("scanInterval"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				})))),
 			)
 
@@ -6997,7 +7005,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineDrainTimeout"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				}))))
 			})
 			It("should forbid setting MachineHealthTimeout to a negative value", func() {
@@ -7009,7 +7017,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineHealthTimeout"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				}))))
 			})
 			It("should forbid setting MachineCreationTimeout to a negative value", func() {
@@ -7021,7 +7029,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineCreationTimeout"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				}))))
 			})
 			It("should forbid setting MachineInPlaceUpdateTimeout to a negative value", func() {
@@ -7033,7 +7041,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("workers[0].machineControllerManagerSettings.machineInPlaceUpdateTimeout"),
-					"Detail": Equal("can not be negative"),
+					"Detail": Equal("must be non-negative"),
 				}))))
 			})
 			It("should forbid setting MaxEvictRetries to a negative value", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -7065,7 +7065,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, fldPath, false)
 				Expect(errList).To(BeEmpty())
 			})
-			
+
 			It("should forbid setting MachineInPlaceUpdateTimeout to negative value for update strategy AutoInPlaceUpdate", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				worker.UpdateStrategy = ptr.To(core.AutoInPlaceUpdate)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3208,6 +3208,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field":  Equal("scanInterval"),
 					"Detail": Equal("must be non-negative"),
 				})))),
+				Entry("valid with verbosity", core.ClusterAutoscaler{
+					Verbosity: &positiveInteger,
+				}, version_1_32, BeEmpty()),
+				Entry("invalid with negative verbosity", core.ClusterAutoscaler{
+					Verbosity: &negativeInteger,
+				}, version_1_32, ConsistOf(field.Invalid(field.NewPath("verbosity"), int64(negativeInteger), "must be greater than or equal to 0").WithOrigin("minimum"))),
 			)
 
 			Describe("taint validation", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area robustness
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR improves input value validations for fields within the following
1. `spec.provider.workers[]`
2. `spec.kubernetes.clusterAutoscaler`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Validations for `spec.provider.worker[]` and `spec.kubernetes.clusterAutoscaler` have been improved.
```
