### PR TITLE
Update virtual garden etcd DB size alert thresholds to 6GB

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/etcd.yaml
@@ -109,13 +109,13 @@ spec:
     - alert: EtcdDbSizeLimitApproaching
       expr: |
         ( etcd_mvcc_db_total_size_in_bytes{job="virtual-garden-etcd"}
-          > bool 4294967296
+          > bool 6442450944
         )
         +
         ( etcd_mvcc_db_total_size_in_bytes{job="virtual-garden-etcd"}
           <= bool 8589900000
         )
-        == 2 # between 4GB and 8GB
+        == 2 # between 6GB and 8GB
       labels:
         severity: warning
         topology: garden
@@ -123,10 +123,10 @@ spec:
       annotations:
         summary: >-
           Virtual garden etcd {{$labels.role}} DB size is approaching its current
-          practical limit in landscape {{$externalLabels.landscape}}.
+          practical limit in landscape {{$externalLabels.landscape}}. Current DB size: {{ $value }}.
         description: >-
           Virtual garden etcd {{$labels.role}} DB size is approaching its current
-          practical limit of 8GB. Etcd quota might need to be increased.
+          practical limit of 8GB. Current DB size: {{ $value }}. Etcd quota might need to be increased.
 
     - alert: EtcdDbSizeLimitCrossed
       expr: |
@@ -139,10 +139,10 @@ spec:
       annotations:
         summary: >-
           Virtual garden etcd {{$labels.role}} DB size has crossed its current
-          practical limit in landscape {{$externalLabels.landscape}}.
+          practical limit in landscape {{$externalLabels.landscape}}. Current DB size: {{ $value }}.
         description: >-
           Virtual garden etcd {{$labels.role}} DB size has crossed its current
-          practical limit of 8GB. Etcd quota must be increased to allow updates.
+          practical limit of 8GB. Current DB size: {{ $value }}. Etcd quota must be increased to allow updates.
 
     - alert: EtcdDeltaBackupFailed
       expr: |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area monitoring
/kind post-mortem

**What this PR does / why we need it**:

we receive a lot of  etc db size alerts, almost a daily occurence. We believe that raising the alert threshold to  6G, in addition to the already present daily automated defragmentation, will reduce the etc defrag toil.

**Release notes**

`operator : the virtual garden etcd DB alerts have been updated from 4GB to 6GB`

