### PR TITLE
Allow non-canonical IPv6 addresses in `DNSRecord` validation.

### DIFF
--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -6,6 +6,7 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"slices"
 	"strings"
 
@@ -112,9 +113,20 @@ func validateValue(recordType extensionsv1alpha1.DNSRecordType, value string, fl
 
 	switch recordType {
 	case extensionsv1alpha1.DNSRecordTypeA, extensionsv1alpha1.DNSRecordTypeAAAA:
-		allErrs = append(allErrs, validation.IsValidIP(fldPath, value)...)
+		allErrs = append(allErrs, isValidIP(fldPath, value)...)
 	case extensionsv1alpha1.DNSRecordTypeCNAME:
 		allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath, value)...)
 	}
+	return allErrs
+}
+
+func isValidIP(fldPath *field.Path, value string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	ip := net.ParseIP(value)
+	if ip == nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, value, "must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"))
+	}
+
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -186,6 +186,14 @@ var _ = Describe("DNSRecord validation tests", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
+		It("should allow valid resources (type AAAA) with non-canonical value", func() {
+			dns.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeAAAA
+			dns.Spec.Values = []string{"2001:db8:f00:0:0:0:0:1"}
+
+			errorList := ValidateDNSRecord(dns)
+			Expect(errorList).To(BeEmpty())
+		})
+
 		It("should allow valid resources (type TXT)", func() {
 			dns.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeTXT
 			dns.Spec.Values = []string{"can be anything"}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Allow non-canonical IPv6 addresses in `DNSRecord` validation.

Previously, the validation of `DNSRecord` resources checked the validity of IP addresses using a helper function from kubernetes. However, this function disallows non-canonical IPv6 addresses, e.g. 2001:db8:0:0:0:0:0:1. Unfortunately, there are some infrastructures, e.g. GCP, which use non-canonical IPv6 addresses for resources like load balancers. It also seems reasonable to allow them in `DNSRecord` resources.
This change adapts the validation accordingly so that non-canonical IPv6 addresses are allowed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`DNSRecord` may now use non-canonical IPv6 addresses.
```

/cc @MartinWeindel