### PR TITLE
Certificate Controller Improvements

### DIFF
--- a/extensions/pkg/webhook/shoot/webhook.go
+++ b/extensions/pkg/webhook/shoot/webhook.go
@@ -77,8 +77,12 @@ func ReconcileWebhooksForAllNamespaces(
 	fns := make([]flow.TaskFn, 0, len(namespaceList.Items)+1)
 
 	for _, namespace := range namespaceList.Items {
-		namespaceName := namespace.Name
+		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
+			// Skip terminating namespace since updates will anyway be rejected.
+			continue
+		}
 
+		namespaceName := namespace.Name
 		fns = append(fns, func(ctx context.Context) error {
 			managedResource := &metav1.PartialObjectMetadata{}
 			managedResource.SetGroupVersionKind(resourcesv1alpha1.SchemeGroupVersion.WithKind("ManagedResource"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR makes the certificate renewal and reloading flow more robust. The previous implementation could leave the system in an unrecoverable error state, whenever a controller restart interrupted the renewal process.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Example error flow:

_t0_: Initial certificate issued and stored as secret.
_t1_: Renewal ongoing - new certificate secret stored - all shoot certificates are [being replaced](https://github.com/gardener/gardener/blob/b8e86e3c39b8495fd9b74085e59c88ffeb398d10/extensions/pkg/webhook/certificates/reconciler.go#L196).
_t2_: Controller restarts - old Secret from `t0` is not yet [cleaned up](https://github.com/gardener/gardener/blob/b8e86e3c39b8495fd9b74085e59c88ffeb398d10/extensions/pkg/webhook/certificates/reconciler.go#L208).
_t3_: Controller start fails because multiple certificate secrets are found.

The PR fixes another issue along the way that blocked `t1` for a longer time because `Terminating` namespaces were not excluded from certificate replacements. Such cases produced the following error log:
```
{"msg":"Reconciler error","controller":"webhook-certificate","error":"error reconciling all shoot webhook configs: 1 error occurred:\n\t* failed reconciling managed resource 'shoot--test--test/extension-controlplane-shoot-webhooks' containing shoot webhooks: could not create or update secret of managed resources: secrets \"extension-controlplane-shoot-webhooks-e273c726\" is forbidden: unable to create new content in namespace shoot--test--test because it is being terminated\n\n"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The certificate issuance and renewal flow for webhooks has been improved. Previously, controller restarts during the renewal process could leave the system in an unrecoverable error state, preventing the extension from starting.
```
