### PR TITLE
Drop the deprecated repository `envoyproxy/envoy-distroless` and change it to `envoyproxy/envoy`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -796,8 +796,8 @@ images:
   # API Server SNI, VPN-SeedServer and Kube-ApiServer Proxy
   - name: envoy-proxy
     sourceRepository: github.com/envoyproxy/envoy
-    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy-distroless
-    tag: "v1.35.0"
+    repository: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy
+    tag: "distroless-v1.35.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind task

**What this PR does / why we need it**:
Envoy changed the repository for the distroless image.
According to https://hub.docker.com/r/envoyproxy/envoy the source `envoyproxy/envoy:distroless-<version>`. See also https://github.com/envoyproxy/envoy/issues/40467.
The image-copy job has been changed accordingly (see https://github.com/gardener/ci-infra/pull/4395).

We cannot update to `v1.35.1` in the same step, since there is an issue with the image build (https://github.com/envoyproxy/envoy/issues/40954).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
We now use `envoyproxy/envoy:distroless-v1.35.0` instead of the deprecated repository `envoyproxy/envoy-distroless:v1.35.0`
```
