### PR TITLE
Add prefix to user name for kubeconfig requests

### DIFF
--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -10,7 +10,7 @@ After creation of a shoot cluster, end-users require a `kubeconfig` to access it
 
 The [`shoots/adminkubeconfig`](../../proposals/16-adminkubeconfig-subresource.md) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
 
-The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front. Apart from this advantage, the created `kubeconfig` will not be persisted anywhere.
+The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front. The created `kubeconfig` will not be persisted anywhere.
 
 In order to request such a `kubeconfig`, you can run the following commands (targeting the garden cluster):
 

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -10,7 +10,7 @@ After creation of a shoot cluster, end-users require a `kubeconfig` to access it
 
 The [`shoots/adminkubeconfig`](../../proposals/16-adminkubeconfig-subresource.md) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
 
-The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API. Apart from this advantage, the created `kubeconfig` will not be persisted anywhere.
+The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front. Apart from this advantage, the created `kubeconfig` will not be persisted anywhere.
 
 In order to request such a `kubeconfig`, you can run the following commands (targeting the garden cluster):
 

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
@@ -326,7 +326,7 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 			cert, err := x509.ParseCertificate(certPem.Bytes)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(cert.Subject.CommonName).To(Equal(userName))
+			Expect(cert.Subject.CommonName).To(HaveSuffix(":" + userName))
 			Expect(cert.Subject.Organization).To(organizationMatcher)
 			Expect(cert.NotAfter.Unix()).To(Equal(getExpirationTimestamp(actual).Unix())) // certificates do not have nano seconds in them
 			Expect(cert.NotBefore.UTC()).To(Equal(secretsutils.AdjustToClockSkew(time.Unix(10, 0).UTC())))

--- a/test/e2e/gardener/shoot/create_authenticate_delete.go
+++ b/test/e2e/gardener/shoot/create_authenticate_delete.go
@@ -208,7 +208,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 				g.Expect(err).ToNot(HaveOccurred())
 			}).Should(Succeed())
 
-			Expect(selfSubjectReview.Status.UserInfo.Username).To(Equal("kubernetes-admin"))
+			Expect(selfSubjectReview.Status.UserInfo.Username).To(HaveSuffix(":kubernetes-admin"))
 			Expect(selfSubjectReview.Status.UserInfo.Groups).To(Equal([]string{"gardener.cloud:system:viewers", "system:authenticated"}))
 
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Add a prefix to the user name in `{Admin,Viewer}KubeconfigRequest` to avoid conflicts. Earlier, a viewer kubeconfig potentially contained more permissions than expected if (cluster)roles were bound to the known user name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Unique usernames are generated for {Admin,Viewer}KubeconfigRequests by prefixing the original/requesting username with a random string. This approach prevents conflicts with existing RBAC rules in the cluster while still preserving the identity of the requesting user.
```
