### PR TITLE
Fixes incorrect `Machine` duplication when persisting the machine state in the `ShootState`

### DIFF
--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -58,7 +58,7 @@ func computeMachineState(ctx context.Context, seedClient client.Client, namespac
 		}
 
 		// get machines that have a machine deployment as owner
-		machinesForMachineDeployment := machineSetOrDeploymentToMachines[machineDeployment.Name]
+		machinesForMachineDeployment := append([]machinev1alpha1.Machine{}, machineSetOrDeploymentToMachines[machineDeployment.Name]...)
 
 		for i, machineSet := range machineSets {
 			removeIrrelevantDataFromObject(&machineSets[i])

--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -46,56 +46,67 @@ func computeMachineState(ctx context.Context, seedClient client.Client, namespac
 		return nil, err
 	}
 
-	machineSetToMachines, err := getMachineSetToMachinesMap(ctx, seedClient, namespace)
+	machineSetOrDeploymentToMachines, err := getMachineSetOrDeploymentToMachinesMap(ctx, seedClient, namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	var allMachines []machinev1alpha1.Machine
 	for _, machineDeployment := range machineDeployments.Items {
 		machineSets, ok := machineDeploymentToMachineSets[machineDeployment.Name]
 		if !ok {
 			continue
 		}
 
-		for i, machineSet := range machineSets {
-			// remove irrelevant data from the machine set
-			machineSets[i].ObjectMeta = metav1.ObjectMeta{
-				Name:        machineSet.Name,
-				Namespace:   machineSet.Namespace,
-				Annotations: machineSet.Annotations,
-				Labels:      machineSet.Labels,
-			}
-			machineSets[i].Status = machinev1alpha1.MachineSetStatus{}
+		// get machines that have a machine deployment as owner
+		machinesForMachineDeployment := machineSetOrDeploymentToMachines[machineDeployment.Name]
+		for i := range machinesForMachineDeployment {
+			removeIrrelevantDataFromObject(&machinesForMachineDeployment[i])
+		}
 
-			// fetch machines related to the machine set/deployment
-			machines := append(machineSetToMachines[machineSet.Name], machineSetToMachines[machineDeployment.Name]...)
-			if len(machines) == 0 {
+		for i, machineSet := range machineSets {
+			removeIrrelevantDataFromObject(&machineSets[i])
+
+			// get machines that have a machine set as owner
+			machinesForMachineSet := machineSetOrDeploymentToMachines[machineSet.Name]
+			if len(machinesForMachineSet) == 0 {
 				continue
 			}
 
-			for j, machine := range machines {
-				// remove irrelevant data from the machine
-				machines[j].ObjectMeta = metav1.ObjectMeta{
-					Name:        machine.Name,
-					Namespace:   machine.Namespace,
-					Annotations: machine.Annotations,
-					Labels:      machine.Labels,
-				}
-				machines[j].Status = machinev1alpha1.MachineStatus{}
+			for j := range machinesForMachineSet {
+				removeIrrelevantDataFromObject(&machinesForMachineSet[j])
 			}
 
-			allMachines = append(allMachines, machines...)
+			machinesForMachineDeployment = append(machinesForMachineDeployment, machinesForMachineSet...)
 		}
 
 		state.MachineDeployments[machineDeployment.Name] = &MachineDeploymentState{
 			Replicas:    machineDeployment.Spec.Replicas,
 			MachineSets: machineSets,
-			Machines:    allMachines,
+			Machines:    machinesForMachineDeployment,
 		}
 	}
 
 	return state, nil
+}
+
+func removeIrrelevantDataFromObject(obj client.Object) {
+	switch o := obj.(type) {
+	case *machinev1alpha1.Machine:
+		resetObjectMeta(&o.ObjectMeta)
+		o.Status = machinev1alpha1.MachineStatus{}
+	case *machinev1alpha1.MachineSet:
+		resetObjectMeta(&o.ObjectMeta)
+		o.Status = machinev1alpha1.MachineSetStatus{}
+	}
+}
+
+func resetObjectMeta(meta *metav1.ObjectMeta) {
+	*meta = metav1.ObjectMeta{
+		Name:        meta.Name,
+		Namespace:   meta.Namespace,
+		Annotations: meta.Annotations,
+		Labels:      meta.Labels,
+	}
 }
 
 func getMachineDeploymentToMachineSetsMap(ctx context.Context, c client.Client, namespace string) (map[string][]machinev1alpha1.MachineSet, error) {
@@ -113,7 +124,7 @@ func getMachineDeploymentToMachineSetsMap(ctx context.Context, c client.Client, 
 	return gardenerutils.BuildOwnerToMachineSetsMap(existingMachineSets.Items), nil
 }
 
-func getMachineSetToMachinesMap(ctx context.Context, seedClient client.Client, namespace string) (map[string][]machinev1alpha1.Machine, error) {
+func getMachineSetOrDeploymentToMachinesMap(ctx context.Context, seedClient client.Client, namespace string) (map[string][]machinev1alpha1.Machine, error) {
 	existingMachines := &machinev1alpha1.MachineList{}
 	if err := seedClient.List(ctx, existingMachines, client.InNamespace(namespace)); err != nil {
 		return nil, err

--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -58,7 +58,7 @@ func computeMachineState(ctx context.Context, seedClient client.Client, namespac
 		}
 
 		// get machines that have a machine deployment as owner
-		machinesForMachineDeployment := append([]machinev1alpha1.Machine{}, machineSetOrDeploymentToMachines[machineDeployment.Name]...)
+		machinesForMachineDeployment := slices.Clone(machineSetOrDeploymentToMachines[machineDeployment.Name])
 
 		for i, machineSet := range machineSets {
 			removeIrrelevantDataFromObject(&machineSets[i])

--- a/pkg/utils/gardener/shootstate/machines.go
+++ b/pkg/utils/gardener/shootstate/machines.go
@@ -59,24 +59,16 @@ func computeMachineState(ctx context.Context, seedClient client.Client, namespac
 
 		// get machines that have a machine deployment as owner
 		machinesForMachineDeployment := machineSetOrDeploymentToMachines[machineDeployment.Name]
-		for i := range machinesForMachineDeployment {
-			removeIrrelevantDataFromObject(&machinesForMachineDeployment[i])
-		}
 
 		for i, machineSet := range machineSets {
 			removeIrrelevantDataFromObject(&machineSets[i])
-
 			// get machines that have a machine set as owner
 			machinesForMachineSet := machineSetOrDeploymentToMachines[machineSet.Name]
-			if len(machinesForMachineSet) == 0 {
-				continue
-			}
-
-			for j := range machinesForMachineSet {
-				removeIrrelevantDataFromObject(&machinesForMachineSet[j])
-			}
-
 			machinesForMachineDeployment = append(machinesForMachineDeployment, machinesForMachineSet...)
+		}
+
+		for i := range machinesForMachineDeployment {
+			removeIrrelevantDataFromObject(&machinesForMachineDeployment[i])
 		}
 
 		state.MachineDeployments[machineDeployment.Name] = &MachineDeploymentState{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that caused `Machines` to be duplicated when being saved in the `ShootState`. In clusters with a large number of `MachineDeployment`s the following error could be observed when trying to create the `ShootState`:
```
rpc error: code = ResourceExhausted desc = trying to send message larger than max (2485683 vs. 2097152)
```

There are actually two issues that caused `Machine`s to be duplicated: 
- The main reason the duplication happens is because the [array variable](https://github.com/gardener/gardener/blob/91e2131d31e1c892f3b67ac42f5c4c44cb1cfa26/pkg/utils/gardener/shootstate/machines.go#L54) in which `Machine`s are collected, is reused while iterating over all `MachineDeployment`s, causing it to grow after each iteration. On each iteration this array is added to a corresponding `MachineDeploymentState`.

- The other issue happens because `Machine`s that do not have a `MachineSet` as an owner reference are mapped to `MachineDeployments` by using their `name` label (name corresponds to the name of the `MachineDeployment`). Then [the same machine is appended multiple times](https://github.com/gardener/gardener/blob/91e2131d31e1c892f3b67ac42f5c4c44cb1cfa26/pkg/utils/gardener/shootstate/machines.go#L72) - for each `MachineSet` that belongs to the same `MachineDeployment` 

With this fix, a ShootState that was originally around 3.2 MiB is reduced to 140KiB 

---

I was also wondering whether to add a check if the `ShootState` exceeds some hard-coded limits of the `kube-apiserver` and `etcd` before allowing the migration to start. 
However, this size might not be exactly equal to the size with which the `ShootState` is created as this happens [much later in the migrate flow](https://github.com/gardener/gardener/blob/78034a9659fff5372a6d2f5ccab83fa956e3922c/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go#L243-L249). Anyway, this could be handled with a follow-up PR.

--- 

**Which issue(s) this PR fixes**:
Fixes #12579

**Special notes for your reviewer**:
In the first commit I have modified the unit test to demonstrate the issue. Below you can see the uncompressed machine states:

<Details>
<Summary>Expected machine state</Summary>

```
machineDeployments:
  deploy1:
    replicas: 3
    machineSets:
      - metadata:
          name: deploy1-set1
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
    machines:
      - metadata:
          name: deploy1-set1-machine1
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            node: nodename
          annotations:
            some: annotation
        spec:
          class: {}
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
  deploy2:
    replicas: 3
    machineSets:
      - metadata:
          name: deploy2-set3
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
      - metadata:
          name: deploy2-set4
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy2
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
    machines:
      - metadata:
          name: deploy2-set3-machine4
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            node: nodename
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
```

</Details>

<Details>
<Summary>Incorrect machine state </Summary>

```
machineDeployments:
  deploy1:
    replicas: 3
    machineSets:
      - metadata:
          name: deploy1-set1
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
    machines:
      - metadata:
          name: deploy1-set1-machine1
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            node: nodename
          annotations:
            some: annotation
        spec:
          class: {}
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
  deploy2:
    replicas: 3
    machineSets:
      - metadata:
          name: deploy2-set3
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
      - metadata:
          name: deploy2-set4
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy2
          annotations:
            some: annotation
        spec:
          machineClass: {}
          template:
            metadata:
              creationTimestamp: null
            spec:
              class: {}
              nodeTemplate:
                metadata:
                  creationTimestamp: null
                spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
    machines:
      - metadata:
          name: deploy1-set1-machine1
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            node: nodename
          annotations:
            some: annotation
        spec:
          class: {}
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy1-set2-machine2
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy1
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy2-set3-machine4
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            node: nodename
          annotations:
            some: annotation
        spec:
          class: {}
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy2-set4-machine5
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy2
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
      - metadata:
          name: deploy2-set4-machine5
          namespace: shoot--my-project--my-shoot
          creationTimestamp: null
          labels:
            name: deploy2
          annotations:
            some: annotation
        spec:
          class: {}
          providerID: provider-id
          nodeTemplate:
            metadata:
              creationTimestamp: null
            spec: {}
        status:
          lastOperation:
            lastUpdateTime: null
          currentStatus:
            lastUpdateTime: null
```

</Details>

To summarise the above
- In the expected macine state: 
    - `MachineDeploymentState` for `deploy1` contains the following machines 
        - `deploy1-set1-machine1` and `deploy1-set2-machine2`
    -  `MachineDeploymentState` for `deploy2` contains the following machines
        -  `deploy2-set3-machine4` and `deploy2-set4-machine5` 

- In the incorrect machine state:
    - `MachineDeploymentState` for `deploy1` contains the following machines 
        - `deploy1-set1-machine1`, `deploy1-set2-machine2` and `deploy1-set2-machine2` (duplicated) 
    -  `MachineDeploymentState` for `deploy2` contains the following machines
        -  `deploy1-set1-machine1` (duplicated), `deploy1-set2-machine2` (duplicated), `deploy1-set2-machine2` (duplicated) `deploy2-set3-machine4`, `deploy2-set4-machine5`, `deploy2-set4-machine5` (duplicated)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue that caused `Machine`s to be duplicated when being saved in the `ShootState`. This caused the `ShootState` to grow exponentially large and fail to be created. The issue could occur when there are multiple `MachineDeployments` created for the `Shoot`.
```
