### PR TITLE
Use v1 version of the API resource `AdmissionConfiguration`

### DIFF
--- a/example/20-admissionconfig.yaml
+++ b/example/20-admissionconfig.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiserver.k8s.io/v1alpha1
+apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - name: ShootTolerationRestriction

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -19,7 +19,6 @@ import (
 	webhookadmissionv1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1"
 	webhookadmissionv1alpha1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
-	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -31,7 +30,6 @@ var admissionCodec runtime.Codec
 func init() {
 	admissionScheme := runtime.NewScheme()
 	utilruntime.Must(apiserverv1.AddToScheme(admissionScheme))
-	utilruntime.Must(apiserverv1alpha1.AddToScheme(admissionScheme))
 	utilruntime.Must(webhookadmissionv1.AddToScheme(admissionScheme))
 	utilruntime.Must(webhookadmissionv1alpha1.AddToScheme(admissionScheme))
 
@@ -42,7 +40,6 @@ func init() {
 			Strict: false,
 		})
 		versions = schema.GroupVersions([]schema.GroupVersion{
-			apiserverv1alpha1.SchemeGroupVersion,
 			webhookadmissionv1.SchemeGroupVersion,
 			webhookadmissionv1alpha1.SchemeGroupVersion,
 		})

--- a/pkg/component/apiserver/admission.go
+++ b/pkg/component/apiserver/admission.go
@@ -18,6 +18,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	webhookadmissionv1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1"
 	webhookadmissionv1alpha1 "k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
+	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -29,6 +30,7 @@ var admissionCodec runtime.Codec
 
 func init() {
 	admissionScheme := runtime.NewScheme()
+	utilruntime.Must(apiserverv1.AddToScheme(admissionScheme))
 	utilruntime.Must(apiserverv1alpha1.AddToScheme(admissionScheme))
 	utilruntime.Must(webhookadmissionv1.AddToScheme(admissionScheme))
 	utilruntime.Must(webhookadmissionv1alpha1.AddToScheme(admissionScheme))
@@ -76,7 +78,7 @@ func ReconcileSecretAdmissionKubeconfigs(ctx context.Context, c client.Client, s
 func ReconcileConfigMapAdmission(ctx context.Context, c client.Client, configMap *corev1.ConfigMap, values Values) error {
 	configMap.Data = map[string]string{}
 
-	admissionConfig := &apiserverv1alpha1.AdmissionConfiguration{}
+	admissionConfig := &apiserverv1.AdmissionConfiguration{}
 	for _, plugin := range values.EnabledAdmissionPlugins {
 		rawConfig, err := computeRelevantAdmissionPluginRawConfig(plugin)
 		if err != nil {
@@ -84,7 +86,7 @@ func ReconcileConfigMapAdmission(ctx context.Context, c client.Client, configMap
 		}
 
 		if rawConfig != nil {
-			admissionConfig.Plugins = append(admissionConfig.Plugins, apiserverv1alpha1.AdmissionPluginConfiguration{
+			admissionConfig.Plugins = append(admissionConfig.Plugins, apiserverv1.AdmissionPluginConfiguration{
 				Name: plugin.Name,
 				Path: volumeMountPathAdmissionConfiguration + "/" + admissionPluginsConfigFilename(plugin.Name),
 			})

--- a/pkg/component/apiserver/admission_test.go
+++ b/pkg/component/apiserver/admission_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Admission", func() {
 					ResourceVersion: "1",
 				},
 				Immutable: ptr.To(true),
-				Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+				Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins: null
 `},
@@ -163,7 +163,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 				},
 				Immutable: ptr.To(true),
 				Data: map[string]string{
-					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+					"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -242,7 +242,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 				},
 				Immutable: ptr.To(true),
 				Data: map[string]string{
-					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+					"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -308,7 +308,7 @@ kubeConfigFile: ""
 				},
 				Immutable: ptr.To(true),
 				Data: map[string]string{
-					"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+					"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -270,7 +270,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				},
 				Annotations: map[string]string{
 					"reference.resources.gardener.cloud/configmap-0e4e3fd5": "gardener-apiserver-audit-policy-config-f5b578b4",
-					"reference.resources.gardener.cloud/configmap-a6e4dc6f": "gardener-apiserver-admission-config-e38ff146",
+					"reference.resources.gardener.cloud/configmap-6e5f123b": "gardener-apiserver-admission-config-07c5248a",
 					"reference.resources.gardener.cloud/secret-9dca243c":    "shoot-access-gardener-apiserver",
 					"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 					"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
@@ -310,7 +310,7 @@ var _ = Describe("GardenerAPIServer", func() {
 						},
 						Annotations: map[string]string{
 							"reference.resources.gardener.cloud/configmap-0e4e3fd5": "gardener-apiserver-audit-policy-config-f5b578b4",
-							"reference.resources.gardener.cloud/configmap-a6e4dc6f": "gardener-apiserver-admission-config-e38ff146",
+							"reference.resources.gardener.cloud/configmap-6e5f123b": "gardener-apiserver-admission-config-07c5248a",
 							"reference.resources.gardener.cloud/secret-9dca243c":    "shoot-access-gardener-apiserver",
 							"reference.resources.gardener.cloud/secret-47fc132b":    "gardener-apiserver-admission-kubeconfigs-e3b0c442",
 							"reference.resources.gardener.cloud/secret-389fbba5":    "etcd-client",
@@ -491,7 +491,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								VolumeSource: corev1.VolumeSource{
 									ConfigMap: &corev1.ConfigMapVolumeSource{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "gardener-apiserver-admission-config-e38ff146",
+											Name: "gardener-apiserver-admission-config-07c5248a",
 										},
 									},
 								},
@@ -1045,7 +1045,7 @@ rules:
 					It("should successfully deploy the configmap resource w/o admission plugins", func() {
 						configMapAdmission := &corev1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{Name: "gardener-apiserver-admission-config", Namespace: namespace},
-							Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+							Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins: null
 `},
@@ -1103,7 +1103,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 						configMapAdmission := &corev1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{Name: "gardener-apiserver-admission-config", Namespace: namespace},
 							Data: map[string]string{
-								"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+								"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -1176,7 +1176,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 						configMapAdmission := &corev1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{Name: "gardener-apiserver-admission-config", Namespace: namespace},
 							Data: map[string]string{
-								"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+								"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -1239,7 +1239,7 @@ kubeConfigFile: ""
 						configMapAdmission := &corev1.ConfigMap{
 							ObjectMeta: metav1.ObjectMeta{Name: "gardener-apiserver-admission-config", Namespace: namespace},
 							Data: map[string]string{
-								"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+								"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -106,7 +106,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameVPNSeedClient           = "vpn-seed-client"
 		secretNameVPNSeedServerTLSAuth    = "vpn-seed-server-tlsauth-a1d0aa00"
 
-		configMapNameAdmissionConfigs  = "kube-apiserver-admission-config-e38ff146"
+		configMapNameAdmissionConfigs  = "kube-apiserver-admission-config-07c5248a"
 		secretNameAdmissionKubeconfigs = "kube-apiserver-admission-kubeconfigs-e3b0c442"
 		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-b2b49c90"
 		configMapNameAuditPolicy       = "audit-policy-config-f5b578b4"
@@ -1396,7 +1396,7 @@ resources:
 				It("should successfully deploy the configmap resource w/o admission plugins", func() {
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
-						Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+						Data: map[string]string{"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins: null
 `},
@@ -1465,7 +1465,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
 						Data: map[string]string{
-							"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+							"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -1555,7 +1555,7 @@ kubeConfigFile: /etc/kubernetes/foobar.yaml
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
 						Data: map[string]string{
-							"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+							"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -1632,7 +1632,7 @@ kubeConfigFile: ""
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
 						Data: map[string]string{
-							"admission-configuration.yaml": `apiVersion: apiserver.k8s.io/v1alpha1
+							"admission-configuration.yaml": `apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
 - configuration: null
@@ -2762,7 +2762,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-af50ac19":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-c4700ce9":    secretNameETCDEncryptionConfig,
-						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
+						"reference.resources.gardener.cloud/configmap-0ddefe9e": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
 					}
@@ -2984,7 +2984,7 @@ kind: AuthorizationConfiguration
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-af50ac19":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-c4700ce9":    secretNameETCDEncryptionConfig,
-						"reference.resources.gardener.cloud/configmap-130aa219": configMapNameAdmissionConfigs,
+						"reference.resources.gardener.cloud/configmap-0ddefe9e": configMapNameAdmissionConfigs,
 						"reference.resources.gardener.cloud/secret-5613e39f":    secretNameAdmissionKubeconfigs,
 						"reference.resources.gardener.cloud/configmap-d4419cd4": configMapNameAuditPolicy,
 					}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR migrates the `AdmissionConfiguration` resource of the `apiserver.k8s.io` API from version `v1alpha1` to `v1`. 
The `v1alpha1` version of the resource [has been deprecated since k8s 1.17](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers).

**Which issue(s) this PR fixes**:
Fixes #12415 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The AdmissionConfiguration API resource has been migrated from version v1alpha1 to v1.
```
