### PR TITLE
Add missing `configmaps` resource to `seed-restriction` webhook config

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
@@ -54,11 +54,6 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   - secrets
   - serviceaccounts

--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -105,7 +105,7 @@ webhooks:
     operations:
     - CREATE
     resources:
-    - configmaps
+    # - configmaps # intentionally not enabled in this deprecated Helm chart since it races with gardener-apiserver start-up
     - secrets
     - serviceaccounts
   - apiGroups:

--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -105,6 +105,7 @@ webhooks:
     operations:
     - CREATE
     resources:
+    - configmaps
     - secrets
     - serviceaccounts
   - apiGroups:

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -1241,7 +1241,7 @@ func validatingWebhookConfiguration(namespace string, caBundle []byte, testValue
 					Rule: admissionregistrationv1.Rule{
 						APIGroups:   []string{""},
 						APIVersions: []string{"v1"},
-						Resources:   []string{"secrets", "serviceaccounts"},
+						Resources:   []string{"configmaps", "secrets", "serviceaccounts"},
 					},
 				},
 				{

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -887,12 +887,6 @@ func clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{""},
 				Resources: []string{
 					"configmaps",
-				},
-				Verbs: []string{"get"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{
 					"namespaces",
 					"secrets",
 					"serviceaccounts",

--- a/pkg/component/gardener/admissioncontroller/rbac.go
+++ b/pkg/component/gardener/admissioncontroller/rbac.go
@@ -61,12 +61,6 @@ func (a *gardenerAdmissionController) clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{corev1.GroupName},
 				Resources: []string{
 					"configmaps",
-				},
-				Verbs: []string{"get"},
-			},
-			{
-				APIGroups: []string{corev1.GroupName},
-				Resources: []string{
 					"namespaces",
 					"secrets",
 					"serviceaccounts",

--- a/pkg/component/gardener/admissioncontroller/webhooks.go
+++ b/pkg/component/gardener/admissioncontroller/webhooks.go
@@ -302,7 +302,7 @@ func (a *gardenerAdmissionController) validatingWebhookConfiguration(caSecret *c
 					Rule: admissionregistrationv1.Rule{
 						APIGroups:   []string{corev1.GroupName},
 						APIVersions: []string{"v1"},
-						Resources:   []string{"secrets", "serviceaccounts"},
+						Resources:   []string{"configmaps", "secrets", "serviceaccounts"},
 					},
 				},
 				{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
The `seed-restriction` admission webhook in `gardener-admission-controller` has a handling for `ConfigMap`s https://github.com/gardener/gardener/blob/e1469fffc86b0ac7f4e050bec5764b5f6c4b4c17/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go#L85-L86
However, the `ValidatingWebhookConfiguration` was not configured with `configmaps` before. This PR fixes this.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A misconfiguration has been fixed which was preventing `gardener-admission-controller` from being called for `ConfigMap` creations of `gardenlet`.
```
