### PR TITLE
Clean up annotations of kube-apiserver service to purge old load balancer annotations.

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/service.go
+++ b/pkg/component/kubernetes/apiserverexposure/service.go
@@ -126,6 +126,10 @@ func (s *service) Deploy(ctx context.Context) error {
 	obj := s.emptyService()
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, obj, func() error {
+		// TODO(scheererj): Remove this after release of v1.125
+		// Clean up old annotations as unnecessary load balancer annotations may reside on a ClusterIP service.
+		obj.Annotations = map[string]string{}
+
 		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.istio.io/exportTo", "*")
 
 		namespaceSelectors := []metav1.LabelSelector{

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -164,7 +164,6 @@ var _ = Describe("#Service", func() {
 	Context("when service is not in shoot namespace", func() {
 		BeforeEach(func() {
 			expected.Annotations = utils.MergeStringMaps(map[string]string{
-				"foo":                          "bar",
 				"networking.istio.io/exportTo": "*",
 			}, netpolAnnotations())
 		})
@@ -177,7 +176,6 @@ var _ = Describe("#Service", func() {
 			namespace = "shoot-" + expected.Namespace
 
 			expected.Annotations = utils.MergeStringMaps(map[string]string{
-				"foo":                          "bar",
 				"networking.istio.io/exportTo": "*",
 			}, shootNetpolAnnotations())
 			expected.Namespace = namespace


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area networking
/area robustness
/kind cleanup

**What this PR does / why we need it**:

Clean up annotations of kube-apiserver service to purge old load balancer annotations.

Since quite a while SNI routing is the only supported approach for kube-apiserver exposure. This means that the kube-apiserver service in the shoot control plane is a service of type ClusterIP. Unfortunately, for quite a lot of releases
`.spec.settings.loadbalancerServices.annotations` were still added to the annotations of the `kube-apiserver` service. This could lead to load balancer controllers spamming kubernetes events and unnecessarily trying to reconile a service of type ClusterIP.
With this change, the old annoations will be purged and replaced only with the needed ones.

**Which issue(s) this PR fixes**:
Fixes #12280 

**Special notes for your reviewer**:

#11728 fixed the issue for new clusters, but left old clusters as is. Now, all clusters should be cleaned with this change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
All annotations of `kube-apiserver` service in the shoot control planes will be replaced by the minimum required set of annotations. Manually added annotations will be removed.
```
