### PR TITLE
Promote Feature Gate `NewWorkerPoolHash` to `GA`  and lock to `true`

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -23,8 +23,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | DefaultSeccompProfile                    | `false` | `Alpha` | `1.54`  |         |
 | ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
 | ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
-| NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.125` |
-| NewWorkerPoolHash                        | `true`  | `Beta`  | `1.126` |         |
 | CredentialsRotationWithoutWorkersRollout | `false` | `Alpha` | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout | `true`  | `Beta`  | `1.121` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
@@ -200,6 +198,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseNamespacedCloudProfile                    | `false` | `Alpha`      | `1.92`  | `1.111` |
 | UseNamespacedCloudProfile                    | `true`  | `Beta`       | `1.112` | `1.124` |
 | UseNamespacedCloudProfile                    | `true`  | `GA`         | `1.125` |         |
+| NewWorkerPoolHash                            | `false` | `Alpha`      | `1.98`  | `1.125` |
+| NewWorkerPoolHash                            | `true`  | `Beta`       | `1.126` | `1.127` |
+| NewWorkerPoolHash                            | `true`  | `GA`         | `1.128` |         |
 
 ## Using a Feature
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -43,6 +43,7 @@ const (
 	// owner: @MichaelEischer
 	// alpha: v1.98.0
 	// beta: v1.126.0
+	// GA: v1.128.0
 	NewWorkerPoolHash featuregate.Feature = "NewWorkerPoolHash"
 
 	// CredentialsRotationWithoutWorkersRollout enables starting the credentials rotation without immediately causing
@@ -114,7 +115,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:                    {Default: false, PreRelease: featuregate.Alpha},
 	UseNamespacedCloudProfile:                {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootCredentialsBinding:                  {Default: true, PreRelease: featuregate.Beta},
-	NewWorkerPoolHash:                        {Default: true, PreRelease: featuregate.Beta},
+	NewWorkerPoolHash:                        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CredentialsRotationWithoutWorkersRollout: {Default: true, PreRelease: featuregate.Beta},
 	InPlaceNodeUpdates:                       {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:                      {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the feature gate `NewWorkerPoolHash` to `GA` status.
Now that we had the feature gate in beta for 2 versions, we are confident this can go `GA`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/9699

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
:warning: The `NewWorkerPoolHash` feature gate has been promoted to `GA` and is now locked to `true`. When the feature gate is enabled, changes to `kubeReserved`, `systemReserved`, `evictionHard` or `cpuManagerPolicy` in the `kubelet` of the `Shoot` will trigger a node-roll. All provider extensions must be upgraded to a version which includes Gardener `v1.98.0` first to support this feature.
```
