### PR TITLE
Rename the `ProjectValidator` admission plugin to `ProjectMutator`

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -107,7 +107,7 @@ It ensures that the finalizers of these resources are not removed by users, as l
 For `CredentialsBinding`s and `SecretBinding`s this means, that the `gardener` finalizer can only be removed if the binding is not referenced by any `Shoot`.
 In case of `Shoot`s, the `gardener` finalizer can only be removed if the last operation of the `Shoot` indicates a successful deletion. 
 
-## `ProjectValidator`
+## `ProjectMutator`
 
 **Type**: Mutating. **Enabled by default**: Yes.
 

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -20,7 +20,7 @@ import (
 	managedseedshoot "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
 	managedseedvalidator "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
 	namespacedcloudprofilevalidator "github.com/gardener/gardener/plugin/pkg/namespacedcloudprofile/validator"
-	projectvalidator "github.com/gardener/gardener/plugin/pkg/project/validator"
+	projectmutator "github.com/gardener/gardener/plugin/pkg/project/mutator"
 	seedmutator "github.com/gardener/gardener/plugin/pkg/seed/mutator"
 	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
@@ -56,7 +56,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	seedmutator.Register(plugins)
 	controllerregistrationresources.Register(plugins)
 	namespacedcloudprofilevalidator.Register(plugins)
-	projectvalidator.Register(plugins)
+	projectmutator.Register(plugins)
 	openidconnectpreset.Register(plugins)
 	clusteropenidconnectpreset.Register(plugins)
 	customverbauthorizer.Register(plugins)

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -37,8 +37,8 @@ const (
 	PluginNameManagedSeed = "ManagedSeed"
 	// PluginNameNamespacedCloudProfileValidator is the name of the NamespacedCloudProfileValidator admission plugin.
 	PluginNameNamespacedCloudProfileValidator = "NamespacedCloudProfileValidator"
-	// PluginNameProjectValidator is the name of the ProjectValidator admission plugin.
-	PluginNameProjectValidator = "ProjectValidator"
+	// PluginNameProjectMutator is the name of the ProjectMutator admission plugin.
+	PluginNameProjectMutator = "ProjectMutator"
 	// PluginNameSeedValidator is the name of the SeedValidator admission plugin.
 	PluginNameSeedValidator = "SeedValidator"
 	// PluginNameSeedMutator is the name of the SeedMutator admission plugin.
@@ -90,7 +90,7 @@ func AllPluginNames() []string {
 		PluginNameSeedMutator,                       // SeedMutator
 		PluginNameControllerRegistrationResources,   // ControllerRegistrationResources
 		PluginNameNamespacedCloudProfileValidator,   // NamespacedCloudProfileValidator
-		PluginNameProjectValidator,                  // ProjectValidator
+		PluginNameProjectMutator,                    // ProjectMutator
 		PluginNameDeletionConfirmation,              // DeletionConfirmation
 		PluginNameFinalizerRemoval,                  // FinalizerRemoval
 		PluginNameOpenIDConnectPreset,               // OpenIDConnectPreset
@@ -135,7 +135,7 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameSeedMutator,                     // SeedMutator
 		PluginNameControllerRegistrationResources, // ControllerRegistrationResources
 		PluginNameNamespacedCloudProfileValidator, // NamespacedCloudProfileValidator
-		PluginNameProjectValidator,                // ProjectValidator
+		PluginNameProjectMutator,                  // ProjectMutator
 		PluginNameDeletionConfirmation,            // DeletionConfirmation
 		PluginNameFinalizerRemoval,                // FinalizerRemoval
 		PluginNameOpenIDConnectPreset,             // OpenIDConnectPreset

--- a/plugin/pkg/project/mutator/admission.go
+++ b/plugin/pkg/project/mutator/admission.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package validator
+package mutator
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameProjectValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(plugin.PluginNameProjectMutator, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/project/mutator/admission_test.go
+++ b/plugin/pkg/project/mutator/admission_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package validator_test
+package mutator_test
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	. "github.com/gardener/gardener/plugin/pkg/project/validator"
+	. "github.com/gardener/gardener/plugin/pkg/project/mutator"
 )
 
 var _ = Describe("Admission", func() {
@@ -162,7 +162,7 @@ var _ = Describe("Admission", func() {
 
 			registered := plugins.Registered()
 			Expect(registered).To(HaveLen(1))
-			Expect(registered).To(ContainElement("ProjectValidator"))
+			Expect(registered).To(ContainElement("ProjectMutator"))
 		})
 	})
 

--- a/plugin/pkg/project/mutator/mutator_suite_test.go
+++ b/plugin/pkg/project/mutator/mutator_suite_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestValidator(t *testing.T) {
+func TestMutator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "AdmissionPlugin Project Validator Suite")
+	RunSpecs(t, "AdmissionPlugin Project Mutator Suite")
 }

--- a/plugin/pkg/project/mutator/validator_suite_test.go
+++ b/plugin/pkg/project/mutator/validator_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package validator_test
+package mutator_test
 
 import (
 	"testing"

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -632,7 +632,7 @@ build:
             - plugin/pkg/managedseed/shoot
             - plugin/pkg/managedseed/validator
             - plugin/pkg/namespacedcloudprofile/validator
-            - plugin/pkg/project/validator
+            - plugin/pkg/project/mutator
             - plugin/pkg/seed/mutator
             - plugin/pkg/seed/validator
             - plugin/pkg/shoot/dns

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -207,7 +207,7 @@ build:
             - plugin/pkg/managedseed/shoot
             - plugin/pkg/managedseed/validator
             - plugin/pkg/namespacedcloudprofile/validator
-            - plugin/pkg/project/validator
+            - plugin/pkg/project/mutator
             - plugin/pkg/seed/mutator
             - plugin/pkg/seed/validator
             - plugin/pkg/shoot/dns


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/kind cleanup

**What this PR does / why we need it**:

Currently, the `ProjectValidator` AdmissionPlugin only mutates the Project Resource's spec, ensuring the validity of the project's members and owner. The plugin does no validations.

This PR renames the admission plugin to a more appropriate name - `ProjectMutator`

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ProjectValidator` admission plugin is now renamed to `ProjectMutator`. If you have references to the old name of the admission plugin, make sure to adapt them before upgrading to this version of Gardener.
```
