### PR TITLE
Remove init container and annotation used for Prometheus volume cleanup migration

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -456,6 +456,8 @@ rules:
   - servicemonitors
   - scrapeconfigs
   - prometheusrules
+  # TODO(vicwicker): Remove this after v1.128 has been released.
+  - prometheuses
   verbs:
   - list
   - watch

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -456,8 +456,6 @@ rules:
   - servicemonitors
   - scrapeconfigs
   - prometheusrules
-  # TODO(vicwicker): Remove this after v1.125 has been released.
-  - prometheuses
   verbs:
   - list
   - watch

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -369,7 +369,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules", "prometheuses"},
+				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules"},
 				Verbs:     []string{"list", "watch", "get", "create", "patch", "update", "delete"},
 			},
 		},

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -369,7 +369,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"monitoring.coreos.com"},
-				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules"},
+				Resources: []string{"servicemonitors", "scrapeconfigs", "prometheusrules", "prometheuses"},
 				Verbs:     []string{"list", "watch", "get", "create", "patch", "update", "delete"},
 			},
 		},

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -10,14 +10,20 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	shootsystem "github.com/gardener/gardener/pkg/component/shoot/system"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
@@ -26,6 +32,11 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 	log.Info("Migrating deprecated failure-domain.beta.kubernetes.io labels to topology.kubernetes.io")
 	if err := migrateDeprecatedTopologyLabels(ctx, log, g.mgr.GetClient()); err != nil {
 		return err
+	}
+
+	log.Info("Removing Prometheus cleaned up obsolete folder annotations")
+	if err := removePrometheusFolderCleanedupAnnotation(ctx, log, g.mgr.GetClient()); err != nil {
+		return fmt.Errorf("failed removing Prometheus cleaned up obsolete folder annotations: %w", err)
 	}
 
 	log.Info("Migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig")
@@ -93,6 +104,107 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+// TODO(vicwicker): Remove this after v1.128 has been released.
+func removePrometheusFolderCleanedupAnnotation(ctx context.Context, log logr.Logger, seedClient client.Client) error {
+	var tasks []flow.TaskFn
+
+	getPrometheusWithPatch := func(ctx context.Context, namespace string) (*monitoringv1.Prometheus, client.Patch, error) {
+		prometheus := &monitoringv1.Prometheus{}
+		if err := seedClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot"}, prometheus); err != nil {
+			return nil, nil, err
+		}
+
+		return prometheus, client.MergeFrom(prometheus.DeepCopy()), nil
+	}
+
+	shouldSkipCluster := func(ctx context.Context, log logr.Logger, cluster *extensionsv1alpha1.Cluster) (bool, error) {
+		shoot, err := extensions.ShootFromCluster(cluster)
+		if err != nil {
+			return false, fmt.Errorf("failed to extract Shoot from Cluster %s: %w", cluster.Name, err)
+		}
+
+		if shoot.DeletionTimestamp != nil {
+			log.Info("Cluster is being deleted, it should be skipped", "cluster", cluster.Name)
+			return true, nil
+		}
+
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Name}}
+		if err := seedClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("Namespace for cluster not found, cluster should be skipped", "cluster", cluster.Name)
+				return true, nil
+			}
+			return false, fmt.Errorf("failed to get Namespace for cluster %s: %w", cluster.Name, err)
+		}
+
+		if namespace.DeletionTimestamp != nil {
+			log.Info("Namespace for cluster is being deleted, cluster should be skipped", "cluster", cluster.Name)
+			return true, nil
+		}
+
+		return false, nil
+	}
+
+	log.Info("Remove folder cleaned up annotations from Prometheus")
+
+	// check if the Cluster resource is available in the seed cluster
+	gvk := schema.GroupVersionKind{
+		Group:   "extensions.gardener.cloud",
+		Version: "v1alpha1",
+		Kind:    "Cluster",
+	}
+
+	if _, err := seedClient.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.Info("The Cluster resource is not available in the extensions.gardener.cloud/v1alpha1 API group")
+			return nil
+		}
+		return fmt.Errorf("failed to check if the Cluster resource is available in the extensions.gardener.cloud/v1alpha1 API group: %w", err)
+	}
+
+	clusterList := &extensionsv1alpha1.ClusterList{}
+	if err := seedClient.List(ctx, clusterList); err != nil {
+		return fmt.Errorf("failed to list clusters for annotation removal from Prometheus: %w", err)
+	}
+
+	for _, cluster := range clusterList.Items {
+		tasks = append(tasks, func(ctx context.Context) error {
+			skip, err := shouldSkipCluster(ctx, log, &cluster)
+			if err != nil {
+				return err
+			}
+
+			if skip {
+				log.Info("Skip annotation removal for cluster", "cluster", cluster.Name)
+				return nil
+			}
+
+			prometheus, prometheusPatch, err := getPrometheusWithPatch(ctx, cluster.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Prometheus resource not found, skipping annotation removal", "cluster", cluster.Name)
+					return nil
+				}
+				return fmt.Errorf("failed to get Prometheus resource for cluster %s: %w", cluster.Name, err)
+			}
+
+			if _, ok := prometheus.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp]; !ok {
+				// annotation already removed, nothing to do
+				return nil
+			}
+
+			delete(prometheus.Annotations, resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp)
+			if err := seedClient.Patch(ctx, prometheus, prometheusPatch); err != nil {
+				return fmt.Errorf("failed to remove annotation from Prometheus resource for cluster %s: %w", cluster.Name, err)
+			}
+
+			return nil
+		})
+	}
+
+	return flow.Parallel(tasks...)(ctx)
 }
 
 // TODO(@vpnachev): Remove this after v1.127.0 has been released

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -8,39 +8,24 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/go-logr/logr"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	shootsystem "github.com/gardener/gardener/pkg/component/shoot/system"
-	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
-	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 	log.Info("Migrating deprecated failure-domain.beta.kubernetes.io labels to topology.kubernetes.io")
 	if err := migrateDeprecatedTopologyLabels(ctx, log, g.mgr.GetClient()); err != nil {
 		return err
-	}
-
-	log.Info("Cleaning up prometheus obsolete folders")
-	if err := cleanupPrometheusObsoleteFolders(ctx, log, g.mgr.GetClient()); err != nil {
-		return fmt.Errorf("failed cleaning up prometheus obsolete folders: %w", err)
 	}
 
 	log.Info("Migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig")
@@ -108,241 +93,6 @@ func migrateDeprecatedTopologyLabels(ctx context.Context, log logr.Logger, seedC
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
-}
-
-// TODO(vicwicker): Remove this after v1.125 has been released.
-func cleanupPrometheusObsoleteFolders(ctx context.Context, log logr.Logger, seedClient client.Client) error {
-	var tasks []flow.TaskFn
-
-	getManagedResourceWithPatch := func(ctx context.Context, namespace string) (*resourcesv1alpha1.ManagedResource, client.Patch, error) {
-		managedResource := &resourcesv1alpha1.ManagedResource{}
-		if err := seedClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "prometheus-shoot"}, managedResource); err != nil {
-			return nil, nil, err
-		}
-
-		return managedResource, client.MergeFrom(managedResource.DeepCopy()), nil
-	}
-
-	unignoreManagedResource := func(ctx context.Context, log logr.Logger, cluster string) error {
-		managedResource, managedResourcePatch, err := getManagedResourceWithPatch(ctx, cluster)
-		if err != nil {
-			// tolerate if the managed resource does not exist, e.g., it might have been deleted
-			if apierrors.IsNotFound(err) {
-				log.Info("ManagedResource for Prometheus not found, nothing to unignore", "cluster", cluster)
-				return nil
-			}
-			return fmt.Errorf("failed to get ManagedResource for Prometheus for cluster %s, it won't be unignored: %w", cluster, err)
-		}
-
-		if value, ok := managedResource.Annotations[resourcesv1alpha1.Ignore]; ok && value == "true" {
-			delete(managedResource.Annotations, resourcesv1alpha1.Ignore)
-			if err := seedClient.Patch(ctx, managedResource, managedResourcePatch); err != nil {
-				return fmt.Errorf("failed to unignore ManagedResource for Prometheus for cluster %s: %w", cluster, err)
-			}
-		}
-
-		return nil
-	}
-
-	getPrometheusWithPatch := func(ctx context.Context, namespace string) (*monitoringv1.Prometheus, client.Patch, error) {
-		prometheus := &monitoringv1.Prometheus{}
-		if err := seedClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot"}, prometheus); err != nil {
-			return nil, nil, err
-		}
-
-		return prometheus, client.MergeFrom(prometheus.DeepCopy()), nil
-	}
-
-	needsInitContainer := func(prometheus *monitoringv1.Prometheus) bool {
-		for _, initContainer := range prometheus.Spec.InitContainers {
-			if initContainer.Name == "cleanup-obsolete-folder" {
-				return false
-			}
-		}
-
-		return true
-	}
-
-	waitUntilCleanedUp := func(ctx context.Context, log logr.Logger, namespace string) error {
-		return retry.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
-			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "prometheus-shoot-0"}}
-			if err := seedClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
-				log.Error(err, "Failed to get prometheus-shoot-0 pod", "namespace", namespace)
-				return retry.MinorError(err)
-			}
-
-			var hasInitContainer bool
-			for _, initContainer := range pod.Spec.InitContainers {
-				if initContainer.Name == "cleanup-obsolete-folder" {
-					hasInitContainer = true
-					break
-				}
-			}
-
-			if !hasInitContainer {
-				err := fmt.Errorf("prometheus-shoot-0 pod does not have the cleanup-obsolete-folder init container")
-				log.Error(err, "Pod prometheus-shoot-0 is not cleaned up", "namespace", namespace)
-				return retry.MinorError(err)
-			}
-
-			if err := health.CheckPod(pod); err != nil {
-				log.Error(err, "Pod prometheus-shoot-0 is not healthy", "namespace", namespace)
-				return retry.MinorError(err)
-			}
-
-			return retry.Ok()
-		})
-	}
-
-	shouldSkipCluster := func(ctx context.Context, log logr.Logger, cluster *extensionsv1alpha1.Cluster) (bool, error) {
-		shoot, err := extensions.ShootFromCluster(cluster)
-		if err != nil {
-			return false, fmt.Errorf("failed to extract Shoot from Cluster %s: %w", cluster.Name, err)
-		}
-
-		if shoot.DeletionTimestamp != nil {
-			log.Info("Cluster is being deleted, it should be skipped", "cluster", cluster.Name)
-			return true, nil
-		}
-
-		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Name}}
-		if err := seedClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-			if apierrors.IsNotFound(err) {
-				log.Info("Namespace for cluster not found, cluster should be skipped", "cluster", cluster.Name)
-				return true, nil
-			}
-			return false, fmt.Errorf("failed to get Namespace for cluster %s: %w", cluster.Name, err)
-		}
-
-		if namespace.DeletionTimestamp != nil {
-			log.Info("Namespace for cluster is being deleted, cluster should be skipped", "cluster", cluster.Name)
-			return true, nil
-		}
-
-		return false, nil
-	}
-
-	log.Info("Clean up obsolete Prometheus folders")
-
-	// check if the Cluster resource is available in the seed cluster
-	gvk := schema.GroupVersionKind{
-		Group:   "extensions.gardener.cloud",
-		Version: "v1alpha1",
-		Kind:    "Cluster",
-	}
-
-	if _, err := seedClient.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
-		if meta.IsNoMatchError(err) {
-			log.Info("The Cluster resource is not available in the extensions.gardener.cloud/v1alpha1 API group")
-			return nil
-		}
-		return fmt.Errorf("failed to check if the Cluster resource is available in the extensions.gardener.cloud/v1alpha1 API group: %w", err)
-	}
-
-	clusterList := &extensionsv1alpha1.ClusterList{}
-	if err := seedClient.List(ctx, clusterList); err != nil {
-		return fmt.Errorf("failed to list clusters while cleaning up Prometheus obsolete folders: %w", err)
-	}
-
-	for _, cluster := range clusterList.Items {
-		tasks = append(tasks, func(ctx context.Context) error {
-			skip, err := shouldSkipCluster(ctx, log, &cluster)
-			if err != nil {
-				return err
-			}
-
-			if skip {
-				log.Info("Skip cleanup for cluster", "cluster", cluster.Name)
-				return nil
-			}
-
-			if err := unignoreManagedResource(ctx, log, cluster.Name); err != nil {
-				return err
-			}
-
-			managedResource, managedResourcePatch, err := getManagedResourceWithPatch(ctx, cluster.Name)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					log.Info("ManagedResource for Prometheus not found, skipping cleanup", "cluster", cluster.Name)
-					return nil
-				}
-				return fmt.Errorf("failed to get ManagedResource for Prometheus for cluster %s: %w", cluster.Name, err)
-			}
-
-			prometheus, prometheusPatch, err := getPrometheusWithPatch(ctx, cluster.Name)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					log.Info("Prometheus resource not found, skipping cleanup", "cluster", cluster.Name)
-					return nil
-				}
-				return fmt.Errorf("failed to get Prometheus resource for cluster %s: %w", cluster.Name, err)
-			}
-
-			if value, ok := prometheus.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp]; ok && value == "true" {
-				// migration already done, nothing to do
-				return nil
-			}
-
-			// ignore the managed resource temporarily to prevent it from reverting the Prometheus patches
-			managedResource.Annotations[resourcesv1alpha1.Ignore] = "true"
-			if err := seedClient.Patch(ctx, managedResource, managedResourcePatch); err != nil {
-				return fmt.Errorf("failed to ignore ManagedResource for Prometheus for cluster %s: %w", cluster.Name, err)
-			}
-
-			log.Info("Clean up obsolete Prometheus folders", "cluster", cluster.Name)
-
-			if needsInitContainer(prometheus) {
-				prometheus.Spec.InitContainers = append(prometheus.Spec.InitContainers, corev1.Container{
-					Name:            "cleanup-obsolete-folder",
-					Image:           *prometheus.Spec.Image,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"sh", "-c", "rm -rf /prometheus/prometheus-; rm -rf /prometheus/prometheus-db/prometheus-"},
-					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: ptr.To(false),
-					},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      "prometheus-db",
-						MountPath: "/prometheus",
-					}},
-				})
-			}
-
-			prometheus.Spec.Replicas = ptr.To(int32(1))
-			if err := seedClient.Patch(ctx, prometheus, prometheusPatch); err != nil {
-				if err := unignoreManagedResource(ctx, log, cluster.Name); err != nil {
-					log.Error(err, "Failed to unignore ManagedResource for Prometheus after error", "cluster", cluster.Name)
-				}
-				return fmt.Errorf("failed to patch Prometheus resource for cluster %s: %w", cluster.Name, err)
-			}
-
-			if err := waitUntilCleanedUp(ctx, log, cluster.Name); err != nil {
-				if err := unignoreManagedResource(ctx, log, cluster.Name); err != nil {
-					log.Error(err, "Failed to unignore ManagedResource for Prometheus after error", "cluster", cluster.Name)
-				}
-				return fmt.Errorf("failed to wait until Prometheus statefulset for cluster %s is cleaned up: %w", cluster.Name, err)
-			}
-
-			prometheus, prometheusPatch, err = getPrometheusWithPatch(ctx, cluster.Name)
-			if err != nil {
-				if err := unignoreManagedResource(ctx, log, cluster.Name); err != nil {
-					log.Error(err, "Failed to unignore ManagedResource for Prometheus after error", "cluster", cluster.Name)
-				}
-				return fmt.Errorf("failed to get Prometheus resource after cleanup for cluster %s: %w", cluster.Name, err)
-			}
-
-			prometheus.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp] = "true"
-			if err := seedClient.Patch(ctx, prometheus, prometheusPatch); err != nil {
-				if err := unignoreManagedResource(ctx, log, cluster.Name); err != nil {
-					log.Error(err, "Failed to unignore ManagedResource for Prometheus after error", "cluster", cluster.Name)
-				}
-				return fmt.Errorf("failed to mark Prometheus resource as cleaned up for cluster %s: %w", cluster.Name, err)
-			}
-
-			return unignoreManagedResource(ctx, log, cluster.Name)
-		})
-	}
-
-	return flow.Parallel(tasks...)(ctx)
 }
 
 // TODO(@vpnachev): Remove this after v1.127.0 has been released

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -191,6 +191,11 @@ const (
 	// NetworkingServiceNamespace is a constant for a label on a NetworkPolicy which contains the namespace of the
 	// Service is has been created for.
 	NetworkingServiceNamespace = NetworkPolicyLabelKeyPrefix + "service-namespace"
+
+	// PrometheusObsoleteFolderCleanedUp is a temporal annotation to indicate that the obsolete "prometheus-" data folder
+	// from Prometheus has been cleaned up. This is used to mark the clean up as complete and avoid repeated attempts to clean up
+	// TODO(vicwicker): Remove this after v1.128 is released.
+	PrometheusObsoleteFolderCleanedUp = "monitoring.resources.gardener.cloud/prometheus-obsolete-folder-cleaned-up"
 )
 
 // +kubebuilder:resource:shortName="mr"

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -191,10 +191,6 @@ const (
 	// NetworkingServiceNamespace is a constant for a label on a NetworkPolicy which contains the namespace of the
 	// Service is has been created for.
 	NetworkingServiceNamespace = NetworkPolicyLabelKeyPrefix + "service-namespace"
-
-	// PrometheusObsoleteFolderCleanedUp is a temporal annotation to indicate that the obsolete "prometheus-" data folder
-	// from Prometheus has been cleaned up. This is used to mark the clean up as complete and avoid repeated attempts to clean up
-	PrometheusObsoleteFolderCleanedUp = "monitoring.resources.gardener.cloud/prometheus-obsolete-folder-cleaned-up"
 )
 
 // +kubebuilder:resource:shortName="mr"

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -243,11 +243,6 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		clusterRoleBinding = p.clusterRoleBinding()
 	}
 
-	prometheus, err := p.prometheus(ctx, cortexConfigMap)
-	if err != nil {
-		return err
-	}
-
 	resources, err := registry.AddAllAndSerialize(
 		p.serviceAccount(),
 		p.service(),
@@ -259,7 +254,7 @@ func (p *prometheus) Deploy(ctx context.Context) error {
 		p.secretAdditionalAlertmanagerConfigs(),
 		p.secretRemoteWriteBasicAuth(),
 		cortexConfigMap,
-		prometheus,
+		p.prometheus(cortexConfigMap),
 		p.vpa(),
 		p.podDisruptionBudget(),
 		ingress,

--- a/pkg/component/observability/monitoring/prometheus/prometheus.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus.go
@@ -5,28 +5,22 @@
 package prometheus
 
 import (
-	"context"
-	"fmt"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/alertmanager"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-func (p *prometheus) prometheus(ctx context.Context, cortexConfigMap *corev1.ConfigMap) (*monitoringv1.Prometheus, error) {
+func (p *prometheus) prometheus(cortexConfigMap *corev1.ConfigMap) *monitoringv1.Prometheus {
 	obj := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.values.Name,
@@ -167,50 +161,6 @@ func (p *prometheus) prometheus(ctx context.Context, cortexConfigMap *corev1.Con
 		obj.Spec.Volumes = append(obj.Spec.Volumes, p.cortexVolume(cortexConfigMap.Name))
 	}
 
-	// TODO(vicwicker): Remove this after v1.125 has been released.
-	switch p.values.Name {
-	case "shoot":
-		var (
-			isNew      bool
-			isMarked   bool
-			prometheus monitoringv1.Prometheus
-		)
-
-		if err := p.client.Get(ctx, client.ObjectKey{Namespace: p.namespace, Name: p.values.Name}, &prometheus); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to check if shoot prometheus exists: %w", err)
-			}
-			isNew = true
-		}
-
-		if value, ok := prometheus.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp]; ok && value == "true" {
-			isMarked = true
-		}
-
-		if isNew || isMarked {
-			if obj.Annotations == nil {
-				obj.Annotations = map[string]string{}
-			}
-			obj.Annotations[resourcesv1alpha1.PrometheusObsoleteFolderCleanedUp] = "true"
-		}
-	case "garden", "longterm", "aggregate", "cache", "seed":
-		obj.Spec.InitContainers = append(obj.Spec.InitContainers, corev1.Container{
-			Name:            "cleanup-obsolete-folder",
-			Image:           p.values.Image,
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"sh", "-c", "rm -rf /prometheus/prometheus-; rm -rf /prometheus/prometheus-db/prometheus-"},
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: ptr.To(false),
-			},
-			VolumeMounts: []corev1.VolumeMount{{
-				Name:      "prometheus-db",
-				MountPath: "/prometheus",
-			}},
-		})
-	default:
-		// Future Prometheus types do not need migration
-	}
-
 	utilruntime.Must(references.InjectAnnotations(obj))
-	return obj, nil
+	return obj
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

We recently identified that certain Prometheus volumes still contain the `prometheus-` folder with outdated Prometheus data. The following PR, with further details, addressed this issue by implementing a cleanup process:

- https://github.com/gardener/gardener/pull/12219

The cleanup code introduced a new init container in the Prometheus resource. For the garden, longterm, aggregate, cache, and seed Prometheus, this init container was added directly to the Prometheus resource. In the case of shoot Prometheus, where successful shoot reconciliation can't be guaranteed, the init container was temporarily added to each shoot Prometheus resource as a one-time migration during the gardenlet startup. Successfully cleaned up shoot Prometheus were annotated to prevent repeated execution of this cleanup process during gardenlet startup.

Now, after three Gardener releases, it is time to drop this init container and annotation from the Prometheus resources and eliminate as much of the migration code as possible.

**Special notes for your reviewer**:

/cc @istvanballok @rfranzke 

**Release note**:

```other operator
Remove the init container and annotation used for the Prometheus volume cleanup migration from Prometheus resources
```
