### PR TITLE
docs(development): Fix indentation of markdown alert

### DIFF
--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -74,18 +74,18 @@ Once a new Go version is released, please consider the guidance below for updati
 
 1. Check the [release notes](https://go.dev/doc/devel/release) to see whether there are any relevant changes that might be useful or affect us in another way.
 
-1. Maintain the image variants of the [`krte`](https://github.com/gardener/ci-infra/tree/master/images/krte) image used for end-to-end testing in [KinD](https://kind.sigs.k8s.io/) in the [`hack/tools/image/variants.yaml`](../../hack/tools/image/variants.yaml) file.
+2. Maintain the image variants of the [`krte`](https://github.com/gardener/ci-infra/tree/master/images/krte) image used for end-to-end testing in [KinD](https://kind.sigs.k8s.io/) in the [`hack/tools/image/variants.yaml`](../../hack/tools/image/variants.yaml) file.
    Remove older Go versions [if they are no longer supported](https://endoflife.date/go) and add the new version ([example](https://github.com/gardener/gardener/pull/12770)).  
    Check the registry to see when the new image variants are available:
    * [europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fkrte)
    * [europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test)
 
-1. The images used by the CI jobs are maintained in the [ci-infra repository](https://github.com/gardener/ci-infra).
+3. The images used by the CI jobs are maintained in the [ci-infra repository](https://github.com/gardener/ci-infra).
    Update the references for the end-to-end tests with the new `krte` image and for unit- and integration tests with the new `golang-test` image ([example](https://github.com/gardener/ci-infra/pull/4338)).
    As a courtesy, consider removing references to no longer maintained image variants and updating to newer images wherever possible ([example](https://github.com/gardener/ci-infra/pull/4352)).
 
-   > [!NOTE]  
-   > Go maintains a [strong backward compatibility promise](https://go.dev/blog/compat), even if a tool has been built for an older Go version try running it with the latest version and update accordingly.
+> [!NOTE]  
+> Go maintains a [strong backward compatibility promise](https://go.dev/blog/compat), even if a tool has been built for an older Go version, try running it with the latest version and update accordingly.
 
-1. Finally, update the Go version references inside this repository (mainly GitHub Actions workflows and image references) to the newer version ([example](https://github.com/gardener/gardener/pull/12753)).
+4. Finally, update the Go version references inside this repository (mainly GitHub Actions workflows and image references) to the newer version ([example](https://github.com/gardener/gardener/pull/12753)).
    In the [`go.mod`](../../go.mod) file, ensure that the language version directive and, if defined, the toolchain directive are set to the lowest supported Go version.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Indenting GitHub Markdown alerts does not render them correctly.
This PR removes the indentation. Unfortunately, not indenting the alert also breaks the automatic numbering of the list.

**Which issue(s) this PR fixes**:

Follow-up to: #12809

**Special notes for your reviewer**:

ℹ️ @n-boshnakov 

* [Current](https://github.com/gardener/gardener/blob/master/docs/development/dependencies.md#updating-go)
* [This branch](https://github.com/marc1404/gardener/blob/71c5b99ab571cfaf9e6d6bd396ab3503dfce9284/docs/development/dependencies.md#updating-go)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
