### PR TITLE
Deflake `test/integration/resourcemanager/garbagecollector` integration test

### DIFF
--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -48,6 +48,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *envtest.Environment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testNamespace *corev1.Namespace
 )
@@ -109,6 +110,7 @@ var _ = BeforeSuite(func() {
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("Register controller")
 	Expect((&garbagecollector.Reconciler{

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -115,10 +115,10 @@ var _ = BeforeSuite(func() {
 	By("Register controller")
 	Expect((&garbagecollector.Reconciler{
 		Config: resourcemanagerconfigv1alpha1.GarbageCollectorControllerConfig{
-			SyncPeriod: &metav1.Duration{Duration: 100 * time.Millisecond},
+			SyncPeriod: &metav1.Duration{Duration: 1 * time.Second},
 		},
 		Clock:                 clock.RealClock{},
-		MinimumObjectLifetime: ptr.To(5 * time.Second),
+		MinimumObjectLifetime: ptr.To(time.Duration(0)),
 	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("Start manager")

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -118,7 +118,7 @@ var _ = BeforeSuite(func() {
 			SyncPeriod: &metav1.Duration{Duration: 100 * time.Millisecond},
 		},
 		Clock:                 clock.RealClock{},
-		MinimumObjectLifetime: ptr.To(time.Duration(0)),
+		MinimumObjectLifetime: ptr.To(5 * time.Second),
 	}).AddToManager(mgr, mgr)).To(Succeed())
 
 	By("Start manager")

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
@@ -200,9 +200,8 @@ var _ = Describe("Garbage collector tests", func() {
 		// Similar to https://github.com/gardener/gardener/issues/6486 and
 		// https://github.com/gardener/gardener/issues/6607.
 		for _, obj := range referencingResources {
-			refObj := obj
 			Eventually(func() error {
-				return mgrClient.Get(ctx, client.ObjectKeyFromObject(refObj), refObj)
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 			}).Should(Succeed())
 		}
 

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go
@@ -6,7 +6,6 @@ package garbagecollector_test
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,13 +51,13 @@ var _ = Describe("Garbage collector tests", func() {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name), client.MatchingLabels(testLabels))).To(Succeed())
 			return secretList.Items
-		}).WithTimeout(15 * time.Second).Should(BeEmpty())
+		}).Should(BeEmpty())
 
 		Eventually(func(g Gomega) []corev1.ConfigMap {
 			configMapList := &corev1.ConfigMapList{}
 			g.Expect(testClient.List(ctx, configMapList, client.InNamespace(testNamespace.Name), client.MatchingLabels(testLabels))).To(Succeed())
 			return configMapList.Items
-		}).WithTimeout(15 * time.Second).Should(BeEmpty())
+		}).Should(BeEmpty())
 	})
 
 	It("should only garbage collect unreferenced resources", func() {
@@ -215,7 +214,7 @@ var _ = Describe("Garbage collector tests", func() {
 			secretList := &corev1.SecretList{}
 			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name), client.MatchingLabels(testLabels))).To(Succeed())
 			return test.ObjectNames(secretList)
-		}).WithTimeout(15 * time.Second).Should(And(
+		}).Should(And(
 			ContainElements(
 				resourceName+"-secret0",
 				resourceName+"-secret1",
@@ -233,7 +232,7 @@ var _ = Describe("Garbage collector tests", func() {
 			configMapList := &corev1.ConfigMapList{}
 			g.Expect(testClient.List(ctx, configMapList, client.InNamespace(testNamespace.Name), client.MatchingLabels(testLabels))).To(Succeed())
 			return test.ObjectNames(configMapList)
-		}).WithTimeout(15 * time.Second).Should(And(
+		}).Should(And(
 			Not(ContainElement(resourceName+"-configmap0")),
 			ContainElements(
 				resourceName+"-configmap1",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

This PR introduces an additional `Eventually()` block within 

https://github.com/gardener/gardener/blob/645d3b17a2c8592d13c423fba09d89e41654aeb1/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go#L63

aiming to validate that the `ResourceManager` has observed the _referencing_ resources before validating the garbage collection outcome, ensuring that it has acknowledged the latest state of the _test_ setup.

In addition, updated the _test_ `GarbageCollectorControllerConfig` synchronisation period 

https://github.com/gardener/gardener/blob/cdf6107e4288ff48080fcbd403d2af77a0bfe3db/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go#L115-L117

from `100ms` to `1s`.

---

Bellow snippets show the [stress](https://pkg.go.dev/golang.org/x/tools/cmd/stress) tool output when building and running the tests from __master__:

```sh
➜ garbagecollector git:(master) ✗ ginkgo build .
2025/07/21 10:55:34 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Compiled garbagecollector.test
➜ garbagecollector git:(master) ✗ stress -p 5 ./garbagecollector.test
5s: 4 runs so far, 0 failures, 5 active
10s: 5 runs so far, 0 failures, 5 active
...
50s: 55 runs so far, 1 failures (1.82%), 5 active
55s: 61 runs so far, 1 failures (1.64%), 5 active
1m0s: 70 runs so far, 1 failures (1.43%), 5 active
1m5s: 75 runs so far, 1 failures (1.33%), 5 active
1m10s: 82 runs so far, 1 failures (1.22%), 5 active

/var/folders/9f/x41_vvm166zg0s005tjmwldm0000gn/T/go-stress-20250721T105618-3901504074
Running Suite: Test Integration ResourceManager GarbageCollector Suite - /Users/I759218/go/src/github.com/gardener/gardener/test/integration/resourcemanager/garbagecollector
=============================================================================================================================================================================
Random Seed: 1753084639

Will run 2 of 2 specs
------------------------------
• [FAILED] [5.972 seconds]
Garbage collector tests [It] should garbage collect all resources because they are not referenced
/Users/I759218/go/src/github.com/gardener/gardener/test/integration/resourcemanager/garbagecollector/garbagecollector_test.go:45

  Timeline >>
  {"level":"info","ts":"2025-07-21T10:57:20.435+0300","msg":"Starting EventSource","controller":"garbage-collector","source":"func source: 0x10212d480"}
  {"level":"info","ts":"2025-07-21T10:57:20.435+0300","msg":"Starting Controller","controller":"garbage-collector"}
  {"level":"info","ts":"2025-07-21T10:57:20.435+0300","msg":"Starting workers","controller":"garbage-collector","worker count":1}
  {"level":"info","ts":"2025-07-21T10:57:20.435+0300","msg":"Starting garbage collection","controller":"garbage-collector","namespace":"","name":"","reconcileID":"fd248a71-50d8-4fa0-9a97-f980ef11c642"}
  {"level":"info","ts":"2025-07-21T10:57:20.536+0300","msg":"Garbage collection finished","controller":"garbage-collector","namespace":"","name":"","reconcileID":"fd248a71-50d8-4fa0-9a97-f980ef11c642"}
  {"level":"error","ts":"2025-07-21T10:57:20.536+0300","msg":"Reconciler error","controller":"garbage-collector","namespace":"","name":"","reconcileID":"fd248a71-50d8-4fa0-9a97-f980ef11c642","error":"failed listing secrets: Timeout: failed waiting for *v1.PartialObjectMetadata Informer to sync","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/I759218/go/pkg/mod/sigs.k8s.io/con
…
1m15s: 88 runs so far, 2 failures (2.27%), 5 active
1m20s: 93 runs so far, 2 failures (2.15%), 5 active
1m25s: 98 runs so far, 2 failures (2.04%), 5 active
1m30s: 106 runs so far, 2 failures (1.89%), 5 active
1m35s: 112 runs so far, 2 failures (1.79%), 5 active
1m40s: 117 runs so far, 2 failures (1.71%), 5 active
1m45s: 119 runs so far, 2 failures (1.68%), 5 active
1m50s: 126 runs so far, 2 failures (1.59%), 5 active
1m55s: 128 runs so far, 2 failures (1.56%), 5 active
2m0s: 132 runs so far, 2 failures (1.52%), 5 active
```

and when using the changes from this PR

```sh
➜ garbagecollector git:(deflake/garbagecollector-collect-unreferenced-resources) ✗ ginkgo build .
2025/07/21 10:10:42 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
Compiled garbagecollector.test
➜ garbagecollector git:(deflake/garbagecollector-collect-unreferenced-resources) ✗ stress -p 5 ./garbagecollector.test
5s: 5 runs so far, 0 failures, 5 active
10s: 10 runs so far, 0 failures, 5 active
15s: 15 runs so far, 0 failures, 5 active
20s: 20 runs so far, 0 failures, 5 active
25s: 29 runs so far, 0 failures, 5 active
30s: 31 runs so far, 0 failures, 5 active
35s: 36 runs so far, 0 failures, 5 active
40s: 42 runs so far, 0 failures, 5 active
45s: 48 runs so far, 0 failures, 5 active
50s: 53 runs so far, 0 failures, 5 active
55s: 59 runs so far, 0 failures, 5 active
1m0s: 65 runs so far, 0 failures, 5 active
1m5s: 70 runs so far, 0 failures, 5 active
1m10s: 74 runs so far, 0 failures, 5 active
1m15s: 79 runs so far, 0 failures, 5 active
1m20s: 84 runs so far, 0 failures, 5 active
1m25s: 86 runs so far, 0 failures, 5 active
1m30s: 89 runs so far, 0 failures, 5 active
1m35s: 94 runs so far, 0 failures, 5 active
1m40s: 98 runs so far, 0 failures, 5 active
1m45s: 104 runs so far, 0 failures, 5 active
1m50s: 109 runs so far, 0 failures, 5 active
1m55s: 112 runs so far, 0 failures, 5 active
2m0s: 117 runs so far, 0 failures, 5 active
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/issues/12404

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
