### PR TITLE
Update Setup Guide to include Cert Management for Garden

### DIFF
--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -134,7 +134,7 @@ Reference documentation:
 
 #### How to install an extension
 
-An extension is commonly described by an `Extension` resources (API group `operator.gardener.cloud/v1alpha1`) in the runtime cluster. The Gardener Operator will take care of deploying the required resources both to the runtime and to the virtual Garden cluster. More details can be found in the [Extension Resource documentation](../concepts/operator.md#extension-resource).
+An extension is commonly described by an `Extension` resource (API group `operator.gardener.cloud/v1alpha1`) in the runtime cluster. The Gardener Operator will take care of deploying the required resources both to the runtime and to the virtual Garden cluster. More details can be found in the [Extension Resource documentation](../concepts/operator.md#extension-resource).
 
 Typically, only a few extensions are needed on the runtime cluster and the Gardener Operator manages them directly through `ManagedResources`. Most of the extensions however, are registered to the virtual Garden cluster and then installed onto the `Seeds`.
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -115,7 +115,7 @@ There are a few extensions considered essential to any Gardener installation:
 - at least one [network plugin (CNI)](../../extensions/README.md#network-plugin)
 - Shoot services
 
-An extension commonly consists of two components - a controller implementing the Gardener's extension contract and an admission controller. The latter is deployed to the runtime cluster and prevents misconfiguration of `Shoot`s. While an extensions primary purpose is to implement functionality for `Shoot` clusters, it can also be deployed to the runtime cluster to provide additional functionality like managing `DNSRecord`s or `BackupBucket`s using the well-known and proven code paths.
+An extension commonly consists of two components – a controller implementing the Gardener's extension contract and an admission controller. The latter is deployed to the runtime cluster and prevents misconfiguration of `Shoot`s. While an extension's primary purpose is to implement functionality for `Shoot` clusters, it can also be deployed to the runtime cluster to provide additional functionality like managing `DNSRecord`s or `BackupBucket`s using the well-known and proven code paths.
 
 #### Choices
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -136,7 +136,7 @@ Reference documentation:
 
 An extension is commonly described by an `Extension` resource (API group `operator.gardener.cloud/v1alpha1`) in the runtime cluster. The Gardener Operator will take care of deploying the required resources both to the runtime and to the virtual Garden cluster. More details can be found in the [Extension Resource documentation](../concepts/operator.md#extension-resource).
 
-Typically, only a few extensions are needed on the runtime cluster and the Gardener Operator manages them directly through `ManagedResources`. Most of the extensions however, are registered to the virtual Garden cluster and then installed onto the `Seeds`.
+Typically, only a few extensions are needed on the runtime cluster, and the Gardener Operator manages them directly through `ManagedResource`s. Most of the extensions, however, are registered to the virtual Garden cluster and then installed onto the `Seed`s.
 
 In order to make an extension known to the `Garden`, the Gardener Operator translates the `Extension` into two resources and applies them to the virtual Garden cluster - firstly, a `ControllerDeployment` and secondly, a matching `ControllerRegistration`. With both in place, Gardener-managed `ControllerInstallation`s take care of the actual deployment of the extension to the target environment.
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -68,7 +68,7 @@ Reference documentation:
 
 ### Certificates
 
-Some components of a Gardener landscape require TLS certificates signed by well-known, trusted certificate authority (CA). While it is certainly possible to provide certificates manually, using an ACME service is much more convenient and recommended. Utilizing the [Gardener extension for certificate services](https://github.com/gardener/gardener-extension-shoot-cert-service) allows to automate the creation and renewal of certificates for the Gardener landscape.
+Some components of a Gardener landscape require TLS certificates signed by a well-known, trusted certificate authority (CA). While it is certainly possible to provide certificates manually, using an ACME service is much more convenient and recommended. Utilizing the [Gardener extension for certificate services](https://github.com/gardener/gardener-extension-shoot-cert-service) allows automating the creation and renewal of certificates for the Gardener landscape.
 
 ### Backup Bucket
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -138,7 +138,7 @@ An extension is commonly described by an `Extension` resource (API group `operat
 
 Typically, only a few extensions are needed on the runtime cluster, and the Gardener Operator manages them directly through `ManagedResource`s. Most of the extensions, however, are registered to the virtual Garden cluster and then installed onto the `Seed`s.
 
-In order to make an extension known to the `Garden`, the Gardener Operator translates the `Extension` into two resources and applies them to the virtual Garden cluster - firstly, a `ControllerDeployment` and secondly, a matching `ControllerRegistration`. With both in place, Gardener-managed `ControllerInstallation`s take care of the actual deployment of the extension to the target environment.
+To make an extension known to the `Garden`, the Gardener Operator translates the `Extension` into two resources and applies them to the virtual Garden cluster – firstly, a `ControllerDeployment` and secondly, a matching `ControllerRegistration`. With both in place, Gardener-managed `ControllerInstallation`s take care of the actual deployment of the extension to the target environment.
 
 Check the [extension registration documentation](../extensions/registration.md) for more details.
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -142,7 +142,7 @@ To make an extension known to the `Garden`, the Gardener Operator translates the
 
 Check the [extension registration documentation](../extensions/registration.md) for more details.
 
-The `ControllerRegistration` is also a useful resource to check, as it declares, which resources it implements. An example of such a `ControllerRegistration`, can be found in the [provider OpenStack](https://github.com/gardener/gardener-extension-provider-openstack) extension's [example file](https://github.com/gardener/gardener-extension-provider-openstack/blob/master/example/controller-registration.yaml).
+The `ControllerRegistration` is also a useful resource to check, as it declares which resources it implements. An example of such a `ControllerRegistration` can be found in the [provider OpenStack](https://github.com/gardener/gardener-extension-provider-openstack) extension's [example file](https://github.com/gardener/gardener-extension-provider-openstack/blob/master/example/controller-registration.yaml).
 
 ![extensions](./content/extensions.png)
 

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -77,7 +77,7 @@ It is recommended for any productive installation of Gardener.
 
 ### Infrastructure
 
-For each infrastructure supported by Gardener a so-called __provider-extension__ exists. It implements the required interfaces. For this example, the [OpenStack extension](https://github.com/gardener/gardener-extension-provider-openstack) will be used. Of course, a single Gardener landscape can support multiple infrastructures, which is a common use case. In this case, the respective provider-extensions need to be deployed as well.
+For each infrastructure supported by Gardener, a so-called __provider-extension__ exists. It implements the required interfaces. For this example, the [OpenStack extension](https://github.com/gardener/gardener-extension-provider-openstack) will be used. Of course, a single Gardener landscape can support multiple infrastructures, which is a common use case. In this case, the respective provider-extensions need to be deployed as well.
 
 Access to the respective infrastructure is required and needs to be handed over to Gardener in the provider-specific format (e.g., OpenStack application credentials).
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

Expand the setup guide to explain the usage of the cert-management extension for managing the `garden` certificates.

I also changed the order to explain the `Extension` resource before referring to it in the `Garden` section.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @marc1404 @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update Setup Guide to include Cert Management for Garden
```
