### PR TITLE
fix: Maintain feature gate `ValidatingAdmissionPolicy` as removed with Kubernetes v1.32

### DIFF
--- a/pkg/utils/validation/features/featuregates.go
+++ b/pkg/utils/validation/features/featuregates.go
@@ -299,7 +299,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"UserNamespacesPodSecurityStandards":               {VersionRange: versionutils.VersionRange{AddedInVersion: "1.29"}},
 	"UserNamespacesStatelessPodsSupport":               {VersionRange: versionutils.VersionRange{RemovedInVersion: "1.28"}},
 	"UserNamespacesSupport":                            {VersionRange: versionutils.VersionRange{AddedInVersion: "1.28"}},
-	"ValidatingAdmissionPolicy":                        {LockedValue: true, LockedToDefaultInVersion: "1.30"},
+	"ValidatingAdmissionPolicy":                        {LockedValue: true, LockedToDefaultInVersion: "1.30", VersionRange: versionutils.VersionRange{RemovedInVersion: "1.32"}},
 	"VolumeAttributesClass":                            {VersionRange: versionutils.VersionRange{AddedInVersion: "1.29"}},
 	"VolumeCapacityPriority":                           {VersionRange: versionutils.VersionRange{RemovedInVersion: "1.33"}},
 	"WatchBookmark":                                    {LockedValue: true, LockedToDefaultInVersion: "1.17", VersionRange: versionutils.VersionRange{RemovedInVersion: "1.33"}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability quality
/kind bug

**What this PR does / why we need it**:

This PR maintains the feature gate `ValidatingAdmissionPolicy` as removed with Kubernetes v1.32.
Otherwise, the `kube-apiserver` crashes when trying to enable this feature gate with Kubernetes versions >= v1.32.

**Which issue(s) this PR fixes**:

Follow-up to: #11020

**Special notes for your reviewer**:

/cc @LucaBernstein @vpnachev

Thanks for bringing this to our attention @vpnachev! 🙏 

We sanity checked the list of added and removed feature gates in the Kubernetes version v1.32 against the code, but did not identify further issues.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The Kubernetes feature gate `ValidatingAdmissionPolicy` is now marked as removed in Kubernetes 1.32. Previously, it was possible to upgrade a Shoot cluster to Kubernetes 1.32 with this feature gate enabled, which resulted in kube-apiserver failing to start due to an unrecognized feature gate.
```
