### PR TITLE
Disable plutono-datasources ConfigMap garbage collection

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -237,7 +237,6 @@ func (p *plutono) computeResourcesData(ctx context.Context) (*corev1.ConfigMap, 
 		},
 		Data: map[string]string{"datasources" + dataSourcesKeySuffix + ".yaml": p.getDataSource()},
 	}
-	utilruntime.Must(kubernetesutils.MakeUnique(dataSourceConfigMap))
 
 	if p.values.OnlyDeployDataSourcesAndDashboards {
 		data, err := registry.AddAllAndSerialize(dataSourceConfigMap)

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -244,25 +244,15 @@ metadata:
 data:
   datasources.yaml: |
     ` + configMapData + `
-immutable: true
 kind: ConfigMap
 metadata:
   creationTimestamp: null
   labels:
     component: plutono
     datasource.monitoring.gardener.cloud/` + clusterLabelKey(values) + `: "true"
-    resources.gardener.cloud/garbage-collectable-reference: "true"
 `
-				var configMapNameSuffix string
-				if values.IsGardenCluster {
-					configMapNameSuffix = "e56271c8"
-				} else if values.ClusterType == comp.ClusterTypeShoot {
-					configMapNameSuffix = "f82429ca"
-				} else {
-					configMapNameSuffix = "46d8c4c5"
-				}
 
-				configMap += `  name: plutono-datasources-` + configMapNameSuffix + `
+				configMap += `  name: plutono-datasources
   namespace: some-namespace
 `
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Follow-up to https://github.com/gardener/gardener/pull/12476:
Stop marking `plutono-datasources` as unique to stop the wrongful garbage collection.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12760

**Special notes for your reviewer**:

/cc @rfranzke 

After this PR, the old and unused (immutable) ConfigMap will eventually be garbage collected for one last time – so that this PR doesn't require any migration code.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `plutono-datasources` `ConfigMap` is no longer wrongfully garbage collected while it is in use.
```
