### PR TITLE
chore: Use Renovate preset for grouping Go updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'github>gardener/ci-infra//config/renovate/makefile-versions.json5',
     'github>gardener/ci-infra//config/renovate/imagevector.json5(^imagevector/containers.yaml$)',
     'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
+    'github>gardener/ci-infra//config/renovate/group-go-updates.json5',
   ],
   labels: [
     'kind/enhancement',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

I'd like to combine Renovate update PRs such as these into a single PR:
* https://github.com/gardener/gardener/pull/12736
* https://github.com/gardener/gardener/pull/12724

As this is a common requirement across Go-based repositories, I've put a shared preset into the `ci-infra` repository:
https://github.com/gardener/ci-infra/blob/master/config/renovate/group-go-updates.json5

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

The Renovate `packageRule` was tested in this PR:
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/452

Making use of the shared preset is being tested with this PR:
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/455

👉 resulting combined PR: 
* https://github.com/gardener/gardener-extension-shoot-cert-service/pull/454

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
