### PR TITLE
Use `hyperdisk-balanced` for GCP shoots with worker pool with arch ARM64

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -145,13 +147,9 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 		}
 	}
 
-	hasARMWorkerPools := false
-	for _, worker := range shoot.Spec.Provider.Workers {
-		if worker.Machine.Architecture != nil && *worker.Machine.Architecture == v1beta1constants.ArchitectureARM64 {
-			hasARMWorkerPools = true
-			break
-		}
-	}
+	hasARMWorkerPools := slices.ContainsFunc(shoot.Spec.Provider.Workers, func(worker gardencorev1beta1.Worker) bool {
+		return worker.Machine.Architecture != nil && *worker.Machine.Architecture == v1beta1constants.ArchitectureARM64
+	})
 
 	// GCP requires a specific storage class for ARM worker pools
 	if shoot.Spec.Provider.Type == "gcp" && hasARMWorkerPools {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Introduces creation of a 'gce-hd-balanced' storage class when deploying the guestbook app on GCP shoots with ARM worker pools.
ARM nodes on GCP only support disk of type hyperdisks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @tobschli @kon-angelo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
