### PR TITLE
Move immutable backup documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,6 @@
 * [Readiness of Shoot Worker Nodes](usage/advanced/node-readiness.md)
 * [Cleanup of Shoot clusters in deletion](usage/advanced/shoot_cleanup.md)
 * [Tolerations](usage/advanced/tolerations.md)
-* [Immutable Backup Buckets](usage/advanced/immutable-backup-buckets.md)
 
 ## [API Reference](api-reference/README.md)
 
@@ -250,6 +249,7 @@
 
 * [Gardener configuration and usage](operations/configuration.md)
 * [Control Plane Migration](operations/control_plane_migration.md)
+* [Immutable Backup Buckets](operations/immutable-backup-buckets.md)
 * [Istio](operations/istio.md)
 * [Kube API server load balancing](operations/kube_apiserver_loadbalancing.md)
 * [`ManagedSeed`s: Register Shoot as Seed](operations/managed_seed.md)

--- a/docs/operations/immutable-backup-buckets.md
+++ b/docs/operations/immutable-backup-buckets.md
@@ -95,8 +95,8 @@ This allows you to proceed with restoring the etcd cluster without being blocked
 
 ## References
 
-* [BackupBucket Resource Contract](../../extensions/resources/backupbucket.md)
-* [Gardenlet Controller Concepts – BackupBucket Controller](../../concepts/gardenlet.md#backupbucket-controller)
+* [BackupBucket Resource Contract](../extensions/resources/backupbucket.md)
+* [Gardenlet Controller Concepts – BackupBucket Controller](../concepts/gardenlet.md#backupbucket-controller)
 * [GCP BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/docs/usage/usage.md#backupbucketconfig)
 * [AWS BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-aws/blob/master/docs/usage/usage.md#backupbucketconfig)
 * [Azure BackupBucketConfig](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage/usage.md#backupbucketconfig)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/pull/12175#issuecomment-3124391963

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vlerenc @seshachalam-yv

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
