### PR TITLE
Extend documentation on force-redeploy of `Gardenlet`s

### DIFF
--- a/docs/deployment/deploy_gardenlet_via_operator.md
+++ b/docs/deployment/deploy_gardenlet_via_operator.md
@@ -140,7 +140,9 @@ gardener.cloud/operation=force-redeploy
 ```
 
 > [!TIP]
-> Do not forget to create the kubeconfig `Secret` and re-add the `.spec.kubeconfigSecretRef` to the `Gardenlet` specification if this is a remote cluster.
+> In case of a remote cluster, do not forget:
+> - to create the kubeconfig `Secret`
+> - to re-add the `gardener.cloud/operation=force-redeploy` annotation and the `.spec.kubeconfigSecretRef` to the `Gardenlet` simultaneously. Otherwise, latter will be deleted immediately by the `gardener-operator` due to an existing `Seed` resource
 
 `gardener-operator` will remove the operation annotation after it's done.
 Just like after the initial deployment, it'll also delete the kubeconfig `Secret` and set `.spec.kubeconfigSecretRef` to `nil`, see above.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area documentation
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
The documentation is not clear about the need of adding the force-redeploy annotation simultaneously with adding the kubeconfigSecretRef in case of a remote cluster. The controller permanently checks this entry and in case of an existing seed (which e.g. still would be the case when deleting the Gardenlet-deployment) will delete the entry. If the annotation is then added afterwards, the Gardenlet deployment would be created in the runtime-cluster. 
