### PR TITLE
Improve validations for `labelSelector`

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -73,7 +73,7 @@ func ValidateCloudProfileSpec(spec *core.CloudProfileSpec, fldPath *field.Path) 
 	allErrs = append(allErrs, validateCloudProfileBastion(spec, fldPath.Child("bastion"))...)
 	allErrs = append(allErrs, validateCloudProfileLimits(spec.Limits, fldPath.Child("limits"))...)
 	if spec.SeedSelector != nil {
-		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, fldPath.Child("seedSelector"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{}, fldPath.Child("seedSelector"))...)
 	}
 
 	if spec.CABundle != nil {

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -68,7 +68,7 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 				allErrs = append(allErrs, field.Forbidden(deploymentPath.Child("seedSelector"), "specifying a seed selector is not allowed when controlling resources primarily"))
 			}
 
-			allErrs = append(allErrs, metav1validation.ValidateLabelSelector(deployment.SeedSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, deploymentPath.Child("seedSelector"))...)
+			allErrs = append(allErrs, metav1validation.ValidateLabelSelector(deployment.SeedSelector, metav1validation.LabelSelectorValidationOptions{}, deploymentPath.Child("seedSelector"))...)
 		}
 
 		deploymentRefsCount := len(deployment.DeploymentRefs)

--- a/pkg/apis/core/validation/exposureclass.go
+++ b/pkg/apis/core/validation/exposureclass.go
@@ -34,7 +34,7 @@ func ValidateExposureClass(exposureClass *core.ExposureClass) field.ErrorList {
 
 	if exposureClass.Scheduling != nil {
 		if exposureClass.Scheduling.SeedSelector != nil {
-			allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&exposureClass.Scheduling.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, field.NewPath("scheduling", "seedSelector"))...)
+			allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&exposureClass.Scheduling.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{}, field.NewPath("scheduling", "seedSelector"))...)
 		}
 		allErrs = append(allErrs, ValidateTolerations(exposureClass.Scheduling.Tolerations, field.NewPath("scheduling", "tolerations"))...)
 	}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -270,7 +270,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), spec.SeedName, "seed name must not be empty when providing the key"))
 	}
 	if spec.SeedSelector != nil {
-		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, fldPath.Child("seedSelector"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.SeedSelector.LabelSelector, metav1validation.LabelSelectorValidationOptions{}, fldPath.Child("seedSelector"))...)
 	}
 	if purpose := spec.Purpose; purpose != nil {
 		allowedShootPurposes := availableShootPurposes

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -512,7 +512,7 @@ func validateGardenerControllerManagerConfig(config *operatorv1alpha1.GardenerCo
 	allErrs = append(allErrs, validateGardenerFeatureGates(config.FeatureGates, fldPath.Child("featureGates"))...)
 
 	for i, quota := range config.DefaultProjectQuotas {
-		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(quota.ProjectSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, fldPath.Child("defaultProjectQuotas").Index(i).Child("projectSelector"))...)
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(quota.ProjectSelector, metav1validation.LabelSelectorValidationOptions{}, fldPath.Child("defaultProjectQuotas").Index(i).Child("projectSelector"))...)
 	}
 
 	return allErrs

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -84,7 +84,7 @@ func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, fldPath
 	if len(spec.Selector.MatchLabels) == 0 && len(spec.Selector.MatchExpressions) == 0 {
 		allErrs = append(allErrs, field.Invalid(selectorPath, spec.Selector, "empty selector is invalid for ManagedSeedSet"))
 	} else {
-		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.Selector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, selectorPath)...)
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.Selector, metav1validation.LabelSelectorValidationOptions{}, selectorPath)...)
 		var err error
 		if selector, err = metav1.LabelSelectorAsSelector(&spec.Selector); err != nil {
 			allErrs = append(allErrs, field.Invalid(selectorPath, spec.Selector, err.Error()))

--- a/pkg/apis/settings/validation/cluster_openidconnect_preset.go
+++ b/pkg/apis/settings/validation/cluster_openidconnect_preset.go
@@ -33,7 +33,7 @@ func ValidateClusterOpenIDConnectPresetUpdate(new, old *settings.ClusterOpenIDCo
 
 func validateClusterOpenIDConnectPresetSpec(spec *settings.ClusterOpenIDConnectPresetSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(spec.ProjectSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, fldPath.Child("projectSelector"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(spec.ProjectSelector, metav1validation.LabelSelectorValidationOptions{}, fldPath.Child("projectSelector"))...)
 	allErrs = append(allErrs, validateOpenIDConnectPresetSpec(&spec.OpenIDConnectPresetSpec, fldPath)...)
 	return allErrs
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/validation/validation.go
@@ -65,7 +65,7 @@ func validateProjectControllerConfiguration(conf *controllermanagerconfigv1alpha
 func validateProjectQuotaConfiguration(conf controllermanagerconfigv1alpha1.QuotaConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(conf.ProjectSelector, metav1validation.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: true}, fldPath.Child("projectSelector"))...)
+	allErrs = append(allErrs, metav1validation.ValidateLabelSelector(conf.ProjectSelector, metav1validation.LabelSelectorValidationOptions{}, fldPath.Child("projectSelector"))...)
 
 	return allErrs
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area robustness
/area security
/kind enhancement

**What this PR does / why we need it**:
Drop `AllowInvalidLabelValueInSelector` from `labelSelector` validation options.
This was added for backwards compatibility, see https://github.com/gardener/gardener/pull/7248/commits/814e58b899b7876d20bb7a2815e90380f2b2d96f

From now on, all label values which are not invalid will be rejected. This applies to existing resources as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is part of a broader issue to ensure proper input data validation for all Gardener components.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The following fields of resources in the `core.gardener.cloud` group are now validated for invalid label values:
- `spec.seedSelector` in the `CloudProfile` API
- `spec.deployment.seedSelector` in the `ControllerRegistration` API
- `scheduling.seedSelector` in the `ExposureClass` API

The following fields of resources in the `operator.gardener.cloud` group are now validated for invalid label values:
- `spec.virtualCluster.gardener.gardenerControllerManager.defaultProjectQuotas.projectSelector` in the `Garden` API

The following fields of resources in the `controllermanager.config.gardener.cloud` group are now validated for invalid label values:
- `controllers.project.quotas[].projectSelector`

The following fields of resources in the `seedmanagement.gardener.cloud` group are now validated for invalid label values:
- `spec.selector` in the `ManagedSeedSet` API

The following fields of resources in the `settings.gardener.cloud` group are now validated for invalid label values:
- `spec.projectSelector` in the `ClusterOpenIDConnectPreset` API
```
```breaking user
The `spec.seedSelector` field in the `Shoot` API is now validated for invalid label values.
```
