### PR TITLE
Prefer using `sets.Set` wherever possible

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2252,7 +2252,7 @@ func ValidateSystemComponentWorkers(workers []core.Worker, fldPath *field.Path) 
 		allErrs                                   = field.ErrorList{}
 		atLeastOnePoolWithAllowedSystemComponents = false
 
-		workerPoolsWithSufficientWorkers   = make(map[string]struct{})
+		workerPoolsWithSufficientWorkers   = sets.New[string]()
 		workerPoolsWithInsufficientWorkers = make(map[string]int)
 	)
 
@@ -2283,11 +2283,11 @@ func ValidateSystemComponentWorkers(workers []core.Worker, fldPath *field.Path) 
 		}
 
 		if hasSufficientWorkers {
-			workerPoolsWithSufficientWorkers[workerPoolKey] = struct{}{}
+			workerPoolsWithSufficientWorkers.Insert(workerPoolKey)
 
 			delete(workerPoolsWithInsufficientWorkers, workerPoolKey)
 		} else {
-			if _, b := workerPoolsWithSufficientWorkers[workerPoolKey]; !b {
+			if !workerPoolsWithSufficientWorkers.Has(workerPoolKey) {
 				workerPoolsWithInsufficientWorkers[workerPoolKey] = i
 			}
 		}

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -857,7 +857,7 @@ func getSearchPathRewrites(clusterDomain string, commonSuffixes []string) string
 
 // GetIPFamilyPolicy returns the IPFamilyPolicy for the CoreDNS service based on the provided IP families and cluster IPs.
 func GetIPFamilyPolicy(ipFamilies []gardencorev1beta1.IPFamily, clusterIPs []net.IP) corev1.IPFamilyPolicy {
-	ipFamiliesSet := sets.New[gardencorev1beta1.IPFamily](ipFamilies...)
+	ipFamiliesSet := sets.New(ipFamilies...)
 	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && hasIPv4andIPv6Address(clusterIPs) {
 		return corev1.IPFamilyPolicyPreferDualStack
 	}

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -494,7 +494,7 @@ func (p *plutono) getDashboardConfigMap() (*corev1.ConfigMap, error) {
 			normalizedPath = filepath.ToSlash(normalizedPath)
 
 			if dirEntry.IsDir() {
-				if len(sets.New[string](strings.Split(path, "/")...).Intersection(ignorePaths)) > 0 {
+				if len(sets.New(strings.Split(path, "/")...).Intersection(ignorePaths)) > 0 {
 					return filepath.SkipDir
 				}
 				return nil

--- a/pkg/gardenadm/cmd/options.go
+++ b/pkg/gardenadm/cmd/options.go
@@ -38,11 +38,11 @@ type Options struct {
 
 // Validate validates the options.
 func (o *Options) Validate() error {
-	if !sets.New[string](logger.AllLogLevels...).Has(o.LogLevel) {
+	if !sets.New(logger.AllLogLevels...).Has(o.LogLevel) {
 		return fmt.Errorf("log-level must be one of %v", logger.AllLogLevels)
 	}
 
-	if !sets.New[string](logger.AllLogFormats...).Has(o.LogFormat) {
+	if !sets.New(logger.AllLogFormats...).Has(o.LogFormat) {
 		return fmt.Errorf("log-format must be one of %v", logger.AllLogFormats)
 	}
 

--- a/pkg/operator/controller/extension/required/runtime/add_test.go
+++ b/pkg/operator/controller/extension/required/runtime/add_test.go
@@ -213,10 +213,10 @@ var _ = Describe("Add", func() {
 					Expect(fakeClient.Create(ctx, backupBucket)).To(Succeed())
 
 					Expect(mapperFunc(ctx, nil)).To(ConsistOf(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: testExtension1.Name, Namespace: testExtension1.Namespace}})))
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string](requiredExtensionType)))
+					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New(requiredExtensionType)))
 
 					By("Invoke mapper again w/o changes and expect no requests")
-					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New[string](requiredExtensionType)))
+					Expect(kindToRequiredTypes).To(HaveKeyWithValue(requiredExtensionKind, sets.New(requiredExtensionType)))
 					Expect(mapperFunc(ctx, nil)).To(BeEmpty())
 
 					By("Delete BackupBucket and expect the extension in the requests")

--- a/pkg/resourcemanager/controller/managedresource/equivalences_test.go
+++ b/pkg/resourcemanager/controller/managedresource/equivalences_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var _ = Describe("Equivalences", func() {
@@ -17,12 +18,12 @@ var _ = Describe("Equivalences", func() {
 	Describe("#NewEquivalences, #GetEquivalencesFor", func() {
 		var (
 			additionalEquivalences  [][]metav1.GroupKind
-			expectedEquivalenceSets map[metav1.GroupKind]EquivalenceSet
+			expectedEquivalenceSets map[metav1.GroupKind]sets.Set[metav1.GroupKind]
 		)
 
 		BeforeEach(func() {
 			additionalEquivalences = [][]metav1.GroupKind{}
-			expectedEquivalenceSets = map[metav1.GroupKind]EquivalenceSet{}
+			expectedEquivalenceSets = map[metav1.GroupKind]sets.Set[metav1.GroupKind]{}
 		})
 
 		AfterEach(func() {
@@ -37,7 +38,7 @@ var _ = Describe("Equivalences", func() {
 		It("no additional equivalence sets (default equivalence sets)", func() {
 			for _, equiList := range defaultEquivalences {
 				for _, gk := range equiList {
-					expectedEquivalenceSets[gk] = EquivalenceSet{}.Insert(equiList...)
+					expectedEquivalenceSets[gk] = sets.New(equiList...)
 				}
 			}
 		})
@@ -50,7 +51,7 @@ var _ = Describe("Equivalences", func() {
 			}
 			additionalEquivalences = append(additionalEquivalences, equis)
 
-			expectedSet := EquivalenceSet{}.Insert(equis...)
+			expectedSet := sets.New(equis...)
 			for _, gk := range equis {
 				expectedEquivalenceSets[gk] = expectedSet
 			}
@@ -72,7 +73,7 @@ var _ = Describe("Equivalences", func() {
 			additionalEquivalences = append(additionalEquivalences, equis...)
 
 			for _, equiSet := range equis {
-				expectedSet := EquivalenceSet{}.Insert(equiSet...)
+				expectedSet := sets.New(equiSet...)
 				for _, gk := range equiSet {
 					expectedEquivalenceSets[gk] = expectedSet
 				}
@@ -92,7 +93,7 @@ var _ = Describe("Equivalences", func() {
 			}
 			additionalEquivalences = append(additionalEquivalences, equis...)
 
-			expectedSet := EquivalenceSet{}.Insert(equis[0]...).Insert(equis[1]...)
+			expectedSet := sets.New(equis[0]...).Insert(equis[1]...)
 
 			for _, equiSet := range equis {
 				for _, gk := range equiSet {

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -169,8 +169,8 @@ func uniteSeedSelectors(shootSeedSelector *core.SeedSelector, exposureClassSeedS
 	shootSeedSelector.MatchExpressions = append(shootSeedSelector.MatchExpressions, exposureClassSeedSelector.MatchExpressions...)
 
 	// Unite provider types.
-	shootProviderTypes := sets.New[string]().Insert(shootSeedSelector.ProviderTypes...)
-	exposureclasssProviderTypes := sets.New[string]().Insert(exposureClassSeedSelector.ProviderTypes...)
+	shootProviderTypes := sets.New(shootSeedSelector.ProviderTypes...)
+	exposureclasssProviderTypes := sets.New(exposureClassSeedSelector.ProviderTypes...)
 	shootSeedSelector.ProviderTypes = sets.List(shootProviderTypes.Union(exposureclasssProviderTypes))
 
 	return shootSeedSelector, nil

--- a/test/utils/namespacefinalizer/namespacefinalizer.go
+++ b/test/utils/namespacefinalizer/namespacefinalizer.go
@@ -73,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	if r.Exceptions.Intersection(sets.New[string](namespace.Finalizers...)).Len() > 0 {
+	if r.Exceptions.Intersection(sets.New(namespace.Finalizers...)).Len() > 0 {
 		log.V(1).Info("Namespace has finalizers that are in the exception list, skipping finalization")
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
- Prefer using `sets.Set` wherever possible
- Remove redundant type arguments

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
