### PR TITLE
Enable the `ShootVPAEnabledByDefault` admission plugin by default for the Gardener API server

### DIFF
--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -53,8 +53,6 @@ spec:
     gardener:
       clusterIdentity: gardener-local
       gardenerAPIServer:
-        admissionPlugins:
-        - name: ShootVPAEnabledByDefault
         featureGates:
           CredentialsRotationWithoutWorkersRollout: true
           CloudProfileCapabilities: true

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -198,7 +198,7 @@ Operators can provide an optional label selector via the `selector` field to lim
 
 ## `ShootVPAEnabledByDefault`
 
-**Type**: Mutating. **Enabled by default**: No.
+**Type**: Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it will enable the managed `VerticalPodAutoscaler` components (for more information, see [Vertical Pod Auto-Scaling](../usage/autoscaling/shoot_autoscaling.md#vertical-pod-auto-scaling))

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -148,8 +148,6 @@ global:
           -----END RSA PRIVATE KEY-----
     # speed-up re-deploying of gardener-apiserver
     minReadySeconds: 0
-    enableAdmissionPlugins:
-    - ShootVPAEnabledByDefault
     # disable audit log, it is enough to set path to empty string
     audit:
       log:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -200,8 +200,8 @@ spec:
     #   certificateSigningDuration: 48h
     gardener:
       clusterIdentity: local
-      gardenerAPIServer:
-        admissionPlugins:
+      gardenerAPIServer: {}
+    #   admissionPlugins:
     #   - name: ShootDNSRewriting
     #     disabled: false
     #     config:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -202,7 +202,6 @@ spec:
       clusterIdentity: local
       gardenerAPIServer:
         admissionPlugins:
-        - name: ShootVPAEnabledByDefault
     #   - name: ShootDNSRewriting
     #     disabled: false
     #     config:

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -147,6 +147,7 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameBackupBucketValidator,           // BackupBucketValidator
 		mutatingwebhook.PluginName,                // MutatingAdmissionWebhook
 		validatingwebhook.PluginName,              // ValidatingAdmissionWebhook
+		PluginNameShootVPAEnabledByDefault,        // ShootVPAEnabledByDefault
 		// TODO(ary1992): Ennable the plugin once our base clusters are updated to k8s >= 1.30
 		// validating.PluginName,                     // ValidatingAdmissionPolicy
 		resourcequota.PluginName, // ResourceQuota

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -86,6 +86,7 @@ func AllPluginNames() []string {
 		PluginNameShootDNSRewriting,                 // ShootDNSRewriting
 		PluginNameShootQuotaValidator,               // ShootQuotaValidator
 		PluginNameShootValidator,                    // ShootValidator
+		PluginNameShootVPAEnabledByDefault,          // ShootVPAEnabledByDefault
 		PluginNameSeedValidator,                     // SeedValidator
 		PluginNameSeedMutator,                       // SeedMutator
 		PluginNameControllerRegistrationResources,   // ControllerRegistrationResources
@@ -96,7 +97,6 @@ func AllPluginNames() []string {
 		PluginNameOpenIDConnectPreset,               // OpenIDConnectPreset
 		PluginNameClusterOpenIDConnectPreset,        // ClusterOpenIDConnectPreset
 		PluginNameCustomVerbAuthorizer,              // CustomVerbAuthorizer
-		PluginNameShootVPAEnabledByDefault,          // ShootVPAEnabledByDefault
 		PluginNameShootResourceReservation,          // ShootResourceReservation
 		PluginNameManagedSeed,                       // ManagedSeed
 		PluginNameManagedSeedShoot,                  // ManagedSeedShoot
@@ -131,6 +131,7 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameShootResourceReservation,        // ShootResourceReservation
 		PluginNameShootQuotaValidator,             // ShootQuotaValidator
 		PluginNameShootValidator,                  // ShootValidator
+		PluginNameShootVPAEnabledByDefault,        // ShootVPAEnabledByDefault
 		PluginNameSeedValidator,                   // SeedValidator
 		PluginNameSeedMutator,                     // SeedMutator
 		PluginNameControllerRegistrationResources, // ControllerRegistrationResources
@@ -147,7 +148,6 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameBackupBucketValidator,           // BackupBucketValidator
 		mutatingwebhook.PluginName,                // MutatingAdmissionWebhook
 		validatingwebhook.PluginName,              // ValidatingAdmissionWebhook
-		PluginNameShootVPAEnabledByDefault,        // ShootVPAEnabledByDefault
 		// TODO(ary1992): Ennable the plugin once our base clusters are updated to k8s >= 1.30
 		// validating.PluginName,                     // ValidatingAdmissionPolicy
 		resourcequota.PluginName, // ResourceQuota

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -86,7 +86,6 @@ func AllPluginNames() []string {
 		PluginNameShootDNSRewriting,                 // ShootDNSRewriting
 		PluginNameShootQuotaValidator,               // ShootQuotaValidator
 		PluginNameShootValidator,                    // ShootValidator
-		PluginNameShootVPAEnabledByDefault,          // ShootVPAEnabledByDefault
 		PluginNameSeedValidator,                     // SeedValidator
 		PluginNameSeedMutator,                       // SeedMutator
 		PluginNameControllerRegistrationResources,   // ControllerRegistrationResources
@@ -97,6 +96,7 @@ func AllPluginNames() []string {
 		PluginNameOpenIDConnectPreset,               // OpenIDConnectPreset
 		PluginNameClusterOpenIDConnectPreset,        // ClusterOpenIDConnectPreset
 		PluginNameCustomVerbAuthorizer,              // CustomVerbAuthorizer
+		PluginNameShootVPAEnabledByDefault,          // ShootVPAEnabledByDefault
 		PluginNameShootResourceReservation,          // ShootResourceReservation
 		PluginNameManagedSeed,                       // ManagedSeed
 		PluginNameManagedSeedShoot,                  // ManagedSeedShoot

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -275,7 +275,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						return shoot.Status.Conditions
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
-						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler machine-controller-manager]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [gardener-resource-manager kube-apiserver kube-controller-manager kube-scheduler machine-controller-manager vpa-admission-controller vpa-recommender vpa-updater]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
@@ -321,7 +321,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 						return shoot.Status.Conditions
 					}).Should(And(
 						ContainCondition(OfType(gardencorev1beta1.ShootAPIServerAvailable), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("APIServerDown")),
-						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver kube-scheduler machine-controller-manager]")),
+						ContainCondition(OfType(gardencorev1beta1.ShootControlPlaneHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-apiserver kube-scheduler machine-controller-manager vpa-admission-controller vpa-recommender vpa-updater]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootObservabilityComponentsHealthy), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason("DeploymentMissing"), WithMessageSubstrings("Missing required deployments: [kube-state-metrics]")),
 						ContainCondition(OfType(gardencorev1beta1.ShootEveryNodeReady), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),
 						ContainCondition(OfType(gardencorev1beta1.ShootSystemComponentsHealthy), WithStatus(gardencorev1beta1.ConditionUnknown), WithReason("ConditionCheckError"), WithMessageSubstrings("Shoot control plane has not been fully created yet.")),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

This PR enables the `ShootVPAEnabledByDefault` Admission Plugin by adding it to the `DefaultOnPlugins` list.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The [`ShootVPAEnabledByDefault`](https://github.com/gardener/gardener/blob/v1.127.0/docs/concepts/apiserver-admission-plugins.md#shootvpaenabledbydefault) admission plugin is now enabled by default for the Gardener API server. Disable this admission plugin explicitly if you don't want VPA to be enabled by default for newly created Shoots. If you already have the admission plugin enabled, you can remove the explicit enablement after upgrading to this version of Gardener as the plugin is now enabled by default.
```
