### PR TITLE
Promote `CredentialsRotationWithoutWorkersRollout` feature gate to GA

### DIFF
--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -56,7 +56,6 @@ spec:
         admissionPlugins:
         - name: ShootVPAEnabledByDefault
         featureGates:
-          CredentialsRotationWithoutWorkersRollout: true
           CloudProfileCapabilities: true
           InPlaceNodeUpdates: true
       gardenerDashboard: {}

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.125` |
 | NewWorkerPoolHash                        | `true`  | `Beta`  | `1.126` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
-| CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
+| CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` | `1.126` |
+| CredentialsRotationWithoutWorkersRollout | `true`  | `GA`    | `1.127` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities                 | `false` | `Alpha` | `1.117` |         |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -155,7 +155,6 @@ global:
       log:
         path: ""
     featureGates:
-      CredentialsRotationWithoutWorkersRollout: true
       CloudProfileCapabilities: true
       InPlaceNodeUpdates: true
     resources: {}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2761,22 +2761,6 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 		allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("annotations %s and %s must not be equal", fldPathOp, fldPathMaintOp)))
 	}
 
-	// TODO(rfranzke): Remove this block once the CredentialsRotationWithoutWorkersRollout feature gate gets promoted
-	//  to GA.
-	if !features.DefaultFeatureGate.Enabled(features.CredentialsRotationWithoutWorkersRollout) {
-		restrictedOperations := sets.New(
-			v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
-			v1beta1constants.OperationRotateCAStartWithoutWorkersRollout,
-			v1beta1constants.OperationRotateServiceAccountKeyStartWithoutWorkersRollout,
-		)
-		if operation != "" && (restrictedOperations.Has(operation) || strings.HasPrefix(operation, v1beta1constants.OperationRotateRolloutWorkers)) {
-			allErrs = append(allErrs, field.Forbidden(fldPathOp, fmt.Sprintf("the %s operation can only be used when the CredentialsRotationWithoutWorkersRollout feature gate is enabled", operation)))
-		}
-		if maintenanceOperation != "" && (restrictedOperations.Has(maintenanceOperation) || strings.HasPrefix(maintenanceOperation, v1beta1constants.OperationRotateRolloutWorkers)) {
-			allErrs = append(allErrs, field.Forbidden(fldPathMaintOp, fmt.Sprintf("the %s operation can only be used when the CredentialsRotationWithoutWorkersRollout feature gate is enabled", maintenanceOperation)))
-		}
-	}
-
 	if operation != "" {
 		if !availableShootOperations.Has(operation) && !strings.HasPrefix(operation, v1beta1constants.OperationRotateRolloutWorkers) {
 			allErrs = append(allErrs, field.NotSupported(fldPathOp, operation, sets.List(availableShootOperations)))

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -51,6 +51,7 @@ const (
 	// owner: @rfranzke
 	// alpha: v1.112.0
 	// beta: v1.121.0
+	// GA: v1.127.0
 	CredentialsRotationWithoutWorkersRollout featuregate.Feature = "CredentialsRotationWithoutWorkersRollout"
 
 	// InPlaceNodeUpdates enables setting the update strategy of worker pools to `AutoInPlaceUpdate` or `ManualInPlaceUpdate` in the Shoot API.
@@ -115,7 +116,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
 	NewWorkerPoolHash:                        {Default: true, PreRelease: featuregate.Beta},
-	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},
+	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},
 	CloudProfileCapabilities:                 {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the `CredentialsRotationWithoutWorkersRollout` feature gate to GA.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10121
Follow-up of https://github.com/gardener/gardener/pull/11027

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `CredentialsRotationWithoutWorkersRollout` feature gate has been promoted to GA and is enabled unconditionally.
```
