### PR TITLE
Add check to disable `device-taint-eviction-controller` for workerless Shoots with versions >= 1.33

### DIFF
--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -44,6 +44,7 @@ import (
 	netutils "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -719,6 +720,10 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 			"pv-protection",
 			"ttl",
 		)
+
+		if versionutils.ConstraintK8sGreaterEqual133.Check(k.values.TargetVersion) {
+			controllersToDisable.Insert("device-taint-eviction-controller")
+		}
 	}
 
 	command = append(command,

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -66,9 +66,9 @@ var _ = Describe("KubeControllerManager", func() {
 		_, serviceCIDR2, _       = net.ParseCIDR("2001:db8::/64")
 		serviceCIDRs             = []net.IPNet{*serviceCIDR1, *serviceCIDR2}
 		namespace                = "shoot--foo--bar"
-		version                  = "1.27.3"
+		version127               = "1.27.3"
 		version133               = "1.33.0"
-		semverVersion, _         = semver.NewVersion(version)
+		semverVersion, _         = semver.NewVersion(version127)
 		runtimeKubernetesVersion = semver.MustParse("1.31.1")
 		image                    = "registry.k8s.io/kube-controller-manager:v1.31.1"
 		isWorkerless             = false
@@ -631,7 +631,7 @@ namespace: kube-system
 		DescribeTable("success tests for various kubernetes versions (shoots with workers)",
 			func(config *gardencorev1beta1.KubeControllerManagerConfig, isScaleDownDisabled bool, runtimeKubernetesVersion *semver.Version) {
 				isWorkerless = false
-				semverVersion, err := semver.NewVersion(version)
+				semverVersion, err := semver.NewVersion(version127)
 				Expect(err).NotTo(HaveOccurred())
 
 				values = Values{
@@ -693,20 +693,20 @@ namespace: kube-system
 				verifyDeployment(config, isScaleDownDisabled, controllerWorkers, semverVersion)
 			},
 
-			Entry("w/o config", emptyConfig, false, controllerWorkers, version),
-			Entry("with scale-down disabled", emptyConfig, true, controllerWorkers, version),
-			Entry("with non-default autoscaler config", configWithAutoscalerConfig, false, controllerWorkers, version),
-			Entry("with feature flags", configWithFeatureFlags, false, controllerWorkers, version),
-			Entry("with NodeCIDRMaskSize", configWithNodeCIDRMaskSize, false, controllerWorkers, version),
-			Entry("with PodEvictionTimeout", configWithPodEvictionTimeout, false, controllerWorkers, version),
-			Entry("with NodeMonitorGracePeriod", configWithNodeMonitorGracePeriod, false, controllerWorkers, version),
-			Entry("with disabled controllers", configWithNodeMonitorGracePeriod, false, controllerWorkersWithDisabledControllers, version),
+			Entry("w/o config", emptyConfig, false, controllerWorkers, version127),
+			Entry("with scale-down disabled", emptyConfig, true, controllerWorkers, version127),
+			Entry("with non-default autoscaler config", configWithAutoscalerConfig, false, controllerWorkers, version127),
+			Entry("with feature flags", configWithFeatureFlags, false, controllerWorkers, version127),
+			Entry("with NodeCIDRMaskSize", configWithNodeCIDRMaskSize, false, controllerWorkers, version127),
+			Entry("with PodEvictionTimeout", configWithPodEvictionTimeout, false, controllerWorkers, version127),
+			Entry("with NodeMonitorGracePeriod", configWithNodeMonitorGracePeriod, false, controllerWorkers, version127),
+			Entry("with disabled controllers", configWithNodeMonitorGracePeriod, false, controllerWorkersWithDisabledControllers, version127),
 			Entry("with disabled controllers and controllers disabled for >= 1.33", configWithNodeMonitorGracePeriod, false, controllerWorkersWithDisabledControllers, version133),
 		)
 
 		DescribeTable("success tests for various runtime config",
 			func(config *gardencorev1beta1.KubeControllerManagerConfig, runtimeConfig map[string]bool, workerless bool, expectedCommand string) {
-				semverVersion, err := semver.NewVersion(version)
+				semverVersion, err := semver.NewVersion(version127)
 				Expect(err).NotTo(HaveOccurred())
 
 				values = Values{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
After a [discussion in the PR introducing support for Kubernetes v1.33](https://github.com/gardener/gardener/pull/12216#discussion_r2137868946), with @plkokanov, @Kostov6 and @ialidzhikov we noticed that the `controller manager` doesn't have versioned checks for controllers that should be disabled for workerless Shoots.
In the context of the introduction of 1.33, `device-taint-eviction-controller` seems to be unnecessary for workerless Shoots, but we decided to add this logic in a separate PR.

This PR adds a version check to disable `device-taint-eviction-controller` when using Kubernetes versions >= 1.33 for workerless Shoots.

**Which issue(s) this PR fixes**:
Related to #12216 

**Special notes for your reviewer**:
cc @ialidzhikov @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `device-taint-eviction-controller` is disabled for workerless Shoots with Kubernetes v1.33+.
```
