### PR TITLE
[GEP-28] `gardener-scheduler` no longer tries scheduling autonomous `Shoot`s

### DIFF
--- a/pkg/scheduler/controller/shoot/add.go
+++ b/pkg/scheduler/controller/shoot/add.go
@@ -87,6 +87,6 @@ func (r *Reconciler) ShootIsNotAutonomous() predicate.Predicate {
 		if shoot, ok := obj.(*gardencorev1beta1.Shoot); ok {
 			return !helper.IsShootAutonomous(shoot)
 		}
-		return true
+		return false
 	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
When an autonomous `Shoot` is created in the system, `gardener-scheduler` should not try to schedule it to a `Seed` (there won't be any seed cluster usage for autonomous shoots).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
