### PR TITLE
Docs: make GRM overview more concise

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -5,7 +5,8 @@ description: Set of controllers with different responsibilities running once per
 
 ## Overview
 
-Gardener heavily utilizes Kubernetes resources for its operations. Therefore, any unintentional changes to those resources by an user or operator could lead to problems ranging from failure of a shoot, seed or even the whole landscape. `gardener-resource-manager` solves this problem by providing a way to define the desired state of a Kubernetes resource in a target cluster, and reverts back any unexpected changes applied to it.
+Gardener heavily utilizes Kubernetes resources for its operations.
+Therefore, any unintentional changes to those resources by a user or operator could lead to problems ranging from failure of a shoot, seed, or even the whole landscape. The `gardener-resource-manager` solves this problem by providing a way to define the desired state of a Kubernetes resource in a target cluster. It reverts any unexpected changes applied to it.
 
 Apart from this functionality, `gardener-resource-manager` has evolved to a more generic component comprising several controllers and webhook handlers.
 It is deployed by gardenlet once per seed (in the `garden` namespace) and once per shoot (in the respective shoot namespaces in the seed).

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -5,17 +5,9 @@ description: Set of controllers with different responsibilities running once per
 
 ## Overview
 
-Initially, the `gardener-resource-manager` was a project similar to the [kube-addon-manager](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager).
-It manages Kubernetes resources in a target cluster which means that it creates, updates, and deletes them.
-Also, it makes sure that manual modifications to these resources are reconciled back to the desired state.
+Gardener heavily utilizes Kubernetes resources for its operations. Therefore any unintentional changes to those resources by an user or operator could lead to problems ranging from failure of a shoot, seed or even the whole landscape. Gardener Resource Manager solves this problem by providing a way to define the desired state of a Kubernetes resource in a target cluster and reverts back any unexpected changes applied to it.
 
-In the Gardener project we were using the kube-addon-manager since more than two years.
-While we have progressed with our [extensibility story](../proposals/01-extensibility.md) (moving cloud providers out-of-tree), we had decided that the kube-addon-manager is no longer suitable for this use-case.
-The problem with it is that it needs to have its managed resources on its file system.
-This requires storing the resources in `ConfigMap`s or `Secret`s and mounting them to the kube-addon-manager pod during deployment time.
-The `gardener-resource-manager` uses `CustomResourceDefinition`s which allows to dynamically add, change, and remove resources with immediate action and without the need to reconfigure the volume mounts/restarting the pod.
-
-Meanwhile, the `gardener-resource-manager` has evolved to a more generic component comprising several controllers and webhook handlers.
+Apart from this functionality `gardener-resource-manager` has evolved to a more generic component comprising several controllers and webhook handlers.
 It is deployed by gardenlet once per seed (in the `garden` namespace) and once per shoot (in the respective shoot namespaces in the seed).
 
 ## Component Configuration

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -5,9 +5,9 @@ description: Set of controllers with different responsibilities running once per
 
 ## Overview
 
-Gardener heavily utilizes Kubernetes resources for its operations. Therefore any unintentional changes to those resources by an user or operator could lead to problems ranging from failure of a shoot, seed or even the whole landscape. Gardener Resource Manager solves this problem by providing a way to define the desired state of a Kubernetes resource in a target cluster and reverts back any unexpected changes applied to it.
+Gardener heavily utilizes Kubernetes resources for its operations. Therefore, any unintentional changes to those resources by an user or operator could lead to problems ranging from failure of a shoot, seed or even the whole landscape. `gardener-resource-manager` solves this problem by providing a way to define the desired state of a Kubernetes resource in a target cluster, and reverts back any unexpected changes applied to it.
 
-Apart from this functionality `gardener-resource-manager` has evolved to a more generic component comprising several controllers and webhook handlers.
+Apart from this functionality, `gardener-resource-manager` has evolved to a more generic component comprising several controllers and webhook handlers.
 It is deployed by gardenlet once per seed (in the `garden` namespace) and once per shoot (in the respective shoot namespaces in the seed).
 
 ## Component Configuration


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR  makes the GRM overview section more concise by highlighting the main problem GRM solves and how the problem can occur. It removes the mention of the legacy reasons for using `kube-addon-manager` and switching to GRM as imo they don't provide much value in the overview section. 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
