### PR TITLE
Deprecate `SecretBinding` and `shoot.spec.secretBindingName`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1483,6 +1483,7 @@ Kubernetes core/v1.ObjectReference
 </h3>
 <p>
 <p>SecretBinding represents a binding to a secret in the same or another namespace.</p>
+<p>Deprecated: Use CredentialsBinding instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </p>
 <table>
 <thead>
@@ -10682,6 +10683,7 @@ Defaults to true.</p>
 </p>
 <p>
 <p>SecretBindingProvider defines the provider type of the SecretBinding.</p>
+<p>Deprecated: Use CredentialsBinding instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </p>
 <table>
 <thead>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2043,6 +2043,7 @@ string
 The credentials inside the provider secret will be used to create the shoot in the respective account.
 The field is mutually exclusive with CredentialsBindingName.
 This field is immutable.</p>
+<p>Deprecated: Use CredentialsBindingName instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </td>
 </tr>
 <tr>
@@ -13003,6 +13004,7 @@ string
 The credentials inside the provider secret will be used to create the shoot in the respective account.
 The field is mutually exclusive with CredentialsBindingName.
 This field is immutable.</p>
+<p>Deprecated: Use CredentialsBindingName instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </td>
 </tr>
 <tr>
@@ -13733,6 +13735,7 @@ string
 The credentials inside the provider secret will be used to create the shoot in the respective account.
 The field is mutually exclusive with CredentialsBindingName.
 This field is immutable.</p>
+<p>Deprecated: Use CredentialsBindingName instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -10684,7 +10684,7 @@ Defaults to true.</p>
 </p>
 <p>
 <p>SecretBindingProvider defines the provider type of the SecretBinding.</p>
-<p>Deprecated: Use CredentialsBinding instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
+<p>Deprecated: Use CredentialsBindingProvider instead. See <a href="https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md">https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md</a> for migration instructions.</p>
 </p>
 <table>
 <thead>

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -51,6 +51,10 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "you are setting the spec.cloudProfileName field. The field is deprecated and will be forcefully set empty starting with Kubernetes 1.34. Use the new spec.cloudProfile.name field instead.")
 	}
 
+	if shoot.Spec.SecretBindingName != nil {
+		warnings = append(warnings, "spec.secretBindingName is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md")
+	}
+
 	return warnings
 }
 

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -52,7 +52,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if shoot.Spec.SecretBindingName != nil {
-		warnings = append(warnings, "spec.secretBindingName is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md")
+		warnings = append(warnings, "spec.secretBindingName is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md")
 	}
 
 	return warnings

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Warnings", func() {
 			},
 
 			Entry("should return a warning when secretBindingName is set", ptr.To("my-secret-binding"),
-				ContainElement(Equal("spec.secretBindingName is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"))),
+				ContainElement(Equal("spec.secretBindingName is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"))),
 			Entry("should not return a warning when secretBindingName is not set", nil, BeEmpty()),
 		)
 

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -261,6 +261,17 @@ var _ = Describe("Warnings", func() {
 			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")))
 		})
 
+		DescribeTable("shoot.spec.secretBindingName",
+			func(secretBindingName *string, expectedWarning gomegatypes.GomegaMatcher) {
+				shoot.Spec.SecretBindingName = secretBindingName
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(expectedWarning)
+			},
+
+			Entry("should return a warning when secretBindingName is set", ptr.To("my-secret-binding"),
+				ContainElement(Equal("spec.secretBindingName is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"))),
+			Entry("should not return a warning when secretBindingName is not set", nil, BeEmpty()),
+		)
+
 		Describe("shoot.spec.cloudProfileName", func() {
 			It("should not return a warning when cloudProfileName is set and the Kubernetes version is < v1.33", func() {
 				shoot.Spec.Kubernetes.Version = "1.32.3"

--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -33,7 +33,7 @@ type SecretBinding struct {
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingProvider instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.
 	//
@@ -46,7 +46,7 @@ type SecretBindingProvider struct {
 
 // SecretBindingList is a collection of SecretBindings.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingList instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingList struct {
 	metav1.TypeMeta
 	// Standard list object metadata.

--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -13,6 +13,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SecretBinding represents a binding to a secret in the same or another namespace.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBinding struct {
 	metav1.TypeMeta
 	// Standard object metadata.
@@ -30,6 +32,8 @@ type SecretBinding struct {
 }
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.
 	//
@@ -41,6 +45,8 @@ type SecretBindingProvider struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SecretBindingList is a collection of SecretBindings.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingList struct {
 	metav1.TypeMeta
 	// Standard list object metadata.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -86,6 +86,8 @@ type ShootSpec struct {
 	// The credentials inside the provider secret will be used to create the shoot in the respective account.
 	// The field is mutually exclusive with CredentialsBindingName.
 	// This field is immutable.
+	//
+	// Deprecated: Use CredentialsBindingName instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 	SecretBindingName *string
 	// SeedName is the name of the seed cluster that runs the control plane of the Shoot.
 	SeedName *string

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3256,6 +3256,8 @@ message ShootSpec {
   // The field is mutually exclusive with CredentialsBindingName.
   // This field is immutable.
   // +optional
+  //
+  // Deprecated: Use CredentialsBindingName instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
   optional string secretBindingName = 13;
 
   // SeedName is the name of the seed cluster that runs the control plane of the Shoot.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2587,6 +2587,8 @@ message SSHAccess {
 }
 
 // SecretBinding represents a binding to a secret in the same or another namespace.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 message SecretBinding {
   // Standard object metadata.
   // +optional
@@ -2608,6 +2610,8 @@ message SecretBinding {
 }
 
 // SecretBindingList is a collection of SecretBindings.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 message SecretBindingList {
   // Standard list object metadata.
   // +optional
@@ -2618,6 +2622,8 @@ message SecretBindingList {
 }
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 message SecretBindingProvider {
   // Type is the type of the provider.
   //

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2611,7 +2611,7 @@ message SecretBinding {
 
 // SecretBindingList is a collection of SecretBindings.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingList instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 message SecretBindingList {
   // Standard list object metadata.
   // +optional
@@ -2623,7 +2623,7 @@ message SecretBindingList {
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingProvider instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 message SecretBindingProvider {
   // Type is the type of the provider.
   //

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -13,6 +13,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SecretBinding represents a binding to a secret in the same or another namespace.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBinding struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -33,6 +35,8 @@ type SecretBinding struct {
 }
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.
 	//
@@ -44,6 +48,8 @@ type SecretBindingProvider struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SecretBindingList is a collection of SecretBindings.
+//
+// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list object metadata.

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -36,7 +36,7 @@ type SecretBinding struct {
 
 // SecretBindingProvider defines the provider type of the SecretBinding.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingProvider instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.
 	//
@@ -49,7 +49,7 @@ type SecretBindingProvider struct {
 
 // SecretBindingList is a collection of SecretBindings.
 //
-// Deprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
+// Deprecated: Use CredentialsBindingList instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 type SecretBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list object metadata.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -104,6 +104,8 @@ type ShootSpec struct {
 	// The field is mutually exclusive with CredentialsBindingName.
 	// This field is immutable.
 	// +optional
+	//
+	// Deprecated: Use CredentialsBindingName instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.
 	SecretBindingName *string `json:"secretBindingName,omitempty" protobuf:"bytes,13,opt,name=secretBindingName"`
 	// SeedName is the name of the seed cluster that runs the control plane of the Shoot.
 	// +optional

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -266,7 +266,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretBindingName"), "is incompatible with credentialsBindingName"))
 		}
 
-		// TODO(dimityrmirchev) Remove once we drop support for Kubernetes 1.34
+		// TODO(dimityrmirchev) Remove once we drop support for Kubernetes <= 1.33
 		// Forbid secretBindingName for Kubernetes versions >= 1.34
 		if spec.SecretBindingName != nil && len(*spec.SecretBindingName) > 0 &&
 			k8sVersion != nil && versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -265,6 +265,13 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 		} else if len(ptr.Deref(spec.SecretBindingName, "")) != 0 && len(ptr.Deref(spec.CredentialsBindingName, "")) != 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretBindingName"), "is incompatible with credentialsBindingName"))
 		}
+
+		// TODO(dimityrmirchev) Remove once we drop support for Kubernetes 1.34
+		// Forbid secretBindingName for Kubernetes versions >= 1.34
+		if spec.SecretBindingName != nil && len(*spec.SecretBindingName) > 0 &&
+			k8sVersion != nil && versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretBindingName"), "is no longer supported for Kubernetes >= 1.34, use spec.credentialsBindingName instead"))
+		}
 	}
 	if spec.SeedName != nil && len(*spec.SeedName) == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), spec.SeedName, "seed name must not be empty when providing the key"))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -5971,6 +5971,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}
 				shoot.Spec.Kubernetes.KubeAPIServer = nil
 				shoot.Spec.Kubernetes.Version = "1.34.0"
+				shoot.Spec.SecretBindingName = nil
+				shoot.Spec.CredentialsBindingName = ptr.To("creds")
 				shoot.Spec.CloudProfileName = nil
 				cloudProfileRef := &core.CloudProfileReference{
 					Kind: "CloudProfile",

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -981,6 +981,23 @@ var _ = Describe("Shoot Validation Tests", func() {
 					})),
 				))
 			})
+
+			DescribeTable("secretBindingName validation for Kubernetes >= 1.34",
+				func(kubernetesVersion string) {
+					shoot.Spec.SecretBindingName = ptr.To("my-secret")
+					shoot.Spec.Kubernetes.Version = kubernetesVersion
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.secretBindingName"),
+						"Detail": Equal("is no longer supported for Kubernetes >= 1.34, use spec.credentialsBindingName instead"),
+					}))))
+				},
+				Entry("should forbid secretBindingName for Kubernetes = 1.34", "1.34.0"),
+				Entry("should forbid secretBindingName for Kubernetes > 1.34", "1.35.0"),
+			)
 		})
 
 		It("should forbid adding invalid/duplicate emails", func() {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -7626,7 +7626,7 @@ func schema_pkg_apis_core_v1beta1_SecretBinding(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SecretBinding represents a binding to a secret in the same or another namespace.",
+				Description: "SecretBinding represents a binding to a secret in the same or another namespace.\n\nDeprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -7690,7 +7690,7 @@ func schema_pkg_apis_core_v1beta1_SecretBindingList(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SecretBindingList is a collection of SecretBindings.",
+				Description: "SecretBindingList is a collection of SecretBindings.\n\nDeprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -7741,7 +7741,7 @@ func schema_pkg_apis_core_v1beta1_SecretBindingProvider(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SecretBindingProvider defines the provider type of the SecretBinding.",
+				Description: "SecretBindingProvider defines the provider type of the SecretBinding.\n\nDeprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -9410,7 +9410,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"secretBindingName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretBindingName is the name of a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account. The field is mutually exclusive with CredentialsBindingName. This field is immutable.",
+							Description: "SecretBindingName is the name of a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account. The field is mutually exclusive with CredentialsBindingName. This field is immutable.\n\nDeprecated: Use CredentialsBindingName instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -7690,7 +7690,7 @@ func schema_pkg_apis_core_v1beta1_SecretBindingList(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SecretBindingList is a collection of SecretBindings.\n\nDeprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
+				Description: "SecretBindingList is a collection of SecretBindings.\n\nDeprecated: Use CredentialsBindingList instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -7741,7 +7741,7 @@ func schema_pkg_apis_core_v1beta1_SecretBindingProvider(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "SecretBindingProvider defines the provider type of the SecretBinding.\n\nDeprecated: Use CredentialsBinding instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
+				Description: "SecretBindingProvider defines the provider type of the SecretBinding.\n\nDeprecated: Use CredentialsBindingProvider instead. See https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md for migration instructions.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {

--- a/pkg/apiserver/registry/core/secretbinding/strategy.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy.go
@@ -65,7 +65,7 @@ func (secretBindingStrategy) ValidateUpdate(_ context.Context, newObj, oldObj ru
 	return validation.ValidateSecretBindingUpdate(newBinding, oldBinding)
 }
 
-const secretBindingDeprecationWarning = "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34." +
+const secretBindingDeprecationWarning = "SecretBinding is deprecated in favour of CredentialsBinding." +
 	" For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 
 // WarningsOnCreate returns warnings to the client performing a create.

--- a/pkg/apiserver/registry/core/secretbinding/strategy.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy.go
@@ -65,12 +65,15 @@ func (secretBindingStrategy) ValidateUpdate(_ context.Context, newObj, oldObj ru
 	return validation.ValidateSecretBindingUpdate(newBinding, oldBinding)
 }
 
+const secretBindingDeprecationWarning = "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped." +
+	" For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+
 // WarningsOnCreate returns warnings to the client performing a create.
 func (secretBindingStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
-	return nil
+	return []string{secretBindingDeprecationWarning}
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (secretBindingStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
-	return nil
+	return []string{secretBindingDeprecationWarning}
 }

--- a/pkg/apiserver/registry/core/secretbinding/strategy.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy.go
@@ -65,7 +65,7 @@ func (secretBindingStrategy) ValidateUpdate(_ context.Context, newObj, oldObj ru
 	return validation.ValidateSecretBindingUpdate(newBinding, oldBinding)
 }
 
-const secretBindingDeprecationWarning = "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped." +
+const secretBindingDeprecationWarning = "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34." +
 	" For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 
 // WarningsOnCreate returns warnings to the client performing a create.

--- a/pkg/apiserver/registry/core/secretbinding/strategy_test.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Strategy", func() {
 	Describe("#WarningsOnCreate", func() {
 		It("should return deprecation warning", func() {
 			warnings := secretbindingregistry.Strategy.WarningsOnCreate(context.TODO(), secretBinding)
-			expected := "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			expected := "SecretBinding is deprecated in favour of CredentialsBinding. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(Equal(expected))
 		})
@@ -108,7 +108,7 @@ var _ = Describe("Strategy", func() {
 	Describe("#WarningsOnUpdate", func() {
 		It("should return deprecation warning", func() {
 			warnings := secretbindingregistry.Strategy.WarningsOnUpdate(context.TODO(), secretBinding, secretBinding)
-			expected := "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			expected := "SecretBinding is deprecated in favour of CredentialsBinding. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(Equal(expected))
 		})

--- a/pkg/apiserver/registry/core/secretbinding/strategy_test.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Strategy", func() {
 	Describe("#WarningsOnCreate", func() {
 		It("should return deprecation warning", func() {
 			warnings := secretbindingregistry.Strategy.WarningsOnCreate(context.TODO(), secretBinding)
-			expected := "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			expected := "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(Equal(expected))
 		})
@@ -108,7 +108,7 @@ var _ = Describe("Strategy", func() {
 	Describe("#WarningsOnUpdate", func() {
 		It("should return deprecation warning", func() {
 			warnings := secretbindingregistry.Strategy.WarningsOnUpdate(context.TODO(), secretBinding, secretBinding)
-			expected := "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			expected := "SecretBinding is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
 			Expect(warnings).To(HaveLen(1))
 			Expect(warnings[0]).To(Equal(expected))
 		})

--- a/pkg/apiserver/registry/core/secretbinding/strategy_test.go
+++ b/pkg/apiserver/registry/core/secretbinding/strategy_test.go
@@ -95,4 +95,22 @@ var _ = Describe("Strategy", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 	})
+
+	Describe("#WarningsOnCreate", func() {
+		It("should return deprecation warning", func() {
+			warnings := secretbindingregistry.Strategy.WarningsOnCreate(context.TODO(), secretBinding)
+			expected := "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(Equal(expected))
+		})
+	})
+
+	Describe("#WarningsOnUpdate", func() {
+		It("should return deprecation warning", func() {
+			warnings := secretbindingregistry.Strategy.WarningsOnUpdate(context.TODO(), secretBinding, secretBinding)
+			expected := "SecretBinding is deprecated and will be removed after support for Kubernetes 1.34 is dropped. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md"
+			Expect(warnings).To(HaveLen(1))
+			Expect(warnings[0]).To(Equal(expected))
+		})
+	})
 })

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -944,6 +944,9 @@ func (r *Reconciler) migrateSecretBindingToCredentialsBinding(ctx context.Contex
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      migratedCredentialsBindingName,
 			Namespace: shoot.Namespace,
+			Labels: map[string]string{
+				"credentialsbinding.gardener.cloud/status": "force-migrated",
+			},
 		},
 		Provider: securityv1alpha1.CredentialsBindingProvider{
 			Type: secretBinding.Provider.Type,

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1655,11 +1655,25 @@ var _ = Describe("Shoot Maintenance", func() {
 			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(createdCredentialsBinding), createdCredentialsBinding)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(createdCredentialsBinding.Provider.Type).To(Equal(providerType))
-			Expect(createdCredentialsBinding.CredentialsRef.Kind).To(Equal("Secret"))
-			Expect(createdCredentialsBinding.CredentialsRef.APIVersion).To(Equal("v1"))
-			Expect(createdCredentialsBinding.CredentialsRef.Name).To(Equal(secretName))
-			Expect(createdCredentialsBinding.CredentialsRef.Namespace).To(Equal(secretNamespace))
+			Expect(createdCredentialsBinding).To(Equal(&securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "force-migrated-" + secretBindingName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"credentialsbinding.gardener.cloud/status": "force-migrated",
+					},
+					ResourceVersion: "1",
+				},
+				Provider: securityv1alpha1.CredentialsBindingProvider{
+					Type: providerType,
+				},
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       secretName,
+					Namespace:  secretNamespace,
+				},
+			}))
 		})
 
 		It("should use existing user-created CredentialsBinding when it references the same Secret and Quotas match", func() {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -1644,11 +1644,11 @@ var _ = Describe("Shoot Maintenance", func() {
 
 			Expect(shoot.Spec.SecretBindingName).To(BeNil())
 			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
-			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("force-migrated-" + secretBindingName))
 
 			createdCredentialsBinding := &securityv1alpha1.CredentialsBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "migrated-" + secretBindingName,
+					Name:      "force-migrated-" + secretBindingName,
 					Namespace: namespace,
 				},
 			}
@@ -1662,7 +1662,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(createdCredentialsBinding.CredentialsRef.Namespace).To(Equal(secretNamespace))
 		})
 
-		It("should use existing CredentialsBinding when it references the same Secret", func() {
+		It("should use existing user-created CredentialsBinding when it references the same Secret and Quotas match", func() {
 			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
 
 			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
@@ -1687,7 +1687,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 			Expect(shoot.Spec.SecretBindingName).To(BeNil())
 			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
-			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal(secretBindingName))
 		})
 
 		It("should fail when existing CredentialsBinding references a different Secret", func() {
@@ -1695,7 +1695,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "migrated-" + secretBindingName,
+					Name:      "force-migrated-" + secretBindingName,
 					Namespace: namespace,
 				},
 				Provider: securityv1alpha1.CredentialsBindingProvider{
@@ -1723,7 +1723,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "migrated-" + secretBindingName,
+					Name:      "force-migrated-" + secretBindingName,
 					Namespace: namespace,
 				},
 				Provider: securityv1alpha1.CredentialsBindingProvider{
@@ -1744,7 +1744,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 			Expect(shoot.Spec.SecretBindingName).To(BeNil())
 			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
-			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("force-migrated-" + secretBindingName))
 		})
 
 		It("should fail when existing CredentialsBinding has different quotas", func() {
@@ -1756,7 +1756,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			quota3 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota3", Namespace: "ns3"}
 			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "migrated-" + secretBindingName,
+					Name:      "force-migrated-" + secretBindingName,
 					Namespace: namespace,
 				},
 				Provider: securityv1alpha1.CredentialsBindingProvider{

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler_test.go
@@ -5,17 +5,23 @@
 package maintenance
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 	admissionpluginsvalidation "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
 	featuresvalidation "github.com/gardener/gardener/pkg/utils/validation/features"
@@ -1575,6 +1581,243 @@ var _ = Describe("Shoot Maintenance", func() {
 				HaveField("Name", Equal(supportedAdmissionPlugin1)),
 				HaveField("Name", Equal(supportedAdmissionPlugin2)),
 			))
+		})
+	})
+
+	Describe("#migrateSecretBindingToCredentialsBinding", func() {
+		var (
+			ctx               context.Context
+			reconciler        *Reconciler
+			fakeClient        client.Client
+			shoot             *gardencorev1beta1.Shoot
+			secretBinding     *gardencorev1beta1.SecretBinding
+			namespace         = "test-namespace"
+			secretBindingName = "test-secret-binding"
+			secretName        = "test-secret"
+			secretNamespace   = "test-secret-namespace"
+			providerType      = "test-provider"
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+
+			scheme := runtime.NewScheme()
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+
+			reconciler = &Reconciler{
+				Client: fakeClient,
+			}
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shoot",
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: ptr.To(secretBindingName),
+				},
+			}
+
+			secretBinding = &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretBindingName,
+					Namespace: namespace,
+				},
+				Provider: &gardencorev1beta1.SecretBindingProvider{
+					Type: providerType,
+				},
+				SecretRef: corev1.SecretReference{
+					Name:      secretName,
+					Namespace: secretNamespace,
+				},
+			}
+		})
+
+		It("should migrate from SecretBinding to CredentialsBinding when none exists", func() {
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+
+			err := reconciler.migrateSecretBindingToCredentialsBinding(ctx, shoot)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(shoot.Spec.SecretBindingName).To(BeNil())
+			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+
+			createdCredentialsBinding := &securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "migrated-" + secretBindingName,
+					Namespace: namespace,
+				},
+			}
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(createdCredentialsBinding), createdCredentialsBinding)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(createdCredentialsBinding.Provider.Type).To(Equal(providerType))
+			Expect(createdCredentialsBinding.CredentialsRef.Kind).To(Equal("Secret"))
+			Expect(createdCredentialsBinding.CredentialsRef.APIVersion).To(Equal("v1"))
+			Expect(createdCredentialsBinding.CredentialsRef.Name).To(Equal(secretName))
+			Expect(createdCredentialsBinding.CredentialsRef.Namespace).To(Equal(secretNamespace))
+		})
+
+		It("should use existing CredentialsBinding when it references the same Secret", func() {
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+
+			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretBindingName,
+					Namespace: namespace,
+				},
+				Provider: securityv1alpha1.CredentialsBindingProvider{
+					Type: providerType,
+				},
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       secretName,
+					Namespace:  secretNamespace,
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingCredentialsBinding)).To(Succeed())
+
+			err := reconciler.migrateSecretBindingToCredentialsBinding(ctx, shoot)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(shoot.Spec.SecretBindingName).To(BeNil())
+			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+		})
+
+		It("should fail when existing CredentialsBinding references a different Secret", func() {
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+
+			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "migrated-" + secretBindingName,
+					Namespace: namespace,
+				},
+				Provider: securityv1alpha1.CredentialsBindingProvider{
+					Type: providerType,
+				},
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       "different-secret",
+					Namespace:  secretNamespace,
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingCredentialsBinding)).To(Succeed())
+
+			err := reconciler.migrateSecretBindingToCredentialsBinding(ctx, shoot)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not reference the same Secret"))
+		})
+
+		It("should use existing CredentialsBinding when quotas match as sets (order doesn't matter)", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1", Namespace: "ns1"}
+			quota2 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota2", Namespace: "ns2"}
+			secretBinding.Quotas = []corev1.ObjectReference{quota1, quota2}
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+
+			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "migrated-" + secretBindingName,
+					Namespace: namespace,
+				},
+				Provider: securityv1alpha1.CredentialsBindingProvider{
+					Type: providerType,
+				},
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       secretName,
+					Namespace:  secretNamespace,
+				},
+				Quotas: []corev1.ObjectReference{quota2, quota1},
+			}
+			Expect(fakeClient.Create(ctx, existingCredentialsBinding)).To(Succeed())
+
+			err := reconciler.migrateSecretBindingToCredentialsBinding(ctx, shoot)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(shoot.Spec.SecretBindingName).To(BeNil())
+			Expect(shoot.Spec.CredentialsBindingName).NotTo(BeNil())
+			Expect(*shoot.Spec.CredentialsBindingName).To(Equal("migrated-" + secretBindingName))
+		})
+
+		It("should fail when existing CredentialsBinding has different quotas", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1", Namespace: "ns1"}
+			quota2 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota2", Namespace: "ns2"}
+			secretBinding.Quotas = []corev1.ObjectReference{quota1, quota2}
+			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
+
+			quota3 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota3", Namespace: "ns3"}
+			existingCredentialsBinding := &securityv1alpha1.CredentialsBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "migrated-" + secretBindingName,
+					Namespace: namespace,
+				},
+				Provider: securityv1alpha1.CredentialsBindingProvider{
+					Type: providerType,
+				},
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       secretName,
+					Namespace:  secretNamespace,
+				},
+				Quotas: []corev1.ObjectReference{quota1, quota3}, // Different quota
+			}
+			Expect(fakeClient.Create(ctx, existingCredentialsBinding)).To(Succeed())
+
+			err := reconciler.migrateSecretBindingToCredentialsBinding(ctx, shoot)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not have the same Quotas"))
+		})
+	})
+
+	Describe("#quotasEqual", func() {
+		It("should return true for empty slices", func() {
+			Expect(quotasEqual(nil, nil)).To(BeTrue())
+			Expect(quotasEqual([]corev1.ObjectReference{}, []corev1.ObjectReference{})).To(BeTrue())
+		})
+
+		It("should return false for different lengths", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1"}
+			Expect(quotasEqual([]corev1.ObjectReference{quota1}, []corev1.ObjectReference{})).To(BeFalse())
+		})
+
+		It("should return true for same quotas in different order", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1", Namespace: "ns1"}
+			quota2 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota2", Namespace: "ns2"}
+
+			slice1 := []corev1.ObjectReference{quota1, quota2}
+			slice2 := []corev1.ObjectReference{quota2, quota1}
+
+			Expect(quotasEqual(slice1, slice2)).To(BeTrue())
+		})
+
+		It("should return false for different quotas", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1", Namespace: "ns1"}
+			quota2 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota2", Namespace: "ns2"}
+			quota3 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota3", Namespace: "ns3"}
+
+			slice1 := []corev1.ObjectReference{quota1, quota2}
+			slice2 := []corev1.ObjectReference{quota1, quota3}
+
+			Expect(quotasEqual(slice1, slice2)).To(BeFalse())
+		})
+
+		It("should handle quotas without namespace", func() {
+			quota1 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota1"}
+			quota2 := corev1.ObjectReference{APIVersion: "v1", Kind: "Quota", Name: "quota2"}
+
+			slice1 := []corev1.ObjectReference{quota1, quota2}
+			slice2 := []corev1.ObjectReference{quota2, quota1}
+
+			Expect(quotasEqual(slice1, slice2)).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup api-change

**What this PR does / why we need it**:
This PR deprecates both `SecretBinding` and `shoot.spec.secretBindingName`. They will be removed after we drop support for kubernetes version 1.34.

**Which issue(s) this PR fixes**:
Fixes #12324

Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
/invite @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
`SecretBinding` API is deprecated in favour of `CredentialsBinding` and will be removed after Kubernetes support for version 1.34 is dropped. Please see https://gardener.cloud/docs/gardener/shoot-operations/secretbinding-to-credentialsbinding-migration.
```

```noteworthy user
`shoot.spec.secretBindingName` field is deprecated in favour of `shoot.spec.credentialsBindingName` and will be removed after Kubernetes support for version 1.34 is dropped. Please see https://gardener.cloud/docs/gardener/shoot-operations/secretbinding-to-credentialsbinding-migration. If users do not perform the migration on their own, the migration will be forced and newly created `CredentialsBinding`s will be labeled with `credentialsbinding.gardener.cloud/status=force-migrated`.
```