### PR TITLE
Run Github Release jobs from release branches only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,12 @@ on:
       next-version:
         type: choice
         options:
-          - bump-minor
           - bump-patch
 
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/heads/release-v')
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: write
@@ -20,6 +20,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
+    if: startsWith(github.ref, 'refs/heads/release-v')
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     needs:
       - build


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We run release jobs from release branches only. These branches are created in advance.
With this PR release jobs run on release branches (`release-vX.Y`) only. Additionally, it allows to bump the patch version only. Both changes should reduce the risk of operating errors. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @ccwienk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
