### PR TITLE
Harden `(Namespaced)CloudProfile` field validation

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -458,6 +458,8 @@ func validateCapabilities(capabilities []core.CapabilityDefinition, fldPath *fie
 	for key, value := range capabilityMap {
 		if key == "" {
 			allErrs = append(allErrs, field.Required(fldPath, "capability keys must not be empty"))
+		} else if errs := validateUnprefixedQualifiedName(key); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath, key, "capability key must be qualified name: "+strings.Join(errs, ", ")))
 		}
 		if len(value) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child(key), "capability values must not be empty"))
@@ -465,6 +467,8 @@ func validateCapabilities(capabilities []core.CapabilityDefinition, fldPath *fie
 		for i, v := range value {
 			if v == "" {
 				allErrs = append(allErrs, field.Required(fldPath.Child(key).Index(i), "capability values must not be empty"))
+			} else if errs := validateUnprefixedQualifiedName(v); len(errs) > 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child(key).Index(i), v, "capability value must be qualified name: "+strings.Join(errs, ", ")))
 			}
 		}
 	}

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -233,6 +233,9 @@ func validateContainerRuntimes(containerRuntimes []core.ContainerRuntime, fldPat
 	duplicateCR := sets.Set[string]{}
 
 	for i, cr := range containerRuntimes {
+		if errs := validateUnprefixedQualifiedName(cr.Type); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("type"), cr.Type, fmt.Sprintf("container runtime type must be a qualified name: %v", errs)))
+		}
 		if duplicateCR.Has(cr.Type) {
 			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("type"), cr.Type))
 		}

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -905,6 +905,36 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				}))))
 			})
 
+			It("should forbid invalid container runtime types", func() {
+				cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []core.CRI{
+					{
+						Name: core.CRINameContainerD,
+						ContainerRuntimes: []core.ContainerRuntime{
+							{
+								Type: "no-emoji-🪴",
+							},
+							{
+								Type: "no spaces",
+							},
+						},
+					},
+				}
+
+				errorList := ValidateCloudProfile(cloudProfile)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.machineImages[0].versions[0].cri[0].containerRuntimes[0].type"),
+						"Detail": ContainSubstring("container runtime type must be a qualified name"),
+					})), PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.machineImages[0].versions[0].cri[0].containerRuntimes[1].type"),
+						"Detail": ContainSubstring("container runtime type must be a qualified name"),
+					})),
+				))
+			})
+
 			Context("machine types validation", func() {
 				It("should enforce that at least one machine type has been defined", func() {
 					cloudProfile.Spec.MachineTypes = []core.MachineType{}

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -331,6 +331,8 @@ func validateVolumeTypes(volumeTypes []core.VolumeType, fldPath *field.Path) fie
 
 		if len(volumeType.Class) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("class"), "must provide a class"))
+		} else if errs := validateUnprefixedQualifiedName(volumeType.Class); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("class"), volumeType.Class, fmt.Sprintf("volume class must be a qualified name: %v", errs)))
 		}
 
 		if volumeType.MinSize != nil {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -284,6 +284,8 @@ func validateMachineTypes(machineTypes []core.MachineType, capabilities core.Cap
 
 		if len(machineType.Name) == 0 {
 			allErrs = append(allErrs, field.Required(namePath, "must provide a name"))
+		} else if errs := validateUnprefixedQualifiedName(machineType.Name); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("name"), machineType.Name, fmt.Sprintf("machine type name must be a qualified name: %v", errs)))
 		}
 
 		if names.Has(machineType.Name) {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -238,7 +238,7 @@ func ValidateMachineImages(machineImages []core.MachineImage, capabilities core.
 
 			if machineVersion.InPlaceUpdates != nil && machineVersion.InPlaceUpdates.MinVersionForUpdate != nil {
 				if _, err = semver.NewVersion(*machineVersion.InPlaceUpdates.MinVersionForUpdate); err != nil {
-					allErrs = append(allErrs, field.Invalid(versionsPath.Child("minVersionForInPlaceUpdate"), machineVersion.Version, "could not parse version. Use a semantic version."))
+					allErrs = append(allErrs, field.Invalid(versionsPath.Child("minVersionForInPlaceUpdate"), *machineVersion.InPlaceUpdates.MinVersionForUpdate, "could not parse version. Use a semantic version."))
 				}
 			}
 

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -206,6 +206,8 @@ func ValidateMachineImages(machineImages []core.MachineImage, capabilities core.
 
 		if len(image.Name) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "machine image name must not be empty"))
+		} else if errs := validation.IsQualifiedName(image.Name); len(errs) > 0 || strings.Contains(image.Name, "/") {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), image.Name, fmt.Sprintf("machine image name must be a qualified name: %v", errs)))
 		}
 
 		if len(image.Versions) == 0 && !allowEmptyVersions {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -319,6 +319,8 @@ func validateVolumeTypes(volumeTypes []core.VolumeType, fldPath *field.Path) fie
 		namePath := idxPath.Child("name")
 		if len(volumeType.Name) == 0 {
 			allErrs = append(allErrs, field.Required(namePath, "must provide a name"))
+		} else if errs := validateUnprefixedQualifiedName(volumeType.Name); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), volumeType.Name, fmt.Sprintf("volume type name must be a qualified name: %v", errs)))
 		}
 
 		if names.Has(volumeType.Name) {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -206,7 +206,7 @@ func ValidateMachineImages(machineImages []core.MachineImage, capabilities core.
 
 		if len(image.Name) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "machine image name must not be empty"))
-		} else if errs := validation.IsQualifiedName(image.Name); len(errs) > 0 || strings.Contains(image.Name, "/") {
+		} else if errs := validateUnprefixedQualifiedName(image.Name); len(errs) != 0 {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), image.Name, fmt.Sprintf("machine image name must be a qualified name: %v", errs)))
 		}
 
@@ -257,6 +257,16 @@ func ValidateMachineImages(machineImages []core.MachineImage, capabilities core.
 	}
 
 	return allErrs
+}
+
+func validateUnprefixedQualifiedName(name string) []string {
+	if errs := validation.IsQualifiedName(name); len(errs) > 0 {
+		return errs
+	}
+	if strings.Contains(name, "/") {
+		return []string{fmt.Sprintf("name '%s' must not contain a prefix", name)}
+	}
+	return nil
 }
 
 // validateMachineTypes validates the given list of machine types for valid values and combinations.

--- a/pkg/apis/core/validation/utils_test.go
+++ b/pkg/apis/core/validation/utils_test.go
@@ -242,4 +242,29 @@ var _ = Describe("Utils tests", func() {
 			),
 		),
 	)
+
+	Describe("#ValidateMachineImages", func() {
+		DescribeTable("should not allow invalid machine image names",
+			func(name string, shouldFail bool) {
+				validationResult := ValidateMachineImages([]core.MachineImage{{Name: name}}, nil, field.NewPath("spec", "machineImages"), true)
+
+				if shouldFail {
+					Expect(validationResult).
+						To(ConsistOf(
+							PointTo(MatchFields(IgnoreExtras, Fields{
+								"Type":   Equal(field.ErrorTypeInvalid),
+								"Field":  Equal("spec.machineImages[0].name"),
+								"Detail": ContainSubstring("machine image name must be a qualified name"),
+							})),
+						))
+				} else {
+					Expect(validationResult).To(BeEmpty())
+				}
+			},
+			Entry("forbid emoji characters", "🪴", true),
+			Entry("forbid whitespaces", "special image", true),
+			Entry("forbid slashes", "nested/image", true),
+			Entry("pass with dashes", "qualified-name", false),
+		)
+	})
 })

--- a/pkg/apis/core/validation/utils_test.go
+++ b/pkg/apis/core/validation/utils_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Utils tests", func() {
 			Entry("forbid emoji characters", "🪴", true),
 			Entry("forbid whitespaces", "special image", true),
 			Entry("forbid slashes", "nested/image", true),
-			Entry("pass with dashes and dots", "quali.fied-name", false),
+			Entry("pass with dashes and dots", "a.qualified-name", false),
 		)
 
 		DescribeTable("should not allow invalid volume type names",
@@ -342,7 +342,7 @@ var _ = Describe("Utils tests", func() {
 			Entry("forbid emoji characters", "🪴", true),
 			Entry("forbid whitespaces", "special image", true),
 			Entry("forbid slashes", "nested/image", true),
-			Entry("pass with dashes and dots", "quali.fied-name", false),
+			Entry("pass with dashes and dots", "a.qualified-name", false),
 		)
 
 		DescribeTable("should not allow invalid volume type class",
@@ -368,7 +368,7 @@ var _ = Describe("Utils tests", func() {
 			Entry("forbid emoji characters", "🪴", true),
 			Entry("forbid whitespaces", "special image", true),
 			Entry("forbid slashes", "nested/image", true),
-			Entry("pass with dashes and dots", "quali.fied-name", false),
+			Entry("pass with dashes and dots", "a.qualified-name", false),
 		)
 	})
 })

--- a/pkg/apis/core/validation/utils_test.go
+++ b/pkg/apis/core/validation/utils_test.go
@@ -344,5 +344,31 @@ var _ = Describe("Utils tests", func() {
 			Entry("forbid slashes", "nested/image", true),
 			Entry("pass with dashes and dots", "quali.fied-name", false),
 		)
+
+		DescribeTable("should not allow invalid volume type class",
+			func(name string, shouldFail bool) {
+				spec := specTemplate.DeepCopy()
+				spec.VolumeTypes[0].Class = name
+
+				validationResult := ValidateCloudProfileSpec(spec, field.NewPath("spec"))
+
+				if shouldFail {
+					Expect(validationResult).
+						To(ConsistOf(
+							PointTo(MatchFields(IgnoreExtras, Fields{
+								"Type":   Equal(field.ErrorTypeInvalid),
+								"Field":  Equal("spec.volumeTypes[0].class"),
+								"Detail": ContainSubstring("volume class must be a qualified name"),
+							})),
+						))
+				} else {
+					Expect(validationResult).To(BeEmpty())
+				}
+			},
+			Entry("forbid emoji characters", "🪴", true),
+			Entry("forbid whitespaces", "special image", true),
+			Entry("forbid slashes", "nested/image", true),
+			Entry("pass with dashes and dots", "quali.fied-name", false),
+		)
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness security usability
/kind enhancement

**What this PR does / why we need it**:
Add more strict validation to multiple fields in the (Namespaced)CloudProfile specs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new validation for the following `(Namespaced)CloudProfile` fields has been added, ensuring qualified names:
- `.spec.machineImages[].name`
- `.spec.machineImages[].versions[].cri[].containerRuntimes[].type`
- `.spec.machineTypes[].name`
- `.spec.capabilities.name`
- `.spec.capabilities.values`
- `.spec.volumeTypes[].class`
- `.spec.volumeTypes[].name`
```
