### PR TITLE
Graduate `UseNamespacedCloudProfile` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -21,8 +21,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | Feature                                  | Default | Stage   | Since   | Until   |
 |------------------------------------------|---------|---------|---------|---------|
 | DefaultSeccompProfile                    | `false` | `Alpha` | `1.54`  |         |
-| UseNamespacedCloudProfile                | `false` | `Alpha` | `1.92`  | `1.111` |
-| UseNamespacedCloudProfile                | `true`  | `Beta`  | `1.112` |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  |         |
@@ -197,7 +195,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | NodeAgentAuthorizer                          | `true`  | `Beta`       | `1.116` | `1.122` |
 | NodeAgentAuthorizer                          | `true`  | `GA`         | `1.123` | `1.123` |
 | NodeAgentAuthorizer                          | `true`  | `Removed`    | `1.124` |         |
-
+| UseNamespacedCloudProfile                    | `false` | `Alpha`      | `1.92`  | `1.111` |
+| UseNamespacedCloudProfile                    | `true`  | `Beta`       | `1.112` | `1.124` |
+| UseNamespacedCloudProfile                    | `true`  | `GA`         | `1.125` |         |
 
 ## Using a Feature
 

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -110,8 +110,7 @@ var _ = Describe("Strategy", func() {
 				}))
 			})
 
-			It("should unset cloudProfileName field if NamespacedCloudProfile is referenced and feature gate is enabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, true))
+			It("should unset cloudProfileName field if NamespacedCloudProfile is referenced", func() {
 				shoot.Spec.CloudProfile = &core.CloudProfileReference{
 					Kind: "NamespacedCloudProfile",
 					Name: "bar",
@@ -123,22 +122,6 @@ var _ = Describe("Strategy", func() {
 				Expect(shoot.Spec.CloudProfile).To(Equal(&core.CloudProfileReference{
 					Kind: "NamespacedCloudProfile",
 					Name: "bar",
-				}))
-			})
-
-			It("should keep cloudProfileName field and overwrite the cloudprofile reference if NamespacedCloudProfile is referenced and feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, false))
-				shoot.Spec.CloudProfile = &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "bar",
-				}
-				shoot.Spec.CloudProfileName = ptr.To("foo")
-				strategy.PrepareForCreate(ctx, shoot)
-
-				Expect(*shoot.Spec.CloudProfileName).To(Equal("foo"))
-				Expect(shoot.Spec.CloudProfile).To(Equal(&core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "foo",
 				}))
 			})
 
@@ -214,48 +197,12 @@ var _ = Describe("Strategy", func() {
 				}))
 			})
 
-			It("should unset cloudProfileName field if NamespacedCloudProfile is referenced and feature gate is enabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, true))
+			It("should unset cloudProfileName field if NamespacedCloudProfile is referenced", func() {
 				newShoot.Spec.CloudProfile = &core.CloudProfileReference{
 					Kind: "NamespacedCloudProfile",
 					Name: "bar",
 				}
 				newShoot.Spec.CloudProfileName = ptr.To("foo")
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Spec.CloudProfileName).To(BeNil())
-				Expect(newShoot.Spec.CloudProfile).To(Equal(&core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "bar",
-				}))
-			})
-
-			It("should keep cloudProfileName field and overwrite the cloudprofile reference if NamespacedCloudProfile is referenced and feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, false))
-				newShoot.Spec.CloudProfile = &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "bar",
-				}
-				newShoot.Spec.CloudProfileName = ptr.To("foo")
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(*newShoot.Spec.CloudProfileName).To(Equal("foo"))
-				Expect(newShoot.Spec.CloudProfile).To(Equal(&core.CloudProfileReference{
-					Kind: "CloudProfile",
-					Name: "foo",
-				}))
-			})
-
-			It("should keep the NamespacedCloudProfile if it has been enabled before and now the feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, false))
-				oldShoot.Spec.CloudProfile = &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "bar",
-				}
-				newShoot.Spec.CloudProfile = &core.CloudProfileReference{
-					Kind: "NamespacedCloudProfile",
-					Name: "bar",
-				}
 				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
 
 				Expect(newShoot.Spec.CloudProfileName).To(BeNil())

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -27,6 +27,7 @@ const (
 	// owner: @timuthy @benedictweis @LucaBernstein
 	// alpha: v1.92.0
 	// beta: v1.112.0
+	// GA: v1.125.0
 	UseNamespacedCloudProfile featuregate.Feature = "UseNamespacedCloudProfile"
 
 	// ShootCredentialsBinding enables the usage of the CredentialsBindingName API in shoot spec.
@@ -117,7 +118,7 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:                    {Default: false, PreRelease: featuregate.Alpha},
-	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.Beta},
+	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: false, PreRelease: featuregate.Alpha},
 	NewVPN:                                   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -15,7 +15,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,7 +24,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/version"
 )
@@ -260,12 +258,6 @@ func SyncCloudProfileFields(oldShoot, newShoot *core.Shoot) {
 			newShoot.Spec.CloudProfileName = nil
 		}
 		return
-	}
-
-	// clear cloudProfile if namespacedCloudProfile is newly provided but feature toggle is disabled
-	if newShoot.Spec.CloudProfile != nil && newShoot.Spec.CloudProfile.Kind == v1beta1constants.CloudProfileReferenceKindNamespacedCloudProfile && !utilfeature.DefaultFeatureGate.Enabled(features.UseNamespacedCloudProfile) &&
-		(oldShoot == nil || oldShoot.Spec.CloudProfile == nil || oldShoot.Spec.CloudProfile.Kind != v1beta1constants.CloudProfileReferenceKindNamespacedCloudProfile) {
-		newShoot.Spec.CloudProfile = nil
 	}
 
 	// fill empty cloudProfile field from cloudProfileName, if provided

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -527,7 +527,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
@@ -746,7 +745,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -378,7 +378,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
@@ -934,7 +933,6 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/controllerutils
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/gardenlet/bootstrap/util
             - pkg/healthz
@@ -1151,7 +1149,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
@@ -1276,7 +1273,6 @@ build:
             - pkg/controllerutils
             - pkg/controllerutils/predicate
             - pkg/extensions
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -461,7 +461,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -509,7 +509,6 @@ build:
             - pkg/client/kubernetes/cache
             - pkg/controllerutils
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/gardenlet/bootstrap/util
             - pkg/healthz
@@ -762,7 +761,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger
@@ -1385,7 +1383,6 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/controllerutils/routes
-            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_suite_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_suite_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/namespacedcloudprofile"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 )
@@ -121,8 +119,6 @@ var _ = BeforeSuite(func() {
 			ConcurrentSyncs: ptr.To(5),
 		},
 	}).AddToManager(mgr)).To(Succeed())
-
-	DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, true))
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)

--- a/test/integration/controllermanager/project/project/project_suite_test.go
+++ b/test/integration/controllermanager/project/project/project_suite_test.go
@@ -36,10 +36,8 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/controller/cloudprofile"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/namespacedcloudprofile"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/project/project"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
@@ -158,8 +156,6 @@ var _ = BeforeSuite(func() {
 			ConcurrentSyncs: ptr.To(5),
 		},
 	}).AddToManager(mgr)).To(Succeed())
-
-	DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseNamespacedCloudProfile, true))
 
 	By("Start manager")
 	mgrContext, mgrCancel := context.WithCancel(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The `UseNamespacedCloudProfile` feature gate is in beta since Gardener v1.112.0 and is now graduated to GA.

**Which issue(s) this PR fixes**:
Part of #9142 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `UseNamespacedCloudProfile` feature gate has been graduated to GA and is locked to `true`. 
```
