### PR TITLE
Deflake `node-agent` unit test

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -575,9 +575,14 @@ PRETTY_NAME="Garden Linux 1592Foo"
 		})
 
 		It("should not patch the node as update successful and delete the pods if the OS is not up-to-date", func() {
-			DeferCleanup(test.WithVar(&GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) {
-				return ptr.To("1.1.0"), nil
-			}))
+			DeferCleanup(test.WithVars(
+				&GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) {
+					return ptr.To("1.1.0"), nil
+				},
+				&ExecCommandCombinedOutput, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+					return []byte("OS update successful, not yet restarted"), nil
+				},
+			))
 
 			oscChanges.InPlaceUpdates.OperatingSystem = true
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler_test.go
@@ -276,8 +276,8 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			}
 
 			DeferCleanup(test.WithVars(
-				&OSUpdateRetryInterval, 1*time.Millisecond,
-				&OSUpdateRetryTimeout, 10*time.Millisecond,
+				&OSUpdateRetryInterval, 100*time.Millisecond,
+				&OSUpdateRetryTimeout, 1*time.Second,
 			))
 		})
 
@@ -369,8 +369,8 @@ PRETTY_NAME="Garden Linux 1592Foo"
 			oscChanges = &operatingSystemConfigChanges{}
 
 			DeferCleanup(test.WithVars(
-				&OSUpdateRetryInterval, 1*time.Millisecond,
-				&OSUpdateRetryTimeout, 10*time.Millisecond,
+				&OSUpdateRetryInterval, 100*time.Millisecond,
+				&OSUpdateRetryTimeout, 1*time.Second,
 				&GetOSVersion, func(*extensionsv1alpha1.InPlaceUpdates, afero.Afero) (*string, error) {
 					return ptr.To(osVersion), nil
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind flake

**What this PR does / why we need it**:
The test is flaking with context deadline exceeded errors,
```
      failed to update OS in-place: failed to execute OS update command: no specific error detected: context deadline exceeded, output: OS update successful

      {
          msg: "failed to update OS in-place: failed to execute OS update command: no specific error detected: context deadline exceeded, output: OS update successful\n",
          err: <*fmt.wrapError | 0x140009c21e0>{
              msg: "failed to execute OS update command: no specific error detected: context deadline exceeded, output: OS update successful\n",
              err: <*fmt.wrapError | 0x140009c2000>{
                  msg: "no specific error detected: context deadline exceeded, output: OS update successful\n",
                  err: <context.deadlineExceededError>{},
              },
          },
      }
```
This PR overwrites `ExecCommandCombinedOutput` in the test; the command in the OSC status seems to take more than 10 milliseconds (previous timeout) sometimes.

The retry timeout and interval are also increased now to prevent future flakes.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12697

**Special notes for your reviewer**:

Before:
```
❯ stress -ignore "unable to grab random port" -p 16 ./pkg/nodeagent/controller/operatingsystemconfig/operatingsystemconfig.test -ginkgo.focus "should not patch the node as update successful and delete the pods if the OS is not up-to-date"
...
35s: 5599 runs so far, 23 failures (0.41%), 16 active
```

After:
```
❯ stress -ignore "unable to grab random port" -p 64 ./pkg/nodeagent/controller/operatingsystemconfig/operatingsystemconfig.test -ginkgo.focus "should not patch the node as update successful and delete the pods if the OS is not up-to-date"

5m0s: 47658 runs so far, 0 failures, 64 active
5m5s: 48465 runs so far, 0 failures, 64 active
5m10s: 49274 runs so far, 0 failures, 64 active
5m15s: 50073 runs so far, 0 failures, 64 active
5m20s: 50869 runs so far, 0 failures, 64 active
5m25s: 51664 runs so far, 0 failures, 64 active
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
