### PR TITLE
Add check for openidconnectionpreset and shoot k8s >=1.32

### DIFF
--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -28,7 +28,7 @@ Gardener provides an admission controller (OpenIDConnectPreset) which, when enab
   1. `.spec.weight` value.
   1. lexicographically ordering their names (e.g., `002preset` > `001preset`)
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.StructuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 ### Simple OpenIDConnectPreset Example
 

--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -160,7 +160,7 @@ Gardener provides an admission controller (ClusterOpenIDConnectPreset) which, wh
   1. `.spec.weight` value.
   1. lexicographically ordering their names ( e.g. `002preset` > `001preset` )
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.StructuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 > **Note:** Due to the previous requirement, if a `Shoot` is matched by both `OpenIDConnectPreset` and `ClusterOpenIDConnectPreset`, then `OpenIDConnectPreset` takes precedence over `ClusterOpenIDConnectPreset`.
 

--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -28,7 +28,7 @@ Gardener provides an admission controller (OpenIDConnectPreset) which, when enab
   1. `.spec.weight` value.
   1. lexicographically ordering their names (e.g., `002preset` > `001preset`)
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig`, then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 ### Simple OpenIDConnectPreset Example
 
@@ -160,7 +160,7 @@ Gardener provides an admission controller (ClusterOpenIDConnectPreset) which, wh
   1. `.spec.weight` value.
   1. lexicographically ordering their names ( e.g. `002preset` > `001preset` )
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 > **Note:** Due to the previous requirement, if a `Shoot` is matched by both `OpenIDConnectPreset` and `ClusterOpenIDConnectPreset`, then `OpenIDConnectPreset` takes precedence over `ClusterOpenIDConnectPreset`.
 

--- a/docs/usage/security/openidconnect-presets.md
+++ b/docs/usage/security/openidconnect-presets.md
@@ -28,7 +28,7 @@ Gardener provides an admission controller (OpenIDConnectPreset) which, when enab
   1. `.spec.weight` value.
   1. lexicographically ordering their names (e.g., `002preset` > `001preset`)
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.StructuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.structuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 ### Simple OpenIDConnectPreset Example
 
@@ -160,7 +160,7 @@ Gardener provides an admission controller (ClusterOpenIDConnectPreset) which, wh
   1. `.spec.weight` value.
   1. lexicographically ordering their names ( e.g. `002preset` > `001preset` )
 
-- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.StructuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
+- If the `Shoot` already has a `.spec.kubernetes.kubeAPIServer.oidcConfig` or а `.spec.kubernetes.kubeAPIServer.structuredAuthentication` or `Shoot` kubernetes version is >= 1.32, then no mutation occurs.
 
 > **Note:** Due to the previous requirement, if a `Shoot` is matched by both `OpenIDConnectPreset` and `ClusterOpenIDConnectPreset`, then `OpenIDConnectPreset` takes precedence over `ClusterOpenIDConnectPreset`.
 

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -11,12 +11,12 @@ import (
 	"io"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -176,17 +176,7 @@ func (c *ClusterOpenIDConnectPreset) Admit(_ context.Context, a admission.Attrib
 	}
 	// We have an OpenIDConnectPreset, use it.
 	if preset != nil {
-		currentVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
-		if err != nil {
-			return apierrors.NewBadRequest(fmt.Errorf("failed to parse shoot version: %w", err).Error())
-		}
-
-		if versionutils.ConstraintK8sGreaterEqual132.Check(currentVersion) {
-			return apierrors.NewBadRequest(errors.New("openidconnectpreset cannot be used for shoot version >=1.32").Error())
-		}
-
 		applier.ApplyOIDCConfiguration(shoot, preset)
-
 		return nil
 	}
 

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -133,7 +133,7 @@ func (c *ClusterOpenIDConnectPreset) Admit(_ context.Context, a admission.Attrib
 	// OIDCConfig is forbidden for clusters with kubernetes version >= 1.32.
 	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("failed to parse shoot version: %w", err))
+		return apierrors.NewInternalError(fmt.Errorf("failed to parse shoot version '%s': %w", shoot.Spec.Kubernetes.Version, err))
 	}
 	if versionutils.ConstraintK8sGreaterEqual132.Check(kubernetesVersion) {
 		return nil

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -130,6 +130,15 @@ func (c *ClusterOpenIDConnectPreset) Admit(_ context.Context, a admission.Attrib
 		return nil
 	}
 
+	// OIDCConfig is forbidden for clusters with kubernetes version >= 1.32.
+	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("failed to parse shoot version: %w", err))
+	}
+	if versionutils.ConstraintK8sGreaterEqual132.Check(kubernetesVersion) {
+		return nil
+	}
+
 	if shoot.Spec.Kubernetes.KubeAPIServer != nil && shoot.Spec.Kubernetes.KubeAPIServer.StructuredAuthentication != nil {
 		return nil
 	}

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
@@ -212,11 +212,8 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 			)
 
 			BeforeEach(func() {
-				shootNameLess132 := "shoot1"
-				shootLess132 = shoot.DeepCopy()
-				shootLess132.Name = shootNameLess132
-				shootLess132.Spec.Kubernetes.Version = "1.31.0"
-				expected = shootLess132.DeepCopy()
+				shoot.Spec.Kubernetes.Version = "1.31.0"
+				expected = shoot.DeepCopy()
 				expected.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
 					OIDCConfig: &core.OIDCConfig{
 						CABundle:     ptr.To("cert"),

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 
 		BeforeEach(func() {
 			namespace := "my-namespace"
-			shootName := "shoot0"
+			shootName := "shoot"
 			presetName := "preset-1"
 			projectName := "project-1"
 			shoot = &core.Shoot{
@@ -157,7 +157,7 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 				expected = shoot.DeepCopy()
 			})
 
-			It("structured authentication settings already exist", func() {
+			It("structured authentication settings already exists", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
 					StructuredAuthentication: &core.StructuredAuthentication{
 						ConfigMapName: "test",
@@ -205,7 +205,7 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 
 		})
 
-		Context("should mutate the result for shoot kubernetes <= 1.32", func() {
+		Context("should mutate the result for shoot kubernetes < 1.32", func() {
 			var (
 				expected     *core.Shoot
 				shootLess132 *core.Shoot // shoot version <1.32

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission_test.go
@@ -207,8 +207,7 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 
 		Context("should mutate the result for shoot kubernetes < 1.32", func() {
 			var (
-				expected     *core.Shoot
-				shootLess132 *core.Shoot // shoot version <1.32
+				expected *core.Shoot
 			)
 
 			BeforeEach(func() {
@@ -241,18 +240,18 @@ var _ = Describe("Cluster OpenIDConfig Preset", func() {
 				Expect(settingsInformerFactory.Settings().V1alpha1().ClusterOpenIDConnectPresets().Informer().GetStore().Add(preset)).To(Succeed())
 				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(project)).To(Succeed())
 
-				attrs := admission.NewAttributesRecord(shootLess132, nil, core.Kind("Shoot").WithVersion("v1beta1"), shootLess132.Namespace, shootLess132.Name, core.Resource("shoots").WithVersion("v1alpha1"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("v1beta1"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("v1alpha1"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer).NotTo(BeNil())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer.OIDCConfig).NotTo(BeNil())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientAuthentication).NotTo(BeNil())
-				Expect(shootLess132).To(Equal(expected))
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer).NotTo(BeNil())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig).NotTo(BeNil())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientAuthentication).NotTo(BeNil())
+				Expect(shoot).To(Equal(expected))
 			})
 
 			It("shoot's kube-apiserver-oidc settings is not set", func() {
-				shootLess132.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{}
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{}
 			})
 
 			It("successfully", func() {

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -115,7 +115,7 @@ func (o *OpenIDConnectPreset) Admit(_ context.Context, a admission.Attributes, _
 	// OIDCConfig is forbidden for clusters with kubernetes version >= 1.32.
 	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("failed to parse shoot version: %w", err))
+		return apierrors.NewInternalError(fmt.Errorf("failed to parse shoot version '%s': %w", shoot.Spec.Kubernetes.Version, err))
 	}
 	if versionutils.ConstraintK8sGreaterEqual132.Check(kubernetesVersion) {
 		return nil

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -11,12 +11,12 @@ import (
 	"io"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/gardener/gardener/pkg/apis/core"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
@@ -178,11 +178,8 @@ var _ = Describe("OpenID Connect Preset", func() {
 			)
 
 			BeforeEach(func() {
-				shootNameLess132 := "shoot1"
-				shootLess132 = shoot.DeepCopy()
-				shootLess132.Name = shootNameLess132
-				shootLess132.Spec.Kubernetes.Version = "1.31.0"
-				expected = shootLess132.DeepCopy()
+				shoot.Spec.Kubernetes.Version = "1.31.0"
+				expected = shoot.DeepCopy()
 				expected.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
 					OIDCConfig: &core.OIDCConfig{
 						CABundle:     ptr.To("cert"),

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
@@ -31,7 +31,7 @@ var _ = Describe("OpenID Connect Preset", func() {
 
 		BeforeEach(func() {
 			namespace := "my-namespace"
-			shootName := "shoot0"
+			shootName := "shoot"
 			presetName := "preset-1"
 			shoot = &core.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
@@ -171,7 +171,7 @@ var _ = Describe("OpenID Connect Preset", func() {
 
 		})
 
-		Context("should mutate the result for shoot kubernetes <= 1.32", func() {
+		Context("should mutate the result for shoot kubernetes < 1.32", func() {
 			var (
 				expected     *core.Shoot
 				shootLess132 *core.Shoot // shoot version <1.32

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission_test.go
@@ -173,8 +173,7 @@ var _ = Describe("OpenID Connect Preset", func() {
 
 		Context("should mutate the result for shoot kubernetes < 1.32", func() {
 			var (
-				expected     *core.Shoot
-				shootLess132 *core.Shoot // shoot version <1.32
+				expected *core.Shoot
 			)
 
 			BeforeEach(func() {
@@ -205,18 +204,18 @@ var _ = Describe("OpenID Connect Preset", func() {
 
 			AfterEach(func() {
 				Expect(settingsInformerFactory.Settings().V1alpha1().OpenIDConnectPresets().Informer().GetStore().Add(preset)).To(Succeed())
-				attrs := admission.NewAttributesRecord(shootLess132, nil, core.Kind("Shoot").WithVersion("v1beta1"), shootLess132.Namespace, shootLess132.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("v1beta1"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer).NotTo(BeNil())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer.OIDCConfig).NotTo(BeNil())
-				Expect(shootLess132.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientAuthentication).NotTo(BeNil())
-				Expect(shootLess132).To(Equal(expected))
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer).NotTo(BeNil())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig).NotTo(BeNil())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientAuthentication).NotTo(BeNil())
+				Expect(shoot).To(Equal(expected))
 			})
 
 			It("oidc settings is not set", func() {
-				shootLess132.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{}
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{}
 			})
 
 			It("successfully", func() {


### PR DESCRIPTION
**How to categorize this PR?**

  /area control-plane
  /kind bug

**What this PR does / why we need it**:

Add check for shoot clusters, returning error when we try to create shoot >= 1.32 without OIDCConfig but with OpenidConnectPreset present, currently this preset is applied altough it is not compatible with 1.32 and thus validationcheck of shoot prevents of creation of shoot cluster

**Which issue(s) this PR fixes**:
Fixes #12744 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix shoot creation failure for shoots with kubernetes version >=1.32 and openidconnect preset present
```
