### PR TITLE
[GEP-33]  Fix default architecture when using capabilities 

### DIFF
--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -531,9 +531,12 @@ func FilterDeprecatedVersion() func(expirableVersion gardencorev1beta1.Expirable
 	}
 }
 
-func extractArchitecturesFromCapabilitySets(capabilities []gardencorev1beta1.CapabilitySet) []string {
+func extractArchitecturesFromCapabilitySets(capabilitySets []gardencorev1beta1.CapabilitySet, defaultArchitecture string) []string {
 	architectures := sets.New[string]()
-	for _, capabilitySet := range capabilities {
+	if len(capabilitySets) == 0 && defaultArchitecture != "" {
+		return []string{defaultArchitecture}
+	}
+	for _, capabilitySet := range capabilitySets {
 		for _, architectureValue := range capabilitySet.Capabilities[constants.ArchitectureName] {
 			architectures.Insert(architectureValue)
 		}
@@ -541,10 +544,26 @@ func extractArchitecturesFromCapabilitySets(capabilities []gardencorev1beta1.Cap
 	return architectures.UnsortedList()
 }
 
+// GetDefaultArchitectureFromCapabilityDefinitions returns the default architecture of the capabilitiesDefinitions.
+func GetDefaultArchitectureFromCapabilityDefinitions(capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) string {
+	if len(capabilitiesDefinitions) == 0 {
+		return ""
+	}
+	for _, capabilityDefinition := range capabilitiesDefinitions {
+		if capabilityDefinition.Name == constants.ArchitectureName {
+			if len(capabilityDefinition.Values) == 1 {
+				return capabilityDefinition.Values[0]
+			}
+			break
+		}
+	}
+	return ""
+}
+
 // GetArchitecturesFromImageVersion returns the list of supported architectures for the machine image version.
 // It first tries to retrieve the architectures from the capability sets and falls back to the architectures field if none are found.
-func GetArchitecturesFromImageVersion(imageVersion gardencorev1beta1.MachineImageVersion) []string {
-	if architectures := extractArchitecturesFromCapabilitySets(imageVersion.CapabilitySets); len(architectures) > 0 {
+func GetArchitecturesFromImageVersion(imageVersion gardencorev1beta1.MachineImageVersion, defaultArchitecture string) []string {
+	if architectures := extractArchitecturesFromCapabilitySets(imageVersion.CapabilitySets, defaultArchitecture); len(architectures) > 0 {
 		return architectures
 	}
 	return imageVersion.Architectures
@@ -552,8 +571,8 @@ func GetArchitecturesFromImageVersion(imageVersion gardencorev1beta1.MachineImag
 
 // ArchitectureSupportedByImageVersion checks if the machine image version supports the given architecture.
 // The function falls back to the architectures field if the passed capabilities are empty.
-func ArchitectureSupportedByImageVersion(version gardencorev1beta1.MachineImageVersion, architecture string) bool {
-	supportedArchitectures := GetArchitecturesFromImageVersion(version)
+func ArchitectureSupportedByImageVersion(version gardencorev1beta1.MachineImageVersion, architecture, defaultArchitecture string) bool {
+	supportedArchitectures := GetArchitecturesFromImageVersion(version, defaultArchitecture)
 	return slices.Contains(supportedArchitectures, architecture)
 }
 
@@ -621,22 +640,35 @@ func intersectSlices(slice1, slice2 []string) []string {
 func AreCapabilitiesSupportedByCapabilitySets(
 	capabilities gardencorev1beta1.Capabilities, capabilitySets []gardencorev1beta1.CapabilitySet, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition,
 ) bool {
-	defaultedCapabilitySets := GetCapabilitySetsWithAppliedDefaults(capabilitySets, capabilitiesDefinitions)
-	defaultedCapabilities := GetCapabilitiesWithAppliedDefaults(capabilities, capabilitiesDefinitions)
+	if len(capabilitySets) == 0 {
+		// if no capability sets are defined, assume all capabilities are supported
+		// this can only occur in cloud profiles with one supported architecture
+		return true
+	}
 
-	for _, capabilitySet := range defaultedCapabilitySets {
-		isSupported := true
-		commonCapabilities := GetCapabilitiesIntersection(capabilitySet.Capabilities, defaultedCapabilities)
-		// If the intersection has at least one value for each capability, the capabilities are supported.
-		for _, values := range commonCapabilities {
-			if len(values) == 0 {
-				isSupported = false
-				break
-			}
-		}
-		if isSupported {
+	for _, capabilitySet := range capabilitySets {
+		if AreCapabilitiesCompatible(capabilitySet.Capabilities, capabilities, capabilitiesDefinitions) {
 			return true
 		}
 	}
 	return false
+}
+
+// AreCapabilitiesCompatible checks if two sets of capabilities are compatible.
+// It applies defaults from the capability definitions to both sets before checking compatibility.
+func AreCapabilitiesCompatible(capabilities1, capabilities2 gardencorev1beta1.Capabilities, capabilitiesDefinitions []gardencorev1beta1.CapabilityDefinition) bool {
+	defaultedCapabilities1 := GetCapabilitiesWithAppliedDefaults(capabilities1, capabilitiesDefinitions)
+	defaultedCapabilities2 := GetCapabilitiesWithAppliedDefaults(capabilities2, capabilitiesDefinitions)
+
+	isSupported := true
+	commonCapabilities := GetCapabilitiesIntersection(defaultedCapabilities1, defaultedCapabilities2)
+	// If the intersection has at least one value for each capability, the capabilities are supported.
+	for _, values := range commonCapabilities {
+		if len(values) == 0 {
+			isSupported = false
+			break
+		}
+	}
+
+	return isSupported
 }

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1479,7 +1479,7 @@ var _ = Describe("CloudProfile Helper", func() {
 					})
 				}
 
-				Expect(GetArchitecturesFromImageVersion(imageVersion)).To(ConsistOf(expectedResult))
+				Expect(GetArchitecturesFromImageVersion(imageVersion, "")).To(ConsistOf(expectedResult))
 			},
 			Entry("Should return nil", nil, nil, nil),
 			Entry("Should return architecture in set", []string{"amd64", "arm64"}, []string{"ia-64"}, []string{"amd64", "arm64"}),
@@ -1498,7 +1498,7 @@ var _ = Describe("CloudProfile Helper", func() {
 					})
 				}
 
-				Expect(ArchitectureSupportedByImageVersion(imageVersion, requestedArchitecture)).To(Equal(expectedResult))
+				Expect(ArchitectureSupportedByImageVersion(imageVersion, requestedArchitecture, "")).To(Equal(expectedResult))
 			},
 			Entry("Should be false for void architectures", nil, "arm64", false),
 			Entry("Should be false for unsupported architecture", []string{"amd64", "arm64"}, "ia-64", false),

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1479,7 +1479,7 @@ var _ = Describe("CloudProfile Helper", func() {
 					})
 				}
 
-				Expect(GetArchitecturesFromImageVersion(imageVersion, "")).To(ConsistOf(expectedResult))
+				Expect(GetArchitecturesFromImageVersion(imageVersion, []gardencorev1beta1.CapabilityDefinition{})).To(ConsistOf(expectedResult))
 			},
 			Entry("Should return nil", nil, nil, nil),
 			Entry("Should return architecture in set", []string{"amd64", "arm64"}, []string{"ia-64"}, []string{"amd64", "arm64"}),
@@ -1498,7 +1498,7 @@ var _ = Describe("CloudProfile Helper", func() {
 					})
 				}
 
-				Expect(ArchitectureSupportedByImageVersion(imageVersion, requestedArchitecture, "")).To(Equal(expectedResult))
+				Expect(ArchitectureSupportedByImageVersion(imageVersion, requestedArchitecture, []gardencorev1beta1.CapabilityDefinition{})).To(Equal(expectedResult))
 			},
 			Entry("Should be false for void architectures", nil, "arm64", false),
 			Entry("Should be false for unsupported architecture", []string{"amd64", "arm64"}, "ia-64", false),

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -197,7 +197,11 @@ type MachineType struct {
 }
 
 // GetArchitecture returns the architecture of the machine type.
-func (m *MachineType) GetArchitecture() string {
+func (m *MachineType) GetArchitecture(defaultArchitecture string) string {
+	if len(m.Capabilities[constants.ArchitectureName]) == 0 && defaultArchitecture != "" {
+		return defaultArchitecture
+	}
+
 	if len(m.Capabilities[constants.ArchitectureName]) == 1 {
 		return m.Capabilities[constants.ArchitectureName][0]
 	}

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -216,7 +216,7 @@ func (m *MachineType) GetArchitecture(capabilityDefinitions []CapabilityDefiniti
 
 	// constants.ArchitectureName is a required capability and
 	// machineType.Capabilities[constants.ArchitectureName] can only
-	// be empty for cloudprofiles supporting exactly architecture.
+	// be empty for cloudprofiles supporting exactly one architecture.
 	// we should never reach this point.
 	return ""
 }

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -197,15 +197,28 @@ type MachineType struct {
 }
 
 // GetArchitecture returns the architecture of the machine type.
-func (m *MachineType) GetArchitecture(defaultArchitecture string) string {
-	if len(m.Capabilities[constants.ArchitectureName]) == 0 && defaultArchitecture != "" {
-		return defaultArchitecture
+func (m *MachineType) GetArchitecture(capabilityDefinitions []CapabilityDefinition) string {
+	if len(capabilityDefinitions) == 0 {
+		return ptr.Deref(m.Architecture, "")
 	}
 
 	if len(m.Capabilities[constants.ArchitectureName]) == 1 {
 		return m.Capabilities[constants.ArchitectureName][0]
 	}
-	return ptr.Deref(m.Architecture, "")
+
+	if len(m.Capabilities[constants.ArchitectureName]) == 0 {
+		for _, capabilityDefinition := range capabilityDefinitions {
+			if capabilityDefinition.Name == constants.ArchitectureName && len(capabilityDefinition.Values) == 1 {
+				return capabilityDefinition.Values[0]
+			}
+		}
+	}
+
+	// constants.ArchitectureName is a required capability and
+	// machineType.Capabilities[constants.ArchitectureName] can only
+	// be empty for cloudprofiles supporting exactly architecture.
+	// we should never reach this point.
+	return ""
 }
 
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -154,7 +154,7 @@ func validateCloudProfileMachineTypes(machineTypes []core.MachineType, capabilit
 	allErrs = append(allErrs, validateMachineTypes(machineTypes, capabilities, fldPath)...)
 
 	for i, machineType := range machineTypes {
-		if ptr.Deref(machineType.Architecture, "") == "" && (len(capabilities) == 0 || len(machineType.Capabilities[v1beta1constants.ArchitectureName]) == 0) {
+		if ptr.Deref(machineType.Architecture, "") == "" && len(capabilities) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("architecture"), "must provide an architecture"))
 		}
 		if len(capabilities) == 0 && len(machineType.Capabilities) > 0 {

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1455,11 +1455,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					Expect(ValidateCloudProfile(cloudProfile)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeRequired),
-							"Field":    Equal("spec.machineTypes[0].architecture"),
-							"BadValue": Equal(""),
-							"Detail":   Equal("must provide an architecture"),
-						})), PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":     Equal(field.ErrorTypeRequired),
 							"Field":    Equal("spec.capabilities.architecture"),
 							"BadValue": Equal(""),
 							"Detail":   Equal("architecture capability is required"),
@@ -1494,11 +1489,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 
 					Expect(ValidateCloudProfile(cloudProfile)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":     Equal(field.ErrorTypeRequired),
-							"Field":    Equal("spec.machineTypes[0].architecture"),
-							"BadValue": Equal(""),
-							"Detail":   Equal("must provide an architecture"),
-						})), PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":     Equal(field.ErrorTypeInvalid),
 							"Field":    Equal("spec.capabilities.architecture"),
 							"BadValue": Equal("custom"),
@@ -1638,11 +1628,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 
 					Expect(ValidateCloudProfile(cloudProfile)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":     Equal(field.ErrorTypeRequired),
-							"Field":    Equal("spec.machineTypes[0].architecture"),
-							"BadValue": Equal(""),
-							"Detail":   Equal("must provide an architecture"),
-						})), PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeForbidden),
 							"Field":  Equal("spec.capabilities"),
 							"Detail": Equal("capabilities are not allowed with disabled CloudProfileCapabilities feature gate"),

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
@@ -23,7 +23,8 @@ func FilterMachineImageVersions(
 	machineTypeFromCloudProfile *gardencorev1beta1.MachineType,
 	capabilityDefinitions []gardencorev1beta1.CapabilityDefinition,
 ) *gardencorev1beta1.MachineImage {
-	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture)
+	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(capabilityDefinitions)
+	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture, defaultArchitecture)
 	filteredMachineImageVersions = filterForCapabilities(filteredMachineImageVersions, machineTypeFromCloudProfile.Capabilities, capabilityDefinitions)
 	filteredMachineImageVersions = filterForCRI(filteredMachineImageVersions, worker.CRI)
 	filteredMachineImageVersions = filterForKubeletVersionConstraint(filteredMachineImageVersions, kubeletVersion)
@@ -138,7 +139,7 @@ func DetermineVersionForStrategy(expirableVersions []gardencorev1beta1.Expirable
 	return versionForForceUpdate, nil
 }
 
-func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, arch *string) *gardencorev1beta1.MachineImage {
+func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, arch *string, defaultArchitecture string) *gardencorev1beta1.MachineImage {
 	filteredMachineImages := gardencorev1beta1.MachineImage{
 		Name:           machineImageFromCloudProfile.Name,
 		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
@@ -146,7 +147,7 @@ func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.Machi
 	}
 
 	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
-		if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(cloudProfileVersion), *arch) {
+		if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(cloudProfileVersion, defaultArchitecture), *arch) {
 			filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
 		}
 	}

--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
@@ -23,8 +23,7 @@ func FilterMachineImageVersions(
 	machineTypeFromCloudProfile *gardencorev1beta1.MachineType,
 	capabilityDefinitions []gardencorev1beta1.CapabilityDefinition,
 ) *gardencorev1beta1.MachineImage {
-	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(capabilityDefinitions)
-	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture, defaultArchitecture)
+	filteredMachineImageVersions := filterForArchitecture(machineImageFromCloudProfile, worker.Machine.Architecture, capabilityDefinitions)
 	filteredMachineImageVersions = filterForCapabilities(filteredMachineImageVersions, machineTypeFromCloudProfile.Capabilities, capabilityDefinitions)
 	filteredMachineImageVersions = filterForCRI(filteredMachineImageVersions, worker.CRI)
 	filteredMachineImageVersions = filterForKubeletVersionConstraint(filteredMachineImageVersions, kubeletVersion)
@@ -139,7 +138,7 @@ func DetermineVersionForStrategy(expirableVersions []gardencorev1beta1.Expirable
 	return versionForForceUpdate, nil
 }
 
-func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, arch *string, defaultArchitecture string) *gardencorev1beta1.MachineImage {
+func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, arch *string, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *gardencorev1beta1.MachineImage {
 	filteredMachineImages := gardencorev1beta1.MachineImage{
 		Name:           machineImageFromCloudProfile.Name,
 		UpdateStrategy: machineImageFromCloudProfile.UpdateStrategy,
@@ -147,7 +146,7 @@ func filterForArchitecture(machineImageFromCloudProfile *gardencorev1beta1.Machi
 	}
 
 	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
-		if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(cloudProfileVersion, defaultArchitecture), *arch) {
+		if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(cloudProfileVersion, capabilityDefinitions), *arch) {
 			filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
 		}
 	}

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -5799,6 +5799,7 @@ var _ = Describe("validator", func() {
 				}
 
 				if !isCapabilitiesCloudprofile {
+					cloudProfile.Spec.Capabilities = []gardencorev1beta1.CapabilityDefinition{}
 					cloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{
 						{
 							Name:         "machine-type-1",

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -64,6 +64,8 @@ func SetupShootWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1
 
 // AddWorker adds a valid default worker to the shoot for the given machineImage and CloudProfile.
 func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile, workerZone string) error {
+	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(cloudProfile.Spec.Capabilities)
+
 	if len(cloudProfile.Spec.MachineTypes) == 0 {
 		return fmt.Errorf("no MachineTypes configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
@@ -72,17 +74,16 @@ func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.C
 
 	// select first machine type of CPU architecture amd64
 	for _, machine := range cloudProfile.Spec.MachineTypes {
-		if machine.GetArchitecture() == v1beta1constants.ArchitectureAMD64 {
+		if machine.GetArchitecture(defaultArchitecture) == v1beta1constants.ArchitectureAMD64 {
 			machineType = machine
 			break
 		}
 	}
 
-	if machineType.GetArchitecture() != v1beta1constants.ArchitectureAMD64 {
+	if machineType.GetArchitecture(defaultArchitecture) != v1beta1constants.ArchitectureAMD64 {
 		return fmt.Errorf("no MachineTypes of architecture amd64 configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
 
-	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(cloudProfile.Spec.Capabilities)
 	machineImage := firstMachineImageWithAMDSupport(cloudProfile.Spec.MachineImages, defaultArchitecture)
 
 	if machineImage == nil {

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -64,8 +64,6 @@ func SetupShootWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1
 
 // AddWorker adds a valid default worker to the shoot for the given machineImage and CloudProfile.
 func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile, workerZone string) error {
-	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(cloudProfile.Spec.Capabilities)
-
 	if len(cloudProfile.Spec.MachineTypes) == 0 {
 		return fmt.Errorf("no MachineTypes configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
@@ -74,17 +72,17 @@ func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.C
 
 	// select first machine type of CPU architecture amd64
 	for _, machine := range cloudProfile.Spec.MachineTypes {
-		if machine.GetArchitecture(defaultArchitecture) == v1beta1constants.ArchitectureAMD64 {
+		if machine.GetArchitecture(cloudProfile.Spec.Capabilities) == v1beta1constants.ArchitectureAMD64 {
 			machineType = machine
 			break
 		}
 	}
 
-	if machineType.GetArchitecture(defaultArchitecture) != v1beta1constants.ArchitectureAMD64 {
+	if machineType.GetArchitecture(cloudProfile.Spec.Capabilities) != v1beta1constants.ArchitectureAMD64 {
 		return fmt.Errorf("no MachineTypes of architecture amd64 configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
 
-	machineImage := firstMachineImageWithAMDSupport(cloudProfile.Spec.MachineImages, defaultArchitecture)
+	machineImage := firstMachineImageWithAMDSupport(cloudProfile.Spec.MachineImages, cloudProfile.Spec.Capabilities)
 
 	if machineImage == nil {
 		return fmt.Errorf("no MachineImage that supports architecture amd64 configured in the Cloudprofile '%s'", cloudProfile.Name)
@@ -149,10 +147,10 @@ func generateRandomWorkerName(prefix string) (string, error) {
 	return prefix + strings.ToLower(randomString), nil
 }
 
-func firstMachineImageWithAMDSupport(machineImageFromCloudProfile []gardencorev1beta1.MachineImage, defaultArchitecture string) *gardencorev1beta1.MachineImage {
+func firstMachineImageWithAMDSupport(machineImageFromCloudProfile []gardencorev1beta1.MachineImage, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *gardencorev1beta1.MachineImage {
 	for _, machineImage := range machineImageFromCloudProfile {
 		for _, version := range machineImage.Versions {
-			if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version, defaultArchitecture), v1beta1constants.ArchitectureAMD64) {
+			if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version, capabilityDefinitions), v1beta1constants.ArchitectureAMD64) {
 				return &machineImage
 			}
 		}

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -82,7 +82,8 @@ func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.C
 		return fmt.Errorf("no MachineTypes of architecture amd64 configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
 
-	machineImage := firstMachineImageWithAMDSupport(cloudProfile.Spec.MachineImages)
+	defaultArchitecture := v1beta1helper.GetDefaultArchitectureFromCapabilityDefinitions(cloudProfile.Spec.Capabilities)
+	machineImage := firstMachineImageWithAMDSupport(cloudProfile.Spec.MachineImages, defaultArchitecture)
 
 	if machineImage == nil {
 		return fmt.Errorf("no MachineImage that supports architecture amd64 configured in the Cloudprofile '%s'", cloudProfile.Name)
@@ -147,10 +148,10 @@ func generateRandomWorkerName(prefix string) (string, error) {
 	return prefix + strings.ToLower(randomString), nil
 }
 
-func firstMachineImageWithAMDSupport(machineImageFromCloudProfile []gardencorev1beta1.MachineImage) *gardencorev1beta1.MachineImage {
+func firstMachineImageWithAMDSupport(machineImageFromCloudProfile []gardencorev1beta1.MachineImage, defaultArchitecture string) *gardencorev1beta1.MachineImage {
 	for _, machineImage := range machineImageFromCloudProfile {
 		for _, version := range machineImage.Versions {
-			if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version), v1beta1constants.ArchitectureAMD64) {
+			if slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version, defaultArchitecture), v1beta1constants.ArchitectureAMD64) {
 				return &machineImage
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
When working with cloudprofiles that use capabilities and only one architecture is supported the following issues arise:
- Cloudprofiles are rejected when no architecture capability is defined on a machineType. Rejection reason: "must provide an architecture"  on `spec.machineTypes[0].architecture` 
- Shoots are rejected as no default image can be found for machineImages without a CapabilitySet.

**Special notes for your reviewer**:
When a cloudprofiles defines only one architecture. The architecture capability is not required on every machineType and machineImage in the cloudprofile. Only when multiple architectures are supported its required to be explicitly set. 
@LucaBernstein @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed MachineImage and MachineType architecture defaulting for `CloudProfile`s supporting one architecture only.
```
