### PR TITLE
Introduce `Seed` annotation to temporarily disable `Shoot` reconciliations

### DIFF
--- a/docs/operations/seed_settings.md
+++ b/docs/operations/seed_settings.md
@@ -142,17 +142,28 @@ Refer to the [Topology-Aware Traffic Routing documentation](./topology_aware_rou
 
 ## Temporarily Disabling Shoot Reconciliations
 
-There may be situations where you need to temporarily stop the reconciliation of `Shoot` clusters in a `Seed` cluster.
-This can be achieved by adding the annotation `gardener.cloud/disable-shoot-reconciliations=true` to the `Seed` resource.
+There may be emergency situations where you need to temporarily stop the reconciliation of `Shoot` clusters in a `Seed` cluster,
+for example, to prevent faulty updates from propagating further or to avoid gardenlet performing unintended actions.
+
+> [!CAUTION]
+> This mechanism should only be used in exceptional cases and not as part of regular operations,
+> as it can have significant implications for cluster health and update consistency.
+
+To temporarily disable reconciliations, add the annotation `shoot.gardener.cloud/emergency-stop-reconciliations=true` to the `Seed` resource.
 
 While this annotation is present:
 - The `Seed` controller will not reconcile any `Shoot` clusters in the affected `Seed`.
 - New `Shoot` clusters will not be scheduled to this `Seed`.
 - The `Seed` will expose the `SeedDisabledShootReconciliations` condition.
-- This is useful, for example, to prevent faulty updates from propagating further.
+
+> [!NOTE]  
+> When you remove this annotation, reconciliation will resume, but `Shoot` clusters will only be reconciled
+during their next scheduled reconciliation window.
+> They are not reconciled immediately.
+> This is important if you expect all clusters to be updated right away after re-enabling reconciliations.
 
 To annotate all `Seed` resources at once, run:
 
 ```bash
-kubectl annotate seed --all gardener.cloud/disable-shoot-reconciliations=true
+kubectl annotate seed --all shoot.gardener.cloud/emergency-stop-reconciliations=true
 ```

--- a/docs/operations/seed_settings.md
+++ b/docs/operations/seed_settings.md
@@ -139,3 +139,20 @@ use MaxAllowed aligned with the allocatable resources of the largest worker.
 ## Topology-Aware Traffic Routing
 
 Refer to the [Topology-Aware Traffic Routing documentation](./topology_aware_routing.md) as this document contains the documentation for the topology-aware routing Seed setting.
+
+## Temporarily Disabling Shoot Reconciliations
+
+There may be situations where you need to temporarily stop the reconciliation of `Shoot` clusters in a `Seed` cluster.
+This can be achieved by adding the annotation `gardener.cloud/disable-shoot-reconciliations=true` to the `Seed` resource.
+
+While this annotation is present:
+- The `Seed` controller will not reconcile any `Shoot` clusters in the affected `Seed`.
+- New `Shoot` clusters will not be scheduled to this `Seed`.
+- The `Seed` will expose the `SeedDisabledShootReconciliations` condition.
+- This is useful, for example, to prevent faulty updates from propagating further.
+
+To annotate all `Seed` resources at once, run:
+
+```bash
+kubectl annotate seed --all gardener.cloud/disable-shoot-reconciliations=true
+```

--- a/docs/operations/seed_settings.md
+++ b/docs/operations/seed_settings.md
@@ -152,13 +152,13 @@ for example, to prevent faulty updates from propagating further or to avoid gard
 To temporarily disable reconciliations, add the annotation `shoot.gardener.cloud/emergency-stop-reconciliations=true` to the `Seed` resource.
 
 While this annotation is present:
-- The `Seed` controller will not reconcile any `Shoot` clusters in the affected `Seed`.
+- The `Shoot` controller will not reconcile any `Shoot` clusters in the affected `Seed`.
 - New `Shoot` clusters will not be scheduled to this `Seed`.
 - The `Seed` will expose the `SeedDisabledShootReconciliations` condition.
 
 > [!NOTE]  
 > When you remove this annotation, reconciliation will resume, but `Shoot` clusters will only be reconciled
-during their next scheduled reconciliation window.
+> during their next scheduled reconciliation window.
 > They are not reconciled immediately.
 > This is important if you expect all clusters to be updated right away after re-enabling reconciliations.
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1036,4 +1036,8 @@ const (
 	// LabelInjectGardenKubeconfig is a constant for a label on workload resources that indicates that a kubeconfig to
 	// the garden cluster should be injected.
 	LabelInjectGardenKubeconfig = "extensions.gardener.cloud/inject-garden-kubeconfig"
+
+	// AnnotationDisableShootReconciliations is the key for the emergency switch annotation for the seed resource
+	// to temporarily pause further shoot reconciliations.
+	AnnotationDisableShootReconciliations = "gardener.cloud/disable-shoot-reconciliations"
 )

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1037,7 +1037,7 @@ const (
 	// the garden cluster should be injected.
 	LabelInjectGardenKubeconfig = "extensions.gardener.cloud/inject-garden-kubeconfig"
 
-	// AnnotationDisableShootReconciliations is the key for the emergency switch annotation for the seed resource
+	// AnnotationEmergencyStopShootReconciliations is the key for the emergency switch annotation for the seed resource
 	// to temporarily pause further shoot reconciliations.
-	AnnotationDisableShootReconciliations = "gardener.cloud/disable-shoot-reconciliations"
+	AnnotationEmergencyStopShootReconciliations = "shoot.gardener.cloud/emergency-stop-reconciliations"
 )

--- a/pkg/apis/core/v1beta1/helper/seed.go
+++ b/pkg/apis/core/v1beta1/helper/seed.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // TaintsHave returns true if the given key is part of the taints list.
@@ -125,4 +126,13 @@ func CalculateSeedUsage(shootList []*gardencorev1beta1.Shoot) map[string]int {
 	}
 
 	return m
+}
+
+// HasShootReconciliationsDisabledAnnotation returns true if shoot reconciliations are currently disabled for the given seed.
+func HasShootReconciliationsDisabledAnnotation(seed *gardencorev1beta1.Seed) bool {
+	if seed == nil {
+		return false
+	}
+	value, ok := seed.Annotations[v1beta1constants.AnnotationDisableShootReconciliations]
+	return ok && value == "true"
 }

--- a/pkg/apis/core/v1beta1/helper/seed.go
+++ b/pkg/apis/core/v1beta1/helper/seed.go
@@ -133,6 +133,6 @@ func HasShootReconciliationsDisabledAnnotation(seed *gardencorev1beta1.Seed) boo
 	if seed == nil {
 		return false
 	}
-	value, ok := seed.Annotations[v1beta1constants.AnnotationDisableShootReconciliations]
+	value, ok := seed.Annotations[v1beta1constants.AnnotationEmergencyStopShootReconciliations]
 	return ok && value == "true"
 }

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -454,8 +454,8 @@ const (
 	SeedGardenletReady ConditionType = "GardenletReady"
 	// SeedSystemComponentsHealthy is a constant for a condition type indicating the system components health.
 	SeedSystemComponentsHealthy ConditionType = "SeedSystemComponentsHealthy"
-	// SeedDisabledShootReconciliations is a constant for a condition type indicating disabled shoot reconciliations.
-	SeedDisabledShootReconciliations ConditionType = "SeedDisabledShootReconciliations"
+	// SeedEmergencyStopShootReconciliations is a constant for a condition type indicating disabled shoot reconciliations.
+	SeedEmergencyStopShootReconciliations ConditionType = "EmergencyStopShootReconciliations"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -454,6 +454,8 @@ const (
 	SeedGardenletReady ConditionType = "GardenletReady"
 	// SeedSystemComponentsHealthy is a constant for a condition type indicating the system components health.
 	SeedSystemComponentsHealthy ConditionType = "SeedSystemComponentsHealthy"
+	// SeedDisabledShootReconciliations is a constant for a condition type indicating disabled shoot reconciliations.
+	SeedDisabledShootReconciliations ConditionType = "SeedDisabledShootReconciliations"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -213,6 +213,7 @@ var _ = Describe("Seed health", func() {
 
 				Expect(conditions.ConvertToSlice()).To(ConsistOf(
 					beConditionWithStatusReasonAndMessage("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionWithStatusReasonAndMessage("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 
@@ -220,12 +221,14 @@ var _ = Describe("Seed health", func() {
 				conditions := NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{
 					Conditions: []gardencorev1beta1.Condition{
 						{Type: "SeedSystemComponentsHealthy"},
+						{Type: "EmergencyStopShootReconciliations"},
 						{Type: "Foo"},
 					},
 				})
 
 				Expect(conditions.ConvertToSlice()).To(HaveExactElements(
 					OfType("SeedSystemComponentsHealthy"),
+					OfType("EmergencyStopShootReconciliations"),
 				))
 			})
 		})
@@ -236,6 +239,7 @@ var _ = Describe("Seed health", func() {
 
 				Expect(conditions.ConvertToSlice()).To(HaveExactElements(
 					OfType("SeedSystemComponentsHealthy"),
+					OfType("EmergencyStopShootReconciliations"),
 				))
 			})
 		})
@@ -246,6 +250,7 @@ var _ = Describe("Seed health", func() {
 
 				Expect(conditions.ConditionTypes()).To(HaveExactElements(
 					gardencorev1beta1.ConditionType("SeedSystemComponentsHealthy"),
+					gardencorev1beta1.ConditionType("EmergencyStopShootReconciliations"),
 				))
 			})
 		})

--- a/pkg/gardenlet/controller/seed/care/reconciler.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler.go
@@ -76,27 +76,11 @@ func (r *Reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		seedConditions,
 	)
 
-	removeExistingReconciliationsBlockedCondition := false
-	if v1beta1helper.HasShootReconciliationsDisabledAnnotation(seed) {
-		updatedConditions = v1beta1helper.MergeConditions(seed.Status.Conditions, v1beta1helper.UpdatedConditionWithClock(
-			r.Clock,
-			v1beta1helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, gardencorev1beta1.SeedDisabledShootReconciliations),
-			gardencorev1beta1.ConditionTrue,
-			string(gardencorev1beta1.SeedDisabledShootReconciliations),
-			"Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation.",
-		))
-	} else if v1beta1helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedDisabledShootReconciliations) != nil {
-		removeExistingReconciliationsBlockedCondition = true
-	}
-
 	// Update Seed status conditions if necessary
-	if v1beta1helper.ConditionsNeedUpdate(seedConditions.ConvertToSlice(), updatedConditions) || removeExistingReconciliationsBlockedCondition {
+	if v1beta1helper.ConditionsNeedUpdate(seedConditions.ConvertToSlice(), updatedConditions) {
 		// Rebuild seed conditions to ensure that only the conditions with the
 		// correct types will be updated, and any other conditions will remain intact
 		conditions := v1beta1helper.BuildConditions(seed.Status.Conditions, updatedConditions, seedConditions.ConditionTypes())
-		if removeExistingReconciliationsBlockedCondition {
-			conditions = v1beta1helper.RemoveConditions(conditions, gardencorev1beta1.SeedDisabledShootReconciliations)
-		}
 
 		log.Info("Updating seed status conditions")
 		patch := client.StrategicMergeFrom(seed.DeepCopy())

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
 	testclock "k8s.io/utils/clock/testing"
@@ -20,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed/care"
@@ -182,6 +184,76 @@ var _ = Describe("Seed Care Control", func() {
 					Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(seed), updatedSeed)).To(Succeed())
 					Expect(updatedSeed.Status.Conditions).To(ConsistOf(conditions))
 				})
+			})
+		})
+	})
+
+	Describe("#Reconcile", func() {
+		Describe("emergency switch annotation condition", func() {
+			var (
+				req        reconcile.Request
+				conditions []gardencorev1beta1.Condition
+			)
+
+			BeforeEach(func() {
+				req = reconcile.Request{NamespacedName: client.ObjectKey{Name: seedName}}
+
+				controllerConfig = gardenletconfigv1alpha1.SeedCareControllerConfiguration{
+					SyncPeriod: &metav1.Duration{Duration: careSyncPeriod},
+				}
+
+				conditions = []gardencorev1beta1.Condition{
+					{
+						Type:   gardencorev1beta1.SeedSystemComponentsHealthy,
+						Status: gardencorev1beta1.ConditionTrue,
+						Reason: "foo",
+					},
+				}
+				DeferCleanup(test.WithVars(&NewHealthCheck,
+					healthCheckFunc(func(_ SeedConditions) []gardencorev1beta1.Condition {
+						return conditions
+					})))
+			})
+
+			JustBeforeEach(func() {
+				reconciler = &Reconciler{GardenClient: gardenClient, SeedClient: seedClient, Config: controllerConfig, Clock: fakeClock}
+				Expect(gardenClient.Create(ctx, seed)).To(Succeed())
+			})
+
+			It("should add a condition for a set annotation", func() {
+				seed.Annotations = map[string]string{
+					v1beta1constants.AnnotationDisableShootReconciliations: "true",
+				}
+				Expect(gardenClient.Update(ctx, seed)).To(Succeed())
+
+				Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
+
+				updatedSeed := &gardencorev1beta1.Seed{}
+				Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(seed), updatedSeed)).To(Succeed())
+				Expect(updatedSeed.Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
+					"Type":    BeEquivalentTo("SeedDisabledShootReconciliations"),
+					"Status":  BeEquivalentTo("True"),
+					"Reason":  Equal("SeedDisabledShootReconciliations"),
+					"Message": Equal("Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation."),
+				})))
+			})
+
+			It("should remove a previously set condition for a removed annotation", func() {
+				seed.Status.Conditions = []gardencorev1beta1.Condition{
+					{
+						Type:    gardencorev1beta1.SeedDisabledShootReconciliations,
+						Status:  gardencorev1beta1.ConditionTrue,
+						Reason:  string(gardencorev1beta1.SeedDisabledShootReconciliations),
+						Message: "Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation.",
+					},
+				}
+				Expect(gardenClient.Status().Update(ctx, seed)).To(Succeed())
+
+				Expect(reconciler.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
+
+				updatedSeed := &gardencorev1beta1.Seed{}
+				Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(seed), updatedSeed)).To(Succeed())
+				Expect(updatedSeed.Status.Conditions).To(ConsistOf(conditions))
 			})
 		})
 	})

--- a/pkg/gardenlet/controller/shoot/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/shoot/add.go
@@ -67,7 +67,7 @@ func (r *Reconciler) EventHandler(log logr.Logger) handler.EventHandler {
 				return
 			}
 
-			enqueueAfter := CalculateControllerInfos(shoot, r.Clock, *r.Config.Controllers.Shoot).EnqueueAfter
+			enqueueAfter := CalculateControllerInfos(nil, shoot, r.Clock, *r.Config.Controllers.Shoot).EnqueueAfter
 			nextReconciliation := r.Clock.Now().UTC().Add(enqueueAfter)
 
 			log.Info("Scheduling next reconciliation for Shoot",

--- a/pkg/gardenlet/controller/shoot/shoot/add_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/add_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Add", func() {
 
 		It("should enqueue the object for Create events according to the calculated duration", func() {
 			duration := time.Minute
-			DeferCleanup(test.WithVar(&CalculateControllerInfos, func(*gardencorev1beta1.Shoot, clock.Clock, gardenletconfigv1alpha1.ShootControllerConfiguration) helper.ControllerInfos {
+			DeferCleanup(test.WithVar(&CalculateControllerInfos, func(*gardencorev1beta1.Seed, *gardencorev1beta1.Shoot, clock.Clock, gardenletconfigv1alpha1.ShootControllerConfiguration) helper.ControllerInfos {
 				return helper.ControllerInfos{
 					EnqueueAfter: duration,
 				}

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
@@ -123,19 +123,19 @@ func CalculateControllerInfos(seed *gardencorev1beta1.Seed, shoot *gardencorev1b
 }
 
 func (i ControllerInfos) shouldReconcileNow() ReconcileNowDecision {
-	// if the shoot is failed or ignored, it doesn't matter which operation is triggered
-	if i.isFailed || i.isIgnored {
-		return ReconcileNowDecision{
-			Result: false,
-			Reason: "Shoot is failed or ignored.",
-		}
-	}
-
 	// Emergency switch: Check Seed annotation to block reconciliation if needed
 	if i.emergencyStopReconciliations {
 		return ReconcileNowDecision{
 			Result: false,
 			Reason: "Shoot reconciliation blocked by Seed emergency switch",
+		}
+	}
+
+	// if the shoot is failed or ignored, it doesn't matter which operation is triggered
+	if i.isFailed || i.isIgnored {
+		return ReconcileNowDecision{
+			Result: false,
+			Reason: "Shoot is failed or ignored.",
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
@@ -12,9 +12,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
 
@@ -39,9 +41,9 @@ type ControllerInfos struct {
 	// E.g., when re-calculating the infos after a successful Create operation, this field will be set to Reconcile, as
 	// the next operation that should be performed on the shoot is a usual Reconcile operation.
 	OperationType gardencorev1beta1.LastOperationType
-	// ShouldReconcileNow is true if the controller should perform reconciliations immediately.
+	// ShouldReconcileNow describes if the controller should perform reconciliations immediately.
 	// This is supposed to be used in the reconciler only.
-	ShouldReconcileNow bool
+	ShouldReconcileNow ReconcileNowDecision
 	// ShouldOnlySyncClusterResource is true if the controller should not perform reconciliations right now
 	// (ShouldReconcileNow == false) but the controller should still sync the cluster resource to the seed.
 	ShouldOnlySyncClusterResource bool
@@ -72,14 +74,26 @@ type ControllerInfos struct {
 	isNowInEffectiveMaintenanceTimeWindow bool
 	alreadyReconciledDuringThisTimeWindow bool
 
+	// based on seed object
+	isReconciliationPaused bool
+
 	// based on gardenlet config and shoot object
 	syncPeriod time.Duration
+}
+
+// ReconcileNowDecision contains the result of the reconciliation decision
+// and a reason explaining why the decision was made.
+type ReconcileNowDecision struct {
+	// Result is true if the controller should perform reconciliations immediately.
+	Result bool
+	// Reason is a human-readable reason for the decision.
+	Reason string
 }
 
 // CalculateControllerInfos calculates whether and when a given shoot should be reconciled.
 // These results are supposed to be used/handled immediately. Always call CalculateControllerInfos to re-calculate the
 // results before using them.
-func CalculateControllerInfos(shoot *gardencorev1beta1.Shoot, clock clock.Clock, cfg gardenletconfigv1alpha1.ShootControllerConfiguration) ControllerInfos {
+func CalculateControllerInfos(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta1.Shoot, clock clock.Clock, cfg gardenletconfigv1alpha1.ShootControllerConfiguration) ControllerInfos {
 	respectSyncPeriodOverwrite := ptr.Deref(cfg.RespectSyncPeriodOverwrite, false)
 
 	i := ControllerInfos{
@@ -97,6 +111,8 @@ func CalculateControllerInfos(shoot *gardencorev1beta1.Shoot, clock clock.Clock,
 		isNowInEffectiveMaintenanceTimeWindow: gardenerutils.IsNowInEffectiveShootMaintenanceTimeWindow(shoot, clock),
 		alreadyReconciledDuringThisTimeWindow: gardenerutils.LastReconciliationDuringThisTimeWindow(shoot, clock),
 
+		isReconciliationPaused: seed != nil && kubernetesutils.HasMetaDataAnnotation(&seed.ObjectMeta, v1beta1constants.AnnotationDisableShootReconciliations, "true"),
+
 		syncPeriod: gardenerutils.SyncPeriodOfShoot(respectSyncPeriodOverwrite, cfg.SyncPeriod.Duration, shoot),
 	}
 
@@ -108,22 +124,33 @@ func CalculateControllerInfos(shoot *gardencorev1beta1.Shoot, clock clock.Clock,
 	return i
 }
 
-func (i ControllerInfos) shouldReconcileNow() bool {
+func (i ControllerInfos) shouldReconcileNow() ReconcileNowDecision {
 	// if the shoot is failed or ignored, it doesn't matter which operation is triggered
 	if i.isFailed || i.isIgnored {
-		return false
+		return ReconcileNowDecision{
+			Result: false,
+			Reason: "Shoot is failed or ignored.",
+		}
+	}
+
+	// Emergency switch: Check Seed annotation to block reconciliation if needed
+	if i.isReconciliationPaused {
+		return ReconcileNowDecision{
+			Result: false,
+			Reason: "Shoot reconciliation blocked by Seed emergency switch",
+		}
 	}
 
 	// in the following checks, we optimize when and how often existing shoots are reconciled
 	// all operations other than Reconcile are excluded from these optimizations as we want to perform the operations immediately
 	if i.OperationType != gardencorev1beta1.LastOperationTypeReconcile {
-		return true
+		return ReconcileNowDecision{Result: true}
 	}
 
 	// if the observedGeneration is outdated (i.e., spec was changed) or the last operation was not successful,
 	// we always want to reconcile immediately
 	if !i.isUpToDate {
-		return true
+		return ReconcileNowDecision{Result: true}
 	}
 
 	// from here on, we have a case of regular reconciliation (i.e., shoot is observed at latest generation and in
@@ -132,7 +159,7 @@ func (i ControllerInfos) shouldReconcileNow() bool {
 	// If we do not confine reconciliations (either by the operator or shoot owner) to the maintenance time window then
 	// we allow immediate reconciliations.
 	if !i.reconcileInMaintenanceOnly && !i.confineSpecUpdateRollout {
-		return true
+		return ReconcileNowDecision{Result: true}
 	}
 
 	// from here on, either:
@@ -142,12 +169,15 @@ func (i ControllerInfos) shouldReconcileNow() bool {
 	// if the shoot is in its maintenance time window right now but has not been reconciled in the time window so far,
 	// now is the time that we have been waiting for :) -> go
 	if i.isNowInEffectiveMaintenanceTimeWindow && !i.alreadyReconciledDuringThisTimeWindow {
-		return true
+		return ReconcileNowDecision{Result: true}
 	}
 
 	// shoot reconciliations are confined, and the shoot's maintenance time window is not met, or it was already
 	// reconciled in this time window -> ¯\_(ツ)_/¯
-	return false
+	return ReconcileNowDecision{
+		Result: false,
+		Reason: "Shoot is not in its effective maintenance time window or was already reconciled during this time window.",
+	}
 }
 
 func (i ControllerInfos) shouldOnlySyncClusterResource() bool {

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
@@ -73,7 +73,7 @@ type ControllerInfos struct {
 	alreadyReconciledDuringThisTimeWindow bool
 
 	// based on seed object
-	isReconciliationPaused bool
+	emergencyStopReconciliations bool
 
 	// based on gardenlet config and shoot object
 	syncPeriod time.Duration
@@ -109,7 +109,7 @@ func CalculateControllerInfos(seed *gardencorev1beta1.Seed, shoot *gardencorev1b
 		isNowInEffectiveMaintenanceTimeWindow: gardenerutils.IsNowInEffectiveShootMaintenanceTimeWindow(shoot, clock),
 		alreadyReconciledDuringThisTimeWindow: gardenerutils.LastReconciliationDuringThisTimeWindow(shoot, clock),
 
-		isReconciliationPaused: v1beta1helper.HasShootReconciliationsDisabledAnnotation(seed),
+		emergencyStopReconciliations: v1beta1helper.HasShootReconciliationsDisabledAnnotation(seed),
 
 		syncPeriod: gardenerutils.SyncPeriodOfShoot(respectSyncPeriodOverwrite, cfg.SyncPeriod.Duration, shoot),
 	}
@@ -132,7 +132,7 @@ func (i ControllerInfos) shouldReconcileNow() ReconcileNowDecision {
 	}
 
 	// Emergency switch: Check Seed annotation to block reconciliation if needed
-	if i.isReconciliationPaused {
+	if i.emergencyStopReconciliations {
 		return ReconcileNowDecision{
 			Result: false,
 			Reason: "Shoot reconciliation blocked by Seed emergency switch",

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos.go
@@ -12,11 +12,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
 )
 
@@ -111,7 +109,7 @@ func CalculateControllerInfos(seed *gardencorev1beta1.Seed, shoot *gardencorev1b
 		isNowInEffectiveMaintenanceTimeWindow: gardenerutils.IsNowInEffectiveShootMaintenanceTimeWindow(shoot, clock),
 		alreadyReconciledDuringThisTimeWindow: gardenerutils.LastReconciliationDuringThisTimeWindow(shoot, clock),
 
-		isReconciliationPaused: seed != nil && kubernetesutils.HasMetaDataAnnotation(&seed.ObjectMeta, v1beta1constants.AnnotationDisableShootReconciliations, "true"),
+		isReconciliationPaused: v1beta1helper.HasShootReconciliationsDisabledAnnotation(seed),
 
 		syncPeriod: gardenerutils.SyncPeriodOfShoot(respectSyncPeriodOverwrite, cfg.SyncPeriod.Duration, shoot),
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
@@ -31,6 +31,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 	var (
 		cl    *testclock.FakeClock
 		shoot *gardencorev1beta1.Shoot
+		seed  *gardencorev1beta1.Seed
 		cfg   gardenletconfigv1alpha1.ShootControllerConfiguration
 
 		timeWindow      timewindow.MaintenanceTimeWindow
@@ -62,6 +63,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				},
 			},
 		}
+		seed = nil
 
 		timeWindow = *gardenerutils.EffectiveShootMaintenanceTimeWindow(shoot)
 		m := timeWindow.Begin()
@@ -77,7 +79,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 	})
 
 	JustBeforeEach(func() {
-		infos = CalculateControllerInfos(shoot, cl, cfg)
+		infos = CalculateControllerInfos(seed, shoot, cl, cfg)
 	})
 
 	Context("shoot creation", func() {
@@ -93,7 +95,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 		Context("creation is triggered", func() {
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -107,7 +109,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -119,7 +121,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -138,7 +140,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -153,7 +155,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -164,9 +166,27 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
+			})
+		})
+
+		Context("seed with emergency switch to temporarily stop reconciliations", func() {
+			BeforeEach(func() {
+				seed = &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "seed",
+						Annotations: map[string]string{
+							v1beta1constants.AnnotationDisableShootReconciliations: "true",
+						},
+					},
+				}
+			})
+
+			It("should not reconcile the shoot", func() {
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Reason).To(Equal("Shoot reconciliation blocked by Seed emergency switch"))
 			})
 		})
 	})
@@ -189,7 +209,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -202,14 +222,14 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
 
 		Context("reconciliations are not confined", func() {
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 
@@ -241,7 +261,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			testReconciliationsConfined := func() {
 				Context("currently not in maintenance time window", func() {
 					It("should not reconcile the shoot immediately", func() {
-						Expect(infos.ShouldReconcileNow).To(BeFalse())
+						Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 						Expect(infos.ShouldOnlySyncClusterResource).To(BeFalse())
 					})
 
@@ -274,7 +294,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 						It("should reconcile the shoot immediately", func() {
 							// If a reconciliation request is passed to the reconciler (e.g., exponential requeue or requeue after),
 							// handle it immediately instead of calculating a new random time in this time window.
-							Expect(infos.ShouldReconcileNow).To(BeTrue())
+							Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 							Expect(infos.ShouldOnlySyncClusterResource).To(BeFalse())
 						})
 
@@ -297,7 +317,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 						})
 
 						It("should not reconcile the shoot immediately", func() {
-							Expect(infos.ShouldReconcileNow).To(BeFalse())
+							Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 							Expect(infos.ShouldOnlySyncClusterResource).To(BeFalse())
 						})
 
@@ -347,7 +367,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -365,7 +385,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -380,7 +400,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -391,9 +411,27 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
+			})
+		})
+
+		Context("seed with emergency switch to temporarily stop reconciliations", func() {
+			BeforeEach(func() {
+				seed = &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "seed",
+						Annotations: map[string]string{
+							v1beta1constants.AnnotationDisableShootReconciliations: "true",
+						},
+					},
+				}
+			})
+
+			It("should not reconcile the shoot", func() {
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Reason).To(Equal("Shoot reconciliation blocked by Seed emergency switch"))
 			})
 		})
 	})
@@ -413,7 +451,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 		Context("migration is triggered", func() {
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -426,7 +464,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -438,7 +476,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -456,7 +494,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -471,7 +509,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -482,7 +520,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -506,7 +544,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 		Context("restoration is triggered", func() {
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -519,7 +557,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -531,7 +569,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -549,7 +587,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -564,7 +602,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -575,7 +613,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -597,7 +635,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 		Context("deletion is triggered", func() {
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -610,7 +648,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should reconcile the shoot immediately", func() {
-				Expect(infos.ShouldReconcileNow).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
 		})
@@ -622,7 +660,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -640,7 +678,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 			})
 
 			It("should not reconcile the shoot but sync the cluster resource", func() {
-				Expect(infos.ShouldReconcileNow).To(BeFalse())
+				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldOnlySyncClusterResource).To(BeTrue())
 				Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 			})
@@ -655,7 +693,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})
@@ -666,7 +704,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 				})
 
 				It("should reconcile the shoot immediately", func() {
-					Expect(infos.ShouldReconcileNow).To(BeTrue())
+					Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
 					Expect(infos.EnqueueAfter).To(Equal(time.Duration(0)))
 				})
 			})

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
@@ -178,7 +178,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "seed",
 						Annotations: map[string]string{
-							v1beta1constants.AnnotationDisableShootReconciliations: "true",
+							v1beta1constants.AnnotationEmergencyStopShootReconciliations: "true",
 						},
 					},
 				}
@@ -187,6 +187,24 @@ var _ = Describe("CalculateControllerInfos", func() {
 			It("should not reconcile the shoot", func() {
 				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldReconcileNow.Reason).To(Equal("Shoot reconciliation blocked by Seed emergency switch"))
+			})
+		})
+
+		Context("seed with inactive emergency switch does not block reconciliations", func() {
+			BeforeEach(func() {
+				seed = &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "seed",
+						Annotations: map[string]string{
+							v1beta1constants.AnnotationEmergencyStopShootReconciliations: "false",
+						},
+					},
+				}
+			})
+
+			It("should not reconcile the shoot", func() {
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Reason).To(BeEmpty())
 			})
 		})
 	})
@@ -423,7 +441,7 @@ var _ = Describe("CalculateControllerInfos", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "seed",
 						Annotations: map[string]string{
-							v1beta1constants.AnnotationDisableShootReconciliations: "true",
+							v1beta1constants.AnnotationEmergencyStopShootReconciliations: "true",
 						},
 					},
 				}
@@ -432,6 +450,24 @@ var _ = Describe("CalculateControllerInfos", func() {
 			It("should not reconcile the shoot", func() {
 				Expect(infos.ShouldReconcileNow.Result).To(BeFalse())
 				Expect(infos.ShouldReconcileNow.Reason).To(Equal("Shoot reconciliation blocked by Seed emergency switch"))
+			})
+		})
+
+		Context("seed with inactive emergency switch does not block reconciliations", func() {
+			BeforeEach(func() {
+				seed = &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "seed",
+						Annotations: map[string]string{
+							v1beta1constants.AnnotationEmergencyStopShootReconciliations: "false",
+						},
+					},
+				}
+			})
+
+			It("should not reconcile the shoot", func() {
+				Expect(infos.ShouldReconcileNow.Result).To(BeTrue())
+				Expect(infos.ShouldReconcileNow.Reason).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -313,7 +313,7 @@ func filterSeedsWithDisabledShootReconciliations(seedList []gardencorev1beta1.Se
 	}
 
 	if len(seedsWithEnabledReconciliations) == 0 {
-		return nil, fmt.Errorf("none of the %d seeds has enabled shoot reconciliations currently", len(seedList))
+		return nil, fmt.Errorf("none of the %d seeds have enabled shoot reconciliations currently", len(seedList))
 	}
 	return seedsWithEnabledReconciliations, nil
 }

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -167,6 +167,10 @@ func (r *Reconciler) DetermineSeed(
 	if err != nil {
 		return nil, err
 	}
+	filteredSeeds, err = filterSeedsWithDisabledShootReconciliations(filteredSeeds)
+	if err != nil {
+		return nil, err
+	}
 	filteredSeeds, err = filterCandidates(shoot, shootList, filteredSeeds)
 	if err != nil {
 		return nil, err
@@ -297,6 +301,21 @@ func filterSeedsForAccessRestrictions(seedList []gardencorev1beta1.Seed, shoot *
 		return nil, fmt.Errorf("none of the %d seeds supports the access restrictions configured in the shoot specification", len(seedList))
 	}
 	return seedsSupportingAccessRestrictions, nil
+}
+
+// filterSeedsWithDisabledShootReconciliations filters seeds which have annotation set to temporarily disable shoot reconciliations.
+func filterSeedsWithDisabledShootReconciliations(seedList []gardencorev1beta1.Seed) ([]gardencorev1beta1.Seed, error) {
+	var seedsWithEnabledReconciliations []gardencorev1beta1.Seed
+	for _, seed := range seedList {
+		if !v1beta1helper.HasShootReconciliationsDisabledAnnotation(&seed) {
+			seedsWithEnabledReconciliations = append(seedsWithEnabledReconciliations, seed)
+		}
+	}
+
+	if len(seedsWithEnabledReconciliations) == 0 {
+		return nil, fmt.Errorf("none of the %d seeds has enabled shoot reconciliations currently", len(seedList))
+	}
+	return seedsWithEnabledReconciliations, nil
 }
 
 func applyStrategy(log logr.Logger, shoot *gardencorev1beta1.Shoot, seedList []gardencorev1beta1.Seed, strategy schedulerconfigv1alpha1.CandidateDeterminationStrategy, regionConfig *corev1.ConfigMap) ([]gardencorev1beta1.Seed, error) {

--- a/test/integration/scheduler/shoot/shoot_test.go
+++ b/test/integration/scheduler/shoot/shoot_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Scheduler tests", func() {
 			cloudProfile := createCloudProfile("some-region")
 			seed := createSeed("some-region", nil, nil)
 			seed.Annotations = map[string]string{
-				constants.AnnotationDisableShootReconciliations: "true",
+				constants.AnnotationEmergencyStopShootReconciliations: "true",
 			}
 			Expect(testClient.Update(ctx, seed)).To(Succeed())
 			shoot := createShoot(cloudProfile.Name, "some-region", nil, ptr.To("somedns.example.com"), nil, nil)

--- a/test/integration/scheduler/shoot/shoot_test.go
+++ b/test/integration/scheduler/shoot/shoot_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Scheduler tests", func() {
 				g.Expect(shoot.Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeCreate))
 				g.Expect(shoot.Status.LastOperation.State).To(Equal(gardencorev1beta1.LastOperationStatePending))
 				return shoot.Status.LastOperation.Description
-			}).Should(ContainSubstring("none of the 1 seeds has enabled shoot reconciliations currently"))
+			}).Should(ContainSubstring("none of the 1 seeds have enabled shoot reconciliations currently"))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness
/kind enhancement

**What this PR does / why we need it**:
There may be situations where you need to temporarily stop the reconciliation of `Shoot` clusters in a `Seed` cluster.
This can be achieved by adding the annotation `gardener.cloud/disable-shoot-reconciliations=true` to the `Seed` resource.

While this annotation is present:
- The `Seed` controller will not reconcile any `Shoot` clusters in the affected `Seed`.
- New `Shoot` clusters will not be scheduled to this `Seed`.
- The `Seed` will expose the `SeedDisabledShootReconciliations` condition.
- This is useful, for example, to prevent faulty updates from propagating further.

**Which issue(s) this PR fixes**:
Fixes #12528

**Special notes for your reviewer**:
/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add annotation `shoot.gardener.cloud/emergency-stop-reconciliations=true` to `Seed` resources to temporarily disable `Shoot` reconciliations.
```
