### PR TITLE
[GEP-28] `gardenadm bootstrap`: Add gardener user to control plane machines

### DIFF
--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -139,7 +139,7 @@ machine-1   Ready    <none>   37s   v1.32.0
 Use the following command to prepare the `gardenadm` medium-touch scenario:
 
 ```shell
-make gardenadm-medium-touch-up
+make gardenadm-up SCENARIO=medium-touch
 ```
 
 This will first build the needed images and then render the needed manifests for `gardenadm bootstrap` to the [`./dev-setup/gardenadm/resources/generated/medium-touch`](../../dev-setup/gardenadm/resources/generated/medium-touch) directory.

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -244,6 +244,7 @@ func (b *AutonomousBotanist) ControlPlaneBootstrapOperatingSystemConfig() (opera
 	return operatingsystemconfig.NewControlPlaneBootstrap(
 		b.Logger,
 		b.SeedClientSet.Client(),
+		b.SecretsManager,
 		&operatingsystemconfig.ControlPlaneBootstrapValues{
 			Namespace:      b.Shoot.ControlPlaneNamespace,
 			Worker:         worker,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR extends the bootstrap OSC introduced in https://github.com/gardener/gardener/pull/12267 to also add the `gardener` user along with the public SSH key to the control plane machines.
With this, we can connect to the control plane machines (via the `Bastion`) using the `ssh-keypair` secret – similar to usual shoot nodes.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @ScheererJ @maboehm @rfranzke 

With this PR, you can manually connect to the control plane machine as follows:

```bash
make kind-up gardenadm-up SCENARIO=medium-touch
export IMAGEVECTOR_OVERWRITE=$PWD/dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml
go run ./cmd/gardenadm bootstrap -d ./dev-setup/gardenadm/resources/generated/medium-touch

machine_ip="$(k -n shoot--garden--root get po -l app=machine -oyaml | yq '.items[0].status.podIP')"

# get the ssh keys for bastion and shoot
k -n shoot--garden--root get secret -l name=bastion-gardenadm-bootstrap-ssh-keypair -oyaml | yq '.items[0].data.id_rsa | @base64d' | tee /tmp/id_rsa_bastion
k -n shoot--garden--root get secret -l name=ssh-keypair -oyaml | yq '.items[0].data.id_rsa | @base64d' | tee /tmp/id_rsa_shoot
# make ssh happy
chmod 0600 /tmp/id_rsa_*
# add ssh keys to ssh agent for simplifying the jump command
ssh-add /tmp/id_rsa_*

# ssh to the machine via the bastion
ssh -t -o "ProxyJump gardener@172.18.255.22" gardener@$machine_ip bash

# should show something like this:
$ id
uid=1000(gardener) gid=1000(gardener) groups=1000(gardener)
$ hostname
machine-shoot--garden--root-control-plane-695dc-nm6xh
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
