### PR TITLE
[GEP-28] Make provider-local machine hostnames resolvable

### DIFF
--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -165,12 +165,6 @@ This webhook reacts on events for the `dependency-watchdog-probe` `Deployment`, 
 All these pods need to be able to resolve the DNS names for shoot clusters.
 It sets the `.spec.dnsPolicy=None` and `.spec.dnsConfig.nameServers` to the cluster IP of the `coredns` `Service` created in the `gardener-extension-provider-local-coredns` namespaces so that these pods can resolve the DNS records for shoot clusters (see the [Bootstrapping section](#bootstrapping) for more details).
 
-#### Machine Controller Manager
-
-This webhook mutates the global `ClusterRole` related to `machine-controller-manager` and injects permissions for `Service` resources.
-The `machine-controller-manager-provider-local` deploys `Pod`s for each `Machine` (while real infrastructure provider obviously deploy VMs, so no Kubernetes resources directly).
-It also deploys a `Service` for these machine pods, and in order to do so, the `ClusterRole` must allow the needed permissions for `Service` resources.
-
 #### Node
 
 This webhook reacts on updates to `nodes/status` in both seed and shoot clusters and sets the `.status.{allocatable,capacity}.cpu="100"` and `.status.{allocatable,capacity}.memory="100Gi"` fields.
@@ -197,14 +191,6 @@ The corresponding test sets the DNS configuration accordingly so that the name r
 
 Out of tree (controller-based) implementation for `local` as a new provider.
 The local out-of-tree provider implements the interface defined at [MCM OOT driver](https://github.com/gardener/machine-controller-manager/blob/master/pkg/util/provider/driver/driver.go).
-
-#### Fundamental Design Principles
-
-Following are the basic principles kept in mind while developing the external plugin.
-
-- Communication between this Machine Controller (MC) and Machine Controller Manager (MCM) is achieved using the Kubernetes native declarative approach.
-- Machine Controller (MC) behaves as the controller used to interact with the `local` provider and manage the VMs corresponding to the machine objects.
-- Machine Controller Manager (MCM) deals with higher level objects such as machine-set and machine-deployment objects.
 
 ## Future Work
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -103,9 +103,10 @@ The shoot worker nodes are `Pod`s with a container based on the `kindest/node` i
 
 #### `Worker`
 
-This controller leverages the standard [generic `Worker` actuator](../../extensions/pkg/controller/worker/genericactuator) in order to deploy the [`machine-controller-manager`](https://github.com/gardener/machine-controller-manager) as well as the [`machine-controller-manager-provider-local`](https://github.com/gardener/machine-controller-manager-provider-local).
+This controller leverages the standard [generic `Worker` actuator](../../extensions/pkg/controller/worker/genericactuator) in order to generate the [`MachineClass`es](https://github.com/gardener/machine-controller-manager-provider-local/blob/master/kubernetes/machine-class.yaml) and the `MachineDeployment`s based on the specification of the `Worker` resource.
 
-Additionally, it generates the [`MachineClass`es](https://github.com/gardener/machine-controller-manager-provider-local/blob/master/kubernetes/machine-class.yaml) and the `MachineDeployment`s based on the specification of the `Worker` resources.
+Additionally, the controller deploys RBAC objects for granting machine-controller-manager additional permissions in the control plane namespace.
+This is needed because the [local machine provider](#machine-controller-manager-provider-local) creates Kubernetes objects in the control plane namespace for starting `Machines`, which is different to all other machine provider implementations.
 
 #### `Bastion`
 

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -192,6 +192,15 @@ The corresponding test sets the DNS configuration accordingly so that the name r
 Out of tree (controller-based) implementation for `local` as a new provider.
 The local out-of-tree provider implements the interface defined at [MCM OOT driver](https://github.com/gardener/machine-controller-manager/blob/master/pkg/util/provider/driver/driver.go).
 
+For every `Machine` object, the [local machine provider](../../pkg/provider-local/machine-provider) creates a `Pod` in the shoot control plane namespace.
+A machine pod uses an [image](../../pkg/provider-local/node) based on [kind's](https://github.com/kubernetes-sigs/kind) node image (`kindest/node`).
+The machine's user data is deployed as a `Secret` in the shoot control plane namespace and mounted into the machine pod.
+In contrast to kind, the local machine image doesn't directly run kubelet as a systemd unit. Instead, it has a unit for running the user data script at `/etc/machine/userdata`.
+
+Typically, machines running in a cloud infrastructure environment can resolve the hostnames of other machines in the same cluster/network.
+To mimic this behavior in the local setup, the machine provider creates a `Service` for every `Machine` with the same name as the `Pod`. 
+With this, local `Nodes` and `Bastions` can connect to other `Nodes` via their hostname.
+
 ## Future Work
 
 Future work could mostly focus on resolving the above listed [limitations](#limitations), i.e.:

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -98,10 +98,6 @@ func wantedExtensionKinds(runsControlPlane bool) sets.Set[string] {
 
 	// In `gardenadm bootstrap`, we create Infrastructure, OSC, and Worker for the control plane of the autonomous shoot
 	// cluster, so we only need these extensions.
-	// TODO(timebertt): consider adding ControlPlane
-	//  While we do not need the ControlPlane object itself, we rely on the ControlPlane webhook to inject the
-	//  machine-controller-manager provider sidecar. However, the webhook might want to read the ControlPlane object for
-	//  reading the providerSpec.
 	return sets.New(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource)
 }
 

--- a/pkg/provider-local/controller/bastion/actuator.go
+++ b/pkg/provider-local/controller/bastion/actuator.go
@@ -155,6 +155,7 @@ func userDataSecretForBastion(bastion *extensionsv1alpha1.Bastion) *corev1.Secre
 func podForBastion(bastion *extensionsv1alpha1.Bastion, image, userDataSecretName string) *corev1.Pod {
 	objectMeta := objectMetaForBastion(bastion)
 	metav1.SetMetaDataLabel(&objectMeta, gardenerutils.NetworkPolicyLabel("machines", SSHPort), v1beta1constants.LabelNetworkPolicyAllowed)
+	metav1.SetMetaDataLabel(&objectMeta, v1beta1constants.LabelNetworkPolicyToDNS, v1beta1constants.LabelNetworkPolicyAllowed)
 
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -21,6 +21,7 @@ const (
 	fieldOwner        = client.FieldOwner("machine-controller-manager-provider-local")
 	labelKeyApp       = "app"
 	labelKeyProvider  = "machine-provider"
+	labelKeyMachine   = "machine"
 	labelValueMachine = "machine"
 	machinePrefix     = "machine-"
 )
@@ -42,6 +43,19 @@ func (d *localDriver) GenerateMachineClassForMigration(_ context.Context, _ *dri
 // InitializeMachine is not implemented.
 func (*localDriver) InitializeMachine(context.Context, *driver.InitializeMachineRequest) (*driver.InitializeMachineResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "InitializeMachine is not yet implemented")
+}
+
+func serviceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName(machine.Name),
+			Namespace: getNamespaceForMachine(machine, machineClass),
+		},
+	}
 }
 
 func podForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Pod {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Typically, machines running in a cloud infrastructure environment can resolve the hostnames of other machines in the same cluster/network. To mimic this behavior in the local setup, the machine provider creates a `Service` for every `Machine` with the same name as the `Pod`. With this, local `Nodes` and `Bastions` can connect to other `Nodes` via their hostname.

When connecting to a `Node` via `gardenctl ssh`, gardenctl prefers the internal IP of a `Node` and falls back to the hostname. With this PR, both addresses also work in provider-local (follow-up to https://github.com/gardener/gardener/pull/12366).

In `gardenadm bootstrap`, we also need to connect to the control plane machines via the `Bastion`. But there is no `Node` object for the `Machines` (see https://github.com/gardener/machine-controller-manager/issues/1007).
Note that this PR alone is not sufficient for successfully connecting from the `Bastion` to the control plane machine, as the hostname is different from the machine name (the pod has an additional `machine-` prefix).
https://github.com/gardener/gardener/pull/12489 will publish to the correct hostname in `Machine.status.addresses`. 
Hence, this PR is rather a "cleanup" for harmonizing the provider-local machines' behavior with typical cloud infrastructure.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @ScheererJ @rfranzke @maboehm 

In draft until
- [x] ~~https://github.com/gardener/gardener/pull/12661 has been merged~~

obsolete with https://github.com/gardener/gardener/pull/12661#issuecomment-3155391741

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The hostname of provider-local `Machines`/`Nodes` can be resolved via DNS, similar to typical cloud infrastructure environments. This allows connecting from a `Bastion` to a `Node` via its hostname.
```
