### PR TITLE
Fix condition status for emergency stop of Shoot reconciliations

### DIFF
--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -95,7 +95,7 @@ func (h *health) checkEmergencyStopShootReconciliations(condition gardencorev1be
 	return ptr.To(v1beta1helper.UpdatedConditionWithClock(
 		h.clock,
 		condition,
-		gardencorev1beta1.ConditionFalse,
+		gardencorev1beta1.ConditionTrue,
 		string(gardencorev1beta1.SeedEmergencyStopShootReconciliations),
 		"Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation.",
 	))

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Seed Care Control", func() {
 						"Type": BeEquivalentTo("SeedSystemComponentsHealthy"),
 					}), MatchFields(IgnoreExtras, Fields{
 						"Type":    BeEquivalentTo("EmergencyStopShootReconciliations"),
-						"Status":  BeEquivalentTo("False"),
+						"Status":  BeEquivalentTo("True"),
 						"Reason":  Equal("EmergencyStopShootReconciliations"),
 						"Message": Equal("Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation."),
 					}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Fix the status of the `EmergencyStopShootReconciliations` `Seed` condition.

**Which issue(s) this PR fixes**:
Fixes #12815

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Flip the status of a set `EmergencyStopShootReconciliations` `Seed` condition from `False` to `True`.
```
