### PR TITLE
[GEP-28] `gardenadm bootstrap`: Compile `ShootState`

### DIFF
--- a/pkg/component/deploy.go
+++ b/pkg/component/deploy.go
@@ -132,3 +132,13 @@ func (d *deploy) WaitCleanup(ctx context.Context) error {
 
 	return nil
 }
+
+// MigrateAndWait returns a function that calls Migrate and then WaitMigrate on the given DeployMigrateWaiter.
+func MigrateAndWait(dw DeployMigrateWaiter) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if err := dw.Migrate(ctx); err != nil {
+			return err
+		}
+		return dw.WaitMigrate(ctx)
+	}
+}

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -228,11 +228,11 @@ func run(ctx context.Context, opts *Options) error {
 		// the autonomous shoot.
 		deleteMachineControllerManager = g.Add(flow.Task{
 			Name:         "Deleting machine-controller-manager",
-			Fn:           component.OpDestroyAndWait(b.Shoot.Components.ControlPlane.MachineControllerManager).Deploy,
+			Fn:           component.OpDestroyAndWait(b.Shoot.Components.ControlPlane.MachineControllerManager).Destroy,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 
-		// In contrast to the usual Shoot migrate flow, we don't delete the extension objects are executing the migrate
+		// In contrast to the usual Shoot migrate flow, we don't delete the extension objects after executing the migrate
 		// operation. The extension controllers are supposed to skip any reconcile operation if the last operation is of
 		// type "Migrate". Also, this makes it easier to allow re-running `gardenadm bootstrap` in case of failures
 		// down the line. If we deleted the extension objects, we would need to restore them when re-running the flow.

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -316,6 +316,7 @@ build:
             - pkg/utils/gardener/gardenlet
             - pkg/utils/gardener/operator
             - pkg/utils/gardener/secretsrotation
+            - pkg/utils/gardener/shootstate
             - pkg/utils/gardener/tokenrequest
             - pkg/utils/imagevector
             - pkg/utils/istio


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR continues the implementation of the `gardenadm bootstrap` flow. 
After all relevant extensions have been deployed (`Infrastructure` and `Worker`) for preparing the control plane infrastructure and machines, we trigger the `migrate` operation and compile the `ShootState` (similar to the usual shoot control plane migration). The `ShootState` includes all objects and state that we need for migrating the objects to the autonomous shoot itself, where `gardenadm init` should eventually pick it up along with the other manifests.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @ScheererJ @rfranzke @maboehm

In draft until

- [x] ~~https://github.com/gardener/gardener/pull/12661 has been merged~~

obsolete with https://github.com/gardener/gardener/pull/12661#issuecomment-3155391741

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
