### PR TITLE
Fix Test Machinery Shoot Application Networking Test for IPv6.

### DIFF
--- a/test/framework/resources/templates/network-nginx-configmap.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-configmap.yaml.tpl
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+data:
+  ipv6.conf: |
+    server {
+        listen [::]:80;
+        server_name localhost;
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }

--- a/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
@@ -18,8 +18,16 @@ spec:
         image: registry.k8s.io/e2e-test-images/nginx:1.15-4
         ports:
         - containerPort: 80
+        volumeMounts:
+        - name: ipv6-config
+          mountPath: /etc/nginx/conf.d/ipv6.conf
+          subPath: ipv6.conf
       - name: pause
         image: registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
         - pause
       serviceAccountName: {{ .name }}
+      volumes:
+      - name: ipv6-config
+        configMap:
+          name: {{ .name }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area testing
/kind enhancement

**What this PR does / why we need it**:

Fix Test Machinery Shoot Application Networking Test for IPv6.

The test uses nginx and tries to curl between the pods. Unfortunately, the default configuration of nginx only uses IPv4, i.e. it does not listen for IPv6 traffic. This causes problems in conjunction with the fact that the test only uses the first pod IP, which is from the primary IP family of the cluster. In case the cluster is IPv6-only or has IPv6 as primary address family the call was failing because nobody was listening on the other end.
In addition to that, the concatenation of IP address and port was only working for IPv4 addresses. With IPv6, the address needs to be enclosed in square brackets.
The first issue was addressed by adding an nginx configuration to listen on IPv6 as well. This also works in IPv4 clusters as IPv6 is always available locally. The second issue was addressed by using the proper utility function from the go standard library.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

/cc @axel7born 