### PR TITLE
add worker volume name validation

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1938,6 +1938,15 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 	}
 
 	if worker.Volume != nil {
+		if name := worker.Volume.Name; name != nil {
+			if len(*name) > 0 {
+				allErrs = append(allErrs, validateDNS1123Label(*name, fldPath.Child("volume", "name"))...)
+			}
+			if len(*name) > maxVolumeNameLength {
+				allErrs = append(allErrs, field.TooLong(fldPath.Child("volume", "name"), *name, maxVolumeNameLength))
+			}
+		}
+
 		if !volumeSizeRegex.MatchString(worker.Volume.VolumeSize) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("volume", "size"), worker.Volume.VolumeSize, fmt.Sprintf("volume size must match the regex %s", volumeSizeRegex)))
 		}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1938,15 +1938,9 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 	}
 
 	if worker.Volume != nil {
-		if name := worker.Volume.Name; name != nil {
-			if len(*name) > 0 {
-				allErrs = append(allErrs, validateDNS1123Label(*name, fldPath.Child("volume", "name"))...)
-			}
-			if len(*name) > maxVolumeNameLength {
-				allErrs = append(allErrs, field.TooLong(fldPath.Child("volume", "name"), *name, maxVolumeNameLength))
-			}
+		if worker.Volume.Name != nil {
+			allErrs = append(allErrs, validateVolumeName(*worker.Volume.Name, fldPath.Child("volume", "name"))...)
 		}
-
 		if !volumeSizeRegex.MatchString(worker.Volume.VolumeSize) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("volume", "size"), worker.Volume.VolumeSize, fmt.Sprintf("volume size must match the regex %s", volumeSizeRegex)))
 		}
@@ -1959,14 +1953,7 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 		}
 		for idx, volume := range worker.DataVolumes {
 			idxPath := fldPath.Child("dataVolumes").Index(idx)
-			if len(volume.Name) == 0 {
-				allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must specify a name"))
-			} else {
-				allErrs = append(allErrs, validateDNS1123Label(volume.Name, idxPath.Child("name"))...)
-			}
-			if len(volume.Name) > maxVolumeNameLength {
-				allErrs = append(allErrs, field.TooLong(idxPath.Child("name"), volume.Name, maxVolumeNameLength))
-			}
+			allErrs = append(allErrs, validateVolumeName(volume.Name, idxPath.Child("name"))...)
 			if _, keyExist := volumeNames[volume.Name]; keyExist {
 				volumeNames[volume.Name]++
 				allErrs = append(allErrs, field.Duplicate(idxPath.Child("name"), volume.Name))
@@ -2016,6 +2003,19 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("priority"), *worker.Priority, "can not be less than -1"))
 	}
 
+	return allErrs
+}
+
+func validateVolumeName(name string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "must specify a name"))
+	} else {
+		allErrs = append(allErrs, validateDNS1123Label(name, fldPath)...)
+	}
+	if len(name) > maxVolumeNameLength {
+		allErrs = append(allErrs, field.TooLong(fldPath, name, maxVolumeNameLength))
+	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6676,7 +6676,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			}))))
 		})
 
-		DescribeTable("should reject if volume name does not match expected regex", func(name string, errType field.ErrorType) {
+		DescribeTable("volume name validation", func(name string, errType field.ErrorType) {
 			maxSurge := intstr.FromInt32(1)
 			maxUnavailable := intstr.FromInt32(0)
 			vol := core.Volume{Name: &name, VolumeSize: "75Gi"}
@@ -6702,6 +6702,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 		},
 			Entry("too long name", "vol1-name-is-too-long-for-test", field.ErrorTypeTooLong),
 			Entry("invalid name", "not%dns/1123", field.ErrorTypeInvalid),
+			Entry("empty name", "", field.ErrorTypeRequired),
 		)
 
 		It("should reject if data volume size does not match size regex", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6649,6 +6649,61 @@ var _ = Describe("Shoot Validation Tests", func() {
 			}))))
 		})
 
+		It("should reject if volume size does not match size regex", func() {
+			maxSurge := intstr.FromInt32(1)
+			maxUnavailable := intstr.FromInt32(0)
+			name := "vol1-name"
+			vol := core.Volume{Name: &name, VolumeSize: "12MiB"}
+			worker := core.Worker{
+				Name: "worker-name",
+				Machine: core.Machine{
+					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
+					Architecture: ptr.To("amd64"),
+				},
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+				Volume:         &vol,
+			}
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, nil, false)
+			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("volume.size"),
+				"BadValue": Equal("12MiB"),
+			}))))
+		})
+
+		DescribeTable("should reject if volume name does not match expected regex", func(name string, errType field.ErrorType) {
+			maxSurge := intstr.FromInt32(1)
+			maxUnavailable := intstr.FromInt32(0)
+			vol := core.Volume{Name: &name, VolumeSize: "75Gi"}
+			worker := core.Worker{
+				Name: "worker-name",
+				Machine: core.Machine{
+					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
+					Architecture: ptr.To("amd64"),
+				},
+				MaxSurge:       &maxSurge,
+				MaxUnavailable: &maxUnavailable,
+				Volume:         &vol,
+			}
+			errList := ValidateWorker(worker, core.Kubernetes{Version: ""}, nil, false)
+			Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(errType),
+				"Field": Equal("volume.name"),
+			}))))
+		},
+			Entry("too long name", "vol1-name-is-too-long-for-test", field.ErrorTypeTooLong),
+			Entry("invalid name", "not%dns/1123", field.ErrorTypeInvalid),
+		)
+
 		It("should reject if data volume size does not match size regex", func() {
 			maxSurge := intstr.FromInt32(1)
 			maxUnavailable := intstr.FromInt32(0)
@@ -6683,7 +6738,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			maxUnavailable := intstr.FromInt32(0)
 			name1 := "vol1-name-is-too-long-for-test"
 			name2 := "not%dns/1123"
-			vol := core.Volume{Name: &name1, VolumeSize: "75Gi"}
+			vol := core.Volume{VolumeSize: "75Gi"}
 			dataVolumes := []core.DataVolume{{VolumeSize: "75Gi"}, {Name: name1, VolumeSize: "75Gi"}, {Name: name2, VolumeSize: "75Gi"}}
 			worker := core.Worker{
 				Name: "worker-name",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Add validation for worker.volume names.
Add missing test for worker.volume size regex.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add validation for the name of worker's root volumes.
```
