### PR TITLE
ci: Build `golang-test` images for Go 1.25

### DIFF
--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -3,7 +3,7 @@
 # - https://github.com/kubernetes/test-infra/blob/master/images/krte/Dockerfile
 # - https://github.com/gardener/ci-infra/blob/master/images/krte
 variants:
-  "1.23":
-    image: golang:1.23.12-bookworm
   "1.24":
     image: golang:1.24.6-bookworm
+  "1.25":
+    image: golang:1.25.0-bookworm


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR starts building `golang-test` images for Go 1.25.
Additionally, it stops building them for Go 1.23 because [it is out of maintenance](https://endoflife.date/go).

**Which issue(s) this PR fixes**:

Preparation for:
* https://github.com/gardener/gardener/pull/12753

**Special notes for your reviewer**:

/cc @shafeeqes 

This PR is based on the same approach taken for Go 1.24:
* https://github.com/gardener/gardener/pull/11369

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`golang-test` images for Go 1.25 are built now. Those for Go 1.23 are not built anymore because it is out of maintenance. 
```

