### PR TITLE
Align validation of watchCacheSizes to `kube-apiserver` flag

### DIFF
--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2357,7 +2357,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 							CacheSize: 0,
 						}},
 					}, BeEmpty()),
-					Entry("valid (\"\"/secrets=0)", &core.WatchCacheSizes{
+					Entry("valid (API group empty)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To(""),
 							Resource:  "secrets",
@@ -2378,7 +2378,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].size"), int64(negativeSize), apivalidation.IsNegativeErrorMsg).WithOrigin("minimum"),
 					)),
-					Entry("invalid (core/resource empty)", &core.WatchCacheSizes{
+					Entry("invalid (resource empty)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "",
 							CacheSize: 42,
@@ -2386,7 +2386,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (core/resource name with casing)", &core.WatchCacheSizes{
+					Entry("invalid (resource with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "Secrets",
 							CacheSize: 42,
@@ -2435,7 +2435,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (apps/deployments name with casing)", &core.WatchCacheSizes{
+					Entry("invalid (api group with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("Apps"),
 							Resource:  "deployments",

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2379,6 +2379,22 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
+					Entry("invalid (core/resource name with casing", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							Resource:  "Secrets",
+							CacheSize: 42,
+						}},
+					}, ConsistOf(
+						field.Invalid(field.NewPath("resources[0].resource"), "Secrets", "must be lower case"),
+					)),
+					Entry("invalid (core/resource name with illegal character", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							Resource:  "secrets#",
+							CacheSize: 42,
+						}},
+					}, ConsistOf(
+						field.Invalid(field.NewPath("resources[0].resource"), "secrets#", `must not contain any of the following characters: ",. #"`),
+					)),
 
 					// APIGroup set
 					Entry("valid (apps/deployments=0)", &core.WatchCacheSizes{
@@ -2411,6 +2427,24 @@ var _ = Describe("Shoot Validation Tests", func() {
 						}},
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
+					)),
+					Entry("invalid (Apps/deployments name with casing", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							APIGroup:  ptr.To("Apps"),
+							Resource:  "deployments",
+							CacheSize: 42,
+						}},
+					}, ConsistOf(
+						field.Invalid(field.NewPath("resources[0].apiGroup"), "Apps", "must be lower case"),
+					)),
+					Entry("invalid (core/resource name with illegal character", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							APIGroup:  ptr.To("apps#"),
+							Resource:  "deployments",
+							CacheSize: 42,
+						}},
+					}, ConsistOf(
+						field.Invalid(field.NewPath("resources[0].apiGroup"), "apps#", `must not contain any of the following characters: ",. #"`),
 					)),
 				)
 			})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2357,6 +2357,13 @@ var _ = Describe("Shoot Validation Tests", func() {
 							CacheSize: 0,
 						}},
 					}, BeEmpty()),
+					Entry("valid (\"\"/secrets=0)", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							APIGroup:  ptr.To(""),
+							Resource:  "secrets",
+							CacheSize: 0,
+						}},
+					}, BeEmpty()),
 					Entry("valid (core/secrets=>0)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "secrets",
@@ -2379,7 +2386,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (core/resource name with casing", &core.WatchCacheSizes{
+					Entry("invalid (core/resource name with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "Secrets",
 							CacheSize: 42,
@@ -2387,7 +2394,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].resource"), "Secrets", "must be lower case"),
 					)),
-					Entry("invalid (core/resource name with illegal character", &core.WatchCacheSizes{
+					Entry("invalid (core/resource name with illegal character)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "secrets#",
 							CacheSize: 42,
@@ -2428,7 +2435,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (Apps/deployments name with casing", &core.WatchCacheSizes{
+					Entry("invalid (apps/deployments name with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("Apps"),
 							Resource:  "deployments",
@@ -2437,7 +2444,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].apiGroup"), "Apps", "must be lower case"),
 					)),
-					Entry("invalid (core/resource name with illegal character", &core.WatchCacheSizes{
+					Entry("invalid (core/resource name with illegal character)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("apps#"),
 							Resource:  "deployments",

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2378,7 +2378,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].size"), int64(negativeSize), apivalidation.IsNegativeErrorMsg).WithOrigin("minimum"),
 					)),
-					Entry("invalid (resource empty)", &core.WatchCacheSizes{
+					Entry("invalid (core resource empty)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "",
 							CacheSize: 42,
@@ -2386,7 +2386,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (resource with casing)", &core.WatchCacheSizes{
+					Entry("invalid (core resource with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "Secrets",
 							CacheSize: 42,
@@ -2394,7 +2394,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].resource"), "Secrets", "must be lower case"),
 					)),
-					Entry("invalid (core/resource name with illegal character)", &core.WatchCacheSizes{
+					Entry("invalid (core resource with illegal character)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							Resource:  "secrets#",
 							CacheSize: 42,
@@ -2427,15 +2427,16 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].size"), int64(negativeSize), apivalidation.IsNegativeErrorMsg).WithOrigin("minimum"),
 					)),
-					Entry("invalid (apps/resource empty)", &core.WatchCacheSizes{
+					Entry("invalid (apps resource empty)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
+							APIGroup:  ptr.To("apps"),
 							Resource:  "",
 							CacheSize: 42,
 						}},
 					}, ConsistOf(
 						field.Required(field.NewPath("resources[0].resource"), "must not be empty"),
 					)),
-					Entry("invalid (api group with casing)", &core.WatchCacheSizes{
+					Entry("invalid (apps API group with casing)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("Apps"),
 							Resource:  "deployments",
@@ -2444,7 +2445,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}, ConsistOf(
 						field.Invalid(field.NewPath("resources[0].apiGroup"), "Apps", "must be lower case"),
 					)),
-					Entry("invalid (core/resource name with illegal character)", &core.WatchCacheSizes{
+					Entry("invalid (apps API group with illegal character)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("apps#"),
 							Resource:  "deployments",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness ipcei security
/kind enhancement

**What this PR does / why we need it**:

There are some special characters that we should disallow the user to specify, because this would result in a `kube-apiserver` in `CrashLoopBackOff`.

We should disallow the special characters that depict delimiters for this flag.

In addition to that, we should disallow capitalized strings, according to documentation. Even though the `kube-apiserver` starts when you specify a capitalized string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
It is not allowed anymore to specify the following characters: [,. #], as well as capitalized letters, within the entries of the Shoot's `.spec.kubernetes.kubeAPIServer.watchCacheSizes.resources[].resource` field. Please update your Shoots accordingly.
```

```breaking user
It is not allowed anymore to specify the following characters: [, #], as well as capitalized letters, within the entries of the Shoot's `.spec.kubernetes.kubeAPIServer.watchCacheSizes.resources[].apiGroup` field. Please update your Shoots accordingly.
```

```breaking operator
It is not allowed anymore to specify the following characters: [,. #], as well as capitalized letters, within the entries of the Garden's `.spec.virtualCluster.Gardener.apiServer.watchCacheSizes.resources[].resource` field. Please update your Gardens accordingly.
```

```breaking operator
It is not allowed anymore to specify the following characters: [, #], as well as capitalized letters, within the entries of the Garden's `.spec.virtualCluster.Gardener.apiServer.watchCacheSizes.resources[].apiGroup` field. Please update your Gardens accordingly.
```
