### PR TITLE
gardenadm: Ignore hidden files and folders when loading manifests

### DIFF
--- a/pkg/gardenadm/resources.go
+++ b/pkg/gardenadm/resources.go
@@ -69,13 +69,14 @@ func ReadManifests(log logr.Logger, fsys fs.FS) (Resources, error) {
 			return fmt.Errorf("failed walking directory: %w", err)
 		}
 
+		// stop walking hidden directories entirely
 		if d.IsDir() && d.Name() != "." && strings.HasPrefix(d.Name(), ".") {
 			return fs.SkipDir
 		}
 
-		if d.IsDir() ||
-			strings.HasPrefix(d.Name(), ".") ||
-			(!strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") && !strings.HasSuffix(path, ".json")) {
+		if d.IsDir() || // don't read directories
+			strings.HasPrefix(d.Name(), ".") || // don't read hidden files
+			(!strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") && !strings.HasSuffix(path, ".json")) { // don't read files with unexpected extension
 			return nil
 		}
 

--- a/pkg/gardenadm/resources_test.go
+++ b/pkg/gardenadm/resources_test.go
@@ -64,6 +64,22 @@ var _ = Describe("Resources", func() {
 			Expect(resources.SecretBinding.Name).To(Equal("secretBinding"))
 			Expect(resources.CredentialsBinding.Name).To(Equal("credentialsBinding"))
 		})
+
+		It("should ignore hidden files", func() {
+			// invalid content should not be read
+			fsys[".cloudprofile-foo.yaml"] = &fstest.MapFile{Data: []byte(`{`)}
+
+			_, err := gardenadm.ReadManifests(log, fsys)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should ignore hidden folders", func() {
+			// invalid content should not be read
+			fsys[".hidden/cloudprofile-foo.yaml"] = &fstest.MapFile{Data: []byte(`{`)}
+
+			_, err := gardenadm.ReadManifests(log, fsys)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	When("it cannot parse a file", func() {


### PR DESCRIPTION
**How to categorize this PR?**
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
Ignores hidden directories and files (starting with a  `.`) when loading manifests.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
We stumbled over this when we tried to run `gardenadm` inside a kubernets job, that got the manifests via a mounted secret. `kubelet` creates hidden files like `..data` to ensure atomic updates to mounted secrets/configmaps ([ref](https://github.com/kubernetes/kubernetes/blob/640c5b822e7436a25f3cb0d4a3fd1d68f935b157/pkg/volume/util/atomic_writer.go#L81-L84)), which causes `gardenadm` to read the manifests twice and error with duplicate resources errors.

/cc @timebertt @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
