### PR TITLE
Let (Admin|Viewer)Kubeconfig to set the groups "gardener.cloud:(project|system):(admins|viewers)"

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -188,6 +188,8 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 		return nil, err
 	}
 
+	apiConfig.SubjectAccessReviewer = kubeClient.AuthorizationV1().SubjectAccessReviews()
+
 	protobufLoopbackConfig := *gardenerAPIServerConfig.LoopbackClientConfig
 	if protobufLoopbackConfig.ContentType == "" {
 		protobufLoopbackConfig.ContentType = runtime.ContentTypeProtobuf
@@ -260,9 +262,9 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 	}
 
 	if initializers, err := o.Recommended.ExtraAdmissionInitializers(gardenerAPIServerConfig); err != nil {
-		return apiConfig, err
+		return nil, err
 	} else if err := o.Recommended.Admission.ApplyTo(&gardenerAPIServerConfig.Config, gardenerAPIServerConfig.SharedInformerFactory, gardenerKubeClient, gardenerDynamicClient, features.DefaultFeatureGate, initializers...); err != nil {
-		return apiConfig, err
+		return nil, err
 	}
 
 	return apiConfig, nil
@@ -302,7 +304,7 @@ func (o *Options) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	server, err := config.Complete().New(kubeClient.AuthorizationV1().SubjectAccessReviews())
+	server, err := config.Complete().New()
 	if err != nil {
 		return err
 	}

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -302,7 +302,7 @@ func (o *Options) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	server, err := config.Complete().New()
+	server, err := config.Complete().New(kubeClient.AuthorizationV1().SubjectAccessReviews())
 	if err != nil {
 		return err
 	}

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -10,7 +10,9 @@ After creation of a shoot cluster, end-users require a `kubeconfig` to access it
 
 The [`shoots/adminkubeconfig`](../../proposals/16-adminkubeconfig-subresource.md) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
 
-The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front. The created `kubeconfig` will not be persisted anywhere.
+The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front.
+If the user is considered Gardener System administrator, i.e. has the permissions to read all secrets in the Garden cluster, then the group `gardener.cloud:system:admins` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:admins`.
+The created `kubeconfig` will not be persisted anywhere.
 
 In order to request such a `kubeconfig`, you can run the following commands (targeting the garden cluster):
 
@@ -45,7 +47,7 @@ config = adminKubeconfigRequest.Status.Kubeconfig
 In Python, you can use the native [`kubernetes` client](https://github.com/kubernetes-client/python) to create such a kubeconfig like this:
 
 ```python
-# This script first loads an existing kubeconfig from your system, and then sends a request to the Gardener API to create a new kubeconfig for a shoot cluster. 
+# This script first loads an existing kubeconfig from your system, and then sends a request to the Gardener API to create a new kubeconfig for a shoot cluster.
 # The received kubeconfig is then decoded and a new API client is created for interacting with the shoot cluster.
 
 import base64
@@ -86,14 +88,16 @@ shoot_api_client = config.new_client_from_config_dict(yaml.safe_load(decoded_kub
 v1 = client.CoreV1Api(shoot_api_client)
 ```
 
-> **Note:** The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2) tool simplifies targeting shoot clusters. It automatically downloads a kubeconfig that uses the [gardenlogin](https://github.com/gardener/gardenlogin) kubectl auth plugin. This transparently manages authentication and certificate renewal without containing any credentials.
+> [!NOTE]
+> The [`gardenctl-v2`](https://github.com/gardener/gardenctl-v2) tool simplifies targeting shoot clusters. It automatically downloads a kubeconfig that uses the [gardenlogin](https://github.com/gardener/gardenlogin) kubectl auth plugin. This transparently manages authentication and certificate renewal without containing any credentials.
 
 ## `shoots/viewerkubeconfig` Subresource
 
-The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource).
-The difference is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (see [this document](../security/etcd_encryption_config.md)).
+The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource) with two differences.
+One is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (see [this document](../security/etcd_encryption_config.md)).
+The other difference is the group associated with the `kubeconfig` - if the user is considered Gardener System viewer, i.e. has the permissions to read all projects in the Garden cluster, then the group `gardener.cloud:system:viewers` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:viewers`.
 
-In order to request such a `kubeconfig`, you can run follow almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
+In order to request such a `kubeconfig`, you can run almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
 For example, in bash this looks like this:
 
 ```bash

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -11,7 +11,7 @@ After creation of a shoot cluster, end-users require a `kubeconfig` to access it
 The [`shoots/adminkubeconfig`](../../proposals/16-adminkubeconfig-subresource.md) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
 
 The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front.
-If the user is considered Gardener System administrator, i.e. has the permissions to read all secrets in the Garden cluster, then the group `gardener.cloud:system:admins` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:admins`.
+If the user is considered Gardener system administrator, i.e. has the permissions to read all secrets in the Garden cluster, then the group `gardener.cloud:system:admins` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:admins`.
 The created `kubeconfig` will not be persisted anywhere.
 
 In order to request such a `kubeconfig`, you can run the following commands (targeting the garden cluster):
@@ -95,7 +95,7 @@ v1 = client.CoreV1Api(shoot_api_client)
 
 The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource) with two differences.
 One is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (see [this document](../security/etcd_encryption_config.md)).
-The other difference is the group associated with the `kubeconfig` - if the user is considered Gardener System viewer, i.e. has the permissions to read all projects in the Garden cluster, then the group `gardener.cloud:system:viewers` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:viewers`.
+The other difference is the group associated with the `kubeconfig` - if the user is considered Gardener system viewer, i.e. has the permissions to read all projects in the Garden cluster, then the group `gardener.cloud:system:viewers` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:viewers`.
 
 In order to request such a `kubeconfig`, you can run almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
 For example, in bash this looks like this:

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	kubeinformers "k8s.io/client-go/informers"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/client-go/util/keyutil"
 
 	corerest "github.com/gardener/gardener/pkg/apiserver/registry/core/rest"
@@ -76,7 +77,7 @@ func (cfg *Config) Complete() CompletedConfig {
 }
 
 // New returns a new instance of GardenerServer from the given config.
-func (c completedConfig) New() (*GardenerServer, error) {
+func (c completedConfig) New(subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface) (*GardenerServer, error) {
 	genericServer, err := c.GenericConfig.New("gardener-apiserver", genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err
@@ -103,6 +104,7 @@ func (c completedConfig) New() (*GardenerServer, error) {
 			CredentialsRotationInterval:   c.ExtraConfig.CredentialsRotationInterval,
 			KubeInformerFactory:           c.kubeInformerFactory,
 			CoreInformerFactory:           c.coreInformerFactory,
+			SubjectAccessReviewer:         subjectAccessReviewer,
 		}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
 		seedManagementAPIGroupInfo = (seedmanagementrest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
 		settingsAPIGroupInfo       = (settingsrest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)

--- a/pkg/apiserver/registry/core/rest/storage_core.go
+++ b/pkg/apiserver/registry/core/rest/storage_core.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	kubeinformers "k8s.io/client-go/informers"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -42,6 +43,7 @@ type StorageProvider struct {
 	CredentialsRotationInterval   time.Duration
 	KubeInformerFactory           kubeinformers.SharedInformerFactory
 	CoreInformerFactory           gardencoreinformers.SharedInformerFactory
+	SubjectAccessReviewer         clientauthorizationv1.SubjectAccessReviewInterface
 }
 
 // NewRESTStorage creates a new API group info object and registers the v1beta1 core storage.
@@ -124,6 +126,7 @@ func (p StorageProvider) v1beta1Storage(restOptionsGetter generic.RESTOptionsGet
 		p.AdminKubeconfigMaxExpiration,
 		p.ViewerKubeconfigMaxExpiration,
 		p.CredentialsRotationInterval,
+		p.SubjectAccessReviewer,
 	)
 	storage["shoots"] = shootStorage.Shoot
 	storage["shoots/status"] = shootStorage.Status

--- a/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
@@ -5,14 +5,19 @@
 package storage
 
 import (
+	"context"
 	"time"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 )
 
@@ -23,13 +28,15 @@ func NewAdminKubeconfigREST(
 	internalSecretLister gardencorev1beta1listers.InternalSecretLister,
 	configMapLister kubecorev1listers.ConfigMapLister,
 	maxExpiration time.Duration,
+	subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface,
 ) *KubeconfigREST {
 	return &KubeconfigREST{
-		secretLister:         secretLister,
-		internalSecretLister: internalSecretLister,
-		configMapLister:      configMapLister,
-		shootStorage:         shootGetter,
-		maxExpirationSeconds: int64(maxExpiration.Seconds()),
+		secretLister:          secretLister,
+		internalSecretLister:  internalSecretLister,
+		configMapLister:       configMapLister,
+		subjectAccessReviewer: subjectAccessReviewer,
+		shootStorage:          shootGetter,
+		maxExpirationSeconds:  int64(maxExpiration.Seconds()),
 
 		gvk: schema.GroupVersionKind{
 			Group:   authenticationv1alpha1.SchemeGroupVersion.Group,
@@ -39,6 +46,34 @@ func NewAdminKubeconfigREST(
 		newObjectFunc: func() runtime.Object {
 			return &authenticationv1alpha1.AdminKubeconfigRequest{}
 		},
-		clientCertificateOrganization: user.SystemPrivilegedGroup,
+		userGroupsFunc: getAdminUserGroups,
 	}
+}
+
+func getAdminUserGroups(ctx context.Context, u user.Info, subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface) ([]string, error) {
+	subjectAccessReview := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "",
+				Group:     "v1",
+				Resource:  "Secret",
+				Verb:      "list",
+			},
+			User:   u.GetName(),
+			Groups: u.GetGroups(),
+			Extra:  convertToAuthorizationExtraValue(u.GetExtra()),
+			UID:    u.GetUID(),
+		},
+	}
+
+	result, err := subjectAccessReviewer.Create(ctx, subjectAccessReview, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Status.Allowed {
+		return []string{v1beta1constants.GardenerSystemAdminsGroupName}, nil
+	}
+
+	return []string{v1beta1constants.GardenerProjectAdminsGroupName}, nil
 }

--- a/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
@@ -72,8 +72,8 @@ func getAdminUserGroups(ctx context.Context, u user.Info, subjectAccessReviewer 
 	}
 
 	if result.Status.Allowed {
-		return []string{v1beta1constants.GardenerSystemAdminsGroupName}, nil
+		return []string{v1beta1constants.ShootSystemAdminsGroupName}, nil
 	}
 
-	return []string{v1beta1constants.GardenerProjectAdminsGroupName}, nil
+	return []string{v1beta1constants.ShootProjectAdminsGroupName}, nil
 }

--- a/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Admin Kubeconfig", func() {
 			akc := obj.(*authenticationv1alpha1.AdminKubeconfigRequest)
 			return akc.Status.Kubeconfig
 		},
-		ConsistOf("system:masters"),
+		ConsistOf("gardener.cloud:system:admins"),
+		ConsistOf("gardener.cloud:project:admins"),
 	)
 })

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
@@ -91,7 +91,7 @@ func (r *KubeconfigREST) Create(ctx context.Context, name string, obj runtime.Ob
 
 	groups, err := r.userGroupsFunc(ctx, userInfo, r.subjectAccessReviewer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user groups: %w", err)
 	}
 
 	// prepare: get shoot object

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
@@ -10,13 +10,16 @@ import (
 	"net/url"
 	"time"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/gardener/gardener/pkg/api"
@@ -33,15 +36,16 @@ import (
 // KubeconfigREST implements a RESTStorage for a kubeconfig request.
 type KubeconfigREST struct {
 	// TODO(petersutter): Remove secretLister field from struct after v1.135 has been released, as the cluster CA should then only be read from the ConfigMap.
-	secretLister         kubecorev1listers.SecretLister
-	internalSecretLister gardencorev1beta1listers.InternalSecretLister
-	configMapLister      kubecorev1listers.ConfigMapLister
-	shootStorage         getter
-	maxExpirationSeconds int64
+	secretLister          kubecorev1listers.SecretLister
+	internalSecretLister  gardencorev1beta1listers.InternalSecretLister
+	configMapLister       kubecorev1listers.ConfigMapLister
+	shootStorage          getter
+	maxExpirationSeconds  int64
+	subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface
 
-	gvk                           schema.GroupVersionKind
-	newObjectFunc                 func() runtime.Object
-	clientCertificateOrganization string
+	gvk            schema.GroupVersionKind
+	newObjectFunc  func() runtime.Object
+	userGroupsFunc func(context.Context, user.Info, clientauthorizationv1.SubjectAccessReviewInterface) ([]string, error)
 }
 
 var (
@@ -83,6 +87,11 @@ func (r *KubeconfigREST) Create(ctx context.Context, name string, obj runtime.Ob
 	userInfo, ok := genericapirequest.UserFrom(ctx)
 	if !ok {
 		return nil, apierrors.NewBadRequest("no user in context")
+	}
+
+	groups, err := r.userGroupsFunc(ctx, userInfo, r.subjectAccessReviewer)
+	if err != nil {
+		return nil, err
 	}
 
 	// prepare: get shoot object
@@ -160,7 +169,7 @@ func (r *KubeconfigREST) Create(ctx context.Context, name string, obj runtime.Ob
 			Name: authName,
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				CommonName:   userNamePrefix + ":" + userInfo.GetName(),
-				Organization: []string{r.clientCertificateOrganization},
+				Organization: groups,
 				CertType:     secrets.ClientCert,
 				Validity:     &validity,
 				SigningCA:    clientCACertificate,
@@ -210,4 +219,15 @@ func (r *KubeconfigREST) GroupVersionKind(schema.GroupVersion) schema.GroupVersi
 
 type getter interface {
 	Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error)
+}
+
+func convertToAuthorizationExtraValue(extra map[string][]string) map[string]authorizationv1.ExtraValue {
+	if extra == nil {
+		return nil
+	}
+	ret := make(map[string]authorizationv1.ExtraValue, len(extra))
+	for k, v := range extra {
+		ret[k] = v
+	}
+	return ret
 }

--- a/pkg/apiserver/registry/core/shoot/storage/storage.go
+++ b/pkg/apiserver/registry/core/shoot/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -44,6 +45,7 @@ func NewStorage(
 	adminKubeconfigMaxExpiration time.Duration,
 	viewerKubeconfigMaxExpiration time.Duration,
 	credentialsRotationInterval time.Duration,
+	subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface,
 ) ShootStorage {
 	shootRest, shootStatusRest, bindingREST := NewREST(optsGetter, credentialsRotationInterval)
 
@@ -51,8 +53,8 @@ func NewStorage(
 		Shoot:            shootRest,
 		Status:           shootStatusRest,
 		Binding:          bindingREST,
-		AdminKubeconfig:  NewAdminKubeconfigREST(shootRest, secretLister, internalSecretLister, configMapLister, adminKubeconfigMaxExpiration),
-		ViewerKubeconfig: NewViewerKubeconfigREST(shootRest, secretLister, internalSecretLister, configMapLister, viewerKubeconfigMaxExpiration),
+		AdminKubeconfig:  NewAdminKubeconfigREST(shootRest, secretLister, internalSecretLister, configMapLister, adminKubeconfigMaxExpiration, subjectAccessReviewer),
+		ViewerKubeconfig: NewViewerKubeconfigREST(shootRest, secretLister, internalSecretLister, configMapLister, viewerKubeconfigMaxExpiration, subjectAccessReviewer),
 	}
 }
 

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
@@ -72,8 +72,8 @@ func getViewerUserGroups(ctx context.Context, u user.Info, subjectAccessReviewer
 	}
 
 	if result.Status.Allowed {
-		return []string{v1beta1constants.GardenerSystemViewersGroupName}, nil
+		return []string{v1beta1constants.ShootSystemViewersGroupName}, nil
 	}
 
-	return []string{v1beta1constants.GardenerProjectViewersGroupName}, nil
+	return []string{v1beta1constants.ShootProjectViewersGroupName}, nil
 }

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
@@ -5,10 +5,15 @@
 package storage
 
 import (
+	"context"
 	"time"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/user"
+	clientauthorizationv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
@@ -23,13 +28,15 @@ func NewViewerKubeconfigREST(
 	internalSecretLister gardencorev1beta1listers.InternalSecretLister,
 	configMapLister kubecorev1listers.ConfigMapLister,
 	maxExpiration time.Duration,
+	subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface,
 ) *KubeconfigREST {
 	return &KubeconfigREST{
-		secretLister:         secretLister,
-		internalSecretLister: internalSecretLister,
-		configMapLister:      configMapLister,
-		shootStorage:         shootGetter,
-		maxExpirationSeconds: int64(maxExpiration.Seconds()),
+		secretLister:          secretLister,
+		internalSecretLister:  internalSecretLister,
+		configMapLister:       configMapLister,
+		shootStorage:          shootGetter,
+		maxExpirationSeconds:  int64(maxExpiration.Seconds()),
+		subjectAccessReviewer: subjectAccessReviewer,
 
 		gvk: schema.GroupVersionKind{
 			Group:   authenticationv1alpha1.SchemeGroupVersion.Group,
@@ -39,6 +46,34 @@ func NewViewerKubeconfigREST(
 		newObjectFunc: func() runtime.Object {
 			return &authenticationv1alpha1.ViewerKubeconfigRequest{}
 		},
-		clientCertificateOrganization: v1beta1constants.ShootSystemViewersGroupName,
+		userGroupsFunc: getViewerUserGroups,
 	}
+}
+
+func getViewerUserGroups(ctx context.Context, u user.Info, subjectAccessReviewer clientauthorizationv1.SubjectAccessReviewInterface) ([]string, error) {
+	sar := &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: "",
+				Group:     "core.gardener.cloud/v1beta1",
+				Resource:  "Project",
+				Verb:      "list",
+			},
+			User:   u.GetName(),
+			Groups: u.GetGroups(),
+			Extra:  convertToAuthorizationExtraValue(u.GetExtra()),
+			UID:    u.GetUID(),
+		},
+	}
+
+	result, err := subjectAccessReviewer.Create(ctx, sar, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Status.Allowed {
+		return []string{v1beta1constants.GardenerSystemViewersGroupName}, nil
+	}
+
+	return []string{v1beta1constants.GardenerProjectViewersGroupName}, nil
 }

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig_test.go
@@ -39,5 +39,6 @@ var _ = Describe("Viewer Kubeconfig", func() {
 			return akc.Status.Kubeconfig
 		},
 		ConsistOf("gardener.cloud:system:viewers"),
+		ConsistOf("gardener.cloud:project:viewers"),
 	)
 })

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -544,6 +544,7 @@ func viewerClusterRoleBindings() []client.Object {
 
 // ClusterRoleBindings is function generating the shoot ClusterRoleBindings related
 // to the AdminKubeconfig and ViewerKubeconfig deployed in the shoot cluster.
+//
 // Deprecated: Do not use, this function is deprecated and will be removed after v1.128.0 has been released.
 // TODO(vpnachev): Remove this func after v1.128.0 has been released.
 func ClusterRoleBindings() []client.Object {

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -544,7 +544,7 @@ func viewerClusterRoleBindings() []client.Object {
 
 // ClusterRoleBindings is function generating the shoot ClusterRoleBindings related
 // to the AdminKubeconfig and ViewerKubeconfig deployed in the shoot cluster.
-// Deprecated: Do not use, this function is deprecated and will be removed after v1.128.0 has been released
+// Deprecated: Do not use, this function is deprecated and will be removed after v1.128.0 has been released.
 // TODO(vpnachev): Remove this func after v1.128.0 has been released.
 func ClusterRoleBindings() []client.Object {
 	return append(adminClusterRoleBindings(), viewerClusterRoleBindings()...)

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -544,7 +544,8 @@ func viewerClusterRoleBindings() []client.Object {
 
 // ClusterRoleBindings is function generating the shoot ClusterRoleBindings related
 // to the AdminKubeconfig and ViewerKubeconfig deployed in the shoot cluster.
-// Deprecated: Do not use, this function is deprecated and will be removed after v1.127.0 has been released
+// Deprecated: Do not use, this function is deprecated and will be removed after v1.128.0 has been released
+// TODO(vpnachev): Remove this func after v1.128.0 has been released.
 func ClusterRoleBindings() []client.Object {
 	return append(adminClusterRoleBindings(), viewerClusterRoleBindings()...)
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement

**What this PR does / why we need it**:
Let (Admin|Viewer)Kubeconfig to set the groups "gardener.cloud:(project|system):(admins|viewers)"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Continuation of https://github.com/gardener/gardener/pull/12673
/hold
To be merged after v1.128.0 is released.

/cc @vitanovs @timuthy 
The PR is ready for review, however must be put onhold until part-1 is released.

Q: Considering https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md#gardenlet, should we hold this PR for at least 2 releases?
A: _Yes, we must hold this PR for 2 releases._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
`AdminKubeconfig` is no longer using the group `system:masters` to grant admin access to the shoot cluster, instead it is now using the groups `gardener.cloud:system:admins` granted to Gardener system admins and `gardener.cloud:project:admins` granted to Gardener Project admins. 
```

```noteworthy user
`ViewerKubeconfig` is no longer using solely the group `gardener.cloud:system:viewers` to grant viewer access to the shoot cluster, instead it is now granted only to Gardener system viewer users. Project Viewer users are granted viewer access to the shoot cluster via the group `gardener.cloud:project:viewers`.
```
