### PR TITLE
Remove setting 'gardenClusterAddress' from docs

### DIFF
--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -429,17 +429,7 @@ spec:
   - key: seed.gardener.cloud/protected
 ```
 
-Up next, a `gardenlet` has to be installed on to this `Shoot` and it needs to be registered as a `Seed`. The recommended way is to create a `ManagedSeed` resource in the virtual Garden. The configuration for the `Seed` needs to be crafted carefully to avoid overlapping CIDR ranges etc. Additionally, the virtual Garden's API endpoint needs to be added. When deploying a `gardenlet` to the runtime cluster, cluster-internal communication through the `Service`'s cluster DNS record works well. Now with the new `gardenlet` running on a different Kubernetes cluster, the public endpoint is required in the `gardenlet`'s configuration within the `ManagedSeed` resource.
-
-```yaml
-spec:
-  gardenlet:
-    config:
-      apiVersion: gardenlet.config.gardener.cloud/v1alpha1
-      kind: GardenletConfiguration
-      gardenClientConnection:
-        gardenClusterAddress: https://api.garden.crazy-botany.gardener.cloud
-```
+Up next, a `gardenlet` has to be installed on to this `Shoot` and it needs to be registered as a `Seed`. The recommended way is to create a `ManagedSeed` resource in the virtual Garden. The configuration for the `Seed` needs to be crafted carefully to avoid overlapping CIDR ranges etc.
 
 ![managed seed](./content/managedseed.png)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Since Gardener 1.123.0 the `Gardenlet.spec.config.gardenClientConnection.gardenClusterAddress` is set automatically by the operator (see [this](https://github.com/gardener/gardener/pull/11996) PR).

The documentation disencourages setting the entry from then on: "You could also specify the gardenClusterAddress and gardenClusterCACert in the Gardenlet resource manually, but this is not recommended." -> [link](https://gardener.cloud/docs/gardener/deployment/deploy_gardenlet_via_operator/#configuring-the-connection-to-garden-cluster) to docs.

Therefore, this whole block in the setup gardener docs can be removed, too.

