### PR TITLE
Refine defaults and validation for worker with ManualInPlaceUpdate strategy

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -42,8 +42,8 @@ spec:
     -kube-apiserver-min-allowed-memory=$KUBE_APISERVER_MIN_ALLOWED_MEMORY
     -etcd-min-allowed-cpu=$ETCD_MIN_ALLOWED_CPU
     -etcd-min-allowed-memory=$ETCD_MIN_ALLOWED_MEMORY
+    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-image-name=$MACHINE_IMAGE
-#    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-type=$MACHINE_TYPE
 #    -external-domain=
 

--- a/.test-defs/ShootMachineImageUpdateTest.yaml
+++ b/.test-defs/ShootMachineImageUpdateTest.yaml
@@ -18,5 +18,5 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE
-    -version-worker-pools=$OS_VERSION_WORKER_POOLS
+    -machine-image-version=$MACHINE_IMAGE_VERSION
   image: golang:1.24.5

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -299,7 +299,10 @@ func SetDefaults_Worker(obj *Worker) {
 			obj.MaxSurge = &DefaultInPlaceWorkerMaxSurge
 		}
 		if obj.MaxUnavailable == nil {
-			obj.MaxUnavailable = &DefaultInPlaceWorkerMaxUnavailable
+			obj.MaxUnavailable = &DefaultAutoInPlaceWorkerMaxUnavailable
+			if *obj.UpdateStrategy == ManualInPlaceUpdate {
+				obj.MaxUnavailable = &DefaultManualInPlaceWorkerMaxUnavailable
+			}
 		}
 		if obj.MachineControllerManagerSettings == nil {
 			obj.MachineControllerManagerSettings = &MachineControllerManagerSettings{}

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -295,13 +295,12 @@ func SetDefaults_Worker(obj *Worker) {
 	}
 
 	if *obj.UpdateStrategy == AutoInPlaceUpdate || *obj.UpdateStrategy == ManualInPlaceUpdate {
-		if obj.MaxSurge == nil {
-			obj.MaxSurge = &DefaultInPlaceWorkerMaxSurge
-		}
-		if obj.MaxUnavailable == nil {
-			obj.MaxUnavailable = &DefaultAutoInPlaceWorkerMaxUnavailable
-			if *obj.UpdateStrategy == ManualInPlaceUpdate {
-				obj.MaxUnavailable = &DefaultManualInPlaceWorkerMaxUnavailable
+		if *obj.UpdateStrategy == AutoInPlaceUpdate {
+			if obj.MaxSurge == nil {
+				obj.MaxSurge = &DefaultAutoInPlaceWorkerMaxSurge
+			}
+			if obj.MaxUnavailable == nil {
+				obj.MaxUnavailable = &DefaultAutoInPlaceWorkerMaxUnavailable
 			}
 		}
 		if obj.MachineControllerManagerSettings == nil {

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -857,7 +857,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Provider.Workers[0].MachineControllerManagerSettings.DisableHealthTimeout).To(PointTo(BeTrue()))
 
 			Expect(obj.Spec.Provider.Workers[1].MaxSurge).To(PointTo(Equal(intstr.FromInt32(0))))
-			Expect(obj.Spec.Provider.Workers[1].MaxUnavailable).To(PointTo(Equal(intstr.FromInt32(1))))
+			Expect(obj.Spec.Provider.Workers[1].MaxUnavailable).To(PointTo(Equal(intstr.FromInt32(0))))
 			Expect(obj.Spec.Provider.Workers[1].SystemComponents).NotTo(BeNil())
 			Expect(obj.Spec.Provider.Workers[1].SystemComponents.Allow).To(BeTrue())
 			Expect(obj.Spec.Provider.Workers[1].UpdateStrategy).To(PointTo(Equal(ManualInPlaceUpdate)))

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -856,8 +856,8 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Provider.Workers[0].MachineControllerManagerSettings).NotTo(BeNil())
 			Expect(obj.Spec.Provider.Workers[0].MachineControllerManagerSettings.DisableHealthTimeout).To(PointTo(BeTrue()))
 
-			Expect(obj.Spec.Provider.Workers[1].MaxSurge).To(PointTo(Equal(intstr.FromInt32(0))))
-			Expect(obj.Spec.Provider.Workers[1].MaxUnavailable).To(PointTo(Equal(intstr.FromInt32(0))))
+			Expect(obj.Spec.Provider.Workers[1].MaxSurge).To(BeNil())
+			Expect(obj.Spec.Provider.Workers[1].MaxUnavailable).To(BeNil())
 			Expect(obj.Spec.Provider.Workers[1].SystemComponents).NotTo(BeNil())
 			Expect(obj.Spec.Provider.Workers[1].SystemComponents.Allow).To(BeTrue())
 			Expect(obj.Spec.Provider.Workers[1].UpdateStrategy).To(PointTo(Equal(ManualInPlaceUpdate)))

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1907,14 +1907,12 @@ type SSHAccess struct {
 var (
 	// DefaultWorkerMaxSurge is the default value for Worker MaxSurge.
 	DefaultWorkerMaxSurge = intstr.FromInt32(1)
-	// DefaultInPlaceWorkerMaxSurge is the default value for In-Place Worker MaxSurge.
-	DefaultInPlaceWorkerMaxSurge = intstr.FromInt32(0)
+	// DefaultAutoInPlaceWorkerMaxSurge is the default value for AutoInPlaceUpdate Worker MaxSurge.
+	DefaultAutoInPlaceWorkerMaxSurge = intstr.FromInt32(0)
 	// DefaultWorkerMaxUnavailable is the default value for Worker MaxUnavailable.
 	DefaultWorkerMaxUnavailable = intstr.FromInt32(0)
 	// DefaultAutoInPlaceWorkerMaxUnavailable is the default value for AutoInPlaceUpdate Worker MaxUnavailable.
 	DefaultAutoInPlaceWorkerMaxUnavailable = intstr.FromInt32(1)
-	// DefaultManualInPlaceWorkerMaxUnavailable is the default value for ManualInPlaceUpdate Worker MaxUnavailable.
-	DefaultManualInPlaceWorkerMaxUnavailable = intstr.FromInt32(0)
 	// DefaultWorkerSystemComponentsAllow is the default value for Worker AllowSystemComponents
 	DefaultWorkerSystemComponentsAllow = true
 )

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1911,8 +1911,10 @@ var (
 	DefaultInPlaceWorkerMaxSurge = intstr.FromInt32(0)
 	// DefaultWorkerMaxUnavailable is the default value for Worker MaxUnavailable.
 	DefaultWorkerMaxUnavailable = intstr.FromInt32(0)
-	// DefaultInPlaceWorkerMaxUnavailable is the default value for In-Place Worker MaxUnavailable.
-	DefaultInPlaceWorkerMaxUnavailable = intstr.FromInt32(1)
+	// DefaultAutoInPlaceWorkerMaxUnavailable is the default value for AutoInPlaceUpdate Worker MaxUnavailable.
+	DefaultAutoInPlaceWorkerMaxUnavailable = intstr.FromInt32(1)
+	// DefaultManualInPlaceWorkerMaxUnavailable is the default value for ManualInPlaceUpdate Worker MaxUnavailable.
+	DefaultManualInPlaceWorkerMaxUnavailable = intstr.FromInt32(0)
 	// DefaultWorkerSystemComponentsAllow is the default value for Worker AllowSystemComponents
 	DefaultWorkerSystemComponentsAllow = true
 )

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1897,7 +1897,7 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 	// 	allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "must be set to 0 or should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
 	// }
 
-	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge != nil && getIntOrPercentValue(*worker.MaxSurge) == 0) && ptr.Deref(worker.UpdateStrategy, "") != core.ManualInPlaceUpdate {
+	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge == nil || getIntOrPercentValue(*worker.MaxSurge) == 0) && ptr.Deref(worker.UpdateStrategy, "") != core.ManualInPlaceUpdate {
 		// Both MaxSurge and MaxUnavailable cannot be zero.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "may not be 0 when `maxSurge` is 0"))
 	}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1888,10 +1888,16 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 
 	if getIntOrPercentValue(ptr.Deref(worker.MaxSurge, intstr.IntOrString{})) != 0 && ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
 		// MaxSurge must be 0 when update strategy is ManualInPlaceUpdate.
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "must be 0 when `updateStrategy` is `ManualInPlaceUpdate`"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "must be set to 0 or should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
 	}
 
-	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge != nil && getIntOrPercentValue(*worker.MaxSurge) == 0) {
+	// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
+	// if getIntOrPercentValue(ptr.Deref(worker.MaxUnavailable, intstr.IntOrString{})) != 0 && ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
+	// 	// MaxUnavailable must be 0 when update strategy is ManualInPlaceUpdate.
+	// 	allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "must be set to 0 or should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+	// }
+
+	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge != nil && getIntOrPercentValue(*worker.MaxSurge) == 0) && ptr.Deref(worker.UpdateStrategy, "") != core.ManualInPlaceUpdate {
 		// Both MaxSurge and MaxUnavailable cannot be zero.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "may not be 0 when `maxSurge` is 0"))
 	}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1886,15 +1886,14 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
 	allErrs = append(allErrs, IsNotMoreThan100Percent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
 
-	if getIntOrPercentValue(ptr.Deref(worker.MaxSurge, intstr.IntOrString{})) != 0 && ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
-		// MaxSurge must be 0 when update strategy is ManualInPlaceUpdate.
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "must be set to 0 or should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
-	}
-
 	// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
-	// if getIntOrPercentValue(ptr.Deref(worker.MaxUnavailable, intstr.IntOrString{})) != 0 && ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
-	// 	// MaxUnavailable must be 0 when update strategy is ManualInPlaceUpdate.
-	// 	allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "must be set to 0 or should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+	// if ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
+	// 	if worker.MaxSurge != nil {
+	// 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+	// 	}
+	// 	if worker.MaxUnavailable != nil {
+	// 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+	// 	}
 	// }
 
 	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge == nil || getIntOrPercentValue(*worker.MaxSurge) == 0) && ptr.Deref(worker.UpdateStrategy, "") != core.ManualInPlaceUpdate {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5949,7 +5949,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 					newShoot.Spec.Provider.Workers[0].UpdateStrategy = ptr.To(core.ManualInPlaceUpdate)
 					newShoot.Spec.Provider.Workers[0].MaxSurge = ptr.To(intstr.FromInt32(0))
-					newShoot.Spec.Provider.Workers[0].MaxUnavailable = ptr.To(intstr.FromInt32(1))
+					newShoot.Spec.Provider.Workers[0].MaxUnavailable = ptr.To(intstr.FromInt32(0))
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 				})
@@ -6452,8 +6452,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Entry("percentage is not less than zero", core.AutoRollingUpdate, intstr.FromString("-90%"), intstr.FromString("90%"), field.ErrorTypeInvalid),
 
 			// manual in-place update tests
-			Entry("maxSurge must be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(1), intstr.FromInt32(1), field.ErrorTypeInvalid),
-			Entry("maxUnavailable should not be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(0), intstr.FromInt32(0), field.ErrorTypeInvalid),
+			Entry("maxSurge must be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(0), intstr.FromInt32(1), field.ErrorTypeInvalid),
+			// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
+			// Entry("maxUnavailable must be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(1), intstr.FromInt32(0), field.ErrorTypeInvalid),
 		)
 
 		DescribeTable("reject when labels are invalid",

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6876,7 +6876,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			BeforeEach(func() {
 				worker = core.Worker{
-					Name: "worker1",
+					Name:           "worker1",
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
 					},
@@ -7048,7 +7049,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			BeforeEach(func() {
 				worker = core.Worker{
-					Name: "worker-1",
+					Name:           "worker-1",
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
 					},
@@ -7134,7 +7136,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			BeforeEach(func() {
 				worker = core.Worker{
-					Name: "worker-1",
+					Name:           "worker-1",
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
 					},

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6415,7 +6415,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 		)
 
 		DescribeTable("reject when maxUnavailable and maxSurge are invalid",
-			func(updateStrategy core.MachineUpdateStrategy, maxUnavailable, maxSurge intstr.IntOrString, expectType field.ErrorType) {
+			func(updateStrategy core.MachineUpdateStrategy, maxUnavailable, maxSurge *intstr.IntOrString, expectType field.ErrorType) {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, true))
 				worker := core.Worker{
 					Name: "worker-name",
@@ -6427,8 +6427,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 						},
 						Architecture: ptr.To("amd64"),
 					},
-					MaxSurge:       &maxSurge,
-					MaxUnavailable: &maxUnavailable,
+					MaxSurge:       maxSurge,
+					MaxUnavailable: maxUnavailable,
 					UpdateStrategy: &updateStrategy,
 				}
 				errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, nil, false)
@@ -6439,22 +6439,22 @@ var _ = Describe("Shoot Validation Tests", func() {
 			},
 
 			// double zero values (percent or int)
-			Entry("two zero integers", core.AutoRollingUpdate, intstr.FromInt32(0), intstr.FromInt32(0), field.ErrorTypeInvalid),
-			Entry("zero int and zero percent", core.AutoRollingUpdate, intstr.FromInt32(0), intstr.FromString("0%"), field.ErrorTypeInvalid),
-			Entry("zero percent and zero int", core.AutoRollingUpdate, intstr.FromString("0%"), intstr.FromInt32(0), field.ErrorTypeInvalid),
-			Entry("two zero percents", core.AutoRollingUpdate, intstr.FromString("0%"), intstr.FromString("0%"), field.ErrorTypeInvalid),
+			Entry("two zero integers", core.AutoRollingUpdate, ptr.To(intstr.FromInt32(0)), ptr.To(intstr.FromInt32(0)), field.ErrorTypeInvalid),
+			Entry("zero int and zero percent", core.AutoRollingUpdate, ptr.To(intstr.FromInt32(0)), ptr.To(intstr.FromString("0%")), field.ErrorTypeInvalid),
+			Entry("zero percent and zero int", core.AutoRollingUpdate, ptr.To(intstr.FromString("0%")), ptr.To(intstr.FromInt32(0)), field.ErrorTypeInvalid),
+			Entry("two zero percents", core.AutoRollingUpdate, ptr.To(intstr.FromString("0%")), ptr.To(intstr.FromString("0%")), field.ErrorTypeInvalid),
 
 			// greater than 100
-			Entry("maxUnavailable greater than 100 percent", core.AutoRollingUpdate, intstr.FromString("101%"), intstr.FromString("100%"), field.ErrorTypeInvalid),
+			Entry("maxUnavailable greater than 100 percent", core.AutoRollingUpdate, ptr.To(intstr.FromString("101%")), ptr.To(intstr.FromString("100%")), field.ErrorTypeInvalid),
 
 			// below zero tests
-			Entry("values are not below zero", core.AutoRollingUpdate, intstr.FromInt32(-1), intstr.FromInt32(0), field.ErrorTypeInvalid),
-			Entry("percentage is not less than zero", core.AutoRollingUpdate, intstr.FromString("-90%"), intstr.FromString("90%"), field.ErrorTypeInvalid),
+			Entry("values are not below zero", core.AutoRollingUpdate, ptr.To(intstr.FromInt32(-1)), ptr.To(intstr.FromInt32(0)), field.ErrorTypeInvalid),
+			Entry("percentage is not less than zero", core.AutoRollingUpdate, ptr.To(intstr.FromString("-90%")), ptr.To(intstr.FromString("90%")), field.ErrorTypeInvalid),
 
 			// manual in-place update tests
-			Entry("maxSurge must be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(0), intstr.FromInt32(1), field.ErrorTypeInvalid),
 			// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
-			// Entry("maxUnavailable must be 0 in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, intstr.FromInt32(1), intstr.FromInt32(0), field.ErrorTypeInvalid),
+			// Entry("maxSurge is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, nil, ptr.To(intstr.FromInt32(1)), field.ErrorTypeInvalid),
+			// Entry("maxUnavailable is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, ptr.To(intstr.FromInt32(0)), nil, field.ErrorTypeInvalid),
 		)
 
 		DescribeTable("reject when labels are invalid",

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -11,6 +11,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -56,8 +57,9 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 								Type:         "some-machine-type",
 								Architecture: ptr.To("amd64"),
 							},
-							Maximum: 2,
-							Minimum: 1,
+							Maximum:        2,
+							Minimum:        1,
+							MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 						},
 					},
 				},

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -238,8 +239,8 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			Name:           workerPool.Name,
 			Minimum:        workerPool.Minimum,
 			Maximum:        workerPool.Maximum,
-			MaxSurge:       *workerPool.MaxSurge,
-			MaxUnavailable: *workerPool.MaxUnavailable,
+			MaxSurge:       ptr.Deref(workerPool.MaxSurge, intstr.FromInt32(0)),
+			MaxUnavailable: ptr.Deref(workerPool.MaxUnavailable, intstr.FromInt32(0)),
 			Annotations:    workerPool.Annotations,
 			Labels:         gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled, gardenerNodeAgentSecretName),
 			Taints:         workerPool.Taints,

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -19,21 +19,6 @@ import (
 )
 
 var _ = Describe("Changes", func() {
-	DescribeTable("#CheckIfMinorVersionUpdate", func(oldVersion, newVersion string, expected bool, errMatcher gomegatypes.GomegaMatcher) {
-		isMinorVersionUpdate, err := CheckIfMinorVersionUpdate(oldVersion, newVersion)
-		Expect(err).To(errMatcher)
-		Expect(isMinorVersionUpdate).To(Equal(expected))
-	},
-		Entry("invalid version", "a.b.c", "1.0.0", false, MatchError(ContainSubstring("failed to parse"))),
-		Entry("1.0.0 to 1.1.0", "1.0.0", "1.1.0", true, BeNil()),
-		Entry("1.1.0 to 1.1.2", "1.1.0", "1.1.2", false, BeNil()),
-		Entry("v1.1.0 to v1.1.2", "v1.1.0", "v1.1.2", false, BeNil()),
-		Entry("v1.2.3 to v1.3.4", "v1.2.3", "v1.3.4", true, BeNil()),
-		Entry("v1.3.4 to v1.5.6", "v1.3.4", "v1.5.6", true, BeNil()),
-		Entry("1.2.3-foo.12 to 1.2.4-foo.23", "1.2.3-foo.12", "1.2.4-foo.12", false, BeNil()),
-		Entry("1.1.1-foo.12 to 1.2.3-foo.23", "1.1.1-foo.12", "1.2.3-foo.23", true, BeNil()),
-	)
-
 	DescribeTable("#ComputeKubeletConfigChange", func(oldKubeletConfig, newKubeletConfig *kubeletconfigv1beta1.KubeletConfiguration, expectedCPUManagerPolicyChange, expectedConfigChange bool, errMatcher gomegatypes.GomegaMatcher) {
 		configChange, cpuManagerPolicyChange, err := ComputeKubeletConfigChange(oldKubeletConfig, newKubeletConfig)
 		Expect(err).To(errMatcher)

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -149,3 +149,17 @@ func (r *VersionRange) SupportedVersionRange() string {
 		return "all kubernetes versions"
 	}
 }
+
+// CheckIfMinorVersionUpdate checks if the new version is a minor version update to the old version.
+func CheckIfMinorVersionUpdate(old, new string) (bool, error) {
+	oldVersion, err := semver.NewVersion(Normalize(old))
+	if err != nil {
+		return false, fmt.Errorf("failed to parse old version %s: %w", old, err)
+	}
+	newVersion, err := semver.NewVersion(Normalize(new))
+	if err != nil {
+		return false, fmt.Errorf("failed to parse new version %s: %w", new, err)
+	}
+
+	return oldVersion.Minor() != newVersion.Minor(), nil
+}

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -171,4 +171,19 @@ var _ = Describe("Version", func() {
 			Entry("AddedInVersion amnd RemovedInVersion", VersionRange{AddedInVersion: "1.1.0", RemovedInVersion: "1.2.0"}, "versions >= 1.1.0, < 1.2.0"),
 		)
 	})
+
+	DescribeTable("#CheckIfMinorVersionUpdate", func(oldVersion, newVersion string, expected bool, errMatcher gomegatypes.GomegaMatcher) {
+		isMinorVersionUpdate, err := CheckIfMinorVersionUpdate(oldVersion, newVersion)
+		Expect(err).To(errMatcher)
+		Expect(isMinorVersionUpdate).To(Equal(expected))
+	},
+		Entry("invalid version", "a.b.c", "1.0.0", false, MatchError(ContainSubstring("failed to parse"))),
+		Entry("1.0.0 to 1.1.0", "1.0.0", "1.1.0", true, BeNil()),
+		Entry("1.1.0 to 1.1.2", "1.1.0", "1.1.2", false, BeNil()),
+		Entry("v1.1.0 to v1.1.2", "v1.1.0", "v1.1.2", false, BeNil()),
+		Entry("v1.2.3 to v1.3.4", "v1.2.3", "v1.3.4", true, BeNil()),
+		Entry("v1.3.4 to v1.5.6", "v1.3.4", "v1.5.6", true, BeNil()),
+		Entry("1.2.3-foo.12 to 1.2.4-foo.23", "1.2.3-foo.12", "1.2.4-foo.12", false, BeNil()),
+		Entry("1.1.1-foo.12 to 1.2.3-foo.23", "1.1.1-foo.12", "1.2.3-foo.23", true, BeNil()),
+	)
 })

--- a/test/integration/controllermanager/managedseedset/managedseedset_test.go
+++ b/test/integration/controllermanager/managedseedset/managedseedset_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -193,8 +194,9 @@ var _ = Describe("ManagedSeedSet controller test", func() {
 								Type:         "some-machine-type",
 								Architecture: ptr.To("amd64"),
 							},
-							Maximum: 2,
-							Minimum: 1,
+							Maximum:        2,
+							Minimum:        1,
+							MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 						},
 					},
 				},

--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
@@ -161,6 +161,7 @@ func RunTest(
 
 	if hasInPlaceUpdateWorkers {
 		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
+		f.Logger.Info("Nodes of in-place workers before test and after test", "beforeNodes", nodesOfInPlaceWorkersBeforeTest.UnsortedList(), "afterNodes", nodesOfInPlaceWorkersAfterTest.UnsortedList())
 		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 
 		inplace.VerifyInPlaceUpdateCompletion(ctx, f.Logger, f.GardenClient.Client(), f.Shoot)

--- a/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
+++ b/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gardener/gardener/test/utils/shoots/update/inplace"
 )
 
-var newWorkerPoolMachineImageVersion = flag.String("version-worker-pools", "", "the version to use for .spec.provider.workers[].machine.image.version")
+var newWorkerPoolMachineImageVersion = flag.String("machine-image-version", "", "the version to use for .spec.provider.workers[].machine.image.version")
 
 const UpdateMachineImageVersionTimeout = 45 * time.Minute
 

--- a/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
+++ b/test/testmachinery/system/shoot_machine_image_update/machine_image_update_test.go
@@ -146,13 +146,14 @@ func RunTest(
 
 	if hasInPlaceUpdateWorkers {
 		nodesOfInPlaceWorkersAfterTest := inplace.FindNodesOfInPlaceWorkers(ctx, f.Logger, f.ShootClient.Client(), f.Shoot)
+		f.Logger.Info("Nodes of in-place workers before test and after test", "beforeNodes", nodesOfInPlaceWorkersBeforeTest.UnsortedList(), "afterNodes", nodesOfInPlaceWorkersAfterTest.UnsortedList())
 		Expect(nodesOfInPlaceWorkersBeforeTest.UnsortedList()).To(ConsistOf(nodesOfInPlaceWorkersAfterTest.UnsortedList()))
 
 		inplace.VerifyInPlaceUpdateCompletion(ctx, f.Logger, f.GardenClient.Client(), f.Shoot)
 	}
 
-	By("Verify the Kubernetes version for all existing nodes matches with the versions defined in the Shoot spec [after update]")
-	Expect(shootupdatesuite.VerifyKubernetesVersions(ctx, shootClient, f.Shoot)).To(Succeed())
+	By("Verify the machine image version for all existing nodes matches with the versions defined in the Shoot spec [after update]")
+	Expect(shootupdatesuite.VerifyMachineImageVersions(ctx, shootClient, f.Shoot)).To(Succeed())
 
 	if v1beta1helper.IsHAControlPlaneConfigured(f.Shoot) {
 		By("Ensure there was no downtime while upgrading shoot")

--- a/test/utils/shoots/update/inplace/nodes.go
+++ b/test/utils/shoots/update/inplace/nodes.go
@@ -88,19 +88,6 @@ func FindNodesOfInPlaceWorkers(ctx context.Context, log logr.Logger, shootClient
 	return nodesOfInPlaceWorkers
 }
 
-// ItShouldFindNodesOfInPlaceWorkers finds all nodes of in-place workers and returns their names.
-func ItShouldFindNodesOfInPlaceWorkers(s *ShootContext) sets.Set[string] {
-	GinkgoHelper()
-
-	nodesOfInPlaceWorkers := sets.New[string]()
-
-	It("should get the nodes of worker with in-place update strategy", func(ctx SpecContext) {
-		nodesOfInPlaceWorkers = FindNodesOfInPlaceWorkers(ctx, s.Log, s.ShootClient, s.Shoot)
-	}, SpecTimeout(2*time.Minute))
-
-	return nodesOfInPlaceWorkers
-}
-
 // ItShouldLabelManualInPlaceNodesWithSelectedForUpdate labels all manual in-place nodes with the selected-for-update label.
 // In the actual scenario, this should be done by the user, but for testing purposes, we do it here.
 func ItShouldLabelManualInPlaceNodesWithSelectedForUpdate(s *ShootContext) {

--- a/test/utils/shoots/update/inplace/shoot.go
+++ b/test/utils/shoots/update/inplace/shoot.go
@@ -82,3 +82,17 @@ func VerifyInPlaceUpdateCompletion(ctx context.Context, log logr.Logger, gardenC
 		))
 	}).Should(Succeed())
 }
+
+// GetTotalInPlaceWorkersMaxSurge calculates the total max surge for all workers with update strategy AutoInPlaceUpdate.
+func GetTotalInPlaceWorkersMaxSurge(shoot *gardencorev1beta1.Shoot) int {
+	GinkgoHelper()
+
+	totalInPlaceWorkersMaxSurge := 0
+	for _, pool := range shoot.Spec.Provider.Workers {
+		if pool.UpdateStrategy != nil && *pool.UpdateStrategy == gardencorev1beta1.AutoInPlaceUpdate {
+			totalInPlaceWorkersMaxSurge += pool.MaxSurge.IntValue()
+		}
+	}
+
+	return totalInPlaceWorkersMaxSurge
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Updated validation to enforce that both `MaxSurge` and `MaxUnavailable` must not be set for `ManualInPlaceUpdate`, as `MaxUnavailable` is not relevant for workers using this strategy nodes selected by the user receive in-place updates simultaneously, regardless of `MaxUnavailable`. Similarly, `MaxSurge` is not applicable, as new node creation is not allowed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Setting shoot's `.spec.providers.workers[].{maxSurge, maxUnavailable}` will be denied in future versions of Gardener for workers with updateStrategy `ManualInPlaceUpdate`. Users should unset these values with this version of Gardener.
```
