### PR TITLE
Set constraint to progressing to prevent it from being displayed as error in the dashboard.

### DIFF
--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -27,9 +27,9 @@ func (b *Botanist) DetermineUpdateFunction(
 	}
 
 	allNodesDualStack := true
-	conditionStatus := gardencorev1beta1.ConditionFalse
+	conditionStatus := gardencorev1beta1.ConditionProgressing
 	conditionReason := "NodesNotMigrated"
-	conditionMessage := "Not all nodes were migrated to dual-stack networking."
+	conditionMessage := "The shoot is migrating to dual-stack networking."
 	for _, node := range nodeList.Items {
 		allNodesDualStack = allNodesDualStack && len(node.Spec.PodCIDRs) == 2
 	}

--- a/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
@@ -106,9 +106,9 @@ var _ = Describe("DualStackMigration", func() {
 
 			condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
 			Expect(condition).NotTo(BeNil())
-			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionFalse))
+			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionProgressing))
 			Expect(condition.Reason).To(Equal("NodesNotMigrated"))
-			Expect(condition.Message).To(Equal("Not all nodes were migrated to dual-stack networking."))
+			Expect(condition.Message).To(Equal("The shoot is migrating to dual-stack networking."))
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
With change #12470, we updated the constraint for ongoing dual-stack migration from 'false' to 'progressing'. Unfortunately, we overlooked one instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The status of constraint  `DualStackNodesMigrationReady`  is now `progressing` instead of `false` at the start of a migration to dual-stack networking.
```
