### PR TITLE
Prevent `gardener-node-agent` entering crash-loop on breaking changes to config

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -66,7 +66,7 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 			ctx, cancel := context.WithCancel(cmd.Context())
-			return run(ctx, cancel, log, opts.config)
+			return run(ctx, cancel, log, opts.config, opts.configDir)
 		},
 	}
 
@@ -99,7 +99,7 @@ func getBootstrapCommand(opts *options) *cobra.Command {
 	return bootstrapCmd
 }
 
-func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *nodeagentconfigv1alpha1.NodeAgentConfiguration) error {
+func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *nodeagentconfigv1alpha1.NodeAgentConfiguration, cfgDir string) error {
 	log.Info("Feature Gates", "featureGates", features.DefaultFeatureGate)
 	fs := afero.Afero{Fs: afero.NewOsFs()}
 
@@ -186,7 +186,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *n
 		},
 		ActualRunnables: []manager.Runnable{
 			manager.RunnableFunc(func(ctx context.Context) error {
-				return controller.AddToManager(ctx, cancel, mgr, cfg, hostName, machineName, nodeName)
+				return controller.AddToManager(ctx, cancel, mgr, cfg, hostName, machineName, nodeName, cfgDir)
 			}),
 		},
 	}); err != nil {

--- a/cmd/gardener-node-agent/app/options.go
+++ b/cmd/gardener-node-agent/app/options.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/gardener/cmd/utils/initrun"
 	"github.com/gardener/gardener/pkg/features"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagenthelper "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1/helper"
 	nodeagentvalidation "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1/validation"
 )
 
@@ -28,22 +29,22 @@ func init() {
 }
 
 type options struct {
-	configFile string
-	config     *nodeagentconfigv1alpha1.NodeAgentConfiguration
+	configDir string
+	config    *nodeagentconfigv1alpha1.NodeAgentConfiguration
 }
 
 var _ initrun.Options = &options{}
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.configFile, "config", o.configFile, "Path to configuration file.")
+	fs.StringVar(&o.configDir, "config-dir", o.configDir, "Path to the directory containing the configuration file.")
 }
 
 func (o *options) Complete() error {
-	if len(o.configFile) == 0 {
-		return fmt.Errorf("missing config file")
+	if len(o.configDir) == 0 {
+		return fmt.Errorf("missing config dir")
 	}
 
-	data, err := os.ReadFile(o.configFile)
+	data, err := os.ReadFile(nodeagenthelper.GetConfigFilePath(o.configDir))
 	if err != nil {
 		return fmt.Errorf("error reading config file: %w", err)
 	}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -117,7 +117,7 @@ func generateInitScript(nodeAgentImage string) ([]byte, error) {
 		"image":           nodeAgentImage,
 		"binaryName":      "gardener-node-agent",
 		"binaryDirectory": nodeagentconfigv1alpha1.BinaryDir,
-		"configFile":      nodeagentconfigv1alpha1.ConfigFilePath,
+		"configDir":       nodeagentconfigv1alpha1.BaseDir,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -6,11 +6,13 @@ package nodeinit_test
 
 import (
 	"context"
+	"fmt"
 	"unicode/utf8"
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
@@ -78,7 +80,7 @@ WantedBy=multi-user.target`),
 						},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/gardener-node-agent/config.yaml",
+						Path:        fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion),
 						Permissions: ptr.To[uint32](0600),
 						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiServer:
   caBundle: ` + utils.EncodeBase64(caBundle) + `
@@ -132,7 +134,7 @@ cp -f "$tmp_dir/gardener-node-agent" "/opt/bin" || cp -f "$tmp_dir/ko-app/garden
 chmod +x "/opt/bin/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"
-exec "/opt/bin/gardener-node-agent" bootstrap --config="/var/lib/gardener-node-agent/config.yaml"
+exec "/opt/bin/gardener-node-agent" bootstrap --config-dir="/var/lib/gardener-node-agent"
 `)),
 							},
 						},
@@ -173,7 +175,7 @@ exec "/opt/bin/gardener-node-agent" bootstrap --config="/var/lib/gardener-node-a
 				_, files, err := Config(worker, image, config)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(files).To(ContainElement(extensionsv1alpha1.File{
-					Path:        "/var/lib/gardener-node-agent/config.yaml",
+					Path:        fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion),
 					Permissions: ptr.To[uint32](0600),
 					Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiServer:
   caBundle: ` + utils.EncodeBase64(caBundle) + `

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -29,5 +29,5 @@ chmod +x "{{ .binaryDirectory }}/{{ .binaryName }}"
 {{- if eq .binaryName "gardener-node-agent" }}
 
 echo "> Bootstrap {{ .binaryName }}"
-exec "{{ .binaryDirectory }}/{{ .binaryName }}" bootstrap --config="{{ .configFile }}"
+exec "{{ .binaryDirectory }}/{{ .binaryName }}" bootstrap --config-dir="{{ .configDir }}"
 {{- end }}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/valitail"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagenthelper "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -99,7 +100,7 @@ After=network-online.target
 
 [Service]
 LimitMEMLOCK=infinity
-ExecStart=` + nodeagentconfigv1alpha1.BinaryDir + `/gardener-node-agent --config=` + nodeagentconfigv1alpha1.ConfigFilePath + `
+ExecStart=` + nodeagentconfigv1alpha1.BinaryDir + `/gardener-node-agent --config-dir=` + nodeagentconfigv1alpha1.BaseDir + `
 Restart=always
 RestartSec=5
 
@@ -144,7 +145,7 @@ func Files(config *nodeagentconfigv1alpha1.NodeAgentConfiguration) ([]extensions
 	}
 
 	return []extensionsv1alpha1.File{{
-		Path:        nodeagentconfigv1alpha1.ConfigFilePath,
+		Path:        nodeagenthelper.GetDefaultConfigFilePath(),
 		Permissions: ptr.To[uint32](0600),
 		Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(configRaw)}},
 	}}, nil

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -5,12 +5,14 @@
 package nodeagent_test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -65,13 +67,13 @@ After=network-online.target
 
 [Service]
 LimitMEMLOCK=infinity
-ExecStart=/opt/bin/gardener-node-agent --config=/var/lib/gardener-node-agent/config.yaml
+ExecStart=/opt/bin/gardener-node-agent --config-dir=/var/lib/gardener-node-agent
 Restart=always
 RestartSec=5
 
 [Install]
 WantedBy=multi-user.target`),
-					FilePaths: []string{"/var/lib/gardener-node-agent/config.yaml", "/opt/bin/gardener-node-agent"},
+					FilePaths: []string{fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion), "/opt/bin/gardener-node-agent"},
 				},
 			))
 			Expect(files).To(ConsistOf(append(expectedFiles, extensionsv1alpha1.File{
@@ -95,7 +97,7 @@ After=network-online.target
 
 [Service]
 LimitMEMLOCK=infinity
-ExecStart=/opt/bin/gardener-node-agent --config=/var/lib/gardener-node-agent/config.yaml
+ExecStart=/opt/bin/gardener-node-agent --config-dir=/var/lib/gardener-node-agent
 Restart=always
 RestartSec=5
 
@@ -135,7 +137,7 @@ WantedBy=multi-user.target`))
 			config := ComponentConfig(oscSecretName, nil, apiServerURL, caBundle, additionalTokenSyncConfigs)
 
 			Expect(Files(config)).To(ConsistOf(extensionsv1alpha1.File{
-				Path:        "/var/lib/gardener-node-agent/config.yaml",
+				Path:        fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion),
 				Permissions: ptr.To[uint32](0600),
 				Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiServer:
   caBundle: ` + utils.EncodeBase64(caBundle) + `

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -139,6 +139,7 @@ func (b *AutonomousBotanist) ApplyOperatingSystemConfig(ctx context.Context) err
 			SecretName:        b.operatingSystemConfigSecret.Name,
 			KubernetesVersion: b.Shoot.KubernetesVersion,
 		},
+		ConfigDir:             nodeagentconfigv1alpha1.BaseDir,
 		CancelContext:         cancelFunc,
 		Recorder:              &record.FakeRecorder{},
 		Extractor:             registry.NewExtractor(),

--- a/pkg/gardenadm/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig_test.go
@@ -6,6 +6,7 @@ package botanist_test
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/coreos/go-systemd/v22/dbus"
@@ -16,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -101,7 +103,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						})),
 					}),
 				}),
-				MatchFields(IgnoreExtras, Fields{"Path": Equal("/var/lib/gardener-node-agent/config.yaml")}),
+				MatchFields(IgnoreExtras, Fields{"Path": Equal(fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion))}),
 			))
 		})
 	})

--- a/pkg/nodeagent/apis/config/v1alpha1/helper/utils.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/helper/utils.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"fmt"
+
+	"k8s.io/component-base/version"
+
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+)
+
+// GetDefaultConfigFilePath returns the default file path on the worker node that contains the configuration of the gardener-node-agent.
+func GetDefaultConfigFilePath() string {
+	return GetConfigFilePath(nodeagentconfigv1alpha1.BaseDir)
+}
+
+// GetConfigFilePath generates the file path on the worker node that contains the configuration of the gardener-node-agent with a baseDir.
+func GetConfigFilePath(baseDir string) string {
+	return fmt.Sprintf("%s/config-%s.yaml", baseDir, version.Get().GitVersion)
+}

--- a/pkg/nodeagent/apis/config/v1alpha1/types.go
+++ b/pkg/nodeagent/apis/config/v1alpha1/types.go
@@ -24,8 +24,6 @@ const (
 	BootstrapTokenFilePath = CredentialsDir + "/bootstrap-token"
 	// TokenFilePath is the file path on the worker node that contains the access token of the gardener-node-agent.
 	TokenFilePath = CredentialsDir + "/token"
-	// ConfigFilePath is the file path on the worker node that contains the configuration of the gardener-node-agent.
-	ConfigFilePath = BaseDir + "/config.yaml"
 	// KubeconfigFilePath is the file path on the worker node that contains the kubeconfig of the gardener-node-agent.
 	KubeconfigFilePath = CredentialsDir + "/kubeconfig"
 	// MachineNameFilePath is the file path on the worker node that contains the machine name.

--- a/pkg/nodeagent/bootstrap/bootstrap_test.go
+++ b/pkg/nodeagent/bootstrap/bootstrap_test.go
@@ -37,7 +37,7 @@ After=network-online.target
 
 [Service]
 LimitMEMLOCK=infinity
-ExecStart=/opt/bin/gardener-node-agent --config=/var/lib/gardener-node-agent/config.yaml
+ExecStart=/opt/bin/gardener-node-agent --config-dir=/var/lib/gardener-node-agent
 Restart=always
 RestartSec=5
 

--- a/pkg/nodeagent/certificate.go
+++ b/pkg/nodeagent/certificate.go
@@ -26,6 +26,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagenthelper "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1/helper"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/certificatesigningrequest"
 )
@@ -86,8 +87,8 @@ func RequestAndStoreKubeconfig(ctx context.Context, log logr.Logger, fs afero.Af
 }
 
 // GetAPIServerConfig reads the gardener-node-agent config file and returns the APIServer configuration.
-func GetAPIServerConfig(fs afero.Afero) (*nodeagentconfigv1alpha1.APIServer, error) {
-	nodeAgentConfigFile, err := fs.ReadFile(nodeagentconfigv1alpha1.ConfigFilePath)
+func GetAPIServerConfig(fs afero.Afero, configDir string) (*nodeagentconfigv1alpha1.APIServer, error) {
+	nodeAgentConfigFile, err := fs.ReadFile(nodeagenthelper.GetConfigFilePath(configDir))
 	if err != nil {
 		return nil, fmt.Errorf("error reading gardener-node-agent config file: %w", err)
 	}

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -25,15 +25,16 @@ import (
 )
 
 // AddToManager adds all controllers to the given manager.
-func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Manager, cfg *nodeagentconfigv1alpha1.NodeAgentConfiguration, hostName, machineName, nodeName string) error {
+func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Manager, cfg *nodeagentconfigv1alpha1.NodeAgentConfiguration, hostName, machineName, nodeName, cfgDir string) error {
 	nodePredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelHostname: hostName}})
 	if err != nil {
 		return fmt.Errorf("failed computing label selector predicate for node: %w", err)
 	}
 
 	if err := (&certificate.Reconciler{
-		Cancel:      cancel,
-		MachineName: machineName,
+		Cancel:             cancel,
+		MachineName:        machineName,
+		NodeAgentConfigDir: cfgDir,
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding certificate controller: %w", err)
 	}
@@ -46,6 +47,7 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 
 	if err := (&operatingsystemconfig.Reconciler{
 		Config:                 cfg.Controllers.OperatingSystemConfig,
+		ConfigDir:              cfgDir,
 		TokenSecretSyncConfigs: cfg.Controllers.Token.SyncConfigs,
 		Channel:                channel,
 		HostName:               hostName,

--- a/pkg/nodeagent/controller/certificate/reconciler.go
+++ b/pkg/nodeagent/controller/certificate/reconciler.go
@@ -25,11 +25,12 @@ import (
 // When the certificate is renewed it saves the resulting kubeconfig on the disk, cancels its context to initiate a
 // restart of gardener-node-agent.
 type Reconciler struct {
-	Cancel      context.CancelFunc
-	Clock       clock.Clock
-	FS          afero.Afero
-	Config      *rest.Config
-	MachineName string
+	Cancel             context.CancelFunc
+	Clock              clock.Clock
+	FS                 afero.Afero
+	Config             *rest.Config
+	NodeAgentConfigDir string
+	MachineName        string
 
 	renewalDeadline *time.Time
 }
@@ -58,7 +59,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		// Otherwise, if the renewal deadline is reached right after the osc reconciler requests a new certificate, but node-agent has
 		// not restarted yet, this reconciler could use the old CA bundle to request a new certificate. This could lead to osc reconciler
 		// marking the certificate rotation as complete, while the persisted certificate is still using the old CA bundle.
-		apiServerConfig, err := nodeagent.GetAPIServerConfig(r.FS)
+		apiServerConfig, err := nodeagent.GetAPIServerConfig(r.FS, r.NodeAgentConfigDir)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed reading the API server config: %w", err)
 		}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -97,6 +97,7 @@ func init() {
 type Reconciler struct {
 	Client        client.Client
 	Config        nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig
+	ConfigDir     string
 	Recorder      record.EventRecorder
 	DBus          dbus.DBus
 	FS            afero.Afero
@@ -824,7 +825,7 @@ func (r *Reconciler) performCredentialsRotationInPlace(ctx context.Context, log 
 	if oscChanges.InPlaceUpdates.CertificateAuthoritiesRotation.Kubelet || oscChanges.InPlaceUpdates.CertificateAuthoritiesRotation.NodeAgent {
 		// Read the updated gardener-node-agent config for the API server CA bundle and server URL.
 		// This must always be called after applying the updated files.
-		apiServerConfig, err := nodeagent.GetAPIServerConfig(r.FS)
+		apiServerConfig, err := nodeagent.GetAPIServerConfig(r.FS, r.ConfigDir)
 		if err != nil {
 			return fmt.Errorf("failed reading the API server config: %w", err)
 		}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -68,10 +69,11 @@ var _ = Describe("Reconciler", func() {
 			Build()
 
 		reconciler = &Reconciler{
-			Client:   c,
-			FS:       fs,
-			DBus:     fakeDBus,
-			Recorder: nil,
+			Client:    c,
+			FS:        fs,
+			DBus:      fakeDBus,
+			ConfigDir: "/var/lib/gardener-node-agent",
+			Recorder:  nil,
 		}
 
 		node = &corev1.Node{
@@ -823,7 +825,7 @@ users:
 apiVersion: nodeagent.config.gardener.cloud/v1alpha1
 kind: NodeAgentConfiguration
 `)
-			Expect(fs.WriteFile(nodeagentconfigv1alpha1.ConfigFilePath, nodeAgentConfigFile, 0600)).To(Succeed())
+			Expect(fs.WriteFile(fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion), nodeAgentConfigFile, 0600)).To(Succeed())
 
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				n, err := fmt.Fprintln(w, "OK")

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -285,6 +285,7 @@ build:
             - pkg/logger
             - pkg/nodeagent
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/nodeagent/bootstrappers
             - pkg/nodeagent/controller/healthcheck
             - pkg/nodeagent/controller/operatingsystemconfig
@@ -426,6 +427,7 @@ build:
             - pkg/logger
             - pkg/nodeagent
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/nodeagent/apis/config/v1alpha1/validation
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -330,6 +330,7 @@ build:
             - pkg/healthz
             - pkg/logger
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/operator/client
             - pkg/resourcemanager/apis/config/v1alpha1
             - pkg/resourcemanager/controller/garbagecollector/references
@@ -597,6 +598,7 @@ build:
             - pkg/logger
             - pkg/nodeagent
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/nodeagent/apis/config/v1alpha1/validation
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1253,6 +1253,7 @@ build:
             - pkg/healthz
             - pkg/logger
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/operator/client
             - pkg/resourcemanager/apis/config/v1alpha1
             - pkg/resourcemanager/controller/garbagecollector/references
@@ -1520,6 +1521,7 @@ build:
             - pkg/logger
             - pkg/nodeagent
             - pkg/nodeagent/apis/config/v1alpha1
+            - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/nodeagent/apis/config/v1alpha1/validation
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -92,6 +92,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		DeferCleanup(func() { Expect(fakeFS.RemoveAll(imageMountDirectory)).To(Succeed()) })
 
 		cancelFunc = cancelFuncEnsurer{}
+		DeferCleanup(test.WithVar(&operatingsystemconfig.RequeueAfterRestart, time.Duration(time.Second)))
 
 		By("Setup manager")
 		mgr, err := manager.New(restConfig, manager.Options{
@@ -850,6 +851,7 @@ units: {}
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(
 			fakedbus.SystemdAction{Action: fakedbus.ActionEnable, UnitNames: []string{gnaUnit.Name}},
+			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 			fakedbus.SystemdAction{Action: fakedbus.ActionDaemonReload},
 		))
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,6 +168,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				SecretName:        oscSecretName,
 				KubernetesVersion: kubernetesVersion,
 			},
+			ConfigDir: "/var/lib/gardener-node-agent",
 			DBus:      fakeDBus,
 			FS:        fakeFS,
 			HostName:  hostName,
@@ -945,7 +947,7 @@ kubeReserved:
 			Expect(fakeFS.WriteFile(nodeagentconfigv1alpha1.KubeconfigFilePath, []byte(nodeAgentKubeconfig), 0600)).To(Succeed())
 
 			nodeAgentConfigFile := extensionsv1alpha1.File{
-				Path: nodeagentconfigv1alpha1.ConfigFilePath,
+				Path: fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion),
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
 						Encoding: "b64",

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -92,7 +92,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		DeferCleanup(func() { Expect(fakeFS.RemoveAll(imageMountDirectory)).To(Succeed()) })
 
 		cancelFunc = cancelFuncEnsurer{}
-		DeferCleanup(test.WithVar(&operatingsystemconfig.RequeueAfterRestart, time.Duration(time.Second)))
+		DeferCleanup(test.WithVar(&operatingsystemconfig.RequeueAfterRestart, time.Second))
 
 		By("Setup manager")
 		mgr, err := manager.New(restConfig, manager.Options{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue with `gardener-node-agent` which was causing it to enter crash-loop when a breaking change on its config was introduced and the pull of the new `gardener-node-agent` image failed. The old instance of `gardener-node-agent` was using the new config. With this fix we add a suffix  containing its version, which would help `gardener-node-agent` use the correct config file.

**Which issue(s) this PR fixes**:
Fixes #11025

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which was causing the `gardener-node-agent` to enter crash-loop when its config was updated with breaking changes was fixed.
```
```other operator
The `gardener-node-agent` now has a `--config-dir` flag that is used to find the config file instead of a `--config` flag.
```
