### PR TITLE
Document the admission plugin types

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -60,7 +60,7 @@ Find all information about it [in this document](../usage/project/projects.md#fo
 Furthermore, this admission controller reacts on `CREATE` or `UPDATE` operations for `Shoot`s.
 It makes sure that the `deletion.gardener.cloud/confirmed-by` annotation is properly maintained in case the `Shoot` deletion is confirmed with above mentioned annotation.
 
-## `ExposureClass`
+## `ShootExposureClass`
 
 **Type**: Mutating. **Enabled by default**: Yes.
 
@@ -215,7 +215,7 @@ This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
 
-## `ManagedSeedValidator`
+## `ManagedSeed`
 
 **Type**: Mutating. **Enabled by default**: Yes.
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -22,7 +22,11 @@ When the backup bucket is using `WorkloadIdentity` as backup credentials, the pl
 **Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Bastion`s.
-It validates that the `Shoot` referenced in the `Bastion` is not in deletion, is assigned to `Seed` and does not disable SSH access for the worker Nodes.
+
+It validates that the `Shoot` referenced in the `Bastion`:
+- is not in deletion.
+- is assigned to a `Seed`.
+- does not disable SSH access for the worker Nodes.
 
 It mutates the `Bastion` in the following way:
 - it sets`.spec.seedName` to the `Shoot` `.spec.seedName`.

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -12,14 +12,14 @@ This document lists all existing admission plugins with a short explanation of w
 
 ## `BackupBucketValidator`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBuckets`s.
 When the backup bucket is using `WorkloadIdentity` as backup credentials, the plugin ensures the backup bucket and the workload identity have the same provider type, i.e. `backupBucket.spec.provider.type` and `workloadIdentity.spec.targetSystem.type` have the same value.
 
 ## `ClusterOpenIDConnectPreset`, `OpenIDConnectPreset`
 
-_(both enabled by default)_
+**Type**: Mutating (for both). **Enabled by default**: Yes (for both).
 
 These admission controllers react on `CREATE` operations for `Shoot`s.
 If the `Shoot` does not specify any OIDC configuration (`.spec.kubernetes.kubeAPIServer.oidcConfig=nil`), then it tries to find a matching `ClusterOpenIDConnectPreset` or `OpenIDConnectPreset`, respectively.
@@ -28,7 +28,7 @@ In this case, the admission controller will default the OIDC configuration in th
 
 ## `ControllerRegistrationResources`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `ControllerRegistration`s.
 It validates that there exists only one `ControllerRegistration` in the system that is primarily responsible for a given kind/type resource combination.
@@ -36,7 +36,7 @@ This prevents misconfiguration by the Gardener administrator/operator.
 
 ## `CustomVerbAuthorizer`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Project`s and `NamespacedCloudProfile`s.
 
@@ -48,7 +48,7 @@ Please see [this document](../usage/project/namespaced-cloud-profiles.md#field-m
 
 ## `DeletionConfirmation`
 
-_(enabled by default)_
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `DELETE` operations for `Project`s, `Shoot`s, and `ShootState`s.
 It validates that the respective resource is annotated with a deletion confirmation annotation, namely `confirmation.gardener.cloud/deletion=true`.
@@ -62,14 +62,14 @@ It makes sure that the `deletion.gardener.cloud/confirmed-by` annotation is prop
 
 ## `ExposureClass`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `Create` operations for `Shoot`s.
 It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
 
 ## `ExtensionValidator`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupEntry`s, `BackupBucket`s, `Seed`s, and `Shoot`s.
 For all the various extension types in the specifications of these objects, it validates whether there exists a `ControllerRegistration` in the system that is primarily responsible for the stated extension type(s).
@@ -77,13 +77,13 @@ This prevents misconfigurations that would otherwise allow users to create such 
 
 ## `ExtensionLabels`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
 ## `FinalizerRemoval`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `UPDATE` operations for `CredentialsBinding`s, `SecretBinding`s, `Shoot`s. 
 It ensures that the finalizers of these resources are not removed by users, as long as the affected resource is still in use.
@@ -92,7 +92,7 @@ In case of `Shoot`s, the `gardener` finalizer can only be removed if the last op
 
 ## `ProjectValidator`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Project`s.
 It prevents creating `Project`s with a non-empty `.spec.namespace` if the value in `.spec.namespace` does not start with `garden-`.
@@ -105,14 +105,14 @@ During subsequent updates, it ensures that the project owner is included in the 
 
 ## `ResourceQuota`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller enables [object count ResourceQuotas](https://kubernetes.io/docs/concepts/policy/resource-quotas/#object-count-quota) for Gardener resources, e.g. `Shoots`, `SecretBindings`, `Projects`, etc.
 > :warning: In addition to this admission plugin, the [ResourceQuota controller](https://github.com/kubernetes/kubernetes/blob/release-1.2/docs/design/admission_control_resource_quota.md#resource-quota-controller) must be enabled for the Kube-Controller-Manager of your Garden cluster.
 
 ## `ResourceReferenceManager`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `CloudProfile`s, `Project`s, `SecretBinding`s, `Seed`s, and `Shoot`s.
 Generally, it checks whether referred resources stated in the specifications of these objects exist in the system (e.g., if a referenced `Secret` exists).
@@ -122,7 +122,7 @@ However, it also has some special behaviours for certain resources:
 
 ## `SeedValidator`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE`, `UPDATE`, and `DELETE` operations for `Seed`s.
 Rejects the deletion if `Shoot`(s) reference the seed cluster.
@@ -131,7 +131,7 @@ When the seed is using `WorkloadIdentity` as backup credentials, the plugin ensu
 
 ## `SeedMutator`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Seed`s.
 It maintains the `name.seed.gardener.cloud/<name>` labels for it.
@@ -141,7 +141,7 @@ More specifically, it adds that the `name.seed.gardener.cloud/<name>=true` label
 
 ## `ShootDNS`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It tries to assign a default domain to the `Shoot`.
@@ -149,7 +149,7 @@ It also validates the DNS configuration (`.spec.dns`) for shoots.
 
 ## `ShootNodeLocalDNSEnabledByDefault`
 
-_(disabled by default)_
+**Type**: Mutating. **Enabled by default**: No.
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it will enable node local dns within the shoot cluster (for more information, see [NodeLocalDNS Configuration](../usage/networking/node-local-dns.md)) by setting `spec.systemComponents.nodeLocalDNS.enabled=true` for newly created Shoots.
@@ -158,7 +158,7 @@ will not be affected by this admission plugin.
 
 ## `ShootQuotaValidator`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It validates the resource consumption declared in the specification against applicable `Quota` resources.
@@ -167,7 +167,7 @@ Applicable `Quota`s are referred in the `SecretBinding` that is used by the `Sho
 
 ## `ShootResourceReservation`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It injects the `Kubernetes.Kubelet.KubeReserved` setting for kubelet either as global setting for a shoot or on a per worker pool basis.
@@ -182,7 +182,7 @@ Operators can provide an optional label selector via the `selector` field to lim
 
 ## `ShootVPAEnabledByDefault`
 
-_(disabled by default)_
+**Type**: Mutating. **Enabled by default**: No.
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it will enable the managed `VerticalPodAutoscaler` components (for more information, see [Vertical Pod Auto-Scaling](../usage/autoscaling/shoot_autoscaling.md#vertical-pod-auto-scaling))
@@ -192,7 +192,7 @@ will not be affected by this admission plugin.
 
 ## `ShootTolerationRestriction`
 
-_(enabled by default)_
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It validates the `.spec.tolerations` used in `Shoot`s against the whitelist of its `Project`, or against the whitelist configured in the admission controller's configuration, respectively.
@@ -200,7 +200,7 @@ Additionally, it defaults the `.spec.tolerations` in `Shoot`s with those configu
 
 ## `ShootValidator`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE`, `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configurations in the specification against the referred `CloudProfile` (e.g., machine images, machine types, used Kubernetes version, ...).
@@ -209,7 +209,7 @@ Additionally, it takes over certain defaulting tasks (e.g., default machine imag
 
 ## `ShootManagedSeed`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
@@ -217,7 +217,7 @@ It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
 
 ## `ManagedSeedValidator`
 
-_(enabled by default)_
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `ManagedSeeds`s.
 It validates certain configuration values in the specification against the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
@@ -226,14 +226,14 @@ Additionally, it performs certain defaulting tasks, making sure that configurati
 
 ## `ManagedSeedShoot`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `DELETE` operations for `ManagedSeed`s.
 It rejects the deletion if there are `Shoot`s that are scheduled onto the `Seed` that is registered by the `ManagedSeed`.
 
 ## `ShootDNSRewriting`
 
-_(disabled by default)_
+**Type**: Mutating. **Enabled by default**: No.
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/networking/dns-search-path-optimization.md)).
@@ -241,7 +241,7 @@ Already existing `Shoot`s will not be affected by this admission plugin.
 
 ## `NamespacedCloudProfileValidator`
 
-_(enabled by default)_
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
 It primarily validates if the referenced parent `CloudProfile` exists in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -17,6 +17,19 @@ This document lists all existing admission plugins with a short explanation of w
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBuckets`s.
 When the backup bucket is using `WorkloadIdentity` as backup credentials, the plugin ensures the backup bucket and the workload identity have the same provider type, i.e. `backupBucket.spec.provider.type` and `workloadIdentity.spec.targetSystem.type` have the same value.
 
+## `Bastion`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `Bastion`s.
+It validates that the `Shoot` referenced in the `Bastion` is not in deletion, is assigned to `Seed` and does not disable SSH access for the worker Nodes.
+
+It mutates the `Bastion` in the following way:
+- it sets`.spec.seedName` to the `Shoot` `.spec.seedName`.
+- it sets `.spec.providerType` to the `Shoot` `.spec.provider.type`.
+- it sets the `gardener.cloud/created-by=<username>` annotation for `CREATE` operations.
+- it adds an owner reference to the `Shoot` to ensure the `Bastion` is deleted when the `Shoot` is deleted.
+
 ## `ClusterOpenIDConnectPreset`, `OpenIDConnectPreset`
 
 **Type**: Mutating (for both). **Enabled by default**: Yes (for both).

--- a/plugin/pkg/backupbucket/validator/admission.go
+++ b/plugin/pkg/backupbucket/validator/admission.go
@@ -71,7 +71,7 @@ func (v *ValidateBackupBucket) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ValidateBackupBucket{}
+var _ admission.ValidationInterface = (*ValidateBackupBucket)(nil)
 
 // Validate validates the BackupBucket details against existing Workload Identities
 func (v *ValidateBackupBucket) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -73,7 +73,7 @@ func (v *Bastion) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &Bastion{}
+var _ admission.MutationInterface = (*Bastion)(nil)
 
 // Admit validates and if appropriate mutates the given bastion against the shoot that it references.
 func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/controllerregistration/resources/admission.go
+++ b/plugin/pkg/controllerregistration/resources/admission.go
@@ -67,7 +67,7 @@ func (r *Resources) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &Resources{}
+var _ admission.ValidationInterface = (*Resources)(nil)
 
 // Validate makes admissions decisions based on the resources specified in a ControllerRegistration object.
 // It does reject the request if there is any other existing ControllerRegistration object in the system that

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -111,7 +111,7 @@ func (c *CustomVerbAuthorizer) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &CustomVerbAuthorizer{}
+var _ admission.ValidationInterface = (*CustomVerbAuthorizer)(nil)
 
 // Validate makes admissions decisions based on custom verbs.
 func (c *CustomVerbAuthorizer) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -119,8 +119,8 @@ func (d *DeletionConfirmation) ValidateInitialization() error {
 }
 
 var (
-	_ admission.ValidationInterface = &DeletionConfirmation{}
-	_ admission.MutationInterface   = &DeletionConfirmation{}
+	_ admission.ValidationInterface = (*DeletionConfirmation)(nil)
+	_ admission.MutationInterface   = (*DeletionConfirmation)(nil)
 )
 
 // Admit maintains the deletion.gardener.cloud/confirmed-by annotation.

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -118,7 +118,7 @@ func (e *ExtensionLabels) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ExtensionLabels{}
+var _ admission.MutationInterface = (*ExtensionLabels)(nil)
 
 // Admit adds extension labels to resources.
 func (e *ExtensionLabels) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -110,7 +110,7 @@ func (e *ExtensionValidator) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ExtensionValidator{}
+var _ admission.ValidationInterface = (*ExtensionValidator)(nil)
 
 // Validate makes admissions decisions based on the extension types.
 func (e *ExtensionValidator) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -80,6 +80,8 @@ func (f *FinalizerRemoval) ValidateInitialization() error {
 	return nil
 }
 
+var _ admission.MutationInterface = &FinalizerRemoval{}
+
 // Admit ensures that finalizers from objects can only be removed if they are not needed anymore.
 func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -80,7 +80,7 @@ func (f *FinalizerRemoval) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &FinalizerRemoval{}
+var _ admission.MutationInterface = (*FinalizerRemoval)(nil)
 
 // Admit ensures that finalizers from objects can only be removed if they are not needed anymore.
 func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -290,6 +290,8 @@ func (r *ReferenceManager) ValidateInitialization() error {
 	return nil
 }
 
+var _ admission.ValidationInterface = &ReferenceManager{}
+
 // Validate ensures that referenced resources do actually exist.
 func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -290,7 +290,7 @@ func (r *ReferenceManager) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ReferenceManager{}
+var _ admission.ValidationInterface = (*ReferenceManager)(nil)
 
 // Validate ensures that referenced resources do actually exist.
 func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/managedseed/shoot/admission.go
+++ b/plugin/pkg/managedseed/shoot/admission.go
@@ -85,7 +85,7 @@ func (v *Shoot) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &Shoot{}
+var _ admission.ValidationInterface = (*Shoot)(nil)
 
 // Validate validates if the ManagedSeed can be deleted.
 func (v *Shoot) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -146,7 +146,7 @@ func (v *ManagedSeed) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ManagedSeed{}
+var _ admission.MutationInterface = (*ManagedSeed)(nil)
 
 // Admit validates and if appropriate mutates the given managed seed against the shoot that it references.
 func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -79,7 +79,7 @@ func (v *ValidateNamespacedCloudProfile) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ValidateNamespacedCloudProfile{}
+var _ admission.ValidationInterface = (*ValidateNamespacedCloudProfile)(nil)
 
 // Validate validates the NamespacedCloudProfile.
 func (v *ValidateNamespacedCloudProfile) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -40,7 +40,7 @@ func New() (*handler, error) {
 	}, nil
 }
 
-var _ admission.MutationInterface = &handler{}
+var _ admission.MutationInterface = (*handler)(nil)
 
 func (v *handler) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Ignore all kinds other than Project

--- a/plugin/pkg/seed/mutator/admission.go
+++ b/plugin/pkg/seed/mutator/admission.go
@@ -87,7 +87,7 @@ func (m *MutateSeed) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &MutateSeed{}
+var _ admission.MutationInterface = (*MutateSeed)(nil)
 
 // Admit mutates the Seed.
 func (m *MutateSeed) Admit(_ context.Context, attrs admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -36,7 +36,6 @@ func Register(plugins *admission.Plugins) {
 type ValidateSeed struct {
 	*admission.Handler
 
-	seedLister             gardencorev1beta1listers.SeedLister
 	shootLister            gardencorev1beta1listers.ShootLister
 	workloadIdentityLister gardensecurityv1alpha1listers.WorkloadIdentityLister
 	readyFunc              admission.ReadyFunc
@@ -64,13 +63,10 @@ func (v *ValidateSeed) AssignReadyFunc(f admission.ReadyFunc) {
 
 // SetCoreInformerFactory gets Lister from SharedInformerFactory.
 func (v *ValidateSeed) SetCoreInformerFactory(f gardencoreinformers.SharedInformerFactory) {
-	seedInformer := f.Core().V1beta1().Seeds()
-	v.seedLister = seedInformer.Lister()
-
 	shootInformer := f.Core().V1beta1().Shoots()
 	v.shootLister = shootInformer.Lister()
 
-	readyFuncs = append(readyFuncs, seedInformer.Informer().HasSynced, shootInformer.Informer().HasSynced)
+	readyFuncs = append(readyFuncs, shootInformer.Informer().HasSynced)
 }
 
 // SetSecurityInformerFactory gets Lister from SharedInformerFactory.
@@ -83,9 +79,6 @@ func (v *ValidateSeed) SetSecurityInformerFactory(f gardensecurityinformers.Shar
 
 // ValidateInitialization checks whether the plugin was correctly initialized.
 func (v *ValidateSeed) ValidateInitialization() error {
-	if v.seedLister == nil {
-		return errors.New("missing seed lister")
-	}
 	if v.shootLister == nil {
 		return errors.New("missing shoot lister")
 	}

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -95,7 +95,7 @@ func (v *ValidateSeed) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ValidateSeed{}
+var _ admission.ValidationInterface = (*ValidateSeed)(nil)
 
 // Validate validates the Seed details against existing Shoots
 func (v *ValidateSeed) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -271,14 +271,14 @@ var _ = Describe("validator", func() {
 	})
 
 	Describe("#ValidateInitialization", func() {
-		It("should return error if no ShootLister or SeedLister is set", func() {
+		It("should return error if no ShootLister is set", func() {
 			dr, _ := New()
 			dr.SetSecurityInformerFactory(gardensecurityinformers.NewSharedInformerFactory(nil, 0))
 
 			err := dr.ValidateInitialization()
 
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError("missing seed lister"))
+			Expect(err).To(MatchError("missing shoot lister"))
 		})
 
 		It("should return error if no WorkloadIdentityLister is set", func() {
@@ -291,7 +291,7 @@ var _ = Describe("validator", func() {
 			Expect(err).To(MatchError("missing WorkloadIdentity lister"))
 		})
 
-		It("should not return error if ShootLister, SeedLister, and WorkloadIdentityLister are set", func() {
+		It("should not return error if ShootLister and WorkloadIdentityLister are set", func() {
 			dr, _ := New()
 			dr.SetCoreInformerFactory(gardencoreinformers.NewSharedInformerFactory(nil, 0))
 			dr.SetSecurityInformerFactory(gardensecurityinformers.NewSharedInformerFactory(nil, 0))

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -104,7 +104,7 @@ func (d *DNS) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &DNS{}
+var _ admission.MutationInterface = (*DNS)(nil)
 
 // Admit tries to determine a DNS hosted zone for the Shoot's external domain.
 func (d *DNS) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/dnsrewriting/admission.go
+++ b/plugin/pkg/shoot/dnsrewriting/admission.go
@@ -49,7 +49,7 @@ func New(commonSuffixes []string) admission.MutationInterface {
 	}
 }
 
-var _ admission.MutationInterface = &DNSRewriting{}
+var _ admission.MutationInterface = (*DNSRewriting)(nil)
 
 // Admit defaults spec.systemComponents.coreDNS.rewriting.commonSuffixes to the configured values for new shoot clusters.
 func (c *DNSRewriting) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/dnsrewriting/admission.go
+++ b/plugin/pkg/shoot/dnsrewriting/admission.go
@@ -49,6 +49,8 @@ func New(commonSuffixes []string) admission.MutationInterface {
 	}
 }
 
+var _ admission.MutationInterface = &DNSRewriting{}
+
 // Admit defaults spec.systemComponents.coreDNS.rewriting.commonSuffixes to the configured values for new shoot clusters.
 func (c *DNSRewriting) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	switch {

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -93,6 +93,8 @@ func (e *ExposureClass) ValidateInitialization() error {
 	return nil
 }
 
+var _ admission.MutationInterface = &ExposureClass{}
+
 // Admit unite the seed selector and/or tolerations of a Shoot resource
 // with the ones from the referenced ExposureClass.
 func (e *ExposureClass) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -93,7 +93,7 @@ func (e *ExposureClass) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ExposureClass{}
+var _ admission.MutationInterface = (*ExposureClass)(nil)
 
 // Admit unite the seed selector and/or tolerations of a Shoot resource
 // with the ones from the referenced ExposureClass.

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -84,7 +84,7 @@ func (v *ManagedSeed) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &ManagedSeed{}
+var _ admission.ValidationInterface = (*ManagedSeed)(nil)
 
 // Validate validates changes to the Shoot referenced by a ManagedSeed.
 func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/nodelocaldns/admission.go
+++ b/plugin/pkg/shoot/nodelocaldns/admission.go
@@ -36,7 +36,7 @@ func New() admission.MutationInterface {
 	}
 }
 
-var _ admission.MutationInterface = &ShootNodeLocalDNS{}
+var _ admission.MutationInterface = (*ShootNodeLocalDNS)(nil)
 
 // Admit defaults spec.systemComponents.nodeLocalDNS.enabled=true for new shoot clusters.
 func (c *ShootNodeLocalDNS) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/nodelocaldns/admission.go
+++ b/plugin/pkg/shoot/nodelocaldns/admission.go
@@ -36,6 +36,8 @@ func New() admission.MutationInterface {
 	}
 }
 
+var _ admission.MutationInterface = &ShootNodeLocalDNS{}
+
 // Admit defaults spec.systemComponents.nodeLocalDNS.enabled=true for new shoot clusters.
 func (c *ShootNodeLocalDNS) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	switch {

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -93,7 +93,7 @@ func (c *ClusterOpenIDConnectPreset) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ClusterOpenIDConnectPreset{}
+var _ admission.MutationInterface = (*ClusterOpenIDConnectPreset)(nil)
 
 // Admit tries to determine a OpenIDConnectPreset hosted zone for the Shoot's external domain.
 func (c *ClusterOpenIDConnectPreset) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -75,7 +75,7 @@ func (o *OpenIDConnectPreset) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &OpenIDConnectPreset{}
+var _ admission.MutationInterface = (*OpenIDConnectPreset)(nil)
 
 // Admit tries to determine a OpenIDConnectPreset hosted zone for the Shoot's external domain.
 func (o *OpenIDConnectPreset) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -137,7 +137,7 @@ func (q *QuotaValidator) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &QuotaValidator{}
+var _ admission.ValidationInterface = (*QuotaValidator)(nil)
 
 // Validate checks that the requested Shoot resources do not exceed the quota limits.
 func (q *QuotaValidator) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -105,7 +105,7 @@ func (c *ResourceReservation) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ResourceReservation{}
+var _ admission.MutationInterface = (*ResourceReservation)(nil)
 
 // Admit injects default resource reservations into worker pools of shoot objects
 func (c *ResourceReservation) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -105,6 +105,8 @@ func (c *ResourceReservation) ValidateInitialization() error {
 	return nil
 }
 
+var _ admission.MutationInterface = &ResourceReservation{}
+
 // Admit injects default resource reservations into worker pools of shoot objects
 func (c *ResourceReservation) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -111,7 +111,10 @@ func (t *TolerationRestriction) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &TolerationRestriction{}
+var (
+	_ admission.ValidationInterface = &TolerationRestriction{}
+	_ admission.MutationInterface   = &TolerationRestriction{}
+)
 
 // Admit defaults shoot tolerations with both global and project defaults.
 func (t *TolerationRestriction) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -112,8 +112,8 @@ func (t *TolerationRestriction) ValidateInitialization() error {
 }
 
 var (
-	_ admission.ValidationInterface = &TolerationRestriction{}
-	_ admission.MutationInterface   = &TolerationRestriction{}
+	_ admission.ValidationInterface = (*TolerationRestriction)(nil)
+	_ admission.MutationInterface   = (*TolerationRestriction)(nil)
 )
 
 // Admit defaults shoot tolerations with both global and project defaults.

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -181,7 +181,7 @@ func (v *ValidateShoot) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = &ValidateShoot{}
+var _ admission.MutationInterface = (*ValidateShoot)(nil)
 
 // Admit validates the Shoot details against the referenced CloudProfile.
 func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/shoot/vpa/admission.go
+++ b/plugin/pkg/shoot/vpa/admission.go
@@ -36,6 +36,8 @@ func New() admission.MutationInterface {
 	}
 }
 
+var _ admission.MutationInterface = &ShootVPA{}
+
 // Admit defaults spec.kubernetes.verticalPodAutoscaler.enabled=true for new shoot clusters.
 func (c *ShootVPA) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	switch {

--- a/plugin/pkg/shoot/vpa/admission.go
+++ b/plugin/pkg/shoot/vpa/admission.go
@@ -36,7 +36,7 @@ func New() admission.MutationInterface {
 	}
 }
 
-var _ admission.MutationInterface = &ShootVPA{}
+var _ admission.MutationInterface = (*ShootVPA)(nil)
 
 // Admit defaults spec.kubernetes.verticalPodAutoscaler.enabled=true for new shoot clusters.
 func (c *ShootVPA) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
The upstream admission plugins have their type documented - see https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#what-does-each-admission-controller-do.

This PR does the same for the Gardener API Server admission plugins.

From the upstream docs:
> Admission control mechanisms may be validating, mutating, or both. Mutating controllers may modify the data for the resource being modified; validating controllers may not.

Hence, I personally find it useful to know which admission plugin can mutate a resource, which one - cannot. 

While documenting the admission plugins, I found an admission plugin which is mutating one but actually performs only validation and can be validating one. I will raise another PR for this.

I also added interface assertions for the admission plugins which did not have such. With this PR, all admission plugins have an interface assertion which denotes their type(s).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
