### PR TITLE
Log `garden-node-agent-init` to journal and console

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -51,6 +51,8 @@ RestartSec=5
 StartLimitBurst=0
 EnvironmentFile=/etc/environment
 ExecStart=/var/lib/gardenadm/download.sh
+StandardOutput=journal+console
+StandardError=journal+console
 [Install]
 WantedBy=multi-user.target`),
 					FilePaths: []string{"/var/lib/gardenadm/download.sh"},

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -143,6 +143,8 @@ RestartSec=5
 StartLimitBurst=0
 EnvironmentFile=/etc/environment
 ExecStart=` + filePath + `
+StandardOutput=journal+console
+StandardError=journal+console
 [Install]
 WantedBy=multi-user.target`),
 		FilePaths: []string{filePath},

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -64,6 +64,8 @@ RestartSec=5
 StartLimitBurst=0
 EnvironmentFile=/etc/environment
 ExecStart=/var/lib/gardener-node-agent/init.sh
+StandardOutput=journal+console
+StandardError=journal+console
 [Install]
 WantedBy=multi-user.target`),
 					FilePaths: []string{"/var/lib/gardener-node-agent/init.sh"},


### PR DESCRIPTION
**How to categorize this PR?**

/area logging
/kind enhancement

**What this PR does / why we need it**:

This PR configures the `garden-node-agent-init` systemd unit to log to `journal+console`.

Currently, troubleshooting nodes that fail to join a shoot cluster is very limited.
Without SSH access, identifying the root cause is difficult, by forwarding the unit logs to the system console (`/dev/console`), issues can be identified by examining the boot logs of a `VM`.

The system console defaults to `/dev/console`, which the kernel maps to the device specified by the last `console=` parameter in the kernel command line.

On `OpenStack` for example, the serial-console (`/dev/ttyS0`) can be accessed with:

```
openstack console log show <server>
```

To map `/dev/console` to `/dev/ttyS0`, the last `console=` argument of the kernel command line is used:

```ini
BOOT_IMAGE=/boot/vmlinuz-5.15.0-144-generic root=LABEL=cloudimg-rootfs ro console=tty1 console=ttyS0
```

With this setup, early issues, such as network issues or DNS resolution failures that prevent nodes from joining the cluster, can be diagnosed directly with the VM logs from the hypervisor.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- I'm not sure how and if this works for other hyperscalers like `AWS` or `GCP`. If there is a way to retrieve logs from a `tty`, this should work, maybe someone can verify this.
- This should also be documented somewhere?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-node-agent-init` now outputs logs to journal and console (`/dev/console`).
```
