### PR TITLE
Add sources to all Helm charts

### DIFF
--- a/charts/gardener/admission-local/charts/application/Chart.yaml
+++ b/charts/gardener/admission-local/charts/application/Chart.yaml
@@ -3,3 +3,5 @@ appVersion: "1.0"
 description: A Helm chart to deploy the gardener-extension-admission-local application related resources
 name: admission-local-application
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/admission-local/charts/runtime/Chart.yaml
+++ b/charts/gardener/admission-local/charts/runtime/Chart.yaml
@@ -3,3 +3,5 @@ appVersion: "1.0"
 description: A Helm chart to deploy the gardener-extension-admission-local runtime related resources
 name: admission-local-runtime
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/controlplane/Chart.yaml
+++ b/charts/gardener/controlplane/Chart.yaml
@@ -3,3 +3,5 @@ description: A Helm chart to deploy the Gardener controlplane (API server, contr
 name: controlplane
 version: 0.1.0
 deprecated: true
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/controlplane/charts/application/Chart.yaml
+++ b/charts/gardener/controlplane/charts/application/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener application related resources
 name: application
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/controlplane/charts/runtime/Chart.yaml
+++ b/charts/gardener/controlplane/charts/runtime/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener runtime related resources
 name: runtime
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/gardenlet/Chart.yaml
+++ b/charts/gardener/gardenlet/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardenlet (primary "seed" agent)
 name: gardenlet
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/operator/Chart.yaml
+++ b/charts/gardener/operator/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the Gardener Operator
 name: gardener-operator
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/provider-local/Chart.yaml
+++ b/charts/gardener/provider-local/Chart.yaml
@@ -3,3 +3,5 @@ appVersion: "1.0"
 description: A Helm chart for the Gardener Local Provider extension
 name: gardener-extension-provider-local
 version: v0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/resource-manager/Chart.yaml
+++ b/charts/gardener/resource-manager/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart for the Gardener Resource Manager.
 name: gardener-resource-manager
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/resource-manager/charts/application/Chart.yaml
+++ b/charts/gardener/resource-manager/charts/application/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the application related resources
 name: runtime
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener

--- a/charts/gardener/resource-manager/charts/runtime/Chart.yaml
+++ b/charts/gardener/resource-manager/charts/runtime/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 description: A Helm chart to deploy the runtime related resources
 name: runtime
 version: 0.1.0
+sources:
+  - https://github.com/gardener/gardener


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a source to every `Chart.yaml` manifest. When publishing a chart as OCI this sets the `org.opencontainers.image.source` annotation, which in turn is used by tools like renovate to lookup release notes. (This feature is not really documented but was introduced in this PR: https://github.com/helm/helm/pull/11204 )

**Which issue(s) this PR fixes**:
A minor annoyance with our renovate PRs :D 

**Special notes for your reviewer**:

**Release note**:
Are not necessary IMO
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
