### PR TITLE
Fix many-to-many matching error in istio dashboards

### DIFF
--- a/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-service-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-service-dashboard.json
@@ -670,7 +670,7 @@
         {
           "datasource": "${datasource}",
           "exemplar": true,
-          "expr": "round(sum(label_replace(irate(istio_requests_total{destination_service=~\"$service\",reporter=~\"source\",source_workload=~\"$srcwl\",source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip), 0.001) * on(pod_ip) group_left (pod) kube_pod_info{host_network=\"false\", pod_ip!=\"\"}",
+          "expr": "round(sum(label_replace(irate(istio_requests_total{destination_service=~\"$service\",reporter=~\"source\",source_workload=~\"$srcwl\",source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip), 0.001) * on(pod_ip) group_left (pod) topk(1, kube_pod_info{host_network=\"false\", pod_ip!=\"\"}) by (pod_ip)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -771,7 +771,7 @@
         {
           "datasource": "${datasource}",
           "exemplar": true,
-          "expr": "sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_service=~\"$service\",response_code!~\"5.*\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) / sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_service=~\"$service\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) * on(pod_ip) group_left (pod) kube_pod_info{host_network=\"false\", pod_ip!=\"\"}",
+          "expr": "sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_service=~\"$service\",response_code!~\"5.*\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) / sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_service=~\"$service\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) * on(pod_ip) group_left (pod) topk(1, kube_pod_info{host_network=\"false\", pod_ip!=\"\"}) by (pod_ip)",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-workload-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-workload-dashboard.json
@@ -677,7 +677,7 @@
         {
           "datasource": "${datasource}",
           "exemplar": true,
-          "expr": "round(sum(label_replace(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\", reporter=~\"source\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip), 0.001) * on(pod_ip) group_left (pod) kube_pod_info{host_network=\"false\", pod_ip!=\"\"}",
+          "expr": "round(sum(label_replace(irate(istio_requests_total{destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\", reporter=~\"source\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip), 0.001) * on(pod_ip) group_left (pod) topk(1, kube_pod_info{host_network=\"false\", pod_ip!=\"\"}) by (pod_ip)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -778,7 +778,7 @@
         {
           "datasource": "${datasource}",
           "exemplar": true,
-          "expr": "sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\",response_code!~\"5.*\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) / sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) * on(pod_ip) group_left (pod) kube_pod_info{host_network=\"false\", pod_ip!=\"\"}",
+          "expr": "sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\",response_code!~\"5.*\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) / sum(label_replace(irate(istio_requests_total{reporter=~\"source\", destination_workload_namespace=~\"$namespace\", destination_workload=~\"$workload\", source_workload=~\"$srcwl\", source_workload_namespace=~\"$srcns\"}[5m]), \"pod_ip\", \"$1\", \"upstream_address\", \"(.*):.*\")) by (source_workload, source_workload_namespace, pod_ip) * on(pod_ip) group_left (pod) topk(1, kube_pod_info{host_network=\"false\", pod_ip!=\"\"}) by (pod_ip)",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
The dashboards introduced in PR #12509 could show a many-to-many matching error.

```
"found duplicate series for the match group {pod_ip=\"10.1.155.88\"} on the right hand-side of the operation: [{__name__=\"kube_pod_info\", created_by_kind=\"ReplicaSet\", created_by_name=\"gardener-admission-controller-fd6f58499\", host_ip=\"172.18.0.2\", host_network=\"false\", instance=\"kube-state-metrics\", job=\"kube-state-metrics\", namespace=\"garden\", node=\"gardener-operator-local-worker2\", pod=\"gardener-admission-controller-fd6f58499-z6gsv\", pod_ip=\"10.1.155.88\", priority_class=\"gardener-garden-system-400\", uid=\"19057011-b4d7-46b9-b14b-487cbc770862\"}, {__name__=\"kube_pod_info\", created_by_kind=\"StatefulSet\", created_by_name=\"prometheus-garden\", host_ip=\"172.18.0.2\", host_network=\"false\", instance=\"kube-state-metrics\", job=\"kube-state-metrics\", namespace=\"garden\", node=\"gardener-operator-local-worker2\", pod=\"prometheus-garden-1\", pod_ip=\"10.1.155.88\", priority_class=\"gardener-garden-system-100\", uid=\"19898772-052f-409f-a842-ad699cb6ac8a\"}];many-to-many matching not allowed: matching labels must be unique on one side"
```

This might happen when `kube-apiserver` pods are rolling. Istio continues to push metrics for a while after a connection has been closed. If the connection has been closed because `kube-apiserver` pods were rolling, their pod IPs could be assigned to different pods while istio still publishes the metric.
In this case plutono shows the error from above and does not show any data in the affected diagram.

**Which issue(s) this PR fixes**:
Fixes #12509

**Special notes for your reviewer**:
We could also fix the issue by using the `METRIC_ROTATION_INTERVAL` feature in istio which was introduced with PR https://github.com/istio/istio/pull/44605.
However, this feature is experimental and potential side effects should be evaluated in detail before using it.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which could cause istio service and workload dashboards to show "many-to-many matching errors" after kube-apiserver pods were rolling has been fixed. 
```
