### PR TITLE
Move the `do not use` note from the `FeatureGates` field to the `KubernetesConfig` type

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -649,10 +649,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           goAwayChance:
                             description: |-
@@ -1043,10 +1041,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logLevel:
                             default: info
@@ -1279,10 +1275,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logLevel:
                             default: info
@@ -1527,10 +1521,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logging:
                             description: Logging contains configuration for the log
@@ -1843,10 +1835,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           horizontalPodAutoscaler:
                             description: HorizontalPodAutoscalerConfig contains horizontal

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -7847,6 +7847,8 @@ ETCD
 </p>
 <p>
 <p>KubernetesConfig contains common configuration fields for the control plane components.</p>
+<p>This is a legacy type that should not be used in new API fields or resources.
+Instead of embedding this type, consider using inline map for feature gates definitions.</p>
 </p>
 <table>
 <thead>
@@ -7866,7 +7868,6 @@ map[string]bool
 <td>
 <em>(Optional)</em>
 <p>FeatureGates contains information about enabled feature gates.</p>
-<p>This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.</p>
 </td>
 </tr>
 </tbody>

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -649,10 +649,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           goAwayChance:
                             description: |-
@@ -1043,10 +1041,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logLevel:
                             default: info
@@ -1279,10 +1275,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logLevel:
                             default: info
@@ -1527,10 +1521,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           logging:
                             description: Logging contains configuration for the log
@@ -1843,10 +1835,8 @@ spec:
                           featureGates:
                             additionalProperties:
                               type: boolean
-                            description: |-
-                              FeatureGates contains information about enabled feature gates.
-
-                              This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                            description: FeatureGates contains information about enabled
+                              feature gates.
                             type: object
                           horizontalPodAutoscaler:
                             description: HorizontalPodAutoscalerConfig contains horizontal

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -327,10 +327,8 @@ spec:
                         featureGates:
                           additionalProperties:
                             type: boolean
-                          description: |-
-                            FeatureGates contains information about enabled feature gates.
-
-                            This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                          description: FeatureGates contains information about enabled
+                            feature gates.
                           type: object
                         imageGCHighThresholdPercent:
                           description: |-

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -652,10 +652,11 @@ type VerticalPodAutoscaler struct {
 }
 
 // KubernetesConfig contains common configuration fields for the control plane components.
+//
+// This is a legacy type that should not be used in new API fields or resources.
+// Instead of embedding this type, consider using inline map for feature gates definitions.
 type KubernetesConfig struct {
 	// FeatureGates contains information about enabled feature gates.
-	//
-	// This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
 	FeatureGates map[string]bool
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1755,10 +1755,11 @@ message Kubernetes {
 }
 
 // KubernetesConfig contains common configuration fields for the control plane components.
+//
+// This is a legacy type that should not be used in new API fields or resources.
+// Instead of embedding this type, consider using inline map for feature gates definitions.
 message KubernetesConfig {
   // FeatureGates contains information about enabled feature gates.
-  //
-  // This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
   // +optional
   map<string, bool> featureGates = 1;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -864,10 +864,11 @@ var (
 )
 
 // KubernetesConfig contains common configuration fields for the control plane components.
+//
+// This is a legacy type that should not be used in new API fields or resources.
+// Instead of embedding this type, consider using inline map for feature gates definitions.
 type KubernetesConfig struct {
 	// FeatureGates contains information about enabled feature gates.
-	//
-	// This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty" protobuf:"bytes,1,rep,name=featureGates"`
 }

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -4542,7 +4542,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -4711,7 +4711,7 @@ func schema_pkg_apis_core_v1beta1_KubeControllerManagerConfig(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -4767,7 +4767,7 @@ func schema_pkg_apis_core_v1beta1_KubeProxyConfig(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -4810,7 +4810,7 @@ func schema_pkg_apis_core_v1beta1_KubeSchedulerConfig(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -4853,7 +4853,7 @@ func schema_pkg_apis_core_v1beta1_KubeletConfig(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -5303,12 +5303,12 @@ func schema_pkg_apis_core_v1beta1_KubernetesConfig(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "KubernetesConfig contains common configuration fields for the control plane components.",
+				Description: "KubernetesConfig contains common configuration fields for the control plane components.\n\nThis is a legacy type that should not be used in new API fields or resources. Instead of embedding this type, consider using inline map for feature gates definitions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"featureGates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FeatureGates contains information about enabled feature gates.\n\nThis is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.",
+							Description: "FeatureGates contains information about enabled feature gates.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -329,10 +329,8 @@ spec:
                         featureGates:
                           additionalProperties:
                             type: boolean
-                          description: |-
-                            FeatureGates contains information about enabled feature gates.
-
-                            This is a legacy field that should no longer be used. Instead, consider using inline map for feature gates definitions.
+                          description: FeatureGates contains information about enabled
+                            feature gates.
                           type: object
                         imageGCHighThresholdPercent:
                           description: |-


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
We should rather put the `do not use` note on the `KubernetesConfig` type, not on the `FeatureGates` field.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/12339

**Special notes for your reviewer**:
The initial idea behind the `KubernetesConfig` type was to hold common configuration options across kubernetes components (kube-apiserver,kube-controller-manager, etc.). After years, it still holds a single field - for `FeatureGates`. The wrong abstraction of `KubernetesConfig` type creates confusion for contributors when introducing feature gates for a component - whether they have to embed the `KubernetesConfig` type of have to define `FeatureGates` field separately.
In https://github.com/gardener/gardener/pull/12339#discussion_r2182797611, we decided that the `KubernetesConfig` type should not be used in new API fields/resources.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
