### PR TITLE
[GEP-31] Add machine-image update TM test for In-Place worker pools

### DIFF
--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -13,7 +13,7 @@ spec:
   command: [bash, -c]
   args:
   - >-
-    go test -timeout=0 ./test/testmachinery/system/shoot_update
+    go test -timeout=0 ./test/testmachinery/system/shoot_kubernetes_update
     --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME

--- a/.test-defs/ShootMachineImageUpdateTest.yaml
+++ b/.test-defs/ShootMachineImageUpdateTest.yaml
@@ -1,0 +1,22 @@
+apiVersion: testmachinery.sapcloud.io
+kind: TestDefinition
+metadata:
+  name: shoot-machine-image-update-test
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the machine image update of a shoot. It verifies that the machine image version is updated without rolling the nodes for in-place update workers. (only relevant for in-place update workers)
+
+  activeDeadlineSeconds: 4200
+
+  labels: ["shoot"]
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 ./test/testmachinery/system/shoot_machine_image_update
+    --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color -verbose=debug
+    -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
+    -shoot-name=$SHOOT_NAME
+    -project-namespace=$PROJECT_NAMESPACE
+    -version-worker-pools=$OS_VERSION_WORKER_POOLS
+  image: golang:1.24.5

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Masterminds/semver/v3"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+)
+
+// FilterMachineImageVersions filters the machine image versions based on the worker's architecture, CRI, and kubelet version.
+func FilterMachineImageVersions(
+	machineImageFromCloudProfile *gardencorev1beta1.MachineImage,
+	worker gardencorev1beta1.Worker,
+	kubeletVersion *semver.Version,
+) *gardencorev1beta1.MachineImage {
+	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture)
+	filteredMachineImageVersions = filterForCRI(filteredMachineImageVersions, worker.CRI)
+	filteredMachineImageVersions = filterForKubeleteVersionConstraint(filteredMachineImageVersions, kubeletVersion)
+	filteredMachineImageVersions = filterForInPlaceUpdateConstraint(filteredMachineImageVersions, worker.Machine.Image.Version, v1beta1helper.IsUpdateStrategyInPlace(worker.UpdateStrategy))
+
+	return filteredMachineImageVersions
+}
+
+// DetermineMachineImage determines the machine image from cloudprofile based on the provided cloud profile and shoot machine image.
+func DetermineMachineImage(cloudProfile *gardencorev1beta1.CloudProfile, shootMachineImage *gardencorev1beta1.ShootMachineImage) (gardencorev1beta1.MachineImage, error) {
+	machineImagesFound, machineImageFromCloudProfile := v1beta1helper.DetermineMachineImageForName(cloudProfile, shootMachineImage.Name)
+	if !machineImagesFound {
+		return gardencorev1beta1.MachineImage{}, fmt.Errorf("failure while determining the default machine image in the CloudProfile: no machineImage with name %q (specified in shoot) could be found in the cloudProfile %q", shootMachineImage.Name, cloudProfile.Name)
+	}
+
+	return machineImageFromCloudProfile, nil
+}
+
+// GetHigherVersion takes a slice of versions and returns if higher suitable version could be found, the version or an error
+type GetHigherVersion func(versions []gardencorev1beta1.ExpirableVersion, currentVersion string) (bool, string, error)
+
+// DetermineMachineImageVersion determines the machine image version for a shoot based on the provided shootMachineImage and machineImage.
+func DetermineMachineImageVersion(shootMachineImage *gardencorev1beta1.ShootMachineImage, machineImage *gardencorev1beta1.MachineImage, isExpired bool) (string, error) {
+	var (
+		getHigherVersionAutoUpdate  GetHigherVersion
+		getHigherVersionForceUpdate GetHigherVersion
+	)
+
+	switch *machineImage.UpdateStrategy {
+	case gardencorev1beta1.UpdateStrategyPatch:
+		getHigherVersionAutoUpdate = v1beta1helper.GetLatestVersionForPatchAutoUpdate
+		getHigherVersionForceUpdate = v1beta1helper.GetVersionForForcefulUpdateToNextHigherMinor
+	case gardencorev1beta1.UpdateStrategyMinor:
+		getHigherVersionAutoUpdate = v1beta1helper.GetLatestVersionForMinorAutoUpdate
+		getHigherVersionForceUpdate = v1beta1helper.GetVersionForForcefulUpdateToNextHigherMajor
+	default:
+		// auto-update strategy: "major"
+		getHigherVersionAutoUpdate = v1beta1helper.GetOverallLatestVersionForAutoUpdate
+		// cannot force update the overall latest version if it is expired
+		getHigherVersionForceUpdate = func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+			return false, "", fmt.Errorf("either the machine image %q is reaching end of life and migration to another machine image is required or there is a misconfiguration in the CloudProfile. If it is the latter, make sure the machine image in the CloudProfile has at least one version that is not expired, not in preview and greater or equal to the current Shoot image version %q", shootMachineImage.Name, *shootMachineImage.Version)
+		}
+	}
+
+	version, err := DetermineVersionForStrategy(
+		v1beta1helper.ToExpirableVersions(machineImage.Versions),
+		*shootMachineImage.Version,
+		getHigherVersionAutoUpdate,
+		getHigherVersionForceUpdate,
+		isExpired)
+	if err != nil {
+		return version, fmt.Errorf("failed to determine the target version for maintenance of machine image %q with strategy %q: %w", machineImage.Name, *machineImage.UpdateStrategy, err)
+	}
+
+	return version, nil
+}
+
+// DetermineVersionForStrategy determines the target version for a machine image based on the update strategy.
+func DetermineVersionForStrategy(expirableVersions []gardencorev1beta1.ExpirableVersion, currentVersion string, getHigherVersionAutoUpdate GetHigherVersion, getHigherVersionForceUpdate GetHigherVersion, isCurrentVersionExpired bool) (string, error) {
+	higherQualifyingVersionFound, latestVersionForMajor, err := getHigherVersionAutoUpdate(expirableVersions, currentVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine a higher patch version for automatic update: %w", err)
+	}
+
+	if higherQualifyingVersionFound {
+		return latestVersionForMajor, nil
+	}
+
+	// The current version is already up-to date
+	//  - Kubernetes version / Auto update strategy "patch": the latest patch version for the current minor version
+	//  - Auto update strategy "minor": the latest patch and minor version for the current major version
+	//  - Auto update strategy "major": the latest overall version
+	if !isCurrentVersionExpired {
+		return "", nil
+	}
+
+	// The version is already the latest version according to the strategy, but is expired. Force update.
+	forceUpdateVersionAvailable, versionForForceUpdate, err := getHigherVersionForceUpdate(expirableVersions, currentVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine version for forceful update: %w", err)
+	}
+
+	// Unable to force update
+	//  - Kubernetes version: no consecutive minor version available (e.g. shoot is on 1.24.X, but there is only 1.26.X, available and not 1.25.X)
+	//  - Auto update strategy "patch": no higher next minor version available (e.g. shoot is on 1.0.X, but there is only 2.2.X, available and not 1.X.X)
+	//  - Auto update strategy "minor": no higher next major version available (e.g. shoot is on 576.3.0, but there is no higher major version available)
+	//  - Auto update strategy "major": already on latest overall version, but the latest version is expired. EOL for image or CloudProfile misconfiguration.
+	if !forceUpdateVersionAvailable {
+		return "", fmt.Errorf("cannot perform forceful update of expired version %q. No suitable version found in CloudProfile - this is most likely a misconfiguration of the CloudProfile", currentVersion)
+	}
+
+	return versionForForceUpdate, nil
+}
+
+func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, arch *string) *gardencorev1beta1.MachineImage {
+	filteredMachineImages := gardencorev1beta1.MachineImage{
+		Name:           machineImageFromCloudProfile.Name,
+		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
+		Versions:       []gardencorev1beta1.MachineImageVersion{},
+	}
+
+	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
+		if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(cloudProfileVersion), *arch) {
+			filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+		}
+	}
+
+	return &filteredMachineImages
+}
+
+func filterForCRI(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, workerCRI *gardencorev1beta1.CRI) *gardencorev1beta1.MachineImage {
+	if workerCRI == nil {
+		return filterForCRI(machineImageFromCloudProfile, &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
+	}
+
+	filteredMachineImages := gardencorev1beta1.MachineImage{
+		Name:           machineImageFromCloudProfile.Name,
+		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
+		Versions:       []gardencorev1beta1.MachineImageVersion{},
+	}
+
+	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
+		criFromCloudProfileVersion, found := findCRIByName(workerCRI.Name, cloudProfileVersion.CRI)
+		if !found {
+			continue
+		}
+
+		if !areAllWorkerCRsPartOfCloudProfileVersion(workerCRI.ContainerRuntimes, criFromCloudProfileVersion.ContainerRuntimes) {
+			continue
+		}
+
+		filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+	}
+
+	return &filteredMachineImages
+}
+
+func filterForKubeleteVersionConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, kubeletVersion *semver.Version) *gardencorev1beta1.MachineImage {
+	filteredMachineImages := gardencorev1beta1.MachineImage{
+		Name:           machineImageFromCloudProfile.Name,
+		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
+		Versions:       []gardencorev1beta1.MachineImageVersion{},
+	}
+
+	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
+		if cloudProfileVersion.KubeletVersionConstraint != nil {
+			// CloudProfile cannot contain an invalid kubeletVersionConstraint
+			constraint, _ := semver.NewConstraint(*cloudProfileVersion.KubeletVersionConstraint)
+			if !constraint.Check(kubeletVersion) {
+				continue
+			}
+		}
+
+		filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+	}
+
+	return &filteredMachineImages
+}
+
+func filterForInPlaceUpdateConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, workerImageVersion *string, isInPlaceUpdateWorker bool) *gardencorev1beta1.MachineImage {
+	if !isInPlaceUpdateWorker {
+		return machineImageFromCloudProfile
+	}
+
+	filteredMachineImages := gardencorev1beta1.MachineImage{
+		Name:           machineImageFromCloudProfile.Name,
+		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
+		Versions:       []gardencorev1beta1.MachineImageVersion{},
+	}
+
+	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
+		if workerImageVersion != nil && cloudProfileVersion.InPlaceUpdates != nil && cloudProfileVersion.InPlaceUpdates.Supported && cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate != nil {
+			if validVersion, _ := versionutils.CompareVersions(*cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate, "<=", *workerImageVersion); validVersion {
+				filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+			}
+		}
+	}
+
+	return &filteredMachineImages
+}
+
+func findCRIByName(wanted gardencorev1beta1.CRIName, cris []gardencorev1beta1.CRI) (gardencorev1beta1.CRI, bool) {
+	for _, cri := range cris {
+		if cri.Name == wanted {
+			return cri, true
+		}
+	}
+	return gardencorev1beta1.CRI{}, false
+}
+
+func areAllWorkerCRsPartOfCloudProfileVersion(workerCRs []gardencorev1beta1.ContainerRuntime, crsFromCloudProfileVersion []gardencorev1beta1.ContainerRuntime) bool {
+	if workerCRs == nil {
+		return true
+	}
+	for _, workerCr := range workerCRs {
+		if !isWorkerCRPartOfCloudProfileVersionCRs(workerCr, crsFromCloudProfileVersion) {
+			return false
+		}
+	}
+	return true
+}
+
+func isWorkerCRPartOfCloudProfileVersionCRs(wanted gardencorev1beta1.ContainerRuntime, cloudProfileVersionCRs []gardencorev1beta1.ContainerRuntime) bool {
+	for _, cr := range cloudProfileVersionCRs {
+		if wanted.Type == cr.Type {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
@@ -23,7 +23,7 @@ func FilterMachineImageVersions(
 ) *gardencorev1beta1.MachineImage {
 	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture)
 	filteredMachineImageVersions = filterForCRI(filteredMachineImageVersions, worker.CRI)
-	filteredMachineImageVersions = filterForKubeleteVersionConstraint(filteredMachineImageVersions, kubeletVersion)
+	filteredMachineImageVersions = filterForKubeletVersionConstraint(filteredMachineImageVersions, kubeletVersion)
 	filteredMachineImageVersions = filterForInPlaceUpdateConstraint(filteredMachineImageVersions, worker.Machine.Image.Version, v1beta1helper.IsUpdateStrategyInPlace(worker.UpdateStrategy))
 
 	return filteredMachineImageVersions
@@ -158,7 +158,7 @@ func filterForCRI(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, 
 	return &filteredMachineImages
 }
 
-func filterForKubeleteVersionConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, kubeletVersion *semver.Version) *gardencorev1beta1.MachineImage {
+func filterForKubeletVersionConstraint(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, kubeletVersion *semver.Version) *gardencorev1beta1.MachineImage {
 	filteredMachineImages := gardencorev1beta1.MachineImage{
 		Name:           machineImageFromCloudProfile.Name,
 		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper_suite_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager Controller Shoot Maintenance Helper Suite")
+}

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper_test.go
@@ -1,0 +1,351 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/controllermanager/controller/shoot/maintenance/helper"
+)
+
+var _ = Describe("Helper Functions", func() {
+	var (
+		machineImage              *gardencorev1beta1.MachineImage
+		shootMachineImage         *gardencorev1beta1.ShootMachineImage
+		worker                    gardencorev1beta1.Worker
+		kubeletVersion            *semver.Version
+		expirationDateInTheFuture metav1.Time
+		expirationDateInThePast   metav1.Time
+	)
+
+	BeforeEach(func() {
+		expirationDateInTheFuture = metav1.Time{Time: time.Now().Add(time.Hour * 24)}
+		expirationDateInThePast = metav1.Time{Time: time.Now().Add(-time.Hour * 24)}
+		kubeletVersion = semver.MustParse("1.30.0")
+
+		machineImage = &gardencorev1beta1.MachineImage{
+			Name: "CoreOS",
+			Versions: []gardencorev1beta1.MachineImageVersion{
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "1.0.0",
+					},
+					CRI:                      []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
+					Architectures:            []string{"amd64"},
+					KubeletVersionConstraint: ptr.To("< 1.27"),
+				},
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version:        "1.1.0",
+						ExpirationDate: &expirationDateInTheFuture,
+					},
+					CRI:                      []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}},
+					Architectures:            []string{"amd64"},
+					KubeletVersionConstraint: ptr.To(">= 1.30.0"),
+					InPlaceUpdates: &gardencorev1beta1.InPlaceUpdates{
+						Supported:           true,
+						MinVersionForUpdate: ptr.To("1.0.0"),
+					},
+				},
+			},
+		}
+
+		worker = gardencorev1beta1.Worker{
+			Machine: gardencorev1beta1.Machine{
+				Architecture: ptr.To("amd64"),
+				Image: &gardencorev1beta1.ShootMachineImage{
+					Name:    "CoreOS",
+					Version: ptr.To("1.0.0"),
+				},
+			},
+			CRI:            &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD},
+			UpdateStrategy: ptr.To(gardencorev1beta1.AutoInPlaceUpdate),
+		}
+
+		shootMachineImage = &gardencorev1beta1.ShootMachineImage{
+			Name:    "CoreOS",
+			Version: ptr.To("1.0.0"),
+		}
+	})
+
+	Describe("#FilterMachineImageVersions", func() {
+		It("should filter machine images which supports worker configuration", func() {
+			filteredMachineImages := FilterMachineImageVersions(machineImage, worker, kubeletVersion)
+
+			Expect(filteredMachineImages.Versions).ShouldNot(BeEmpty())
+		})
+
+		It("should return an empty machine image if no versions found with matching architecture", func() {
+			worker.Machine.Architecture = ptr.To("arm64")
+			filteredMachineImages := FilterMachineImageVersions(machineImage, worker, kubeletVersion)
+
+			Expect(filteredMachineImages.Versions).Should(BeEmpty())
+		})
+
+		It("should return an empty machine image if no versions found with matching kubelet version", func() {
+			worker.Machine.Image.Version = ptr.To("1.1.0")
+			kubeletVersion = semver.MustParse("1.29.0")
+			filteredMachineImages := FilterMachineImageVersions(machineImage, worker, kubeletVersion)
+
+			Expect(filteredMachineImages.Versions).Should(BeEmpty())
+		})
+
+		It("should return an empty machine image if no versions found with matching CRI", func() {
+			worker.CRI = &gardencorev1beta1.CRI{Name: "test-cri"}
+			filteredMachineImages := FilterMachineImageVersions(machineImage, worker, kubeletVersion)
+
+			Expect(filteredMachineImages.Versions).Should(BeEmpty())
+		})
+
+		It("should return an empty machine image if no versions found with in-place update constraint", func() {
+			worker.Machine.Image.Version = ptr.To("0.1.0")
+			worker.UpdateStrategy = ptr.To(gardencorev1beta1.AutoInPlaceUpdate)
+			filteredMachineImages := FilterMachineImageVersions(machineImage, worker, kubeletVersion)
+
+			Expect(filteredMachineImages.Versions).Should(BeEmpty())
+		})
+	})
+
+	Describe("#DetermineMachineImage", func() {
+		var cloudProfile *gardencorev1beta1.CloudProfile
+
+		BeforeEach(func() {
+			cloudProfile = &gardencorev1beta1.CloudProfile{
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					MachineImages: []gardencorev1beta1.MachineImage{
+						{
+							Name: "CoreOS",
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{
+									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+										Version: "1.0.0",
+									},
+								},
+								{
+									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+										Version: "1.1.0",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should return an error if no machine image found", func() {
+			shootMachineImage.Name = "NonExistentImage"
+			_, err := DetermineMachineImage(cloudProfile, shootMachineImage)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure while determining the default machine image in the CloudProfile"))
+		})
+
+		It("should determine the correct machine image from the CloudProfile", func() {
+			machineImage, err := DetermineMachineImage(cloudProfile, shootMachineImage)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(machineImage.Name).To(Equal("CoreOS"))
+			Expect(machineImage.Versions).To(HaveLen(2))
+		})
+	})
+
+	Describe("#DetermineMachineImageVersion", func() {
+		It("should determine the correct machine image version for patch strategy", func() {
+			machineImage.UpdateStrategy = ptr.To(gardencorev1beta1.UpdateStrategyPatch)
+			version, err := DetermineMachineImageVersion(shootMachineImage, machineImage, false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal(""))
+		})
+
+		It("should determine the correct machine image version for minor strategy", func() {
+			machineImage.UpdateStrategy = ptr.To(gardencorev1beta1.UpdateStrategyMinor)
+			version, err := DetermineMachineImageVersion(shootMachineImage, machineImage, false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("1.1.0"))
+		})
+
+		It("should determine the correct machine image version for major strategy", func() {
+			machineImage.UpdateStrategy = ptr.To(gardencorev1beta1.UpdateStrategyMajor)
+			version, err := DetermineMachineImageVersion(shootMachineImage, machineImage, false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("1.1.0"))
+		})
+
+		It("should return an error if the current version is expired and no force update version is available", func() {
+			machineImage.UpdateStrategy = ptr.To(gardencorev1beta1.UpdateStrategyMajor)
+			machineImage.Versions = []gardencorev1beta1.MachineImageVersion{
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version:        "1.0.0",
+						ExpirationDate: &expirationDateInThePast,
+					},
+				},
+			}
+
+			version, err := DetermineMachineImageVersion(shootMachineImage, machineImage, true)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to determine the target version for maintenance"))
+			Expect(version).To(BeEmpty())
+		})
+
+		It("should return an error if the machine image is reaching end of life", func() {
+			machineImage.UpdateStrategy = ptr.To(gardencorev1beta1.UpdateStrategyMajor)
+			machineImage.Versions = []gardencorev1beta1.MachineImageVersion{}
+
+			version, err := DetermineMachineImageVersion(shootMachineImage, machineImage, true)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("either the machine image \"CoreOS\" is reaching end of life"))
+			Expect(version).To(BeEmpty())
+		})
+	})
+
+	Describe("#DetermineVersionForStrategy", func() {
+		It("should return the latest version for major if higher qualifying version is found", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+				{Version: "1.1.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(
+					_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return true, "1.1.0", nil
+				},
+				func(
+					_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				false,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("1.1.0"))
+		})
+
+		It("should return an empty string if the current version is already up-to-date and not expired", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				false,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(BeEmpty())
+		})
+
+		It("should return the force update version if the current version is expired and force update is available", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+				{Version: "1.1.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return true, "1.1.0", nil
+				},
+				true,
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("1.1.0"))
+		})
+
+		It("should return an error if the current version is expired and no force update version is available", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", fmt.Errorf("no suitable version found")
+				},
+				true,
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to determine version for forceful update: no suitable version found"))
+			Expect(version).To(BeEmpty())
+		})
+
+		It("should return an error if automatic update fails", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", fmt.Errorf("failed to determine a higher patch version")
+				},
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				false,
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to determine a higher patch version"))
+			Expect(version).To(BeEmpty())
+		})
+
+		It("should return an error if force update fails", func() {
+			versions := []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0"},
+			}
+
+			version, err := DetermineVersionForStrategy(
+				versions,
+				"1.0.0",
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", nil
+				},
+				func(_ []gardencorev1beta1.ExpirableVersion, _ string) (bool, string, error) {
+					return false, "", fmt.Errorf("failed to determine version for forceful update")
+				},
+				true,
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to determine version for forceful update"))
+			Expect(version).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/nodeagent/apis/config/v1alpha1/types.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/types.go
@@ -5,6 +5,8 @@
 package v1alpha1
 
 import (
+	"regexp"
+
 	"github.com/Masterminds/semver/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -46,6 +48,9 @@ const (
 	// checksum of the last applied operating system configuration.
 	AnnotationKeyChecksumAppliedOperatingSystemConfig = "checksum/cloud-config-data"
 )
+
+// OSVersionRegex is a regular expression to match operating system versions.
+var OSVersionRegex = regexp.MustCompile(`\b\d+(?:\.\d+)*\b`)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -69,7 +69,6 @@ const (
 
 var (
 	codec                         runtime.Codec
-	osVersionRegex                = regexp.MustCompile(`\b\d+(?:\.\d+)*\b`)
 	retriableErrorPatternRegex    = regexp.MustCompile(`(?i)network problems`)
 	nonRetriableErrorPatternRegex = regexp.MustCompile(`(?i)invalid arguments|system failure`)
 
@@ -993,9 +992,9 @@ var GetOSVersion = func(inPlaceUpdates *extensionsv1alpha1.InPlaceUpdates, fs af
 		return nil, fmt.Errorf("unable to get operating system name: %w", err)
 	}
 
-	version := osVersionRegex.FindString(os)
+	version := nodeagentconfigv1alpha1.OSVersionRegex.FindString(os)
 	if version == "" {
-		return nil, fmt.Errorf("unable to find version in %q with regex: %s", os, osVersionRegex.String())
+		return nil, fmt.Errorf("unable to find version in %q with regex: %s", os, nodeagentconfigv1alpha1.OSVersionRegex.String())
 	}
 	return ptr.To(version), nil
 }

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -749,6 +749,7 @@ build:
             - pkg/controllermanager/controller/shoot/conditions
             - pkg/controllermanager/controller/shoot/hibernation
             - pkg/controllermanager/controller/shoot/maintenance
+            - pkg/controllermanager/controller/shoot/maintenance/helper
             - pkg/controllermanager/controller/shoot/migration
             - pkg/controllermanager/controller/shoot/quota
             - pkg/controllermanager/controller/shoot/reference

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -324,6 +324,7 @@ build:
             - pkg/controllermanager/controller/shoot/conditions
             - pkg/controllermanager/controller/shoot/hibernation
             - pkg/controllermanager/controller/shoot/maintenance
+            - pkg/controllermanager/controller/shoot/maintenance/helper
             - pkg/controllermanager/controller/shoot/migration
             - pkg/controllermanager/controller/shoot/quota
             - pkg/controllermanager/controller/shoot/reference

--- a/test/e2e/gardener/shoot/create_rotate_delete.go
+++ b/test/e2e/gardener/shoot/create_rotate_delete.go
@@ -71,13 +71,13 @@ func testCredentialRotation(s *ShootContext, shootVerifiers, utilsverifiers rota
 		}, SpecTimeout(time.Minute))
 
 		if inPlaceUpdate {
-			inplace.ItShouldVerifyInPlaceUpdateStart(s.GardenClient, s.Shoot, true, true)
+			inplace.ItShouldVerifyInPlaceUpdateStart(s, true, true)
 		}
 
 		ItShouldWaitForShootToBeReconciledAndHealthy(s)
 
 		if inPlaceUpdate {
-			inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+			inplace.ItShouldVerifyInPlaceUpdateCompletion(s)
 		}
 
 		shootVerifiers.AfterPrepared(context.TODO())
@@ -213,13 +213,13 @@ func testCredentialRotationWithoutWorkersRollout(s *ShootContext, shootVerifiers
 
 	// In case of rotation without workers rollout, the in-place update status in only populated when the rollout for that worker pool is triggered
 	if inPlaceUpdate {
-		inplace.ItShouldVerifyInPlaceUpdateStart(s.GardenClient, s.Shoot, true, true)
+		inplace.ItShouldVerifyInPlaceUpdateStart(s, true, true)
 	}
 
 	ItShouldWaitForShootToBeReconciledAndHealthy(s)
 
 	if inPlaceUpdate {
-		inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+		inplace.ItShouldVerifyInPlaceUpdateCompletion(s)
 	}
 
 	It("Credential rotation in status prepared", func() {

--- a/test/e2e/gardener/shoot/create_update-in-place_delete.go
+++ b/test/e2e/gardener/shoot/create_update-in-place_delete.go
@@ -116,7 +116,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				}).Should(Succeed())
 			}, SpecTimeout(time.Minute))
 
-			inplace.ItShouldVerifyInPlaceUpdateStart(s.GardenClient, s.Shoot, true, true)
+			inplace.ItShouldVerifyInPlaceUpdateStart(s, true, true)
 
 			ItShouldWaitForShootToBeReconciledAndHealthy(s)
 			ItShouldInitializeShootClient(s)
@@ -125,7 +125,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 			nodesOfInPlaceWorkersAfterTest := inplace.ItShouldFindNodesOfInPlaceWorkers(s)
 			Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
-			inplace.ItShouldVerifyInPlaceUpdateCompletion(s.GardenClient, s.Shoot)
+			inplace.ItShouldVerifyInPlaceUpdateCompletion(s)
 
 			ItShouldDeleteShoot(s)
 			ItShouldWaitForShootToBeDeleted(s)

--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_suite_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package shootupdate_test
+package shootkubernetesupdate_test
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestUpdateShoot(t *testing.T) {
+func TestKubernetesUpdateShoot(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Shoot Update Test Machinery Suite")
+	RunSpecs(t, "Shoot Kubernetes Update Test Machinery Suite")
 }

--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
@@ -14,7 +14,7 @@
 		- Successful reconciliation of the Shoot after the Kubernetes Version update.
  **/
 
-package shootupdate_test
+package shootkubernetesupdate_test
 
 import (
 	"context"

--- a/test/testmachinery/system/shoot_machine_image_update/machine_image_update_suite_test.go
+++ b/test/testmachinery/system/shoot_machine_image_update/machine_image_update_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootmachineimageupdate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMachineImageUpdateShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Machine Image Update Test Machinery Suite")
+}

--- a/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
+++ b/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+	Overview
+		- Tests the update of a Shoot's Worker Pool Machine Image version to the next supported version
+
+	Prerequisites
+		- A Shoot exists.
+
+	Test: Update the Shoot's Worker Pool Machine Image version to the next supported version
+	Expected Output
+		- Successful reconciliation of the Shoot after the Worker Pool Machine Image Version update.
+ **/
+
+package shootmachineimageupdate_test
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/utils/access"
+	shootupdatesuite "github.com/gardener/gardener/test/utils/shoots/update"
+	"github.com/gardener/gardener/test/utils/shoots/update/highavailability"
+	"github.com/gardener/gardener/test/utils/shoots/update/inplace"
+)
+
+var newWorkerPoolMachineImageVersion = flag.String("version-worker-pools", "", "the version to use for .spec.provider.workers[].machine.image.version")
+
+const UpdateMachineImageVersionTimeout = 45 * time.Minute
+
+func init() {
+	framework.RegisterShootFrameworkFlags()
+}
+
+var _ = Describe("Shoot machine image update testing", func() {
+	f := framework.NewShootFramework(nil)
+
+	framework.CIt("should update machine image version for worker pools with in-place update strategy", func(ctx context.Context) {
+		RunTest(ctx, f, newWorkerPoolMachineImageVersion)
+	}, UpdateMachineImageVersionTimeout)
+})
+
+// RunTest runs the update test for an existing shoot cluster. If provided, it updates the worker pools with the specified machine image version.
+// It verifies that the machine image version is updated without rolling the nodes for in-place update workers.
+func RunTest(
+	ctx context.Context,
+	f *framework.ShootFramework,
+	newWorkerPoolMachineImageVersion *string,
+) {
+	By("Create shoot client")
+	var (
+		job *batchv1.Job
+		err error
+	)
+
+	shootClient, err := access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
+	Expect(err).NotTo(HaveOccurred())
+
+	if v1beta1helper.IsHAControlPlaneConfigured(f.Shoot) {
+		f.Seed, f.SeedClient, err = f.GetSeed(ctx, *f.Shoot.Spec.SeedName)
+		Expect(err).NotTo(HaveOccurred())
+		controlPlaneNamespace := f.Shoot.Status.TechnicalID
+
+		By("Deploy zero-downtime validator job")
+		job, err = highavailability.DeployZeroDownTimeValidatorJob(ctx,
+			f.SeedClient.Client(), "update", controlPlaneNamespace, shootupdatesuite.GetKubeAPIServerAuthToken(ctx, f.SeedClient.Client(), controlPlaneNamespace))
+		Expect(err).NotTo(HaveOccurred())
+		shootupdatesuite.WaitForJobToBeReady(ctx, f.SeedClient.Client(), job)
+	}
+
+	var hasAutoInPlaceUpdateWorkers, hasManualInPlaceUpdateWorkers, hasInPlaceUpdateWorkers bool
+
+	for _, worker := range f.Shoot.Spec.Provider.Workers {
+		switch ptr.Deref(worker.UpdateStrategy, "") {
+		case gardencorev1beta1.AutoInPlaceUpdate:
+			hasAutoInPlaceUpdateWorkers = true
+		case gardencorev1beta1.ManualInPlaceUpdate:
+			hasManualInPlaceUpdateWorkers = true
+		}
+	}
+
+	hasInPlaceUpdateWorkers = hasAutoInPlaceUpdateWorkers || hasManualInPlaceUpdateWorkers
+
+	// Verify that the test has at least one worker pool with in-place update strategy
+	// OS update test is only relevant for in-place update workers to ensure that the OS version is updated
+	// without rolling the nodes
+	Expect(hasInPlaceUpdateWorkers).To(BeTrue(), "the test requires at least one worker pool with in-place update strategy")
+
+	By("Verify the machine image version for all existing nodes matches with the versions defined in the Shoot spec [before update]")
+	Expect(shootupdatesuite.VerifyMachineImageVersions(ctx, shootClient, f.Shoot)).To(Succeed())
+
+	By("Read CloudProfile")
+	cloudProfile, err := f.GetCloudProfile(ctx)
+	Expect(err).NotTo(HaveOccurred())
+
+	poolNameToMachineImageVersion, err := shootupdatesuite.ComputeNewMachineImageVersions(cloudProfile, f.Shoot, newWorkerPoolMachineImageVersion)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Update shoot")
+	for poolName, machineImageVersion := range poolNameToMachineImageVersion {
+		By("Update .spec.provider.workers[].machine.image.version to " + machineImageVersion + " for pool " + poolName)
+	}
+
+	var nodesOfInPlaceWorkersBeforeTest sets.Set[string]
+	if hasInPlaceUpdateWorkers {
+		nodesOfInPlaceWorkersBeforeTest = inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
+	}
+
+	Expect(f.UpdateShootSpec(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
+		for i, worker := range shoot.Spec.Provider.Workers {
+			if workerMachineImageVersion, ok := poolNameToMachineImageVersion[worker.Name]; ok {
+				shoot.Spec.Provider.Workers[i].Machine.Image.Version = &workerMachineImageVersion
+			}
+		}
+
+		return nil
+	})).To(Succeed())
+
+	if hasInPlaceUpdateWorkers {
+		inplace.VerifyInPlaceUpdateStart(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, hasAutoInPlaceUpdateWorkers, hasManualInPlaceUpdateWorkers)
+		if hasManualInPlaceUpdateWorkers {
+			inplace.LabelManualInPlaceNodesWithSelectedForUpdate(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
+		}
+	}
+
+	err = f.WaitForShootToBeReconciled(ctx, f.Shoot)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Re-creating shoot client")
+	shootClient, err = access.CreateShootClientFromAdminKubeconfig(ctx, f.GardenClient, f.Shoot)
+	Expect(err).NotTo(HaveOccurred())
+
+	if hasInPlaceUpdateWorkers {
+		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
+		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
+
+		inplace.VerifyInPlaceUpdateCompletion(ctx, f.Logger, f.GardenClient.Client(), f.Shoot)
+	}
+
+	By("Verify the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [after update]")
+	Expect(shootupdatesuite.VerifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
+
+	if v1beta1helper.IsHAControlPlaneConfigured(f.Shoot) {
+		By("Ensure there was no downtime while upgrading shoot")
+		Expect(f.SeedClient.Client().Get(ctx, client.ObjectKeyFromObject(job), job)).To(Succeed())
+		Expect(job.Status.Failed).Should(BeZero())
+		Expect(client.IgnoreNotFound(
+			f.SeedClient.Client().Delete(ctx,
+				job,
+				client.PropagationPolicy(metav1.DeletePropagationForeground),
+			),
+		),
+		).To(Succeed())
+	}
+}

--- a/test/testmachinery/system/shoot_update/update_test.go
+++ b/test/testmachinery/system/shoot_update/update_test.go
@@ -128,7 +128,7 @@ func RunTest(
 
 	var nodesOfInPlaceWorkersBeforeTest sets.Set[string]
 	if hasInPlaceUpdateWorkers {
-		nodesOfInPlaceWorkersBeforeTest = inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
+		nodesOfInPlaceWorkersBeforeTest = inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
 	}
 
 	Expect(f.UpdateShootSpec(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
@@ -146,9 +146,9 @@ func RunTest(
 	})).To(Succeed())
 
 	if hasInPlaceUpdateWorkers {
-		inplace.ItShouldVerifyInPlaceUpdateStart(f.GardenClient.Client(), f.Shoot, hasAutoInPlaceUpdateWorkers, hasManualInPlaceUpdateWorkers)
+		inplace.VerifyInPlaceUpdateStart(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, hasAutoInPlaceUpdateWorkers, hasManualInPlaceUpdateWorkers)
 		if hasManualInPlaceUpdateWorkers {
-			inplace.LabelManualInPlaceNodesWithSelectedForUpdate(ctx, f.ShootClient.Client(), f.Shoot)
+			inplace.LabelManualInPlaceNodesWithSelectedForUpdate(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
 		}
 	}
 
@@ -160,10 +160,10 @@ func RunTest(
 	Expect(err).NotTo(HaveOccurred())
 
 	if hasInPlaceUpdateWorkers {
-		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.ShootClient.Client(), f.Shoot)
+		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
 		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 
-		inplace.ItShouldVerifyInPlaceUpdateCompletion(f.GardenClient.Client(), f.Shoot)
+		inplace.VerifyInPlaceUpdateCompletion(ctx, f.Logger, f.GardenClient.Client(), f.Shoot)
 	}
 
 	By("Verify the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [after update]")

--- a/test/utils/shoots/update/inplace/nodes.go
+++ b/test/utils/shoots/update/inplace/nodes.go
@@ -6,9 +6,11 @@ package inplace
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -24,8 +26,10 @@ import (
 
 // LabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
 // In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
-func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) {
+func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, log logr.Logger, shootClient client.Client, shoot *gardencorev1beta1.Shoot) {
 	GinkgoHelper()
+
+	log = log.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 
 	for _, pool := range shoot.Spec.Provider.Workers {
 		if !v1beta1helper.IsUpdateStrategyManualInPlace(pool.UpdateStrategy) {
@@ -37,11 +41,13 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 			return shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})
 		}).Should(Succeed())
 
+		nodes := make([]string, 0, len(nodeList.Items))
 		for _, node := range nodeList.Items {
 			if metav1.HasLabel(node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate) {
 				continue
 			}
 
+			nodes = append(nodes, node.Name)
 			patch := client.MergeFrom(node.DeepCopy())
 			metav1.SetMetaDataLabel(&node.ObjectMeta, machinev1alpha1.LabelKeyNodeSelectedForUpdate, "true")
 
@@ -49,13 +55,16 @@ func LabelManualInPlaceNodesWithSelectedForUpdate(ctx context.Context, shootClie
 				g.Expect(shootClient.Patch(ctx, &node, patch)).To(Succeed())
 			}).Should(Succeed(), "node %s should be labeled", node.Name)
 		}
+
+		log.Info("All manual in-place nodes have been labeled with selected-for-update", "workerPool", pool.Name, "nodes", strings.Join(nodes, ", "))
 	}
 }
 
 // FindNodesOfInPlaceWorkers finds all nodes of in-place workers and returns their names.
-func FindNodesOfInPlaceWorkers(ctx context.Context, shootClient client.Client, shoot *gardencorev1beta1.Shoot) sets.Set[string] {
+func FindNodesOfInPlaceWorkers(ctx context.Context, log logr.Logger, shootClient client.Client, shoot *gardencorev1beta1.Shoot) sets.Set[string] {
 	GinkgoHelper()
 
+	log = log.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 	nodesOfInPlaceWorkers := sets.New[string]()
 
 	for _, pool := range shoot.Spec.Provider.Workers {
@@ -68,9 +77,12 @@ func FindNodesOfInPlaceWorkers(ctx context.Context, shootClient client.Client, s
 			return shootClient.List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: pool.Name})
 		}).Should(Succeed())
 
+		nodes := make([]string, 0, len(nodeList.Items))
 		for _, node := range nodeList.Items {
+			nodes = append(nodes, node.Name)
 			nodesOfInPlaceWorkers.Insert(node.Name)
 		}
+		log.Info("Found nodes for worker pool with in-place update strategy", "workerPool", pool.Name, "nodes", strings.Join(nodes, ", "))
 	}
 
 	return nodesOfInPlaceWorkers
@@ -83,7 +95,7 @@ func ItShouldFindNodesOfInPlaceWorkers(s *ShootContext) sets.Set[string] {
 	nodesOfInPlaceWorkers := sets.New[string]()
 
 	It("should get the nodes of worker with in-place update strategy", func(ctx SpecContext) {
-		nodesOfInPlaceWorkers = FindNodesOfInPlaceWorkers(ctx, s.ShootClient, s.Shoot)
+		nodesOfInPlaceWorkers = FindNodesOfInPlaceWorkers(ctx, s.Log, s.ShootClient, s.Shoot)
 	}, SpecTimeout(2*time.Minute))
 
 	return nodesOfInPlaceWorkers
@@ -95,6 +107,6 @@ func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {
 	GinkgoHelper()
 
 	It("should label all the manual in-place nodes with selected-for-update", func(ctx SpecContext) {
-		LabelManualInPlaceNodesWithSelectedForUpdate(ctx, s.ShootClient, s.Shoot)
+		LabelManualInPlaceNodesWithSelectedForUpdate(ctx, s.Log, s.ShootClient, s.Shoot)
 	}, SpecTimeout(2*time.Minute))
 }

--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -5,55 +5,80 @@
 package inplace
 
 import (
+	"context"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/test/e2e/gardener"
 )
 
 // ItShouldVerifyInPlaceUpdateStart verifies that the starting of in-place update  by checking the
 // .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateStart(gardenClient client.Client, shoot *gardencorev1beta1.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
+func ItShouldVerifyInPlaceUpdateStart(s *ShootContext, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
 	GinkgoHelper()
 
 	It("Verify in-place update start", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
-
-			g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
-			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
-			if hasAutoInplaceUpdate {
-				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
-			}
-			if hasManualInplaceUpdate {
-				g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
-				g.Expect(shoot.Status.Constraints).To(ContainCondition(
-					OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-					WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
-					Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
-				))
-			}
-		}).Should(Succeed())
+		VerifyInPlaceUpdateStart(ctx, s.Log, s.GardenClient, s.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate)
 	}, SpecTimeout(2*time.Minute))
+}
+
+// VerifyInPlaceUpdateStart verifies that the in-place update has started by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func VerifyInPlaceUpdateStart(ctx context.Context, log logr.Logger, gardenClient client.Client, shoot *gardencorev1beta1.Shoot, hasAutoInplaceUpdate, hasManualInplaceUpdate bool) {
+	GinkgoHelper()
+
+	log = log.WithValues("shoot", client.ObjectKeyFromObject(shoot))
+	log.Info("Verifying in-place update start", "hasWorkerWithAutoInplaceUpdate", hasAutoInplaceUpdate, "hasWorkerWithManualInplaceUpdate", hasManualInplaceUpdate)
+
+	Eventually(ctx, func(g Gomega) {
+		g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+		g.Expect(shoot.Status.InPlaceUpdates).NotTo(BeNil())
+		g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates).NotTo(BeNil())
+		if hasAutoInplaceUpdate {
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate).NotTo(BeEmpty())
+		}
+		if hasManualInplaceUpdate {
+			g.Expect(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate).NotTo(BeEmpty())
+			g.Expect(shoot.Status.Constraints).To(ContainCondition(
+				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+				WithReason("WorkerPoolsWithManualInPlaceUpdateStrategyPending"),
+				Or(WithStatus(gardencorev1beta1.ConditionFalse), WithStatus(gardencorev1beta1.ConditionProgressing)),
+			))
+		}
+	}).Should(Succeed())
 }
 
 // ItShouldVerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
 // .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
-func ItShouldVerifyInPlaceUpdateCompletion(gardenClient client.Client, shoot *gardencorev1beta1.Shoot) {
+func ItShouldVerifyInPlaceUpdateCompletion(s *ShootContext) {
 	GinkgoHelper()
 
 	It("Verify in-place update completion", func(ctx SpecContext) {
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
-
-			g.Expect(shoot.Status.InPlaceUpdates).To(BeNil())
-			g.Expect(shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
-			))
-		}).Should(Succeed())
+		VerifyInPlaceUpdateCompletion(ctx, s.Log, s.GardenClient, s.Shoot)
 	}, SpecTimeout(5*time.Minute))
+}
+
+// VerifyInPlaceUpdateCompletion verifies that the in-place update was completed successfully by checking the
+// .status.inPlaceUpdates and the ManualInPlaceWorkersUpdated constraint of the Shoot.
+func VerifyInPlaceUpdateCompletion(ctx context.Context, log logr.Logger, gardenClient client.Client, shoot *gardencorev1beta1.Shoot) {
+	GinkgoHelper()
+
+	log = log.WithValues("shoot", client.ObjectKeyFromObject(shoot))
+	log.Info("Verifying in-place update completion")
+
+	Eventually(ctx, func(g Gomega) {
+		g.Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).Should(Succeed())
+
+		g.Expect(shoot.Status.InPlaceUpdates).To(BeNil())
+		g.Expect(shoot.Status.Constraints).NotTo(ContainCondition(
+			OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+		))
+	}).Should(Succeed())
 }

--- a/test/utils/shoots/update/update.go
+++ b/test/utils/shoots/update/update.go
@@ -194,11 +194,11 @@ func VerifyMachineImageVersions(ctx context.Context, shootClient kubernetes.Inte
 
 	for _, node := range nodeList.Items {
 		var (
-			poolName            = node.Labels[v1beta1constants.LabelWorkerPool]
-			machineImageVersion = poolNameToMachineImageVersion[poolName]
+			poolName = node.Labels[v1beta1constants.LabelWorkerPool]
 		)
 
-		if _, ok := poolNameToMachineImageVersion[poolName]; !ok {
+		machineImageVersion, ok := poolNameToMachineImageVersion[poolName]
+		if !ok {
 			// not a in-place update worker pool, skip
 			continue
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds a TestMachinery test to verify OS version updates for InPlace update shoots, ensuring that the OS is updated to the new version on the node without rolling the node.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
/cc @ary1992 @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
