### PR TITLE
Disallow the separator in audience names for the apiserver

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1619,6 +1619,8 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 
 	allErrs = append(allErrs, featuresvalidation.ValidateFeatureGates(kubeAPIServer.FeatureGates, version, fldPath.Child("featureGates"))...)
 
+	allErrs = append(allErrs, validateAPIAudiences(kubeAPIServer.APIAudiences, fldPath.Child("apiAudiences"))...)
+
 	return allErrs
 }
 
@@ -1713,6 +1715,16 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 
 	allErrs = append(allErrs, featuresvalidation.ValidateFeatureGates(kcm.FeatureGates, version, fldPath.Child("featureGates"))...)
 
+	return allErrs
+}
+
+func validateAPIAudiences(audiences []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, audience := range audiences {
+		if strings.Contains(audience, ",") {
+			allErrs = append(allErrs, field.Invalid(fldPath, audience, "audience must not contain commas"))
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1720,10 +1720,20 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 
 func validateAPIAudiences(audiences []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	for _, audience := range audiences {
-		if strings.Contains(audience, ",") {
-			allErrs = append(allErrs, field.Invalid(fldPath, audience, "audience must not contain commas"))
+
+	audienceSet := sets.New[string]()
+
+	for i, audience := range audiences {
+		idxPath := fldPath.Index(i)
+
+		if audienceSet.Has(audience) {
+			allErrs = append(allErrs, field.Duplicate(idxPath, audience))
 		}
+		if strings.Contains(audience, ",") {
+			allErrs = append(allErrs, field.Invalid(idxPath, audience, "audience must not contain commas"))
+		}
+
+		audienceSet.Insert(audience)
 	}
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2591,6 +2591,38 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})
 			})
 
+			Context("Audience validation", func() {
+				It("should allow specifying individual audiences", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.APIAudiences = []string{"foo", "bar"}
+
+					errorList := ValidateShoot(shoot)
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should not allow specifying audiences with the delimiter included", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.APIAudiences = []string{"foo,baz", "bar"}
+
+					errorList := ValidateShoot(shoot)
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.kubernetes.kubeAPIServer.apiAudiences[0]"),
+						"Detail": Equal("audience must not contain commas"),
+					}))))
+				})
+
+				It("should not contain duplicates", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.APIAudiences = []string{"foo", "bar", "foo"}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeDuplicate),
+						"Field":    Equal("spec.kubernetes.kubeAPIServer.apiAudiences[2]"),
+						"BadValue": Equal("foo"),
+					}))))
+				})
+			})
+
 			It("should not allow to specify a negative event ttl duration", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: -1}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Until now, users could specify the `kube-apiserver`'s audiences via the `Shoot.spec.kubernetes.kubeAPIServer.apiAudiences[]` list.
Within the list it is allowed to specify any string, which will be concatenated and then set for the `kube-apiserver`'s `--api-audiences` flag.
This list is comma-delimited, which could also be part of a single audience entry within the `Shoot` API.
To keep each entry in that list a singular audience, let's make sure users do not specify the delimiter within the string.

This PR also makes sure no audience is used as a duplicate.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
It is not allowed anymore to specify a comma ",", as well as duplicate values, within the entries of the`Shoot.spec.kubernetes.kubeAPIServer.apiAudiences[]`. Please update your `Shoot`s accordingly.
```
