### PR TITLE
chore: Disable major updates of go-toml by Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -464,6 +464,21 @@
       allowedVersions: '<v1.12.0',
     },
     {
+      // TODO(marc1404): Remove when supported for containerd v1 is dropped or the following issue is resolved: https://github.com/gardener/gardener/issues/12600
+      // Disable major updates of go-toml to stay on v1.x.x.
+      // Related issue: https://github.com/gardener/gardener/issues/12600
+      matchDatasources: [
+        'go',
+      ],
+      matchPackageNames: [
+        'github.com/pelletier/go-toml',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
+    },
+    {
       // Ignore paths which most likely create false positives.
       matchFileNames: [
         'cmd/**',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/area dev-productivity
/kind task

**What this PR does / why we need it**:

Disables major updates of [`pelletier/go-toml`](https://github.com/pelletier/go-toml) by Renovate to stay on `v1.x.x`.

**Which issue(s) this PR fixes**:

Related to:
* https://github.com/gardener/gardener/issues/12600

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
