### PR TITLE
[GEP-28] `gardenadm bootstrap`: Deploy `ControlPlane` resource

### DIFF
--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -96,13 +96,9 @@ func wantedExtensionKinds(runsControlPlane bool) sets.Set[string] {
 		return extensionsv1alpha1.AllExtensionKinds.Clone().Delete(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.WorkerResource)
 	}
 
-	// In `gardenadm bootstrap`, we create Infrastructure, OSC, and Worker for the control plane of the autonomous shoot
-	// cluster, so we only need these extensions.
-	// TODO(timebertt): consider adding ControlPlane
-	//  While we do not need the ControlPlane object itself, we rely on the ControlPlane webhook to inject the
-	//  machine-controller-manager provider sidecar. However, the webhook might want to read the ControlPlane object for
-	//  reading the providerSpec.
-	return sets.New(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource)
+	// In `gardenadm bootstrap`, we create Infrastructure, ControlPlane, OSC, and Worker for the control plane machines
+	// of the autonomous shoot cluster, so we only need these extensions.
+	return sets.New(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.ControlPlaneResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource)
 }
 
 // computeWantedControllerRegistrationNames returns the names of all ControllerRegistrations relevant for the autonomous

--- a/pkg/gardenadm/botanist/extensions_test.go
+++ b/pkg/gardenadm/botanist/extensions_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Extensions", func() {
 		})
 
 		When("not running the control plane", func() {
-			It("should return the Infrastructure, Worker, and OSC extensions", func() {
+			It("should return the Infrastructure, ControlPlane, OSC, and Worker extensions", func() {
 				extensions, err := ComputeExtensions(gardenadm.Resources{
 					Shoot:                   shoot,
 					ControllerRegistrations: controllerRegistrations,
@@ -235,6 +235,18 @@ var _ = Describe("Extensions", func() {
 				}, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(extensions).To(Equal([]Extension{
+					{
+						ControllerRegistration: controllerRegistration1,
+						ControllerDeployment:   controllerDeploymentWithoutInjectGardenKubeconfig(controllerDeployment1),
+						ControllerInstallation: &gardencorev1beta1.ControllerInstallation{
+							ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration1.Name},
+							Spec: gardencorev1beta1.ControllerInstallationSpec{
+								RegistrationRef: corev1.ObjectReference{Name: controllerRegistration1.Name},
+								DeploymentRef:   &corev1.ObjectReference{Name: controllerDeployment1.Name},
+								SeedRef:         corev1.ObjectReference{Name: shoot.Name},
+							},
+						},
+					},
 					{
 						ControllerRegistration: controllerRegistration2,
 						ControllerDeployment:   controllerDeploymentWithoutInjectGardenKubeconfig(controllerDeployment2),

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -47,7 +47,7 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 			Eventually(ctx, session.Err).Should(gbytes.Say("Using auto-detected public IP addresses as bastion ingress CIDRs"))
 		}, SpecTimeout(time.Minute))
 
-		It("should find the cloud provider secret", func(ctx SpecContext) {
+		It("should deploy the cloud provider secret", func(ctx SpecContext) {
 			cloudProviderSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloudprovider", Namespace: technicalID}}
 			Eventually(ctx, Object(cloudProviderSecret)).Should(HaveField("ObjectMeta.Labels", HaveKeyWithValue("gardener.cloud/purpose", "cloudprovider")))
 		}, SpecTimeout(time.Minute))
@@ -62,9 +62,14 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 			Eventually(ctx, Object(deployment)).Should(BeHealthy(health.CheckDeployment))
 		}, SpecTimeout(time.Minute))
 
-		It("should deploy the infrastructure", func(ctx SpecContext) {
+		It("should deploy the Infrastructure", func(ctx SpecContext) {
 			infra := &extensionsv1alpha1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: technicalID}}
 			Eventually(ctx, Object(infra)).Should(BeHealthy(health.CheckExtensionObject))
+		}, SpecTimeout(time.Minute))
+
+		It("should deploy the ControlPlane", func(ctx SpecContext) {
+			controlPlane := &extensionsv1alpha1.ControlPlane{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: technicalID}}
+			Eventually(ctx, Object(controlPlane)).Should(BeHealthy(health.CheckExtensionObject))
 		}, SpecTimeout(time.Minute))
 
 		It("should deploy machine-controller-manager", func(ctx SpecContext) {
@@ -83,7 +88,7 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 			), "should be healthy and not have default (open) ingress CIDRs")
 		}, SpecTimeout(time.Minute))
 
-		It("should deploy the worker", func(ctx SpecContext) {
+		It("should deploy the Worker", func(ctx SpecContext) {
 			worker := &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: technicalID}}
 			Eventually(ctx, Object(worker)).Should(BeHealthy(health.CheckExtensionObject))
 		}, SpecTimeout(5*time.Minute))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `ControlPlane` resource to `gardenadm bootstrap` to allow extensions to deploy additional provider-specific resources, e.g, for the machine-controller-manager provider (first use case: https://github.com/gardener/gardener/pull/12657).
The `ControlPlane` controller is expected to skip the deployment of unneeded components like cloud-controller-manager and CSI driver controller (see docs in the first commit). If using the generic actuator from the extensions library, most things are already taken care of.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ @maboehm 

Also see the previous discussion in https://github.com/gardener/gardener/pull/12152#discussion_r2101791556.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Extension developers need to adapt the `ControlPlane` controller implementation for supporting autonomous shoot clusters (`gardenadm bootstrap`) as explained in [this document](https://github.com/gardener/gardener/blob/master/docs/extensions/resources/controlplane.md#supporting-autonomous-shoot-clusters-gardenadm-bootstrap).
```
