### PR TITLE
Make the `FinalizerRemoval` admission plugin validating

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -100,7 +100,7 @@ This admission controller reacts on `CREATE` and `UPDATE` operations for `Backup
 
 ## `FinalizerRemoval`
 
-**Type**: Mutating. **Enabled by default**: Yes.
+**Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `UPDATE` operations for `CredentialsBinding`s, `SecretBinding`s, `Shoot`s. 
 It ensures that the finalizers of these resources are not removed by users, as long as the affected resource is still in use.

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -82,7 +82,7 @@ func (f *FinalizerRemoval) ValidateInitialization() error {
 
 var _ admission.ValidationInterface = &FinalizerRemoval{}
 
-// Admit ensures that finalizers from objects can only be removed if they are not needed anymore.
+// Validate ensures that finalizers from objects can only be removed if they are not needed anymore.
 func (f *FinalizerRemoval) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced
 	if f.readyFunc == nil {

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -80,10 +80,10 @@ func (f *FinalizerRemoval) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = (*FinalizerRemoval)(nil)
+var _ admission.ValidationInterface = &FinalizerRemoval{}
 
 // Admit ensures that finalizers from objects can only be removed if they are not needed anymore.
-func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+func (f *FinalizerRemoval) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced
 	if f.readyFunc == nil {
 		f.AssignReadyFunc(func() bool {
@@ -99,10 +99,7 @@ func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ ad
 		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
 	}
 
-	var (
-		err            error
-		newObj, oldObj client.Object
-	)
+	var newObj, oldObj client.Object
 
 	oldObj, ok := a.GetOldObject().(client.Object)
 	if !ok {
@@ -163,9 +160,6 @@ func (f *FinalizerRemoval) Admit(_ context.Context, a admission.Attributes, _ ad
 		}
 	}
 
-	if err != nil {
-		return admission.NewForbidden(a, err)
-	}
 	return nil
 }
 

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -80,7 +80,7 @@ func (f *FinalizerRemoval) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.ValidationInterface = &FinalizerRemoval{}
+var _ admission.ValidationInterface = (*FinalizerRemoval)(nil)
 
 // Validate ensures that finalizers from objects can only be removed if they are not needed anymore.
 func (f *FinalizerRemoval) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/plugin/pkg/global/finalizerremoval/admission_test.go
+++ b/plugin/pkg/global/finalizerremoval/admission_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var _ = Describe("finalizerremoval", func() {
-	Describe("#Admit", func() {
+	Describe("#Validate", func() {
 		var (
 			ctx                       context.Context
 			admissionHandler          *FinalizerRemoval
@@ -75,7 +75,7 @@ var _ = Describe("finalizerremoval", func() {
 			It("should admit the removal because object is not used by any shoot", func() {
 				attrs := admission.NewAttributesRecord(&core.SecretBinding{}, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(HaveOccurred())
 			})
 
 			It("should admit the removal because finalizer is irrelevant", func() {
@@ -84,7 +84,7 @@ var _ = Describe("finalizerremoval", func() {
 
 				attrs := admission.NewAttributesRecord(newSecretBinding, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(HaveOccurred())
 			})
 
 			It("should reject the removal because object is not used by any shoot", func() {
@@ -100,7 +100,7 @@ var _ = Describe("finalizerremoval", func() {
 
 				attrs := admission.NewAttributesRecord(newSecretBinding, coreSecretBinding, core.Kind("SecretBinding").WithVersion("version"), "", coreSecretBinding.Name, core.Resource("SecretBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
 			})
 		})
 
@@ -120,7 +120,7 @@ var _ = Describe("finalizerremoval", func() {
 			It("should admit the removal because object is not used by any shoot", func() {
 				attrs := admission.NewAttributesRecord(&security.CredentialsBinding{}, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(HaveOccurred())
 			})
 
 			It("should admit the removal because finalizer is irrelevant", func() {
@@ -129,7 +129,7 @@ var _ = Describe("finalizerremoval", func() {
 
 				attrs := admission.NewAttributesRecord(newCredentialsBinding, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(HaveOccurred())
 			})
 
 			It("should reject the removal because object is not used by any shoot", func() {
@@ -145,7 +145,7 @@ var _ = Describe("finalizerremoval", func() {
 
 				attrs := admission.NewAttributesRecord(newCredentialsBinding, coreCredentialsBinding, security.Kind("CredentialsBinding").WithVersion("version"), "", coreCredentialsBinding.Name, security.Resource("CredentialsBinding").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("finalizer must not be removed")))
 			})
 		})
 
@@ -174,7 +174,7 @@ var _ = Describe("finalizerremoval", func() {
 
 				attrs := admission.NewAttributesRecord(newShoot, coreShoot, security.Kind("Shoot").WithVersion("version"), "", coreShoot.Name, security.Resource("Shoot").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
 			It("should admit the removal if the shoot deletion succeeded ", func() {
@@ -183,7 +183,7 @@ var _ = Describe("finalizerremoval", func() {
 				newShoot.Status.LastOperation.Type = core.LastOperationTypeDelete
 
 				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
 			It("should reject the removal if the shoot has not yet been deleted successfully", func() {
@@ -191,7 +191,7 @@ var _ = Describe("finalizerremoval", func() {
 				newShoot.Finalizers = nil
 
 				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(MatchError(ContainSubstring("shoot deletion has not completed successfully yet")))
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("shoot deletion has not completed successfully yet")))
 			})
 
 			It("should admit the removal if the shoot has not yet a last operation", func() {
@@ -200,7 +200,7 @@ var _ = Describe("finalizerremoval", func() {
 				newShoot.Status.LastOperation = nil
 
 				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
 			It("should admit the removal if the shoot has not yet a technical id", func() {
@@ -209,7 +209,7 @@ var _ = Describe("finalizerremoval", func() {
 				newShoot.Status.TechnicalID = ""
 
 				attrs := admission.NewAttributesRecord(newShoot, coreShoot, core.Kind("Shoot").WithVersion("version"), coreShoot.Namespace, coreShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The `FinalizerRemoval` admission plugin currently is implemented as a Mutator. Since the plugin itself does not do any mutation to the evaluated resources, it could be refactored to implement the `admission.ValidationInterface` interface.

This PR refactors the FinalizerRemoval to implement this interface.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-apiserver: The `FinalizerRemoval` admission plugin's type is now changed from mutating to validating.
```
