### PR TITLE
Fix `import-boss` installation

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -186,6 +186,7 @@ $(IMPORT_BOSS): $(call tool_version_file,$(IMPORT_BOSS),$(K8S_VERSION))
 	mkdir -p hack/tools/bin/work/import-boss
 	curl -L -o hack/tools/bin/work/import-boss/main.go https://raw.githubusercontent.com/kubernetes/kubernetes/$(K8S_VERSION)/cmd/import-boss/main.go
 	go build -o $(IMPORT_BOSS) ./hack/tools/bin/work/import-boss
+	rm -rf hack/tools/bin/work/import-boss
 
 $(KIND): $(call tool_version_file,$(KIND),$(KIND_VERSION))
 	curl -L -o $(KIND) https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(SYSTEM_NAME)-$(SYSTEM_ARCH)

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -17,8 +17,8 @@ ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
-RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin
-RUN rm -rf /go/src/github.com/gardener/gardener/hack/tools/bin/work
+RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin && \
+    rm -rf /go/src/github.com/gardener/gardener/hack/tools/bin/work
 
 # golang-test
 FROM base AS golang-test

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -12,12 +12,13 @@ RUN echo "Installing Packages ..." \
 		&& rm -rf /var/lib/apt/lists/*
 
 # builder
-FROM base as builder
+FROM base AS builder
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin
+RUN rm -rf /go/src/github.com/gardener/gardener/hack/tools/bin/work
 
 # golang-test
 FROM base AS golang-test


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Fix `import-boss` installation by deleting the downloaded `main.go` file which is only for building the binary.
Before, the remaining `main.go` caused Go to consider all imports as direct dependencies of `gardener/gardener` or any other project that includes the [`tools.mk`](https://github.com/gardener/gardener/blob/master/hack/tools.mk) file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The fix appeared after several Prow jobs were adjusted to call `make import-tools-bin` (see [PR](https://github.com/gardener/ci-infra/pull/4344) and [failed run](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-networking-cilium/623/pull-extension-networking-cilium/1959979240501809152)). 

A rough sequence of actions that led to the failure:
- Tools image created all tools during the build (see [here](https://github.com/gardener/gardener/blob/52aae1478fa6641ead977694bb913538a9e1ccbd/hack/tools/image/Dockerfile#L20)).
- The `main.go` file of `import-boss` is downloaded to the `builder` layer (see [here](https://github.com/gardener/gardener/blob/52aae1478fa6641ead977694bb913538a9e1ccbd/hack/tools.mk#L187)).
- A dependent project (e.g. `networking-cilium`) used the Tools image and copies the previously downloaded/built tools, including `main.go`, to the project directory in the container.
- `make verify-extended` which calls `go mod tidy` causes the imports in `main.go` to be recognized as new dependencies.

/cc @marc1404

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Ambiguous `go.mod` dependencies were removed when calling `make import-tools-bin`.
```
