### PR TITLE
Fix wrong sandbox image path in containerd/config.toml v3

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -55,7 +55,7 @@ var (
 		},
 		3: {
 			registryConfigPath: {"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
-			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.runtime", "sandbox_image"},
+			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"},
 			cgroupDriverPath:   {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
 		},

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -189,7 +189,7 @@ var _ = Describe("containerd configuration file tests", func() {
 			structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "cni", "bin_dir"},
 		),
 		Entry("for containerd config file v3", "testfiles/containerd-config.toml-v3",
-			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "sandbox_image"},
+			structuredmap.Path{"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"},
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:

With PR #11623 the paths for various configuration items in `containerd/config.toml` are retrieved from a look-up table depending on the version of the `containerd/config.toml` file. Unfortunately, said PR contained an error for the sandbox image configuration which results in containerd 2.x always using the default `registry.k8s.io/pause:3.10`. This will not work in environments that cannot access the `registry.k8s.io` container registry and nodes with containerd 2.x in such environments will not be able to join the cluster.

With containerd 2.x (and thus `containerd/config.toml` v3), the sandbox image is configured at `[plugins.'io.containerd.cri.v1.images'.pinned_images]` according to https://github.com/containerd/containerd/blob/e2404157c476efcf0ecf6cd49aa3c7ed8a26c858/docs/cri/config.md?plain=1#L189-L190.

This PR fixes the wrong path so that the sandbox image location can be properly configured to a custom image with containerd 2.x.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug in `gardener-node-agent` that prevented the location for the sandbox image to be configurable to a custom value on worker nodes with containerd 2.x was fixed.
```
