### PR TITLE
chore(renovate): Drop inline package rule for grouping Go updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -110,16 +110,6 @@
       ],
     },
     {
-      // Group golang updates in one PR.
-      groupName: 'golang',
-      matchDatasources: [
-        'docker',
-      ],
-      matchPackageNames: [
-        '/golang/',
-      ],
-    },
-    {
       // Group Istio updates in one PR.
       groupName: 'istio',
       groupSlug: 'istio',


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Renovate update PRs for Go are still being separated:
* https://github.com/gardener/gardener/pull/12753
* https://github.com/gardener/gardener/pull/12736

I missed that there is an inline package rule that covers the same, but only for Docker images.
Removing this should let the preset take precedence:
https://github.com/gardener/gardener/blob/80e0ba15811d22e54b1771f60a59d066009d483e/.github/renovate.json5#L9

**Which issue(s) this PR fixes**:

Follow-up to:
* https://github.com/gardener/gardener/pull/12747

**Special notes for your reviewer**:

/cc @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
