### PR TITLE
Fix nil panic in Container Runtime TM tests

### DIFF
--- a/test/framework/framework_suite_test.go
+++ b/test/framework/framework_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package framework_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFramework(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Framework Suite")
+}

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -198,7 +198,7 @@ func GetAllNodes(ctx context.Context, c kubernetes.Interface) (*corev1.NodeList,
 func GetAllNodesInWorkerPool(ctx context.Context, c kubernetes.Interface, workerGroup *string) (*corev1.NodeList, error) {
 	nodeList := &corev1.NodeList{}
 
-	selectorOption := &client.MatchingLabelsSelector{}
+	selectorOption := &client.MatchingLabelsSelector{Selector: labels.Everything()}
 	if workerGroup != nil && len(*workerGroup) > 0 {
 		selectorOption.Selector = labels.SelectorFromSet(labels.Set{"worker.gardener.cloud/pool": *workerGroup})
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The Container Runtime TM test is failing after https://github.com/gardener/gardener/pull/12687 PR. This PR attempts to list all nodes using an empty [MatchingLabelsSelector](https://github.com/gardener/gardener/blob/90be35f69c5a6defacfb92252ea3af74aaffa55b/test/framework/k8s_utils.go#L201), which causes a panic because the selector is empty. To fix this, the PR sets the label selector to match everything when no worker is specified. 

PR in [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/pull/3279) to address this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
