### PR TITLE
🧹  Cleanup TODOs

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 	shootsystem "github.com/gardener/gardener/pkg/component/shoot/system"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -38,11 +36,6 @@ import (
 func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 	log.Info("Migrating deprecated failure-domain.beta.kubernetes.io labels to topology.kubernetes.io")
 	if err := migrateDeprecatedTopologyLabels(ctx, log, g.mgr.GetClient()); err != nil {
-		return err
-	}
-
-	log.Info("Migrating RBAC resources for machine-controller-manager")
-	if err := migrateMCMRBAC(ctx, g.mgr.GetClient()); err != nil {
 		return err
 	}
 
@@ -121,41 +114,6 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
-}
-
-// TODO(@aaronfern): Remove this after v1.123 is released
-func migrateMCMRBAC(ctx context.Context, seedClient client.Client) error {
-	namespaceList := &corev1.NamespaceList{}
-	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
-		return fmt.Errorf("failed listing namespaces with '%s: %s' label: %w", v1beta1constants.GardenRole, v1beta1constants.GardenRoleShoot, err)
-	}
-
-	var tasks []flow.TaskFn
-
-	for _, namespace := range namespaceList.Items {
-		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
-			continue
-		}
-		tasks = append(tasks, func(ctx context.Context) error {
-			clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-			if err := seedClient.Get(ctx, client.ObjectKey{Name: "machine-controller-manager-" + namespace.Name}, clusterRoleBinding); err != nil {
-				//If MCM clusterRoleBinding does not exist, nothing to do
-				return client.IgnoreNotFound(err)
-			}
-
-			return machinecontrollermanager.New(seedClient, namespace.Name, nil, machinecontrollermanager.Values{}).MigrateRBAC(ctx)
-		})
-	}
-
-	if err := flow.Parallel(tasks...)(ctx); err != nil {
-		return err
-	}
-	if err := managedresources.DeleteForSeed(ctx, seedClient, "garden", "machine-controller-manager"); err != nil {
-		if !meta.IsNoMatchError(err) {
-			return err
-		}
-	}
-	return nil
 }
 
 // TODO(shafeeqes): Remove this function in gardener v1.125

--- a/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/mock/mocks.go
@@ -68,20 +68,6 @@ func (mr *MockInterfaceMockRecorder) Destroy(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), ctx)
 }
 
-// MigrateRBAC mocks base method.
-func (m *MockInterface) MigrateRBAC(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MigrateRBAC", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// MigrateRBAC indicates an expected call of MigrateRBAC.
-func (mr *MockInterfaceMockRecorder) MigrateRBAC(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateRBAC", reflect.TypeOf((*MockInterface)(nil).MigrateRBAC), ctx)
-}
-
 // SetReplicas mocks base method.
 func (m *MockInterface) SetReplicas(arg0 int32) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR removes some migration codes:
1. MCM RBAC migration logic, added with https://github.com/gardener/gardener/pull/12181, released in gardener `v1.121.0`. /cc @aaronfern 
2. Nginx ingress ConfigMap cleanup in seeds. Added with https://github.com/gardener/gardener/pull/12318, Reelased in gardener `v1.122.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
