### PR TITLE
Grant Viewer/Admin permissions in the shoot to new groups "gardener.cloud:(project|system):(admins|viewers)"

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -23,7 +24,9 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
+	shootsystem "github.com/gardener/gardener/pkg/component/shoot/system"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -48,7 +51,17 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 		return fmt.Errorf("failed deleting nginx ingress controller resource lock configmaps: %w", err)
 	}
 
-	return cleanupPrometheusObsoleteFolders(ctx, log, g.mgr.GetClient())
+	log.Info("Cleaning up prometheus obsolete folders")
+	if err := cleanupPrometheusObsoleteFolders(ctx, log, g.mgr.GetClient()); err != nil {
+		return fmt.Errorf("failed cleaning up prometheus obsolete folders: %w", err)
+	}
+
+	log.Info("Migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig")
+	if err := migrateAdminViewerKubeconfigClusterRoleBindings(ctx, log, g.mgr.GetClient()); err != nil {
+		return fmt.Errorf("failed migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig: %w", err)
+	}
+
+	return nil
 }
 
 // TODO: Remove this function when Kubernetes 1.27 support gets dropped.
@@ -398,4 +411,62 @@ func cleanupPrometheusObsoleteFolders(ctx context.Context, log logr.Logger, seed
 	}
 
 	return flow.Parallel(tasks...)(ctx)
+}
+
+// TODO(@vpnachev): Remove this after v1.127.0 has been released
+func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log logr.Logger, seedClient client.Client) error {
+	namespaceList := &corev1.NamespaceList{}
+	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
+		return fmt.Errorf("failed listing namespaces: %w", err)
+	}
+
+	var tasks []flow.TaskFn
+
+	for _, namespace := range namespaceList.Items {
+		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
+			continue
+		}
+
+		tasks = append(tasks, func(ctx context.Context) error {
+			managedResource := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace.Name,
+					Name:      shootsystem.ManagedResourceName,
+				},
+			}
+			if err := seedClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
+				return fmt.Errorf("failed to get ManagedResource %q: %w", client.ObjectKeyFromObject(managedResource), err)
+			}
+
+			if managedResource.DeletionTimestamp != nil {
+				return nil
+			}
+
+			objects, err := managedresources.GetObjects(ctx, seedClient, managedResource.Namespace, managedResource.Name)
+			if err != nil {
+				return fmt.Errorf("failed to get objects for ManagedResource %q: %w", client.ObjectKeyFromObject(managedResource), err)
+			}
+
+			crbs := []string{v1beta1constants.ShootProjectAdminsGroupName, v1beta1constants.ShootProjectViewersGroupName, v1beta1constants.ShootSystemAdminsGroupName, v1beta1constants.ShootSystemViewersGroupName}
+			objects = slices.DeleteFunc(objects, func(obj client.Object) bool {
+				return slices.Contains(crbs, obj.GetName())
+			})
+
+			objects = append(objects, shootsystem.ClusterRoleBindings()...)
+
+			log.Info("Migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig access in managed resource", "managedResource", client.ObjectKeyFromObject(managedResource))
+			registry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+			resources, err := registry.AddAllAndSerialize(objects...)
+			if err != nil {
+				return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", client.ObjectKeyFromObject(managedResource), err)
+			}
+
+			return managedresources.CreateForShoot(ctx, seedClient, managedResource.Namespace, managedResource.Name, managedresources.LabelValueGardener, false, resources)
+		})
+	}
+
+	if err := flow.Parallel(tasks...)(ctx); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -812,18 +812,20 @@ const (
 	// GardenerReadOnlyClusterRoleName is the name of a cluster role allowing read-only access to a shoot cluster.
 	GardenerReadOnlyClusterRoleName = "gardener.cloud:system:read-only"
 	// GardenerSystemAdminsGroupName is a group assigned to gardener system administrators
-	// when they are using the AdminKubeconfig to access a shoot cluster.
+	// when they request an AdminKubeconfig to access a shoot cluster.
 	GardenerSystemAdminsGroupName = "gardener.cloud:system:admins"
 	// GardenerSystemViewersGroupName is a group assigned to gardener system viewers
-	// when they are using the ViewerKubeconfig to access a shoot cluster.
+	// when they request a ViewerKubeconfig to access a shoot cluster.
 	GardenerSystemViewersGroupName = "gardener.cloud:system:viewers"
-	// GardenerProjectAdminsGroupName is a group assigned to gardener project administrators,
-	// or other users allowed to create shoot/adminkubeconfig on the shoot but not system administrator,
-	// when they are using the AdminKubeconfig to access a shoot cluster.
+	// GardenerProjectAdminsGroupName is a group assigned during AdminKubeconfig generation to
+	// gardener project administrators or other users allowed to request an AdminKubeconfig.
+	// System administrators do not get assigned to this group when requesting an AdminKubeconfig.
+	// Instead, they are assigned to the group "gardener.cloud:system:admins".
 	GardenerProjectAdminsGroupName = "gardener.cloud:project:admins"
-	// GardenerProjectViewersGroupName is a group assigned to gardener project viewers,
-	// or other users allowed to create shoot/viewerkubeconfig on the shoot but not system viewers,
-	// when they are using the ViewerKubeconfig to access a shoot cluster.
+	// GardenerProjectViewersGroupName is a group assigned during ViewerKubeconfig generation to
+	// gardener project viewers or other users allowed to request a ViewerKubeconfig.
+	// System viewers do not get assigned to this group when requesting a ViewerKubeconfig.
+	// Instead, they are assigned to the group "gardener.cloud:system:viewers".
 	GardenerProjectViewersGroupName = "gardener.cloud:project:viewers"
 
 	// ProjectName is the key of a label on namespaces whose value holds the project name.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -809,6 +809,23 @@ const (
 	// for administrators.
 	ClusterRoleNameGardenerAdministrators = "gardener.cloud:system:administrators"
 
+	// GardenerReadOnlyClusterRoleName is the name of a cluster role allowing read-only access to a shoot cluster.
+	GardenerReadOnlyClusterRoleName = "gardener.cloud:system:read-only"
+	// GardenerSystemAdminsGroupName is a group assigned to gardener system administrators
+	// when they are using the AdminKubeconfig to access a shoot cluster.
+	GardenerSystemAdminsGroupName = "gardener.cloud:system:admins"
+	// GardenerSystemViewersGroupName is a group assigned to gardener system viewers
+	// when they are using the ViewerKubeconfig to access a shoot cluster.
+	GardenerSystemViewersGroupName = "gardener.cloud:system:viewers"
+	// GardenerProjectAdminsGroupName is a group assigned to gardener project administrators,
+	// or other users allowed to create shoot/adminkubeconfig on the shoot but not system administrator,
+	// when they are using the AdminKubeconfig to access a shoot cluster.
+	GardenerProjectAdminsGroupName = "gardener.cloud:project:admins"
+	// GardenerProjectViewersGroupName is a group assigned to gardener project viewers,
+	// or other users allowed to create shoot/viewerkubeconfig on the shoot but not system viewers,
+	// when they are using the ViewerKubeconfig to access a shoot cluster.
+	GardenerProjectViewersGroupName = "gardener.cloud:project:viewers"
+
 	// ProjectName is the key of a label on namespaces whose value holds the project name.
 	ProjectName = "project.gardener.cloud/name"
 	// ProjectSkipStaleCheck is the key of an annotation on a project namespace that marks the associated Project to be

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -802,31 +802,29 @@ const (
 	// SeedUserNamePrefix is the identity user name prefix for gardenlets when authenticating to the API server.
 	SeedUserNamePrefix = "gardener.cloud:system:seed:"
 
-	// ShootGroupViewers is a constant for a group name in shoot clusters whose users get read-only privileges (except
-	// for core/v1.Secrets).
-	ShootGroupViewers = "gardener.cloud:system:viewers"
 	// ClusterRoleNameGardenerAdministrators is the name of a cluster role in the garden cluster defining privileges
 	// for administrators.
 	ClusterRoleNameGardenerAdministrators = "gardener.cloud:system:administrators"
 
-	// GardenerReadOnlyClusterRoleName is the name of a cluster role allowing read-only access to a shoot cluster.
-	GardenerReadOnlyClusterRoleName = "gardener.cloud:system:read-only"
-	// GardenerSystemAdminsGroupName is a group assigned to gardener system administrators
+	// ShootReadOnlyClusterRoleName is the name of a cluster role allowing read-only access to resources
+	// in a shoot cluster, except core/v1.Secrets and those that are encrypted in the ETCD.
+	ShootReadOnlyClusterRoleName = "gardener.cloud:system:read-only"
+	// ShootSystemAdminsGroupName is a group assigned to gardener system administrators
 	// when they request an AdminKubeconfig to access a shoot cluster.
-	GardenerSystemAdminsGroupName = "gardener.cloud:system:admins"
-	// GardenerSystemViewersGroupName is a group assigned to gardener system viewers
+	ShootSystemAdminsGroupName = "gardener.cloud:system:admins"
+	// ShootSystemViewersGroupName is a group assigned to gardener system viewers
 	// when they request a ViewerKubeconfig to access a shoot cluster.
-	GardenerSystemViewersGroupName = "gardener.cloud:system:viewers"
-	// GardenerProjectAdminsGroupName is a group assigned during AdminKubeconfig generation to
+	ShootSystemViewersGroupName = "gardener.cloud:system:viewers"
+	// ShootProjectAdminsGroupName is a group assigned during AdminKubeconfig generation to
 	// gardener project administrators or other users allowed to request an AdminKubeconfig.
 	// System administrators do not get assigned to this group when requesting an AdminKubeconfig.
 	// Instead, they are assigned to the group "gardener.cloud:system:admins".
-	GardenerProjectAdminsGroupName = "gardener.cloud:project:admins"
-	// GardenerProjectViewersGroupName is a group assigned during ViewerKubeconfig generation to
+	ShootProjectAdminsGroupName = "gardener.cloud:project:admins"
+	// ShootProjectViewersGroupName is a group assigned during ViewerKubeconfig generation to
 	// gardener project viewers or other users allowed to request a ViewerKubeconfig.
 	// System viewers do not get assigned to this group when requesting a ViewerKubeconfig.
 	// Instead, they are assigned to the group "gardener.cloud:system:viewers".
-	GardenerProjectViewersGroupName = "gardener.cloud:project:viewers"
+	ShootProjectViewersGroupName = "gardener.cloud:project:viewers"
 
 	// ProjectName is the key of a label on namespaces whose value holds the project name.
 	ProjectName = "project.gardener.cloud/name"

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
@@ -39,6 +39,6 @@ func NewViewerKubeconfigREST(
 		newObjectFunc: func() runtime.Object {
 			return &authenticationv1alpha1.ViewerKubeconfigRequest{}
 		},
-		clientCertificateOrganization: v1beta1constants.ShootGroupViewers,
+		clientCertificateOrganization: v1beta1constants.ShootSystemViewersGroupName,
 	}
 }

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -436,7 +436,7 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: v1beta1constants.GardenerReadOnlyClusterRoleName,
+			Name: v1beta1constants.ShootReadOnlyClusterRoleName,
 		},
 		Rules: make([]rbacv1.PolicyRule, 0, len(allAPIGroups)),
 	}
@@ -453,32 +453,32 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 		clusterRole,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.GardenerSystemViewersGroupName,
+				Name:        v1beta1constants.ShootSystemViewersGroupName,
 				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
 				Kind:     "ClusterRole",
-				Name:     v1beta1constants.GardenerReadOnlyClusterRoleName,
+				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
 			},
 			Subjects: []rbacv1.Subject{{
 				Kind: rbacv1.GroupKind,
-				Name: v1beta1constants.GardenerSystemViewersGroupName,
+				Name: v1beta1constants.ShootSystemViewersGroupName,
 			}},
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.GardenerProjectViewersGroupName,
+				Name:        v1beta1constants.ShootProjectViewersGroupName,
 				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
 				Kind:     "ClusterRole",
-				Name:     v1beta1constants.GardenerReadOnlyClusterRoleName,
+				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
 			},
 			Subjects: []rbacv1.Subject{{
 				Kind: rbacv1.GroupKind,
-				Name: v1beta1constants.GardenerProjectViewersGroupName,
+				Name: v1beta1constants.ShootProjectViewersGroupName,
 			}},
 		},
 	}
@@ -505,7 +505,7 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 	return []client.Object{
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.GardenerSystemAdminsGroupName,
+				Name:        v1beta1constants.ShootSystemAdminsGroupName,
 				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -516,7 +516,7 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 			Subjects: []rbacv1.Subject{
 				{
 					Kind: rbacv1.GroupKind,
-					Name: v1beta1constants.GardenerSystemAdminsGroupName,
+					Name: v1beta1constants.ShootSystemAdminsGroupName,
 				},
 				{
 					Kind: rbacv1.GroupKind,
@@ -526,7 +526,7 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.GardenerProjectAdminsGroupName,
+				Name:        v1beta1constants.ShootProjectAdminsGroupName,
 				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -537,7 +537,7 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 			Subjects: []rbacv1.Subject{
 				{
 					Kind: rbacv1.GroupKind,
-					Name: v1beta1constants.GardenerProjectAdminsGroupName,
+					Name: v1beta1constants.ShootProjectAdminsGroupName,
 				},
 				{
 					Kind: rbacv1.GroupKind,

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -19,7 +19,6 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -515,17 +514,11 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 				Kind:     "ClusterRole",
 				Name:     "cluster-admin",
 			},
-			Subjects: []rbacv1.Subject{
-				{
-					APIGroup: rbacv1.GroupName,
-					Kind:     rbacv1.GroupKind,
-					Name:     v1beta1constants.ShootSystemAdminsGroupName,
-				},
-				{
-					Kind: rbacv1.GroupKind,
-					Name: user.SystemPrivilegedGroup, // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
-				},
-			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.GroupName,
+				Kind:     rbacv1.GroupKind,
+				Name:     v1beta1constants.ShootSystemAdminsGroupName,
+			}},
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
@@ -537,17 +530,11 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 				Kind:     "ClusterRole",
 				Name:     "cluster-admin",
 			},
-			Subjects: []rbacv1.Subject{
-				{
-					APIGroup: rbacv1.GroupName,
-					Kind:     rbacv1.GroupKind,
-					Name:     v1beta1constants.ShootProjectAdminsGroupName,
-				},
-				{
-					Kind: rbacv1.GroupKind,
-					Name: user.SystemPrivilegedGroup, // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
-				},
-			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.GroupName,
+				Kind:     rbacv1.GroupKind,
+				Name:     v1beta1constants.ShootProjectAdminsGroupName,
+			}},
 		},
 	}
 }

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -462,8 +462,9 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
 			},
 			Subjects: []rbacv1.Subject{{
-				Kind: rbacv1.GroupKind,
-				Name: v1beta1constants.ShootSystemViewersGroupName,
+				APIGroup: rbacv1.GroupName,
+				Kind:     rbacv1.GroupKind,
+				Name:     v1beta1constants.ShootSystemViewersGroupName,
 			}},
 		},
 		&rbacv1.ClusterRoleBinding{
@@ -477,8 +478,9 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
 			},
 			Subjects: []rbacv1.Subject{{
-				Kind: rbacv1.GroupKind,
-				Name: v1beta1constants.ShootProjectViewersGroupName,
+				APIGroup: rbacv1.GroupName,
+				Kind:     rbacv1.GroupKind,
+				Name:     v1beta1constants.ShootProjectViewersGroupName,
 			}},
 		},
 	}
@@ -515,8 +517,9 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 			},
 			Subjects: []rbacv1.Subject{
 				{
-					Kind: rbacv1.GroupKind,
-					Name: v1beta1constants.ShootSystemAdminsGroupName,
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
+					Name:     v1beta1constants.ShootSystemAdminsGroupName,
 				},
 				{
 					Kind: rbacv1.GroupKind,
@@ -536,8 +539,9 @@ func (s *shootSystem) adminRBACResources() []client.Object {
 			},
 			Subjects: []rbacv1.Subject{
 				{
-					Kind: rbacv1.GroupKind,
-					Name: v1beta1constants.ShootProjectAdminsGroupName,
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.GroupKind,
+					Name:     v1beta1constants.ShootProjectAdminsGroupName,
 				},
 				{
 					Kind: rbacv1.GroupKind,

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -611,17 +611,11 @@ var _ = Describe("ShootSystem", func() {
 							Kind:     "ClusterRole",
 							Name:     "cluster-admin",
 						},
-						Subjects: []rbacv1.Subject{
-							{
-								APIGroup: "rbac.authorization.k8s.io",
-								Kind:     "Group",
-								Name:     "gardener.cloud:system:admins",
-							},
-							{
-								Kind: "Group",
-								Name: "system:masters", // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
-							},
-						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:system:admins",
+						}},
 					}
 
 					projectAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
@@ -636,17 +630,11 @@ var _ = Describe("ShootSystem", func() {
 							Kind:     "ClusterRole",
 							Name:     "cluster-admin",
 						},
-						Subjects: []rbacv1.Subject{
-							{
-								APIGroup: "rbac.authorization.k8s.io",
-								Kind:     "Group",
-								Name:     "gardener.cloud:project:admins",
-							},
-							{
-								Kind: "Group",
-								Name: "system:masters", // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
-							},
-						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:project:admins",
+						}},
 					}
 
 					Expect(managedResource).To(contain(clusterRole, systemViewersClusterRoleBinding, projectViewersClusterRoleBinding, systemAdminClusterRoleBinding, projectAdminClusterRoleBinding))

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -454,7 +454,7 @@ var _ = Describe("ShootSystem", func() {
 		})
 
 		Context("RBAC resources", func() {
-			It("should do not add read-only RBACs when the API resource list is unset", func() {
+			It("should not add read-only RBACs when the API resource list is unset", func() {
 				manifests, err := test.ExtractManifestsFromManagedResourceData(managedResourceSecret.Data)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -573,12 +573,11 @@ var _ = Describe("ShootSystem", func() {
 							Kind:     "ClusterRole",
 							Name:     "gardener.cloud:system:read-only",
 						},
-						Subjects: []rbacv1.Subject{
-							{
-								Kind: "Group",
-								Name: "gardener.cloud:system:viewers",
-							},
-						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:system:viewers",
+						}},
 					}
 
 					projectViewersClusterRoleBinding := &rbacv1.ClusterRoleBinding{
@@ -593,12 +592,11 @@ var _ = Describe("ShootSystem", func() {
 							Kind:     "ClusterRole",
 							Name:     "gardener.cloud:system:read-only",
 						},
-						Subjects: []rbacv1.Subject{
-							{
-								Kind: "Group",
-								Name: "gardener.cloud:project:viewers",
-							},
-						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:project:viewers",
+						}},
 					}
 
 					systemAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
@@ -615,8 +613,9 @@ var _ = Describe("ShootSystem", func() {
 						},
 						Subjects: []rbacv1.Subject{
 							{
-								Kind: "Group",
-								Name: "gardener.cloud:system:admins",
+								APIGroup: "rbac.authorization.k8s.io",
+								Kind:     "Group",
+								Name:     "gardener.cloud:system:admins",
 							},
 							{
 								Kind: "Group",
@@ -639,8 +638,9 @@ var _ = Describe("ShootSystem", func() {
 						},
 						Subjects: []rbacv1.Subject{
 							{
-								Kind: "Group",
-								Name: "gardener.cloud:project:admins",
+								APIGroup: "rbac.authorization.k8s.io",
+								Kind:     "Group",
+								Name:     "gardener.cloud:project:admins",
 							},
 							{
 								Kind: "Group",

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ShootSystem", func() {
 		namespace           = "some-namespace"
 
 		projectName       = "foo"
-		shootNamespace    = "garden-" + projectName
+		projectNamespace  = "garden-" + projectName
 		shootName         = "bar"
 		region            = "test-region"
 		providerType      = "test-provider"
@@ -59,7 +59,7 @@ var _ = Describe("ShootSystem", func() {
 		shootObj          = &gardencorev1beta1.Shoot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      shootName,
-				Namespace: shootNamespace,
+				Namespace: projectNamespace,
 			},
 			Spec: gardencorev1beta1.ShootSpec{
 				Kubernetes: gardencorev1beta1.Kubernetes{
@@ -453,14 +453,25 @@ var _ = Describe("ShootSystem", func() {
 			})
 		})
 
-		Context("Read-Only resources", func() {
-			It("should do nothing when the API resource list is unset", func() {
+		Context("RBAC resources", func() {
+			It("should do not add read-only RBACs when the API resource list is unset", func() {
 				manifests, err := test.ExtractManifestsFromManagedResourceData(managedResourceSecret.Data)
 				Expect(err).NotTo(HaveOccurred())
 
-				for _, manifest := range manifests {
-					Expect(manifest).NotTo(And(ContainSubstring("name: gardener.cloud:system:read-only"), ContainSubstring("kind: ClusterRole")))
-				}
+				Expect(manifests).NotTo(ContainElement(And(
+					ContainSubstring("name: gardener.cloud:system:read-only"),
+					ContainSubstring("kind: ClusterRole"),
+				)))
+				Expect(manifests).To(ContainElements(
+					And(
+						ContainSubstring("name: gardener.cloud:system:admins"),
+						ContainSubstring("kind: ClusterRoleBinding"),
+					),
+					And(
+						ContainSubstring("name: gardener.cloud:project:admins"),
+						ContainSubstring("kind: ClusterRoleBinding"),
+					),
+				))
 			})
 
 			When("API resource list is set", func() {
@@ -550,9 +561,9 @@ var _ = Describe("ShootSystem", func() {
 						},
 					}
 
-					clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+					systemViewersClusterRoleBinding := &rbacv1.ClusterRoleBinding{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "gardener.cloud:system:read-only",
+							Name: "gardener.cloud:system:viewers",
 							Annotations: map[string]string{
 								"resources.gardener.cloud/delete-on-invalid-update": "true",
 							},
@@ -570,7 +581,75 @@ var _ = Describe("ShootSystem", func() {
 						},
 					}
 
-					Expect(managedResource).To(contain(clusterRole, clusterRoleBinding))
+					projectViewersClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardener.cloud:project:viewers",
+							Annotations: map[string]string{
+								"resources.gardener.cloud/delete-on-invalid-update": "true",
+							},
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "ClusterRole",
+							Name:     "gardener.cloud:system:read-only",
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind: "Group",
+								Name: "gardener.cloud:project:viewers",
+							},
+						},
+					}
+
+					systemAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardener.cloud:system:admins",
+							Annotations: map[string]string{
+								"resources.gardener.cloud/delete-on-invalid-update": "true",
+							},
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "ClusterRole",
+							Name:     "cluster-admin",
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind: "Group",
+								Name: "gardener.cloud:system:admins",
+							},
+							{
+								Kind: "Group",
+								Name: "system:masters", // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
+							},
+						},
+					}
+
+					projectAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardener.cloud:project:admins",
+							Annotations: map[string]string{
+								"resources.gardener.cloud/delete-on-invalid-update": "true",
+							},
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "ClusterRole",
+							Name:     "cluster-admin",
+						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind: "Group",
+								Name: "gardener.cloud:project:admins",
+							},
+							{
+								Kind: "Group",
+								Name: "system:masters", // TODO(vpnachev): Remove "system:masters" subject after v1.125 is released
+							},
+						},
+					}
+
+					Expect(managedResource).To(contain(clusterRole, systemViewersClusterRoleBinding, projectViewersClusterRoleBinding, systemAdminClusterRoleBinding, projectAdminClusterRoleBinding))
 				})
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement

**What this PR does / why we need it**:
Grant Viewer/Admin permissions in the shoot to new groups "gardener.cloud:(project|system):(admins|viewers)".
With this change we are preparing users accessing the shoot clusters via `AdminKubeconfig` or `ViewerKubeconfig` shoot subresource to get use dedicated groups so that these users can be easily distinguished, for example in the audit logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There is a second PR https://github.com/gardener/gardener/pull/12674 where the `AdminKubeconfig` and `ViewerKubeconfig` generation are changed to assign the new groups to the users, however for backward compatibility we firstly need to grant the permissions to the new groups, otherwise the access to a shoot cluster will be lost until it is reconciled with the new version of gardenlet.   

/cc @timuthy @vitanovs 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
New ClusterRoleBindings are deployed in the shoot clusters, they will grant Admin and Viewer permissions that will be later leveraged by the `AdminKubeconfig` and `ViewerKubeconfig` feature of Gardener.
- `gardener.cloud:system:admins` - grants admin access to users that are Gardener System admins
- `gardener.cloud:system:viewers`- grants viewer access to users that are Gardener System viewers
- `gardener.cloud:project:admins` - grants admin access to users that are Gardener Project admins
- `gardener.cloud:project:viewers` - grants viewer access to users that are Gardener Project viewers
```

```breaking developer
The constant `github.com/gardener/gardener/pkg/apis/core/v1beta1/constants.ShootGroupViewers` has been removed, please use `github.com/gardener/gardener/pkg/apis/core/v1beta1/constants.ShootSystemViewersGroupName`
```
