### PR TITLE
Add migration of kube-dns service to dual-stack.

### DIFF
--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -66,17 +66,17 @@ Nodes must support the new network protocol. However, node rollout is a manual s
 
 Cluster owners can monitor the progress of this step by checking the `DualStackNodesMigrationReady` constraint in the shoot status. During shoot reconciliation, the system verifies if all nodes support dual-stack networking and updates the migration state accordingly.
 
-### Step 5: Final Reconciliation
+### Step 5: Control Plane and CNI Configuration
 
-Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The nodes migration constraint is removed at the end of this step and the constraint `
+Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The nodes migration constraint is removed at the end of this step and the constraint `DNSServiceMigrationReady` is added with status `progressing`.
 
 ### Step 6: Restart of CoreDNS Pods
 
-With the next reconciliation, CoreDNS pods are restarted and get IPv6 addresses.
+With the next reconciliation, CoreDNS pods are restarted to obtain IPv6 addresses. The constraint `DNSServiceMigrationReady` is set to status `true` once all pods have both IPv4 and IPv6 addresses.
 
 ### Step 7: Switch Service `kube-dns` to Dual-Stack
 
-When all CoreDNS pods have IPv6 addresses, the `kube-dns` service will be configured as a dual-stack service with both IPv4 and IPv6 cluster IPs.
+When all CoreDNS pods have IPv6 addresses, the `kube-dns` service will be configured as a dual-stack service with both IPv4 and IPv6 cluster IPs and the constraint `DNSServiceMigrationReady` will be removed.
 
 ## Post-Migration Behavior
 
@@ -87,3 +87,4 @@ After completing the migration:
 - New pods will receive IP addresses from both address families.
 - Existing pods will only receive a second IP address upon recreation.
 - If full dual-stack networking is required, all pods need to be rolled.
+- Existing services remain IPv4-only until recreated with dual-stack configuration.

--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -68,12 +68,22 @@ Cluster owners can monitor the progress of this step by checking the `DualStackN
 
 ### Step 5: Final Reconciliation
 
-Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The migration constraint is removed at the end of this step.
+Once all nodes are migrated, the remaining control plane components and the Container Network Interface (CNI) are configured for dual-stack networking. The nodes migration constraint is removed at the end of this step and the constraint `
+
+### Step 6: Restart of CoreDNS Pods
+
+With the next reconciliation, CoreDNS pods are restarted and get IPv6 addresses.
+
+### Step 7: Switch Service `kube-dns` to Dual-Stack
+
+When all CoreDNS pods have IPv6 addresses, the `kube-dns` service will be configured as a dual-stack service with both IPv4 and IPv6 cluster IPs.
 
 ## Post-Migration Behavior
 
 After completing the migration:
 - The shoot cluster supports dual-stack networking.
+- The `kube-dns` service operates with both IPv4 and IPv6 cluster IPs.
+- CoreDNS pods handle DNS queries for both address families.
 - New pods will receive IP addresses from both address families.
 - Existing pods will only receive a second IP address upon recreation.
-- If full dual-stack networking is required all pods need to be rolled.
+- If full dual-stack networking is required, all pods need to be rolled.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2026,6 +2026,8 @@ const (
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
 	// ShootDualStackNodesMigrationReady is a constant for a condition type indicating whether all nodes are migrated to dual-stack .
 	ShootDualStackNodesMigrationReady ConditionType = "DualStackNodesMigrationReady"
+	// ShootDNSServiceMigrationReady is a constant for a condition type indicating whether the kube-dns service is migrated.
+	ShootDNSServiceMigrationReady ConditionType = "DNSServiceMigrationReady"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -620,6 +620,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployNetwork),
 		})
 		_ = g.Add(flow.Task{
+			Name: "Check coreDNS migration",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.CheckDNSServiceMigration(ctx)
+			}),
+			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			Dependencies: flow.NewTaskIDs(waitUntilNetworkIsReady),
+		})
+		_ = g.Add(flow.Task{
 			Name: "Deploying shoot cluster identity",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.DeployClusterIdentity(ctx)

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -624,7 +624,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.CheckDNSServiceMigration(ctx)
 			}),
-			SkipIf:       o.Shoot.IsWorkerless || skipReadiness,
+			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(waitUntilNetworkIsReady),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/coredns.go
+++ b/pkg/gardenlet/operation/botanist/coredns.go
@@ -6,9 +6,12 @@ package botanist
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,6 +21,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
+	corednsconstants "github.com/gardener/gardener/pkg/component/networking/coredns/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -62,11 +66,31 @@ func (b *Botanist) DeployCoreDNS(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	ipFamiliesLen, err := b.getCoreDNSPodIPFamilies(ctx)
+	if err != nil {
+		return err
+	}
+
+	shootIPFamilies := b.Shoot.GetInfo().Spec.Networking.IPFamilies
+	if len(shootIPFamilies) == 0 {
+		return fmt.Errorf("no IP families configured in shoot spec")
+	}
+
+	if len(b.Shoot.Networks.CoreDNS) == 0 {
+		return fmt.Errorf("no CoreDNS cluster IPs available")
+	}
+
+	if ipFamiliesLen == 1 && len(shootIPFamilies) >= 1 {
+		b.Shoot.Components.SystemComponents.CoreDNS.SetIPFamilies([]gardencorev1beta1.IPFamily{shootIPFamilies[0]})
+		b.Shoot.Components.SystemComponents.CoreDNS.SetClusterIPs([]net.IP{b.Shoot.Networks.CoreDNS[0]})
+	} else {
+		b.Shoot.Components.SystemComponents.CoreDNS.SetIPFamilies(shootIPFamilies)
+		b.Shoot.Components.SystemComponents.CoreDNS.SetClusterIPs(b.Shoot.Networks.CoreDNS)
+	}
 	b.Shoot.Components.SystemComponents.CoreDNS.SetNodeNetworkCIDRs(b.Shoot.Networks.Nodes)
 	b.Shoot.Components.SystemComponents.CoreDNS.SetPodNetworkCIDRs(b.Shoot.Networks.Pods)
-	b.Shoot.Components.SystemComponents.CoreDNS.SetClusterIPs(b.Shoot.Networks.CoreDNS)
 	b.Shoot.Components.SystemComponents.CoreDNS.SetPodAnnotations(restartedAtAnnotations)
-	b.Shoot.Components.SystemComponents.CoreDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 
 	return b.Shoot.Components.SystemComponents.CoreDNS.Deploy(ctx)
 }
@@ -82,6 +106,10 @@ func (b *Botanist) getCoreDNSRestartedAtAnnotations(ctx context.Context) (map[st
 		return map[string]string{key: NowFunc().UTC().Format(time.RFC3339)}, nil
 	}
 
+	if constraint := v1beta1helper.GetCondition(b.Shoot.GetInfo().Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady); constraint != nil && constraint.Status == gardencorev1beta1.ConditionProgressing {
+		return map[string]string{key: NowFunc().UTC().Format(time.RFC3339)}, nil
+	}
+
 	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: coredns.DeploymentName, Namespace: metav1.NamespaceSystem}}
 	if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(deployment), deployment); client.IgnoreNotFound(err) != nil {
 		return nil, err
@@ -92,6 +120,28 @@ func (b *Botanist) getCoreDNSRestartedAtAnnotations(ctx context.Context) (map[st
 	}
 
 	return nil, nil
+}
+
+func (b *Botanist) getCoreDNSPodIPFamilies(ctx context.Context) (int, error) {
+	podList := &corev1.PodList{}
+	if err := b.ShootClientSet.Client().List(ctx, podList,
+		client.InNamespace(metav1.NamespaceSystem),
+		client.MatchingLabels{corednsconstants.LabelKey: corednsconstants.LabelValue}); err != nil {
+		return 0, err
+	}
+
+	if len(podList.Items) == 0 {
+		return 0, nil
+	}
+
+	minIPCount := len(podList.Items[0].Status.PodIPs)
+	for _, pod := range podList.Items[1:] {
+		if ipCount := len(pod.Status.PodIPs); ipCount < minIPCount {
+			minIPCount = ipCount
+		}
+	}
+
+	return minIPCount, nil
 }
 
 func getCommonSuffixesForRewriting(systemComponents *gardencorev1beta1.SystemComponents) []string {

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -18,9 +18,7 @@ import (
 )
 
 // DetermineUpdateFunction determines the update function for the shoot's status based on dual-stack migration readiness.
-func (b *Botanist) DetermineUpdateFunction(networkReadyForDualStackMigration bool,
-	nodeList *corev1.NodeList,
-) func(*gardencorev1beta1.Shoot) error {
+func (b *Botanist) DetermineUpdateFunction(networkReadyForDualStackMigration bool, nodeList *corev1.NodeList) func(*gardencorev1beta1.Shoot) error {
 	if networkReadyForDualStackMigration {
 		return func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -9,19 +9,27 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	corednsconstants "github.com/gardener/gardener/pkg/component/networking/coredns/constants"
 )
 
 // DetermineUpdateFunction determines the update function for the shoot's status based on dual-stack migration readiness.
-func (b *Botanist) DetermineUpdateFunction(
-	networkReadyForDualStackMigration bool,
+func (b *Botanist) DetermineUpdateFunction(networkReadyForDualStackMigration bool,
 	nodeList *corev1.NodeList,
 ) func(*gardencorev1beta1.Shoot) error {
 	if networkReadyForDualStackMigration {
 		return func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
+			constraint := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+			if constraint == nil {
+				constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+				constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, gardencorev1beta1.ConditionProgressing, "DNSServiceMigration", "The shoot is migrating the kube-dns service.")
+				shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
+			}
 			return nil
 		}
 	}
@@ -45,6 +53,68 @@ func (b *Botanist) DetermineUpdateFunction(
 		shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
 		return nil
 	}
+}
+
+// DetermineUpdateFunctionDNS determines the update function for the shoot's status based on DNS service and pod readiness.
+func (b *Botanist) DetermineUpdateFunctionDNS(svcReady, podsReady bool) func(*gardencorev1beta1.Shoot) error {
+	if svcReady {
+		return func(shoot *gardencorev1beta1.Shoot) error {
+			shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+			return nil
+		}
+	}
+
+	if podsReady {
+		return func(shoot *gardencorev1beta1.Shoot) error {
+			constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+			constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, gardencorev1beta1.ConditionTrue, "DNSServiceMigration", "The coreDNS pods are ready for DNS service migration.")
+			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
+			return nil
+		}
+	}
+	return func(shoot *gardencorev1beta1.Shoot) error {
+		constraint := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+		if constraint == nil {
+			constraint := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady)
+			constraint = v1beta1helper.UpdatedConditionWithClock(b.Clock, constraint, gardencorev1beta1.ConditionProgressing, "DNSServiceMigration", "The shoot is migrating the kube-dns service.")
+			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, constraint)
+		}
+		return nil
+	}
+}
+
+// CheckDNSServiceMigration checks the DNS service migration status.
+func (b *Botanist) CheckDNSServiceMigration(ctx context.Context) error {
+	if condition := v1beta1helper.GetCondition(b.Shoot.GetInfo().Status.Constraints, gardencorev1beta1.ShootDNSServiceMigrationReady); condition == nil {
+		return nil
+	}
+
+	service := &corev1.Service{}
+	if err := b.ShootClientSet.Client().Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: corednsconstants.LabelValue}, service); err != nil {
+		return err
+	}
+
+	svcReady := len(service.Spec.ClusterIPs) == 2
+
+	podList := &corev1.PodList{}
+	if err := b.ShootClientSet.Client().List(ctx, podList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{corednsconstants.LabelKey: corednsconstants.LabelValue}); err != nil {
+		return err
+	}
+	if len(podList.Items) == 0 {
+		return nil
+	}
+
+	podsReady := len(podList.Items) != 0
+
+	for _, pod := range podList.Items {
+		podsReady = podsReady && len(pod.Status.PodIPs) == 2
+	}
+
+	updateFunction := b.DetermineUpdateFunctionDNS(svcReady, podsReady)
+	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, updateFunction); err != nil {
+		return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
+	}
+	return nil
 }
 
 // CheckPodCIDRsInNodes verifies the pod CIDRs in the nodes during dual-stack migration and updates the shoot's status accordingly.
@@ -78,6 +148,7 @@ func (b *Botanist) CheckPodCIDRsInNodes(ctx context.Context) error {
 	if err := b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, updateFunction); err != nil {
 		return fmt.Errorf("failed to update shoot info status during dual-stack migration: %w", err)
 	}
+
 	return nil
 }
 
@@ -96,5 +167,6 @@ func (b *Botanist) UpdateDualStackMigrationConditionIfNeeded(ctx context.Context
 			return fmt.Errorf("failed updating %s constraint in shoot status: %w", gardencorev1beta1.ShootDualStackNodesMigrationReady, err)
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
Before this change, the kube-dns service was configured as dual-stack with two cluster IP addresses even when CoreDNS pods only had IPv4 addresses. This caused DNS queries to the IPv6 cluster IP address to fail.

This PR introduces a controlled migration process where:
1. CoreDNS pods are restarted first to obtain IPv6 addresses
2. The kube-dns service is switched to dual-stack only in a subsequent reconciliation run after all CoreDNS pods have both IP addresses

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improved dual-stack migration by ensuring CoreDNS pods are restarted before configuring the kube-dns service as dual-stack, preventing IPv6 DNS query failures during migration.
```
