### PR TITLE
Configure `vpa-updater` with a `ServiceMonitor` to allow metrics scraping

### DIFF
--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -7,6 +7,7 @@ package vpa
 import (
 	"fmt"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 const (

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -10,9 +10,12 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 
@@ -21,8 +24,11 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 const (
@@ -65,6 +71,8 @@ func (v *vpa) updaterResourceConfigs() component.ResourceConfigs {
 		deployment                = v.emptyDeployment(updater)
 		podDisruptionBudget       = v.emptyPodDisruptionBudget(updater)
 		vpa                       = v.emptyVerticalPodAutoscaler(updater)
+		service                   = v.emptyService(updater)
+		serviceMonitor            = v.emptyServiceMonitor(updater)
 	)
 
 	configs := component.ResourceConfigs{
@@ -75,6 +83,8 @@ func (v *vpa) updaterResourceConfigs() component.ResourceConfigs {
 			v.reconcileUpdaterRoleBindingLeaderLocking(roleBindingLeaderLocking, roleLeaderLocking, updater)
 		}},
 		{Obj: vpa, Class: component.Runtime, MutateFn: func() { v.reconcileUpdaterVPA(vpa, deployment) }},
+		{Obj: service, Class: component.Runtime, MutateFn: func() { v.reconcileUpdaterService(service) }},
+		{Obj: serviceMonitor, Class: component.Runtime, MutateFn: func() { v.reconcileUpdaterServiceMonitor(serviceMonitor) }},
 	}
 
 	if isEnabled, ok := v.values.FeatureGates["InPlaceOrRecreate"]; ok && isEnabled {
@@ -302,4 +312,57 @@ func (v *vpa) computeUpdaterArgs() []string {
 	}
 
 	return out
+}
+
+func (v *vpa) reconcileUpdaterService(service *corev1.Service) {
+	metricsNetworkPolicyPort := networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(updaterPortMetrics)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}
+
+	switch v.values.ClusterType {
+	case component.ClusterTypeSeed:
+		if v.values.IsGardenCluster {
+			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, metricsNetworkPolicyPort))
+		} else {
+			utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, metricsNetworkPolicyPort))
+		}
+	case component.ClusterTypeShoot:
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, metricsNetworkPolicyPort))
+	}
+
+	service.Labels = getAppLabel(updater)
+	service.Spec.Selector = getAppLabel(updater)
+	desiredPorts := []corev1.ServicePort{{
+		Port:       updaterPortMetrics,
+		TargetPort: intstr.FromInt32(updaterPortMetrics),
+		Name:       metricsPortName,
+	}}
+	service.Spec.Ports = kubernetesutils.ReconcileServicePorts(service.Spec.Ports, desiredPorts, "")
+}
+
+func (v *vpa) reconcileUpdaterServiceMonitor(serviceMonitor *monitoringv1.ServiceMonitor) {
+	serviceMonitor.Labels = monitoringutils.Labels(v.getPrometheusLabel())
+	serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
+		Selector: metav1.LabelSelector{MatchLabels: getAppLabel(updater)},
+		Endpoints: []monitoringv1.Endpoint{{
+			Port: metricsPortName,
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					Action:      "replace",
+					Replacement: ptr.To(updater),
+					TargetLabel: "job",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_container_port_name"},
+					Regex:        metricsPortName,
+					Action:       "keep",
+				},
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_pod_label_(.+)`,
+				},
+			},
+		}},
+	}
 }

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -507,18 +507,16 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			switch clusterType {
-			case "seed":
-				if isGardenCluster {
-					obj.Annotations = map[string]string{
-						"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8943}]`,
-					}
-				} else {
-					obj.Annotations = map[string]string{
-						"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8943}]`,
-					}
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
+				obj.Annotations = map[string]string{
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8943}]`,
 				}
-			case "shoot":
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				obj.Annotations = map[string]string{
+					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8943}]`,
+				}
+			case clusterType == component.ClusterTypeShoot:
 				obj.Annotations = map[string]string{
 					"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8943}]`,
 				}
@@ -555,17 +553,14 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			if clusterType == component.ClusterTypeSeed {
-				if isGardenCluster {
-					obj.Labels = map[string]string{"prometheus": "garden"}
-					obj.Name = "garden-vpa-updater"
-				} else {
-					obj.Labels = map[string]string{"prometheus": "seed"}
-					obj.Name = "seed-vpa-updater"
-				}
-			}
-
-			if clusterType == component.ClusterTypeShoot {
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "garden"}
+				obj.Name = "garden-vpa-updater"
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "seed"}
+				obj.Name = "seed-vpa-updater"
+			case clusterType == component.ClusterTypeShoot:
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-updater"
 			}
@@ -778,18 +773,16 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			switch clusterType {
-			case "seed":
-				if isGardenCluster {
-					obj.Annotations = map[string]string{
-						"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8942}]`,
-					}
-				} else {
-					obj.Annotations = map[string]string{
-						"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8942}]`,
-					}
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
+				obj.Annotations = map[string]string{
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8942}]`,
 				}
-			case "shoot":
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				obj.Annotations = map[string]string{
+					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8942}]`,
+				}
+			case clusterType == component.ClusterTypeShoot:
 				obj.Annotations = map[string]string{
 					"networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":8942}]`,
 				}
@@ -1009,17 +1002,14 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			if clusterType == component.ClusterTypeSeed {
-				if isGardenCluster {
-					obj.Labels = map[string]string{"prometheus": "garden"}
-					obj.Name = "garden-vpa-recommender"
-				} else {
-					obj.Labels = map[string]string{"prometheus": "seed"}
-					obj.Name = "seed-vpa-recommender"
-				}
-			}
-
-			if clusterType == component.ClusterTypeShoot {
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "garden"}
+				obj.Name = "garden-vpa-recommender"
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "seed"}
+				obj.Name = "seed-vpa-recommender"
+			case clusterType == component.ClusterTypeShoot:
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-recommender"
 			}
@@ -1136,15 +1126,14 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			if clusterType == "seed" {
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-world-to-ports", `[{"protocol":"TCP","port":10250}]`)
-				if isGardenCluster {
-					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
-				} else {
-					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
-				}
-			}
-			if clusterType == "shoot" {
+				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-world-to-ports", `[{"protocol":"TCP","port":10250}]`)
+				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
+			case clusterType == component.ClusterTypeShoot:
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports", `[{"protocol":"TCP","port":10250}]`)
 				metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports", `[{"protocol":"TCP","port":8944}]`)
 			}
@@ -1359,17 +1348,14 @@ var _ = Describe("VPA", func() {
 				},
 			}
 
-			if clusterType == component.ClusterTypeSeed {
-				if isGardenCluster {
-					obj.Labels = map[string]string{"prometheus": "garden"}
-					obj.Name = "garden-vpa-admission-controller"
-				} else {
-					obj.Labels = map[string]string{"prometheus": "seed"}
-					obj.Name = "seed-vpa-admission-controller"
-				}
-			}
-
-			if clusterType == component.ClusterTypeShoot {
+			switch {
+			case clusterType == component.ClusterTypeSeed && isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "garden"}
+				obj.Name = "garden-vpa-admission-controller"
+			case clusterType == component.ClusterTypeSeed && !isGardenCluster:
+				obj.Labels = map[string]string{"prometheus": "seed"}
+				obj.Name = "seed-vpa-admission-controller"
+			case clusterType == component.ClusterTypeShoot:
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-admission-controller"
 			}

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -1619,6 +1619,11 @@ var _ = Describe("VPA", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeSeed, true)
 						Expect(managedResource).To(contain(serviceMonitorRecommender))
 					})
+
+					It("should label vpa-updater ServiceMonitor with `prometheus=garden`", func() {
+						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, true)
+						Expect(managedResource).To(contain(serviceMonitorUpdater))
+					})
 				})
 
 				Context("when not deployed in a garden cluster", func() {
@@ -1634,6 +1639,11 @@ var _ = Describe("VPA", func() {
 					It("should label vpa-recommender ServiceMonitor with `prometheus=seed`", func() {
 						serviceMonitorRecommender := serviceMonitorRecommenderFor(component.ClusterTypeSeed, false)
 						Expect(managedResource).To(contain(serviceMonitorRecommender))
+					})
+
+					It("should label vpa-updater ServiceMonitor with `prometheus=seed`", func() {
+						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, false)
+						Expect(managedResource).To(contain(serviceMonitorUpdater))
 					})
 				})
 			})
@@ -2041,6 +2051,16 @@ var _ = Describe("VPA", func() {
 
 						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})
+
+					It("should label vpa-updater ServiceMonitor with `prometheus=shoot`", func() {
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, true)
+						serviceMonitorExpected.ResourceVersion = "1"
+
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-updater"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
+					})
 				})
 
 				Context("when not deployed in a garden cluster", func() {
@@ -2065,6 +2085,16 @@ var _ = Describe("VPA", func() {
 
 						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
 						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-recommender"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
+					})
+
+					It("should label vpa-updater ServiceMonitor with `prometheus=shoot`", func() {
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false)
+						serviceMonitorExpected.ResourceVersion = "1"
+
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-updater"}, serviceMonitorActual)).To(Succeed())
 
 						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
 					})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

This PR introduces an additional `ServiceMonitor` and `Service` records for the `vpa-updater`, allowing the Prometheus [operator](https://prometheus-operator.dev/) deployment to scrape the component [_vpa-updater_] [metrics](https://github.com/kubernetes/autoscaler/blob/24ba0e7df0704ad34f034b66b400282c28cf3310/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L46-L129).

Following the local setup [guide](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster), the following metric _entries_ should be available:

<img width="1048" height="778" alt="vpa-updater-metrics" src="https://github.com/user-attachments/assets/424990ab-2650-479f-9aba-7bcd1c37118f" />

> __Note__: The above screenshot showcases a set of the available [metrics](https://github.com/kubernetes/autoscaler/blob/3344f064df90eacb441c68daeb27cf689dd830aa/vertical-pod-autoscaler/pkg/utils/metrics/updater/updater.go#L46-L129) as an example of a successful scraping iteration.

**Which issue(s) this PR fixes**:

Fixes https://github.com/gardener/gardener/issues/12676

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardenlet now deploys a `ServiceMonitor` resource for the `vpa-updater`. With this, the `vpa-updater` metrics are scraped by prometheus.
```
