### PR TITLE
Drop `maxprocs` from `gardener-controller-manager`

### DIFF
--- a/cmd/gardener-controller-manager/app/app.go
+++ b/cmd/gardener-controller-manager/app/app.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
-	"go.uber.org/automaxprocs/maxprocs"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -74,15 +73,6 @@ func NewCommand() *cobra.Command {
 
 func run(ctx context.Context, log logr.Logger, cfg *controllermanagerconfigv1alpha1.ControllerManagerConfiguration) error {
 	log.Info("Feature Gates", "featureGates", features.DefaultFeatureGate)
-
-	// This is like importing the automaxprocs package for its init func (it will in turn call maxprocs.Set).
-	// Here we pass a custom logger, so that the result of the library gets logged to the same logger we use for the
-	// component itself.
-	if _, err := maxprocs.Set(maxprocs.Logger(func(s string, i ...any) {
-		log.Info(fmt.Sprintf(s, i...)) //nolint:logcheck
-	})); err != nil {
-		log.Error(err, "Failed to set GOMAXPROCS")
-	}
 
 	log.Info("Getting rest config")
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/spf13/pflag v1.0.7
 	github.com/spf13/viper v1.20.1
 	github.com/texttheater/golang-levenshtein v1.0.1
-	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.0
@@ -256,6 +255,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.3 // indirect


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup

**What this PR does / why we need it**:
`GOMAXPROCS` is automatically set by the Go runtime version >= 1.25, see https://go.dev/blog/container-aware-gomaxprocs.

**Special notes for your reviewer**:
Please note the deviations between the Go runtime and the Maxprocs implementations (see [comparison in proposal](https://github.com/golang/go/issues/73193)). Since GCM limits are uncommon and typically only applied when deployed using the control-plane chart (see this [discussion](https://github.com/gardener/gardener/pull/5627/files#r834044583)), these differences are considered acceptable.

/cc @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`GOMAXPROCS` for the `gardener-controller-manager` is set by the Go runtime instead of the external `go.uber.org/automaxprocs/maxprocs` library.
```
