### PR TITLE
[GEP-28] Fix Platform Architecture Detection of `gardenadm` Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,13 +331,16 @@ kind-single-node-down kind-multi-node-down kind-multi-zone-down: $(KIND)
 	# We need root privileges to clean the backup bucket directory, see https://github.com/gardener/gardener/issues/6752
 	docker run --rm --user root:root -v $(REPO_ROOT)/dev/local-backupbuckets:/dev/local-backupbuckets alpine rm -rf /dev/local-backupbuckets/garden-*
 
-export SKAFFOLD_BUILD_CONCURRENCY = 0 # speed-up skaffold deployments by building all images concurrently
-export SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS = true # build the images for the platform matching the nodes of the active kubernetes cluster, even in `skaffold build`, which doesn't enable this by default
+# speed-up skaffold deployments by building all images concurrently
+export SKAFFOLD_BUILD_CONCURRENCY = 0
+# build the images for the platform matching the nodes of the active kubernetes cluster, even in `skaffold build`, which doesn't enable this by default
+export SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS = true
 export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 export SKAFFOLD_PUSH = true
 export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)
 export GARDENER_VERSION = $(VERSION)
-export SKAFFOLD_LABEL = "skaffold.dev/run-id=gardener-local" # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
+# use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
+export SKAFFOLD_LABEL = "skaffold.dev/run-id=gardener-local"
 
 %up %dev %debug: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION Gardener $(BUILD_DATE))
 # skaffold dev and debug clean up deployed modules by default, disable this


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area robustness
/kind bug

**What this PR does / why we need it**:

Fix Platform Architecture Detection of `gardenadm` Build.

Additional whitespace caused the platform architecture to yield incorrect results. This would lead to non-amd64 systems using amd64 by chance causing `gardenadm` invocations to eventually fail. The failure could be directly as the `gardenadm` binary was built for amd64 or as a follow up action, e.g. due to `kubelet` being pulled for amd64 instead of arm64.
Removing the unnecessary whitespace by moving the comments before the export statements instead of keeping them in line resolves the issue.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

Before this change the `skaffold` environment variables reaching `dev-setup/gardenadm.sh` looked like this:

```
declare -x SKAFFOLD_BUILD_CONCURRENCY="0 "
declare -x SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS="true "
declare -x SKAFFOLD_DEFAULT_REPO="garden.local.gardener.cloud:5001"
declare -x SKAFFOLD_FILENAME="skaffold-gardenadm.yaml"
declare -x SKAFFOLD_LABEL="\"skaffold.dev/run-id=gardener-local\" "
declare -x SKAFFOLD_PUSH="true"
```

Please note the trailing whitespace for the environment variables using an in line comment (`SKAFFOLD_BUILD_CONCURRENCY`, `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS`, `SKAFFOLD_LABEL`).

After the change, the trailing whitespace is gone:

```
declare -x SKAFFOLD_BUILD_CONCURRENCY="0"
declare -x SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS="true"
declare -x SKAFFOLD_DEFAULT_REPO="garden.local.gardener.cloud:5001"
declare -x SKAFFOLD_FILENAME="skaffold-gardenadm.yaml"
declare -x SKAFFOLD_LABEL="\"skaffold.dev/run-id=gardener-local\""
declare -x SKAFFOLD_PUSH="true"
```

The trailing whitespace seem to have confused skaffold, i.e. a check for `true` is not necessarily working for `true ` (with trailing space).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed local `gardenadm` development setup for non-amd64 systems.
```

/cc @rfranzke @timebertt @oliver-goetz @LucaBernstein 