### PR TITLE
Clean up unused `_ "embed"` imports

### DIFF
--- a/pkg/component/autoscaling/vpa/crd_test.go
+++ b/pkg/component/autoscaling/vpa/crd_test.go
@@ -6,7 +6,6 @@ package vpa_test
 
 import (
 	"context"
-	_ "embed"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/component/etcd/etcd/crd.go
+++ b/pkg/component/etcd/etcd/crd.go
@@ -5,7 +5,6 @@
 package etcd
 
 import (
-	_ "embed"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
@@ -6,7 +6,6 @@ package nodeinit
 
 import (
 	"bytes"
-	_ "embed"
 	"fmt"
 	"path/filepath"
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -5,7 +5,6 @@
 package kubelet
 
 import (
-	_ "embed"
 	"strconv"
 	"strings"
 

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -6,7 +6,6 @@ package apiserver
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"slices"
 	"strconv"

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -6,7 +6,6 @@ package seedserver
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"net"
 	"path/filepath"

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -6,7 +6,6 @@ package seedserver_test
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"net"
 

--- a/pkg/component/observability/monitoring/prometheus/aggregate/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/scrapeconfigs.go
@@ -5,8 +5,6 @@
 package aggregate
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -5,8 +5,6 @@
 package aggregate
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/pkg/component/observability/monitoring/prometheus/cache/networkpolicy.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/networkpolicy.go
@@ -5,8 +5,6 @@
 package cache
 
 import (
-	_ "embed"
-
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/component/observability/monitoring/prometheus/cache/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/servicemonitors.go
@@ -5,8 +5,6 @@
 package cache
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/component/observability/monitoring/prometheus/garden/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/servicemonitors.go
@@ -5,8 +5,6 @@
 package garden
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -5,8 +5,6 @@
 package longterm
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -5,7 +5,6 @@
 package shoot
 
 import (
-	_ "embed"
 	"strconv"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"

--- a/pkg/component/observability/monitoring/prometheus/shoot/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/servicemonitors.go
@@ -5,8 +5,6 @@
 package shoot
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/component/observability/monitoring/utils/decoder.go
+++ b/pkg/component/observability/monitoring/utils/decoder.go
@@ -5,8 +5,6 @@
 package utils
 
 import (
-	_ "embed"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringv1beta1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1"

--- a/pkg/nodeagent/bootstrap/bootstrap.go
+++ b/pkg/nodeagent/bootstrap/bootstrap.go
@@ -6,7 +6,6 @@ package bootstrap
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"os"
 	"path"

--- a/pkg/provider-local/controller/operatingsystemconfig/actuator.go
+++ b/pkg/provider-local/controller/operatingsystemconfig/actuator.go
@@ -6,7 +6,6 @@ package operatingsystemconfig
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 
 	"github.com/go-logr/logr"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/12204 and https://github.com/gardener/gardener/pull/12576 we have new occurrences of unused `_ "embed"` imports.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
According to chatgpt, there is no golangci-lint linter that catches unused goembed import -  `_ "embed"` import without `//go:embed` directive/comment. 🥲

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
