### PR TITLE
Move the Validation of a `Project` resource's `.spec.namespace` field to the Storage Layer

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -95,9 +95,8 @@ In case of `Shoot`s, the `gardener` finalizer can only be removed if the last op
 _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Project`s.
-It prevents creating `Project`s with a non-empty `.spec.namespace` if the value in `.spec.namespace` does not start with `garden-`.
 
-In addition, the project specification is initialized during creation:
+When the project specification is initialized during creation:
 - `.spec.createdBy` is set to the user creating the project.
 - `.spec.owner` defaults to the value of `.spec.createdBy` if it is not specified.
 

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/api/validation/path"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -64,6 +66,11 @@ func ValidateProjectSpec(projectSpec *core.ProjectSpec, fldPath *field.Path) fie
 	if projectSpec.Namespace != nil && slices.Contains(reservedNamespaceNames, *projectSpec.Namespace) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), projectSpec.Namespace, fmt.Sprintf("Project namespaces %q are reserved by Gardener", reservedNamespaceNames)))
 	}
+
+	if projectSpec.Namespace != nil && *projectSpec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*projectSpec.Namespace, gardenerutils.ProjectNamespacePrefix) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("namespace"), fmt.Sprintf("must start with %s", gardenerutils.ProjectNamespacePrefix)))
+	}
+
 	ownerFound := false
 
 	members := make(sets.Set[string], len(projectSpec.Members))

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/api/validation/path"
@@ -21,6 +20,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ValidateProject validates a Project object.

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -63,13 +63,13 @@ func ValidateProjectSpec(projectSpec *core.ProjectSpec, fldPath *field.Path) fie
 	allErrs := field.ErrorList{}
 
 	if projectSpec.Namespace != nil {
-		reservedNamespaceNames := []string{v1beta1constants.GardenNamespace, core.GardenerSeedLeaseNamespace, core.GardenerShootIssuerNamespace, core.GardenerSystemPublicNamespace}
+		reservedNamespaceNames := []string{core.GardenerSeedLeaseNamespace, core.GardenerShootIssuerNamespace, core.GardenerSystemPublicNamespace}
 		if slices.Contains(reservedNamespaceNames, *projectSpec.Namespace) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), *projectSpec.Namespace, fmt.Sprintf("Project namespaces [%s] are reserved by Gardener", strings.Join(reservedNamespaceNames, ", "))))
 			return allErrs
 		}
 
-		if !strings.HasPrefix(*projectSpec.Namespace, gardenerutils.ProjectNamespacePrefix) {
+		if *projectSpec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*projectSpec.Namespace, gardenerutils.ProjectNamespacePrefix) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), *projectSpec.Namespace, fmt.Sprintf("must start with %s", gardenerutils.ProjectNamespacePrefix)))
 		}
 	}

--- a/pkg/apis/core/validation/project_test.go
+++ b/pkg/apis/core/validation/project_test.go
@@ -127,22 +127,13 @@ var _ = Describe("Project Validation Tests", func() {
 				Expect(errorList).To(matcher)
 			},
 
-			Entry("should forbid Project with namespace garden",
-				"garden",
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("spec.namespace"),
-					"BadValue": Equal("garden"),
-					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
-				}))),
-			),
 			Entry("should forbid Project with namespace gardener-system-seed-lease",
 				"gardener-system-seed-lease",
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("spec.namespace"),
 					"BadValue": Equal("gardener-system-seed-lease"),
-					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+					"Detail":   Equal("Project namespaces [gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
 				}))),
 			),
 			Entry("should forbid Project with namespace gardener-system-shoot-issuer",
@@ -151,7 +142,7 @@ var _ = Describe("Project Validation Tests", func() {
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("spec.namespace"),
 					"BadValue": Equal("gardener-system-shoot-issuer"),
-					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+					"Detail":   Equal("Project namespaces [gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
 				}))),
 			),
 			Entry("should forbid Project with namespace gardener-system-public",
@@ -160,7 +151,7 @@ var _ = Describe("Project Validation Tests", func() {
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal("spec.namespace"),
 					"BadValue": Equal("gardener-system-public"),
-					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+					"Detail":   Equal("Project namespaces [gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
 				}))),
 			),
 			Entry("should forbid Project with a non `garden-` prefixed namespace",
@@ -171,6 +162,10 @@ var _ = Describe("Project Validation Tests", func() {
 					"BadValue": Equal("foo"),
 					"Detail":   Equal("must start with garden-"),
 				}))),
+			),
+			Entry("should allow Project with namespace garden",
+				"garden",
+				BeEmpty(),
 			),
 		)
 

--- a/pkg/apis/core/validation/project_test.go
+++ b/pkg/apis/core/validation/project_test.go
@@ -109,27 +109,6 @@ var _ = Describe("Project Validation Tests", func() {
 					"Field": Equal("metadata.name"),
 				}))),
 			),
-			Entry("should forbid Project with namespace gardener-system-seed-lease",
-				metav1.ObjectMeta{Name: "project-1", Namespace: "gardener-system-seed-lease"},
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("metadata.namespace"),
-				}))),
-			),
-			Entry("should forbid Project with namespace gardener-system-shoot-issuer",
-				metav1.ObjectMeta{Name: "project-1", Namespace: "gardener-system-shoot-issuer"},
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("metadata.namespace"),
-				}))),
-			),
-			Entry("should forbid Project with namespace gardener-system-public",
-				metav1.ObjectMeta{Name: "project-1", Namespace: "gardener-system-public"},
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("metadata.namespace"),
-				}))),
-			),
 			Entry("should forbid Project with name containing two consecutive hyphens",
 				metav1.ObjectMeta{Name: "in--valid"},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -139,16 +118,61 @@ var _ = Describe("Project Validation Tests", func() {
 			),
 		)
 
-		It("should forbid Project specification with a non `garden-` prefixed namespace", func() {
-			project.Spec.Namespace = ptr.To("kube-system")
+		DescribeTable("Project spec.namespace",
+			func(namespace string, matcher gomegatypes.GomegaMatcher) {
+				project.Spec.Namespace = ptr.To(namespace)
 
-			errorList := ValidateProject(project)
+				errorList := ValidateProject(project)
 
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeForbidden),
-				"Field": Equal("spec.namespace"),
-			}))))
-		})
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid Project with namespace garden",
+				"garden",
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.namespace"),
+					"BadValue": Equal("garden"),
+					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+				}))),
+			),
+			Entry("should forbid Project with namespace gardener-system-seed-lease",
+				"gardener-system-seed-lease",
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.namespace"),
+					"BadValue": Equal("gardener-system-seed-lease"),
+					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+				}))),
+			),
+			Entry("should forbid Project with namespace gardener-system-shoot-issuer",
+				"gardener-system-shoot-issuer",
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.namespace"),
+					"BadValue": Equal("gardener-system-shoot-issuer"),
+					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+				}))),
+			),
+			Entry("should forbid Project with namespace gardener-system-public",
+				"gardener-system-public",
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.namespace"),
+					"BadValue": Equal("gardener-system-public"),
+					"Detail":   Equal("Project namespaces [garden, gardener-system-seed-lease, gardener-system-shoot-issuer, gardener-system-public] are reserved by Gardener"),
+				}))),
+			),
+			Entry("should forbid Project with a non `garden-` prefixed namespace",
+				"foo",
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.namespace"),
+					"BadValue": Equal("foo"),
+					"Detail":   Equal("must start with garden-"),
+				}))),
+			),
+		)
 
 		It("should forbid Project specification with empty or invalid key for description", func() {
 			project.Spec.Description = ptr.To("")

--- a/pkg/apis/core/validation/project_test.go
+++ b/pkg/apis/core/validation/project_test.go
@@ -139,6 +139,17 @@ var _ = Describe("Project Validation Tests", func() {
 			),
 		)
 
+		It("should forbid Project specification with a non `garden-` prefixed namespace", func() {
+			project.Spec.Namespace = ptr.To("kube-system")
+
+			errorList := ValidateProject(project)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeForbidden),
+				"Field": Equal("spec.namespace"),
+			}))))
+		})
+
 		It("should forbid Project specification with empty or invalid key for description", func() {
 			project.Spec.Description = ptr.To("")
 

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -6,18 +6,14 @@ package validator
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"slices"
-	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	plugin "github.com/gardener/gardener/plugin/pkg"
 	"github.com/gardener/gardener/plugin/pkg/utils"
 )
@@ -57,11 +53,6 @@ func (v *handler) Admit(_ context.Context, a admission.Attributes, _ admission.O
 	project, ok := a.GetObject().(*gardencore.Project)
 	if !ok {
 		return apierrors.NewBadRequest("could not convert object to Project")
-	}
-
-	// TODO: Remove this check in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
-	if project.Spec.Namespace != nil && *project.Spec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*project.Spec.Namespace, gardenerutils.ProjectNamespacePrefix) {
-		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gardenerutils.ProjectNamespacePrefix))
 	}
 
 	if utils.SkipVerification(a.GetOperation(), project.ObjectMeta) {

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -70,12 +70,6 @@ var _ = Describe("Admission", func() {
 				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
-			It("should prevent creating the project because namespace prefix is missing", func() {
-				project.Spec.Namespace = ptr.To("foo")
-
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(".spec.namespace must start with garden-")))
-			})
-
 			It("should maintain createdBy and project owner", func() {
 				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -13,10 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/plugin/pkg/project/validator"
 )
 
@@ -28,12 +26,10 @@ var _ = Describe("Admission", func() {
 			admissionHandler admission.MutationInterface
 			attrs            admission.Attributes
 
-			namespaceName = "garden-my-project"
-			projectName   = "my-project"
-			projectBase   = core.Project{
+			projectName = "my-project"
+			projectBase = core.Project{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      projectName,
-					Namespace: namespaceName,
+					Name: projectName,
 				},
 			}
 
@@ -52,22 +48,6 @@ var _ = Describe("Admission", func() {
 		When("project is created", func() {
 			BeforeEach(func() {
 				attrs = admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-			})
-
-			It("should allow creating the project (namespace nil)", func() {
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
-			})
-
-			It("should allow creating the project(namespace non-nil)", func() {
-				project.Spec.Namespace = &namespaceName
-
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
-			})
-
-			It("should allow creating the project (namespace is 'garden')", func() {
-				project.Spec.Namespace = ptr.To(v1beta1constants.GardenNamespace)
-
-				Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should maintain createdBy and project owner", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:

Currently, a `Project` resource's `.spec.namespace` field is validated via the `ProjectValidator` mutating AdmissionPlugin.
The plugin has been added as a validating plugin [in the following PR](https://github.com/gardener/gardener/pull/4228), and later on it was [refactored as a mutating one](https://github.com/gardener/gardener/pull/12061).

Currently, there is a TODO suggests moving the `.spec.namespace` field validation to the storage layer:
https://github.com/gardener/gardener/blob/b78c985a99dd9e489fa922249a312dfa8ad6c590/plugin/pkg/project/validator/admission.go#L62-L65

This PR addresses the aforementioned TODO comment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
A Project resource's `.spec.namespace` field is now validated in the storage layer. It was previously validated in the `ProjectValidator` admission plugin due to backwards-compatibility reasons. With this change, gardener-apiserver unconditionally accepts only `garden` and values with prefix `garden-` as valid Project namespaces.
```
