### PR TITLE
[kind-local] Add DNS entry for discovery.ingress.runtime-garden.local.gardener.cloud

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -407,6 +407,8 @@ cat <<EOF | sudo tee -a /etc/hosts
 # Begin of Gardener Operator local setup section
 172.18.255.3 api.virtual-garden.local.gardener.cloud
 172.18.255.3 plutono-garden.ingress.runtime-garden.local.gardener.cloud
+172.18.255.3 dashboard.ingress.runtime-garden.local.gardener.cloud
+172.18.255.3 discovery.ingress.runtime-garden.local.gardener.cloud
 # End of Gardener Operator local setup section
 EOF
 ```

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -368,6 +368,7 @@ kubectl -n kube-system get configmap coredns -ojson | \
       $garden_cluster_ip gardener.virtual-garden.local.gardener.cloud\n\
       $garden_cluster_ip api.virtual-garden.local.gardener.cloud\n\
       $garden_cluster_ip dashboard.ingress.runtime-garden.local.gardener.cloud\n\
+      $garden_cluster_ip discovery.ingress.runtime-garden.local.gardener.cloud\n\
       fallthrough\n\
     }\
 "'/' | \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
When running the local kind setup, pods attempting to resolve
`discovery.ingress.runtime-garden.local.gardener.cloud` failed with:

    dial tcp: lookup discovery.ingress.runtime-garden.local.gardener.cloud on 10.2.0.10:53: no such host

This change updates the local `kind-up` setup script to inject the DNS mapping
for `discovery.ingress.runtime-garden.local.gardener.cloud` into CoreDNS ConfigMap (in kube-system).

With this fix, DNS resolution works as expected in local environment.

**Which issue(s) this PR fixes**:
This was found when trying to run locally a OIDC webhook authenticator in the Garden cluster that authenticates shoot clusters with managed issuer annotation ([managed service account issuer](https://gardener.cloud/docs/gardener/security/shoot_serviceaccounts/#Managed-Service-Account-Issuer))

**Special notes for your reviewer**:
Verification: 
```
kubectl -n kube-system get cm coredns -o yaml
apiVersion: v1
data:
  Corefile: |+
    .:53 {
        errors
        health {
           lameduck 5s
        }
        ready
        hosts {
          172.18.0.3 garden.local.gardener.cloud
          172.18.0.3 gardener.virtual-garden.local.gardener.cloud
          172.18.0.3 api.virtual-garden.local.gardener.cloud
          172.18.0.3 dashboard.ingress.runtime-garden.local.gardener.cloud
          172.18.0.3 discovery.ingress.runtime-garden.local.gardener.cloud
          fallthrough
        }
        ...
    }

kind: ConfigMap
```

CC: @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
