### PR TITLE
Make `gardenlet` check version skew with `gardener-apiserver` when starting

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -340,6 +340,11 @@ func (g *garden) Start(ctx context.Context) error {
 		}
 	}
 
+	log.Info("Perform Gardener version verification")
+	if err := bootstrappers.VerifyGardenerVersion(ctx, g.mgr.GetLogger(), gardenCluster.GetAPIReader()); err != nil {
+		return fmt.Errorf("failed verifying Gardener version: %w", err)
+	}
+
 	log.Info("Adding field indexes to informers")
 	if err := addAllFieldIndexes(ctx, gardenCluster.GetFieldIndexer()); err != nil {
 		return fmt.Errorf("failed adding indexes: %w", err)

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -321,6 +321,12 @@ func (a *authorizer) authorizeSecret(log logr.Logger, seedName string, attrs aut
 }
 
 func (a *authorizer) authorizeConfigMap(log logr.Logger, seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
+	if attrs.GetVerb() == "get" &&
+		attrs.GetNamespace() == gardencorev1beta1.GardenerSystemPublicNamespace &&
+		attrs.GetName() == v1beta1constants.ConfigMapNameGardenerInfo {
+		return auth.DecisionAllow, "", nil
+	}
+
 	return a.authorize(log, seedName, graph.VertexTypeConfigMap, attrs,
 		[]string{"get", "patch", "update", "delete", "list", "watch"},
 		[]string{"create"},

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -220,6 +220,17 @@ var _ = Describe("Seed", func() {
 					}
 				})
 
+				It("should allow reading the public gardener-info ConfigMap without consulting the graph", func() {
+					attrs.Name = "gardener-info"
+					attrs.Namespace = "gardener-system-public"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
 				It("should allow because cluster-identity is retrieved", func() {
 					attrs.Name = "cluster-identity"
 					attrs.Namespace = "kube-system"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1040,4 +1040,10 @@ const (
 	// AnnotationEmergencyStopShootReconciliations is the key for the emergency switch annotation for the seed resource
 	// to temporarily pause further shoot reconciliations.
 	AnnotationEmergencyStopShootReconciliations = "shoot.gardener.cloud/emergency-stop-reconciliations"
+
+	// ConfigMapNameGardenerInfo is the name of the gardener-info ConfigMap.
+	ConfigMapNameGardenerInfo = "gardener-info"
+	// GardenerInfoConfigMapDataKeyGardenerAPIServer is the data key in the gardener-info ConfigMap that contains
+	// information about gardener-apiserver.
+	GardenerInfoConfigMapDataKeyGardenerAPIServer = "gardenerAPIServer"
 )

--- a/pkg/gardenlet/bootstrappers/verify_version.go
+++ b/pkg/gardenlet/bootstrappers/verify_version.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrappers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+)
+
+// GetCurrentVersion returns the current version. Exposed for testing.
+var GetCurrentVersion = version.Get
+
+// VerifyGardenerVersion verifies that the operator's version is not lower and not more than one version higher than
+// the version last operated on a Garden.
+func VerifyGardenerVersion(ctx context.Context, log logr.Logger, reader client.Reader) error {
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "gardener-info", Namespace: gardencorev1beta1.GardenerSystemPublicNamespace}}
+	if err := reader.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
+		return fmt.Errorf("failed reading ConfigMap %s from garden cluster: %w", client.ObjectKeyFromObject(configMap), err)
+	}
+
+	gardenerAPIServerInfo := gardenerutils.APIServerInfo{}
+	if err := yaml.Unmarshal([]byte(configMap.Data[v1beta1constants.GardenerInfoConfigMapDataKeyGardenerAPIServer]), &gardenerAPIServerInfo); err != nil {
+		return fmt.Errorf("failed unmarshalling the gardener-apiserver information structure: %w", err)
+	}
+
+	gardenerAPIServerVersion, err := semver.NewVersion(gardenerAPIServerInfo.Version)
+	if err != nil {
+		return fmt.Errorf("failed parsing version of gardener-apiserver %q: %w", gardenerAPIServerInfo.Version, err)
+	}
+	gardenletVersion, err := semver.NewVersion(GetCurrentVersion().GitVersion)
+	if err != nil {
+		return fmt.Errorf("failed parsing version of gardenlet %q: %w", GetCurrentVersion().GitVersion, err)
+	}
+
+	if gardenletVersionTooHigh, err := versionutils.CompareVersions(gardenletVersion.String(), ">", gardenerAPIServerVersion.String()); err != nil {
+		return fmt.Errorf("failed comparing versions: %w", err)
+	} else if gardenletVersionTooHigh {
+		return fmt.Errorf("gardenlet version must not be newer than gardener-apiserver version (gardener-apiserver version: %s, my version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
+	}
+
+	// IncMinor implicitly sets the patch version to '0'.
+	if gardenletVersionTooLow, err := versionutils.CompareVersions(gardenletVersion.IncMinor().IncMinor().String(), "<", fmt.Sprintf("%d.%d.0", gardenerAPIServerVersion.Major(), gardenerAPIServerVersion.Minor())); err != nil {
+		return fmt.Errorf("failed comparing versions: %w", err)
+	} else if gardenletVersionTooLow {
+		return fmt.Errorf("gardenlet version must not be older than two minor gardener-apiserver versions (gardener-apiserver version: %s, my version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
+	}
+
+	log.Info("Successfully verified Gardener version skew")
+	return nil
+}

--- a/pkg/gardenlet/bootstrappers/verify_version.go
+++ b/pkg/gardenlet/bootstrappers/verify_version.go
@@ -58,16 +58,16 @@ func VerifyGardenerVersion(ctx context.Context, log logr.Logger, reader client.R
 	if gardenletVersionTooHigh, err := versionutils.CompareVersions(gardenletVersion.String(), ">", gardenerAPIServerVersion.String()); err != nil {
 		return fmt.Errorf("failed comparing versions: %w", err)
 	} else if gardenletVersionTooHigh {
-		return fmt.Errorf("gardenlet version must not be newer than gardener-apiserver version (gardener-apiserver version: %s, my version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
+		return fmt.Errorf("gardenlet version must not be newer than gardener-apiserver version (gardener-apiserver version: %s, gardenlet version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
 	}
 
 	// IncMinor implicitly sets the patch version to '0'.
 	if gardenletVersionTooLow, err := versionutils.CompareVersions(gardenletVersion.IncMinor().IncMinor().String(), "<", fmt.Sprintf("%d.%d.0", gardenerAPIServerVersion.Major(), gardenerAPIServerVersion.Minor())); err != nil {
 		return fmt.Errorf("failed comparing versions: %w", err)
 	} else if gardenletVersionTooLow {
-		return fmt.Errorf("gardenlet version must not be older than two minor gardener-apiserver versions (gardener-apiserver version: %s, my version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
+		return fmt.Errorf("gardenlet version must not be older than two minor gardener-apiserver versions (gardener-apiserver version: %s, gardenlet version: %s), please consult https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#version-skew-policy", gardenerAPIServerVersion, gardenletVersion)
 	}
 
-	log.Info("Successfully verified Gardener version skew")
+	log.Info("Successfully verified Gardener version skew", "gardener-apiserver", gardenerAPIServerVersion.String(), "gardenlet", gardenletVersion.String())
 	return nil
 }

--- a/pkg/gardenlet/bootstrappers/verify_version_test.go
+++ b/pkg/gardenlet/bootstrappers/verify_version_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrappers_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/gardener/gardener/pkg/gardenlet/bootstrappers"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("VerifyVersion", func() {
+	var (
+		ctx        = context.Background()
+		log        logr.Logger
+		fakeClient client.Client
+		configMap  *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		log = logr.Discard()
+		configMap = &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "gardener-info", Namespace: "gardener-system-public"}}
+		fakeClient = fakeclient.NewClientBuilder().Build()
+	})
+
+	Describe("#VerifyGardenerVersion", func() {
+		It("should fail if the gardener-info ConfigMap does not exist", func() {
+			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(MatchError(ContainSubstring("failed reading ConfigMap gardener")))
+		})
+
+		It("should fail if the gardener-apiserver information data cannot be parsed", func() {
+			configMap.Data = map[string]string{"gardenerAPIServer": "CANNOT-PARSE-THIS"}
+			Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+
+			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(MatchError(ContainSubstring("failed unmarshalling the gardener-apiserver information structure")))
+		})
+
+		DescribeTable("tests",
+			func(gardenerAPIServerVersion, gardenletVersion string, matcher gomegatypes.GomegaMatcher) {
+				configMap.Data = map[string]string{"gardenerAPIServer": "version: " + gardenerAPIServerVersion}
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+
+				DeferCleanup(test.WithVar(&GetCurrentVersion, func() apimachineryversion.Info { return apimachineryversion.Info{GitVersion: gardenletVersion} }))
+
+				Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(matcher)
+			},
+
+			Entry("fail because gardener-apiserver version cannot be parsed", "unparsable$version", "v1.2.3", MatchError(ContainSubstring("failed parsing version of gardener-apiserver"))),
+			Entry("fail because gardenlet version cannot be parsed", "v1.2.3", "unparsable$version", MatchError(ContainSubstring("failed parsing version of gardenlet"))),
+
+			Entry("fail because gardenlet version is too high", "v1.2.3", "v1.3.0", MatchError(ContainSubstring("gardenlet version must not be newer than gardener-apiserver version"))),
+			Entry("fail because gardenlet version is too high", "v1.2.3", "v1.2.4", MatchError(ContainSubstring("gardenlet version must not be newer than gardener-apiserver version"))),
+			Entry("fail because gardenlet version is too high (gardener-apiserver version suffixed with '-dev')", "v1.2.3-dev", "v1.2.4", MatchError(ContainSubstring("gardenlet version must not be newer than gardener-apiserver version"))),
+			Entry("fail because gardenlet version is too high (gardenlet version suffixed with '-dev')", "v1.2.3", "v1.2.4-dev", MatchError(ContainSubstring("gardenlet version must not be newer than gardener-apiserver version"))),
+			Entry("fail because gardenlet version is too high (both version suffixed with '-dev')", "v1.2.3-dev", "v1.2.4-dev", MatchError(ContainSubstring("gardenlet version must not be newer than gardener-apiserver version"))),
+
+			Entry("fail because gardenlet version is too low", "v1.3.3", "v1.0.4", MatchError(ContainSubstring("gardenlet version must not be older than two minor gardener-apiserver versions"))),
+			Entry("fail because gardenlet version is too low (old version suffixed with '-dev')", "v1.3.3-dev", "v1.0.4", MatchError(ContainSubstring("gardenlet version must not be older than two minor gardener-apiserver versions"))),
+			Entry("fail because gardenlet version is too low (new version suffixed with '-dev')", "v1.3.3", "v1.0.4-dev", MatchError(ContainSubstring("gardenlet version must not be older than two minor gardener-apiserver versions"))),
+			Entry("fail because gardenlet version is too low (both version suffixed with '-dev')", "v1.3.3-dev", "v1.0.4-dev", MatchError(ContainSubstring("gardenlet version must not be older than two minor gardener-apiserver versions"))),
+
+			Entry("succeed because gardenlet version is equal to gardener-apiserver version", "v1.2.3", "v1.2.3", Succeed()),
+			Entry("succeed because gardenlet version is equal to gardener-apiserver version (gardener-apiserver version suffixed with '-dev')", "v1.2.3-dev", "v1.2.3", Succeed()),
+			Entry("succeed because gardenlet version is equal to gardener-apiserver version (gardenlet version suffixed with '-dev')", "v1.2.3", "v1.2.3-dev", Succeed()),
+			Entry("succeed because gardenlet version is equal to gardener-apiserver version (both versions suffixed with '-dev')", "v1.2.3-dev", "v1.2.3-dev", Succeed()),
+
+			Entry("succeed because gardenlet patch version is lower than gardener-apiserver version", "v1.2.3", "v1.2.2", Succeed()),
+			Entry("succeed because gardenlet patch version is lower than gardener-apiserver version (gardener-apiserver version suffixed with '-dev')", "v1.2.3-dev", "v1.2.2", Succeed()),
+			Entry("succeed because gardenlet patch version is lower than gardener-apiserver version (gardenlet version suffixed with '-dev')", "v1.2.3", "v1.2.2-dev", Succeed()),
+			Entry("succeed because gardenlet patch version is lower than gardener-apiserver version (both versions suffixed with '-dev')", "v1.2.3-dev", "v1.2.2-dev", Succeed()),
+
+			Entry("succeed because gardenlet minor version is lower (by 1) than gardener-apiserver version", "v1.2.3", "v1.1.3", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 1) than gardener-apiserver version (gardener-apiserver version suffixed with '-dev')", "v1.2.3-dev", "v1.1.3", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 1) than gardener-apiserver version (gardenlet version suffixed with '-dev')", "v1.2.3", "v1.1.3-dev", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 1) than gardener-apiserver version (both versions suffixed with '-dev')", "v1.2.3-dev", "v1.1.3-dev", Succeed()),
+
+			Entry("succeed because gardenlet minor version is lower (by 2) than gardener-apiserver version", "v1.2.3", "v1.0.3", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 2) than gardener-apiserver version (gardener-apiserver version suffixed with '-dev')", "v1.2.3-dev", "v1.0.3", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 2) than gardener-apiserver version (gardenlet version suffixed with '-dev')", "v1.2.3", "v1.0.3-dev", Succeed()),
+			Entry("succeed because gardenlet minor version is lower (by 2) than gardener-apiserver version (both versions suffixed with '-dev')", "v1.2.3-dev", "v1.0.3-dev", Succeed()),
+		)
+	})
+})

--- a/pkg/gardenlet/bootstrappers/verify_version_test.go
+++ b/pkg/gardenlet/bootstrappers/verify_version_test.go
@@ -36,9 +36,10 @@ var _ = Describe("VerifyVersion", func() {
 	})
 
 	Describe("#VerifyGardenerVersion", func() {
-		It("should fail if the gardener-info ConfigMap does not exist", func() {
-			Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(MatchError(ContainSubstring("failed reading ConfigMap gardener")))
-		})
+		// TODO(rfranzke): Enable this test once the `gardener/controlplane` chart is removed.
+		// It("should fail if the gardener-info ConfigMap does not exist", func() {
+		// 	Expect(VerifyGardenerVersion(ctx, log, fakeClient)).To(MatchError(ContainSubstring("failed reading ConfigMap gardener")))
+		// })
 
 		It("should fail if the gardener-apiserver information data cannot be parsed", func() {
 			configMap.Data = map[string]string{"gardenerAPIServer": "CANNOT-PARSE-THIS"}

--- a/pkg/utils/gardener/identity.go
+++ b/pkg/utils/gardener/identity.go
@@ -127,3 +127,11 @@ func MaintainSeedNameLabels(obj client.Object, names ...*string) {
 
 	obj.SetLabels(labels)
 }
+
+// APIServerInfo contains information about the Gardener API server via the gardener-info ConfigMap.
+type APIServerInfo struct {
+	// Version is the version of the Gardener API server.
+	Version string `json:"version" yaml:"version"`
+	// WorkloadIdentityIssuerURL is the URL of the issuer for WorkloadIdentities.
+	WorkloadIdentityIssuerURL string `json:"workloadIdentityIssuerURL" yaml:"workloadIdentityIssuerURL"`
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
When `gardenlet` starts, it now verifies the [version skew](https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#gardenlet) with `gardener-apiserver` by reading the `gardener-info` `ConfigMap` in the `gardener-system-public` namespace. This is helpful in general, but also when it comes to connecting autonomous `Shoot`s to Gardener (here, the `gardenlet` deployment can eventually be influenced by non-Gardener operators, so we must be particularly careful).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
When `gardenlet` starts up, it now checks the version skew with the `gardener-apiserver` (click [here](https://gardener.cloud/docs/gardener/deployment/version_skew_policy/#gardenlet) for the policy document).
```
