### PR TITLE
Suffix `plutono-datasources` configmap name to avoid name collision with operator

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -231,7 +231,7 @@ func (p *plutono) computeResourcesData(ctx context.Context) (*corev1.ConfigMap, 
 	}
 	dataSourceConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "plutono-datasources",
+			Name:      "plutono-datasources" + dataSourcesKeySuffix,
 			Namespace: p.namespace,
 			Labels:    utils.MergeStringMaps(getLabels(), map[string]string{p.dataSourceLabel(): labelValueTrue}),
 		},

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -6,6 +6,8 @@ package plutono_test
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -201,7 +203,7 @@ metadata:
       access: proxy
       url: http://prometheus-` + prometheusSuffix + `:80
       basicAuth: false
-      isDefault: true
+      isDefault: ` + strconv.FormatBool(!values.OnlyDeployDataSourcesAndDashboards) + `
       version: 1
       editable: false
       jsonData:
@@ -232,17 +234,23 @@ metadata:
         timeInterval: 1m
 `
 				}
-
-				configMapData += `    - name: vali
+				if !values.OnlyDeployDataSourcesAndDashboards {
+					configMapData += `    - name: vali
       type: vali
       access: proxy
       url: http://logging.` + namespace + `.svc:3100
       jsonData:
         maxLines: ` + maxLine
 
+				}
+				configMapData = strings.TrimSuffix(configMapData, "\n")
+				var dataSourcesKeySuffix string
+				if values.OnlyDeployDataSourcesAndDashboards {
+					dataSourcesKeySuffix = "-seed"
+				}
 				configMap := `apiVersion: v1
 data:
-  datasources.yaml: |
+  datasources` + dataSourcesKeySuffix + `.yaml: |
     ` + configMapData + `
 kind: ConfigMap
 metadata:
@@ -577,6 +585,10 @@ status:
 
 		JustBeforeEach(func() {
 			component = New(c, namespace, fakeSecretManager, values)
+			if values.OnlyDeployDataSourcesAndDashboards {
+				managedResource.Name = "plutono-seed-config-only"
+
+			}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 
@@ -694,6 +706,37 @@ status:
 
 					It("should successfully deploy all resources", func() {
 						checkDeployedResources("plutono-dashboards-garden", 31)
+					})
+				})
+
+				Context("managed by gardener-operator", func() {
+					BeforeEach(func() {
+						values.OnlyDeployDataSourcesAndDashboards = true
+					})
+
+					It("should successfully deploy all resources", func() {
+
+						dashboardConfigMapName := "plutono-dashboards-garden"
+						dashboardCount := 28
+						GinkgoHelper()
+
+						deployment := deploymentYAMLFor(values)
+						utilruntime.Must(references.InjectAnnotations(deployment))
+
+						Expect(manifests).To(ConsistOf(
+							dataSourceConfigMapYAMLFor(values),
+						), "Resource manifests do not match the expected ones")
+
+						dashboardsConfigMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: dashboardConfigMapName, Namespace: namespace}}
+						Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(Succeed(), "Could not successfully get dashboards configMap")
+						Expect(dashboardsConfigMap.Labels).To(HaveKeyWithValue("dashboard.monitoring.gardener.cloud/"+clusterLabelKey(values), "true"), "Dashboards configMap does not contain expected key")
+
+						availableDashboards := sets.Set[string]{}
+						for key := range dashboardsConfigMap.Data {
+							availableDashboards.Insert(key)
+						}
+						Expect(availableDashboards).To(HaveLen(dashboardCount), "The number of deployed dashboards differs from the expected one")
+
 					})
 				})
 

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -260,7 +260,7 @@ metadata:
     datasource.monitoring.gardener.cloud/` + clusterLabelKey(values) + `: "true"
 `
 
-				configMap += `  name: plutono-datasources
+				configMap += `  name: plutono-datasources` + dataSourcesKeySuffix + `
   namespace: some-namespace
 `
 

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -715,13 +715,8 @@ status:
 					})
 
 					It("should successfully deploy all resources", func() {
-
 						dashboardConfigMapName := "plutono-dashboards-garden"
 						dashboardCount := 28
-						GinkgoHelper()
-
-						deployment := deploymentYAMLFor(values)
-						utilruntime.Must(references.InjectAnnotations(deployment))
 
 						Expect(manifests).To(ConsistOf(
 							dataSourceConfigMapYAMLFor(values),
@@ -736,7 +731,6 @@ status:
 							availableDashboards.Insert(key)
 						}
 						Expect(availableDashboards).To(HaveLen(dashboardCount), "The number of deployed dashboards differs from the expected one")
-
 					})
 				})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Seems to be caused by https://github.com/gardener/gardener/pull/12762

This PR suffixes `plutono-datasources` when `OnlyDeployDataSourcesAndDashboards` is set mirroring the behavior of the data field
https://github.com/gardener/gardener/blob/bdfa23af92eb972840ed93f3c7541cc00bb1c3cf/pkg/component/observability/plutono/plutono.go#L238


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12785


**Special notes for your reviewer**:
Result after running local operator setup
```
❯ k -n garden get configmap | grep plutono
plutono-dashboard-providers-140e41f3                1      8m6s
plutono-dashboards-garden                           31     8m6s
plutono-dashboards-seed                             18     96s
plutono-datasources                                 1      8m6s
plutono-datasources-seed                            1      96s
```

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the `plutono-datasources` ConfigMap to be reconciled by 2 ManagedResources when Seed is Garden managed by `gardener-operator` is now fixed. Occasionally, the issue was preventing successful Seed deletion.
```
