### PR TITLE
Add in-place update filtering for machine images in maintenance controller

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -767,8 +767,8 @@ func filterForKubeleteVersionConstraint(machineImageFromCloudProfile *gardencore
 	return &filteredMachineImages
 }
 
-func filterForInPlaceUpdateConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, isInPlaceUpdate bool) *gardencorev1beta1.MachineImage {
-	if !isInPlaceUpdate {
+func filterForInPlaceUpdateConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, isInPlaceUpdateWorker bool) *gardencorev1beta1.MachineImage {
+	if !isInPlaceUpdateWorker {
 		return machineImageFromCloudProfile
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality usability
/kind enhancement

**What this PR does / why we need it**:
Introduces filterForInPlaceUpdateConstraint to ensure only machine image versions supporting in-place updates are considered when the worker update strategy is set to AutoInPlaceUpdate/ManualnPlaceUpdate. 

**Which issue(s) this PR fixes**:
Part of #10219 

**Special notes for your reviewer**:
/cc @shafeeqes  @ary1992

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
