### PR TITLE
Move admission plugin name constants to their corresponding packages

### DIFF
--- a/plugin/pkg/backupbucket/validator/admission.go
+++ b/plugin/pkg/backupbucket/validator/admission.go
@@ -18,12 +18,16 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardensecurityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
 	gardensecurityv1alpha1listers "github.com/gardener/gardener/pkg/client/security/listers/security/v1alpha1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "BackupBucketValidator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameBackupBucketValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -23,12 +23,16 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "Bastion"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameBastion, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/controllerregistration/resources/admission.go
+++ b/plugin/pkg/controllerregistration/resources/admission.go
@@ -17,12 +17,16 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ControllerRegistrationResources"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameControllerRegistrationResources, NewFactory)
+	plugins.Register(PluginName, NewFactory)
 }
 
 // NewFactory creates a new PluginFactory.

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -27,7 +27,6 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 )
 
 const (
@@ -50,11 +49,13 @@ const (
 	// CustomVerbNamespacedCloudProfileRaiseLimits is a constant for the custom verb that allows raising the
 	// `.spec.limits` limits in `NamespacedCloudProfile` resources above values defined in the parent `CloudProfile`.
 	CustomVerbNamespacedCloudProfileRaiseLimits = "raise-spec-limits"
+	// PluginName indicates the name of admission plug-in
+	PluginName = "CustomVerbAuthorizer"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameCustomVerbAuthorizer, NewFactory)
+	plugins.Register(PluginName, NewFactory)
 }
 
 // NewFactory creates a new PluginFactory.

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -32,13 +32,17 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "DeletionConfirmation"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameDeletionConfirmation, NewFactory)
+	plugins.Register(PluginName, NewFactory)
 }
 
 // NewFactory creates a new PluginFactory.

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -27,12 +27,16 @@ import (
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ExtensionLabels"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameExtensionLabels, NewFactory)
+	plugins.Register(PluginName, NewFactory)
 }
 
 // NewFactory creates a new PluginFactory.

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -27,12 +27,16 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ExtensionValidator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameExtensionValidator, NewFactory)
+	plugins.Register(PluginName, NewFactory)
 }
 
 // NewFactory creates a new PluginFactory.

--- a/plugin/pkg/global/finalizerremoval/admission.go
+++ b/plugin/pkg/global/finalizerremoval/admission.go
@@ -25,12 +25,16 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "FinalizerRemoval"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameFinalizerRemoval, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -55,13 +55,17 @@ import (
 	seedmanagementv1alpha1listers "github.com/gardener/gardener/pkg/client/seedmanagement/listers/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ResourceReferenceManager"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameResourceReferenceManager, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/managedseed/shoot/admission.go
+++ b/plugin/pkg/managedseed/shoot/admission.go
@@ -21,13 +21,17 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ManagedSeedShoot"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameManagedSeedShoot, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -39,13 +39,16 @@ import (
 	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	PluginName = "ManagedSeed"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameManagedSeed, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	// PluginName indicates the name of admission plug-in
 	PluginName = "ManagedSeed"
 )
 

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -27,12 +27,16 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/controller/namespacedcloudprofile"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "NamespacedCloudProfileValidator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameNamespacedCloudProfileValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -12,96 +12,68 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
-)
 
-const (
-	// PluginNameBastion is the name of the Bastion admission plugin.
-	PluginNameBastion = "Bastion"
-	// PluginNameControllerRegistrationResources is the name of the ControllerRegistrationResources admission plugin.
-	PluginNameControllerRegistrationResources = "ControllerRegistrationResources"
-	// PluginNameCustomVerbAuthorizer is the name of the CustomVerbAuthorizer admission plugin.
-	PluginNameCustomVerbAuthorizer = "CustomVerbAuthorizer"
-	// PluginNameDeletionConfirmation is the name of the DeletionConfirmation admission plugin.
-	PluginNameDeletionConfirmation = "DeletionConfirmation"
-	// PluginNameExtensionLabels is the name of the ExtensionLabels admission plugin.
-	PluginNameExtensionLabels = "ExtensionLabels"
-	// PluginNameExtensionValidator is the name of the ExtensionValidator admission plugin.
-	PluginNameExtensionValidator = "ExtensionValidator"
-	// PluginNameFinalizerRemoval is the name of the FinalizerRemoval admission plugin.
-	PluginNameFinalizerRemoval = "FinalizerRemoval"
-	// PluginNameResourceReferenceManager is the name of the ResourceReferenceManager admission plugin.
-	PluginNameResourceReferenceManager = "ResourceReferenceManager"
-	// PluginNameManagedSeedShoot is the name of the ManagedSeedShoot admission plugin.
-	PluginNameManagedSeedShoot = "ManagedSeedShoot"
-	// PluginNameManagedSeed is the name of the ManagedSeed admission plugin.
-	PluginNameManagedSeed = "ManagedSeed"
-	// PluginNameNamespacedCloudProfileValidator is the name of the NamespacedCloudProfileValidator admission plugin.
-	PluginNameNamespacedCloudProfileValidator = "NamespacedCloudProfileValidator"
-	// PluginNameProjectValidator is the name of the ProjectValidator admission plugin.
-	PluginNameProjectValidator = "ProjectValidator"
-	// PluginNameSeedValidator is the name of the SeedValidator admission plugin.
-	PluginNameSeedValidator = "SeedValidator"
-	// PluginNameSeedMutator is the name of the SeedMutator admission plugin.
-	PluginNameSeedMutator = "SeedMutator"
-	// PluginNameShootDNS is the name of the ShootDNS admission plugin.
-	PluginNameShootDNS = "ShootDNS"
-	// PluginNameShootDNSRewriting is the name of the ShootDNSRewriting admission plugin.
-	PluginNameShootDNSRewriting = "ShootDNSRewriting"
-	// PluginNameShootExposureClass is the name of the ShootExposureClass admission plugin.
-	PluginNameShootExposureClass = "ShootExposureClass"
-	// PluginNameShootManagedSeed is the name of the ShootManagedSeed admission plugin.
-	PluginNameShootManagedSeed = "ShootManagedSeed"
-	// PluginNameShootNodeLocalDNSEnabledByDefault is the name of the ShootNodeLocalDNSEnabledByDefault admission plugin.
-	PluginNameShootNodeLocalDNSEnabledByDefault = "ShootNodeLocalDNSEnabledByDefault"
-	// PluginNameClusterOpenIDConnectPreset is the name of the ClusterOpenIDConnectPreset admission plugin.
-	PluginNameClusterOpenIDConnectPreset = "ClusterOpenIDConnectPreset"
-	// PluginNameOpenIDConnectPreset is the name of the OpenIDConnectPreset admission plugin.
-	PluginNameOpenIDConnectPreset = "OpenIDConnectPreset"
-	// PluginNameShootQuotaValidator is the name of the ShootQuotaValidator admission plugin.
-	PluginNameShootQuotaValidator = "ShootQuotaValidator"
-	// PluginNameShootTolerationRestriction is the name of the ShootTolerationRestriction admission plugin.
-	PluginNameShootTolerationRestriction = "ShootTolerationRestriction"
-	// PluginNameShootValidator is the name of the ShootValidator admission plugin.
-	PluginNameShootValidator = "ShootValidator"
-	// PluginNameShootVPAEnabledByDefault is the name of the ShootVPAEnabledByDefault admission plugin.
-	PluginNameShootVPAEnabledByDefault = "ShootVPAEnabledByDefault"
-	// PluginNameShootResourceReservation is the name of the ShootResourceReservation admission plugin.
-	PluginNameShootResourceReservation = "ShootResourceReservation"
-	// PluginNameBackupBucketValidator is the name of the BackupBucketValidator admission plugin.
-	PluginNameBackupBucketValidator = "BackupBucketValidator"
+	backupbucketvalidator "github.com/gardener/gardener/plugin/pkg/backupbucket/validator"
+	bastion "github.com/gardener/gardener/plugin/pkg/bastion/validator"
+	"github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
+	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
+	"github.com/gardener/gardener/plugin/pkg/global/customverbauthorizer"
+	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
+	"github.com/gardener/gardener/plugin/pkg/global/extensionlabels"
+	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
+	"github.com/gardener/gardener/plugin/pkg/global/finalizerremoval"
+	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
+	managedseedshoot "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
+	managedseed "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
+	namespacedcloudprofilevalidator "github.com/gardener/gardener/plugin/pkg/namespacedcloudprofile/validator"
+	projectvalidator "github.com/gardener/gardener/plugin/pkg/project/validator"
+	seedmutator "github.com/gardener/gardener/plugin/pkg/seed/mutator"
+	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
+	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
+	shootdnsrewriting "github.com/gardener/gardener/plugin/pkg/shoot/dnsrewriting"
+	shootexposureclass "github.com/gardener/gardener/plugin/pkg/shoot/exposureclass"
+	shootmanagedseed "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
+	shootnodelocaldns "github.com/gardener/gardener/plugin/pkg/shoot/nodelocaldns"
+	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
+	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
+	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
+	shootresourcereservation "github.com/gardener/gardener/plugin/pkg/shoot/resourcereservation"
+	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction"
+	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
+	shootvpa "github.com/gardener/gardener/plugin/pkg/shoot/vpa"
 )
 
 // AllPluginNames returns the names of all plugins.
 func AllPluginNames() []string {
 	return []string{
-		lifecycle.PluginName,                        // NamespaceLifecycle
-		PluginNameResourceReferenceManager,          // ResourceReferenceManager
-		PluginNameExtensionValidator,                // ExtensionValidator
-		PluginNameExtensionLabels,                   // ExtensionLabels
-		PluginNameShootTolerationRestriction,        // ShootTolerationRestriction
-		PluginNameShootExposureClass,                // ShootExposureClass
-		PluginNameShootDNS,                          // ShootDNS
-		PluginNameShootManagedSeed,                  // ShootManagedSeed
-		PluginNameShootNodeLocalDNSEnabledByDefault, // ShootNodeLocalDNSEnabledByDefault
-		PluginNameShootDNSRewriting,                 // ShootDNSRewriting
-		PluginNameShootQuotaValidator,               // ShootQuotaValidator
-		PluginNameShootValidator,                    // ShootValidator
-		PluginNameSeedValidator,                     // SeedValidator
-		PluginNameSeedMutator,                       // SeedMutator
-		PluginNameControllerRegistrationResources,   // ControllerRegistrationResources
-		PluginNameNamespacedCloudProfileValidator,   // NamespacedCloudProfileValidator
-		PluginNameProjectValidator,                  // ProjectValidator
-		PluginNameDeletionConfirmation,              // DeletionConfirmation
-		PluginNameFinalizerRemoval,                  // FinalizerRemoval
-		PluginNameOpenIDConnectPreset,               // OpenIDConnectPreset
-		PluginNameClusterOpenIDConnectPreset,        // ClusterOpenIDConnectPreset
-		PluginNameCustomVerbAuthorizer,              // CustomVerbAuthorizer
-		PluginNameShootVPAEnabledByDefault,          // ShootVPAEnabledByDefault
-		PluginNameShootResourceReservation,          // ShootResourceReservation
-		PluginNameManagedSeed,                       // ManagedSeed
-		PluginNameManagedSeedShoot,                  // ManagedSeedShoot
-		PluginNameBastion,                           // Bastion
-		PluginNameBackupBucketValidator,             // BackupBucketValidator
+		lifecycle.PluginName,                       // NamespaceLifecycle
+		resourcereferencemanager.PluginName,        // ResourceReferenceManager
+		extensionvalidation.PluginName,             // ExtensionValidator
+		extensionlabels.PluginName,                 // ExtensionLabels
+		tolerationrestriction.PluginName,           // ShootTolerationRestriction
+		shootexposureclass.PluginName,              // ShootExposureClass
+		shootdns.PluginName,                        // ShootDNS
+		shootmanagedseed.PluginName,                // ShootManagedSeed
+		shootnodelocaldns.PluginName,               // ShootNodeLocalDNSEnabledByDefault
+		shootdnsrewriting.PluginName,               // ShootDNSRewriting
+		shootquotavalidator.PluginName,             // ShootQuotaValidator
+		shootvalidator.PluginName,                  // ShootValidator
+		seedvalidator.PluginName,                   // SeedValidator
+		seedmutator.PluginName,                     // SeedMutator
+		resources.PluginName,                       // ControllerRegistrationResources
+		namespacedcloudprofilevalidator.PluginName, // NamespacedCloudProfileValidator
+		projectvalidator.PluginName,                // ProjectValidator
+		deletionconfirmation.PluginName,            // DeletionConfirmation
+		finalizerremoval.PluginName,                // FinalizerRemoval
+		openidconnectpreset.PluginName,             // OpenIDConnectPreset
+		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
+		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
+		shootvpa.PluginName,                        // ShootVPAEnabledByDefault
+		shootresourcereservation.PluginName,        // ShootResourceReservation
+		managedseed.PluginName,                     // ManagedSeed
+		managedseedshoot.PluginName,                // ManagedSeedShoot
+		bastion.PluginName,                         // Bastion
+		backupbucketvalidator.PluginName,           // BackupBucketValidator
 
 		// new admission plugins should generally be inserted above here
 		// webhook, and resourcequota plugins must go at the end
@@ -120,33 +92,33 @@ func AllPluginNames() []string {
 // DefaultOnPlugins is the set of admission plugins that are enabled by default.
 func DefaultOnPlugins() sets.Set[string] {
 	return sets.New[string](
-		lifecycle.PluginName,                      // NamespaceLifecycle
-		PluginNameResourceReferenceManager,        // ResourceReferenceManager
-		PluginNameExtensionValidator,              // ExtensionValidator
-		PluginNameExtensionLabels,                 // ExtensionLabels
-		PluginNameShootTolerationRestriction,      // ShootTolerationRestriction
-		PluginNameShootExposureClass,              // ShootExposureClass
-		PluginNameShootDNS,                        // ShootDNS
-		PluginNameShootManagedSeed,                // ShootManagedSeed
-		PluginNameShootResourceReservation,        // ShootResourceReservation
-		PluginNameShootQuotaValidator,             // ShootQuotaValidator
-		PluginNameShootValidator,                  // ShootValidator
-		PluginNameSeedValidator,                   // SeedValidator
-		PluginNameSeedMutator,                     // SeedMutator
-		PluginNameControllerRegistrationResources, // ControllerRegistrationResources
-		PluginNameNamespacedCloudProfileValidator, // NamespacedCloudProfileValidator
-		PluginNameProjectValidator,                // ProjectValidator
-		PluginNameDeletionConfirmation,            // DeletionConfirmation
-		PluginNameFinalizerRemoval,                // FinalizerRemoval
-		PluginNameOpenIDConnectPreset,             // OpenIDConnectPreset
-		PluginNameClusterOpenIDConnectPreset,      // ClusterOpenIDConnectPreset
-		PluginNameCustomVerbAuthorizer,            // CustomVerbAuthorizer
-		PluginNameManagedSeed,                     // ManagedSeed
-		PluginNameManagedSeedShoot,                // ManagedSeedShoot
-		PluginNameBastion,                         // Bastion
-		PluginNameBackupBucketValidator,           // BackupBucketValidator
-		mutatingwebhook.PluginName,                // MutatingAdmissionWebhook
-		validatingwebhook.PluginName,              // ValidatingAdmissionWebhook
+		lifecycle.PluginName,                       // NamespaceLifecycle
+		resourcereferencemanager.PluginName,        // ResourceReferenceManager
+		extensionvalidation.PluginName,             // ExtensionValidator
+		extensionlabels.PluginName,                 // ExtensionLabels
+		tolerationrestriction.PluginName,           // ShootTolerationRestriction
+		shootexposureclass.PluginName,              // ShootExposureClass
+		shootdns.PluginName,                        // ShootDNS
+		shootmanagedseed.PluginName,                // ShootManagedSeed
+		shootresourcereservation.PluginName,        // ShootResourceReservation
+		shootquotavalidator.PluginName,             // ShootQuotaValidator
+		shootvalidator.PluginName,                  // ShootValidator
+		seedvalidator.PluginName,                   // SeedValidator
+		seedmutator.PluginName,                     // SeedMutator
+		controllerregistrationresources.PluginName, // ControllerRegistrationResources
+		namespacedcloudprofilevalidator.PluginName, // NamespacedCloudProfileValidator
+		projectvalidator.PluginName,                // ProjectValidator
+		deletionconfirmation.PluginName,            // DeletionConfirmation
+		finalizerremoval.PluginName,                // FinalizerRemoval
+		openidconnectpreset.PluginName,             // OpenIDConnectPreset
+		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
+		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
+		managedseed.PluginName,                     // ManagedSeed
+		managedseedshoot.PluginName,                // ManagedSeedShoot
+		bastion.PluginName,                         // Bastion
+		backupbucketvalidator.PluginName,           // BackupBucketValidator
+		mutatingwebhook.PluginName,                 // MutatingAdmissionWebhook
+		validatingwebhook.PluginName,               // ValidatingAdmissionWebhook
 		// TODO(ary1992): Ennable the plugin once our base clusters are updated to k8s >= 1.30
 		// validating.PluginName,                     // ValidatingAdmissionPolicy
 		resourcequota.PluginName, // ResourceQuota

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -15,7 +15,6 @@ import (
 
 	backupbucketvalidator "github.com/gardener/gardener/plugin/pkg/backupbucket/validator"
 	bastion "github.com/gardener/gardener/plugin/pkg/bastion/validator"
-	"github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
 	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
 	"github.com/gardener/gardener/plugin/pkg/global/customverbauthorizer"
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
@@ -60,7 +59,7 @@ func AllPluginNames() []string {
 		shootvalidator.PluginName,                  // ShootValidator
 		seedvalidator.PluginName,                   // SeedValidator
 		seedmutator.PluginName,                     // SeedMutator
-		resources.PluginName,                       // ControllerRegistrationResources
+		controllerregistrationresources.PluginName, // ControllerRegistrationResources
 		namespacedcloudprofilevalidator.PluginName, // NamespacedCloudProfileValidator
 		projectvalidator.PluginName,                // ProjectValidator
 		deletionconfirmation.PluginName,            // DeletionConfirmation

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -14,13 +14,17 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	"github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ProjectValidator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameProjectValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/seed/mutator/admission.go
+++ b/plugin/pkg/seed/mutator/admission.go
@@ -21,12 +21,16 @@ import (
 	seedmanagementinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	seedmanagementv1alpha1listers "github.com/gardener/gardener/pkg/client/seedmanagement/listers/seedmanagement/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "SeedMutator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameSeedMutator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -21,13 +21,17 @@ import (
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	gardensecurityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
 	gardensecurityv1alpha1listers "github.com/gardener/gardener/pkg/client/security/listers/security/v1alpha1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "SeedValidator"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameSeedValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -30,13 +30,17 @@ import (
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootDNS"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootDNS, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/dnsrewriting/admission.go
+++ b/plugin/pkg/shoot/dnsrewriting/admission.go
@@ -14,13 +14,17 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	"github.com/gardener/gardener/plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootDNSRewriting"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootDNSRewriting, func(config io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		cfg, err := LoadConfiguration(config)
 		if err != nil {
 			return nil, err

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -20,12 +20,16 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootExposureClass"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootExposureClass, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -23,13 +23,17 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	"github.com/gardener/gardener/plugin/pkg/utils"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootManagedSeed"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootManagedSeed, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/nodelocaldns/admission.go
+++ b/plugin/pkg/shoot/nodelocaldns/admission.go
@@ -14,12 +14,16 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootNodeLocalDNSEnabledByDefault"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootNodeLocalDNSEnabledByDefault, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New(), nil
 	})
 }

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -26,13 +26,17 @@ import (
 	settingsinformers "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	settingsv1alpha1lister "github.com/gardener/gardener/pkg/client/settings/listers/settings/v1alpha1"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	applier "github.com/gardener/gardener/plugin/pkg/shoot/oidc"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ClusterOpenIDConnectPreset"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameClusterOpenIDConnectPreset, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -23,13 +23,17 @@ import (
 	settingsinformers "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	settingsv1alpha1lister "github.com/gardener/gardener/pkg/client/settings/listers/settings/v1alpha1"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	applier "github.com/gardener/gardener/plugin/pkg/shoot/oidc"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "OpenIDConnectPreset"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameOpenIDConnectPreset, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -31,7 +31,11 @@ import (
 	securityv1alpha1listers "github.com/gardener/gardener/pkg/client/security/listers/security/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	timeutils "github.com/gardener/gardener/pkg/utils/time"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootQuotaValidator"
 )
 
 var (
@@ -46,7 +50,7 @@ var (
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootQuotaValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New(timeutils.DefaultOps())
 	})
 }

--- a/plugin/pkg/shoot/resourcereservation/admission.go
+++ b/plugin/pkg/shoot/resourcereservation/admission.go
@@ -23,7 +23,6 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 )
 
 const (
@@ -31,11 +30,13 @@ const (
 	kib
 	mib
 	gib
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootResourceReservation"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootResourceReservation, func(config io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		cfg, err := LoadConfiguration(config)
 		if err != nil {
 			return nil, err

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -21,15 +21,19 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/validation"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootTolerationRestriction"
+)
+
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootTolerationRestriction, func(cfg io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(cfg io.Reader) (admission.Interface, error) {
 		config, err := LoadConfiguration(cfg)
 		if err != nil {
 			return nil, err

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -49,15 +49,18 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	plugin "github.com/gardener/gardener/plugin/pkg"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 )
 
-const internalVersionErrorMsg = "must not use apiVersion 'internal'"
+const (
+	internalVersionErrorMsg = "must not use apiVersion 'internal'"
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootValidator"
+)
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootValidator, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New()
 	})
 }

--- a/plugin/pkg/shoot/vpa/admission.go
+++ b/plugin/pkg/shoot/vpa/admission.go
@@ -14,12 +14,16 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
-	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+const (
+	// PluginName indicates the name of admission plug-in
+	PluginName = "ShootVPAEnabledByDefault"
 )
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {
-	plugins.Register(plugin.PluginNameShootVPAEnabledByDefault, func(_ io.Reader) (admission.Interface, error) {
+	plugins.Register(PluginName, func(_ io.Reader) (admission.Interface, error) {
 		return New(), nil
 	})
 }

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -146,9 +146,9 @@ build:
             - pkg/component/networking/nginxingress
             - pkg/component/networking/nodelocaldns
             - pkg/component/networking/nodelocaldns/constants
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
-            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -57,19 +57,55 @@ build:
             - pkg/apis/security/v1alpha1/constants
             - pkg/apis/seedmanagement
             - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/helper
             - pkg/apis/seedmanagement/install
             - pkg/apis/seedmanagement/v1alpha1
             - pkg/apis/seedmanagement/v1alpha1/helper
             - pkg/apis/settings
             - pkg/apis/settings/install
             - pkg/apis/settings/v1alpha1
+            - pkg/apiserver/admission/initializer
             - pkg/chartrenderer
+            - pkg/client/core/clientset/versioned
+            - pkg/client/core/clientset/versioned/scheme
+            - pkg/client/core/clientset/versioned/typed/core/v1
+            - pkg/client/core/clientset/versioned/typed/core/v1beta1
+            - pkg/client/core/informers/externalversions
+            - pkg/client/core/informers/externalversions/core
+            - pkg/client/core/informers/externalversions/core/v1
+            - pkg/client/core/informers/externalversions/core/v1beta1
+            - pkg/client/core/informers/externalversions/internalinterfaces
+            - pkg/client/core/listers/core/v1
             - pkg/client/core/listers/core/v1beta1
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
             - pkg/client/kubernetes/clientmap
             - pkg/client/kubernetes/clientmap/builder
             - pkg/client/kubernetes/clientmap/keys
+            - pkg/client/security/clientset/versioned
+            - pkg/client/security/clientset/versioned/scheme
+            - pkg/client/security/clientset/versioned/typed/security/v1alpha1
+            - pkg/client/security/informers/externalversions
+            - pkg/client/security/informers/externalversions/internalinterfaces
+            - pkg/client/security/informers/externalversions/security
+            - pkg/client/security/informers/externalversions/security/v1alpha1
+            - pkg/client/security/listers/security/v1alpha1
+            - pkg/client/seedmanagement/clientset/versioned
+            - pkg/client/seedmanagement/clientset/versioned/scheme
+            - pkg/client/seedmanagement/clientset/versioned/typed/seedmanagement/v1alpha1
+            - pkg/client/seedmanagement/informers/externalversions
+            - pkg/client/seedmanagement/informers/externalversions/internalinterfaces
+            - pkg/client/seedmanagement/informers/externalversions/seedmanagement
+            - pkg/client/seedmanagement/informers/externalversions/seedmanagement/v1alpha1
+            - pkg/client/seedmanagement/listers/seedmanagement/v1alpha1
+            - pkg/client/settings/clientset/versioned
+            - pkg/client/settings/clientset/versioned/scheme
+            - pkg/client/settings/clientset/versioned/typed/settings/v1alpha1
+            - pkg/client/settings/informers/externalversions
+            - pkg/client/settings/informers/externalversions/internalinterfaces
+            - pkg/client/settings/informers/externalversions/settings
+            - pkg/client/settings/informers/externalversions/settings/v1alpha1
+            - pkg/client/settings/listers/settings/v1alpha1
             - pkg/component
             - pkg/component/apiserver
             - pkg/component/autoscaling/vpa
@@ -230,6 +266,7 @@ build:
             - pkg/controller/service
             - pkg/controller/vpaevictionrequirements
             - pkg/controllermanager/apis/config/v1alpha1
+            - pkg/controllermanager/controller/namespacedcloudprofile
             - pkg/controllerutils
             - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
@@ -311,6 +348,7 @@ build:
             - pkg/utils/retry
             - pkg/utils/secrets
             - pkg/utils/secrets/manager
+            - pkg/utils/time
             - pkg/utils/timewindow
             - pkg/utils/validation
             - pkg/utils/validation/admissionplugins
@@ -322,6 +360,46 @@ build:
             - pkg/utils/version
             - pkg/utils/workloadidentity
             - plugin/pkg
+            - plugin/pkg/backupbucket/validator
+            - plugin/pkg/bastion/validator
+            - plugin/pkg/controllerregistration/resources
+            - plugin/pkg/global/customverbauthorizer
+            - plugin/pkg/global/deletionconfirmation
+            - plugin/pkg/global/extensionlabels
+            - plugin/pkg/global/extensionvalidation
+            - plugin/pkg/global/finalizerremoval
+            - plugin/pkg/global/resourcereferencemanager
+            - plugin/pkg/managedseed/shoot
+            - plugin/pkg/managedseed/validator
+            - plugin/pkg/namespacedcloudprofile/validator
+            - plugin/pkg/project/validator
+            - plugin/pkg/seed/mutator
+            - plugin/pkg/seed/validator
+            - plugin/pkg/shoot/dns
+            - plugin/pkg/shoot/dnsrewriting
+            - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting
+            - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/install
+            - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/v1alpha1
+            - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation
+            - plugin/pkg/shoot/exposureclass
+            - plugin/pkg/shoot/managedseed
+            - plugin/pkg/shoot/nodelocaldns
+            - plugin/pkg/shoot/oidc
+            - plugin/pkg/shoot/oidc/clusteropenidconnectpreset
+            - plugin/pkg/shoot/oidc/openidconnectpreset
+            - plugin/pkg/shoot/quotavalidator
+            - plugin/pkg/shoot/resourcereservation
+            - plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation
+            - plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/install
+            - plugin/pkg/shoot/resourcereservation/apis/shootresourcereservation/v1alpha1
+            - plugin/pkg/shoot/tolerationrestriction
+            - plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction
+            - plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/install
+            - plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/v1alpha1
+            - plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/validation
+            - plugin/pkg/shoot/validator
+            - plugin/pkg/shoot/vpa
+            - plugin/pkg/utils
             - third_party/gopkg.in/yaml.v2
             - VERSION
         ldflags:

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -172,9 +172,9 @@ build:
             - pkg/component/networking/nginxingress
             - pkg/component/networking/nodelocaldns
             - pkg/component/networking/nodelocaldns/constants
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
-            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1094,9 +1094,9 @@ build:
             - pkg/component/networking/nginxingress
             - pkg/component/networking/nodelocaldns
             - pkg/component/networking/nodelocaldns/constants
+            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/envoy
             - pkg/component/networking/vpn/envoy/templates/envoy.yaml.tpl
-            - pkg/component/networking/nodelocaldns/resources/cleanup.sh
             - pkg/component/networking/vpn/seedserver
             - pkg/component/networking/vpn/shoot
             - pkg/component/nodemanagement/dependencywatchdog


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Currently, all of Gardener's admission plugin name constants are stored in a single file within the `plugins` package:
https://github.com/gardener/gardener/blob/e1469fffc86b0ac7f4e050bec5764b5f6c4b4c17/plugin/pkg/plugins.go#L17-L72.

When an admission plugin is registered, the package has to be imported in order to access it's corresponding name constant:
https://github.com/gardener/gardener/blob/1d2c2a7a52990379b5b05796b80a2a1861d2e4fa/plugin/pkg/shoot/vpa/admission.go#L21-L25

This PR moves all `PluginName.*` constants to the corresponding admission plugins' packages. This way, the admission plugins can store their own constants, thereby improving searching within the codebase, as well as removing the need to import the aforementioned central package to all admission plugins.

Additionally, it adheres to the way Kubernetes codebase handles it's plugin naming:
https://github.com/kubernetes/kubernetes/blob/1bcfd5cee7905ee7c2b17cec0ecd88609693f44c/plugin/pkg/admission/admit/admission.go#L27-L28

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
