### PR TITLE
export testresults as inlined ocm-resource

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p /tmp/blobs.d
           if [ '${{ inputs.mode }}' == 'release' ]; then
-            make verify-extended
+            make verify-extended |& tee /tmp/blobs.d/tests-log.txt
+            tar czf /tmp/blobs.d/tests-log.tar.gz -C/tmp/blobs.d tests-log.txt
           else
-             # tests are run using prow for non-release-runs, so early-exit
+            # tests are run using prow for non-release-runs, so early-exit
+            echo "dummy" > /tmp/blobs.d/tests-log.tar.gz
             exit 0
           fi
+      - name: add-tests-report-to-component-descriptor
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
+        with:
+          blobs-directory: /tmp/blobs.d
+          ocm-resources: |
+            name: test-results
+            relation: local
+            access:
+              type: localBlob
+              localReference: tests-log.tar.gz
+            labels:
+              - name: gardener.cloud/purposes
+                value:
+                  - test
 
   sast-lint:
     uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p /tmp/blobs.d
           if [ '${{ inputs.mode }}' == 'release' ]; then
             make verify-extended |& tee /tmp/blobs.d/tests-log.txt
-            tar czf /tmp/blobs.d/tests-log.tar.gz -C/tmp/blobs.d tests-log.txt
+            tar czf /tmp/blobs.d/tests-log.tar.gz -C /tmp/blobs.d tests-log.txt
           else
             # tests are run using prow for non-release-runs, so early-exit
             echo "dummy" > /tmp/blobs.d/tests-log.tar.gz


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind task

**What this PR does / why we need it**:

export testresults as inlined ocm-resource

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
