### PR TITLE
Prevent deploying empty MR and resources when VPA is disabled

### DIFF
--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -91,8 +91,6 @@ type Values struct {
 	ClusterType component.ClusterType
 	// IsGardenCluster specifies if the VPA is being deployed in a cluster registered as a Garden.
 	IsGardenCluster bool
-	// Enabled specifies if VPA is enabled.
-	Enabled bool
 	// SecretNameServerCA is the name of the server CA secret.
 	SecretNameServerCA string
 	// RuntimeKubernetesVersion is the Kubernetes version of the runtime cluster.
@@ -128,15 +126,12 @@ func (v *vpa) Deploy(ctx context.Context) error {
 	}
 	v.serverSecretName = serverSecret.Name
 
-	var allResources component.ResourceConfigs
-	if v.values.Enabled {
-		allResources = component.MergeResourceConfigs(
-			v.admissionControllerResourceConfigs(),
-			v.recommenderResourceConfigs(),
-			v.updaterResourceConfigs(),
-			v.generalResourceConfigs(),
-		)
-	}
+	allResources := component.MergeResourceConfigs(
+		v.admissionControllerResourceConfigs(),
+		v.recommenderResourceConfigs(),
+		v.updaterResourceConfigs(),
+		v.generalResourceConfigs(),
+	)
 
 	var registry *managedresources.Registry
 	if v.values.ClusterType == component.ClusterTypeSeed {

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -194,7 +194,6 @@ var _ = Describe("VPA", func() {
 			vpa = New(c, namespace, sm, Values{
 				ClusterType:              clusterType,
 				IsGardenCluster:          isGardenCluster,
-				Enabled:                  true,
 				SecretNameServerCA:       secretNameCA,
 				RuntimeKubernetesVersion: runtimeKubernetesVersion,
 				AdmissionController:      valuesAdmissionController,
@@ -1801,7 +1800,6 @@ var _ = Describe("VPA", func() {
 
 				vpa = New(c, namespace, sm, Values{
 					ClusterType:              component.ClusterTypeSeed,
-					Enabled:                  true,
 					SecretNameServerCA:       secretNameCA,
 					RuntimeKubernetesVersion: runtimeKubernetesVersion,
 					AdmissionController:      valuesAdmissionController,
@@ -2254,7 +2252,6 @@ var _ = Describe("VPA", func() {
 					It("should successfully deploy with expected vpa-webhook service annotation, label and spec field", func() {
 						vpa = New(c, namespace, sm, Values{
 							ClusterType:              component.ClusterTypeShoot,
-							Enabled:                  true,
 							SecretNameServerCA:       secretNameCA,
 							RuntimeKubernetesVersion: runtimeKubernetesVersion,
 							AdmissionController:      valuesAdmissionController,
@@ -2278,7 +2275,6 @@ var _ = Describe("VPA", func() {
 					It("should successfully deploy with expected vpa-webhook service annotation, label and spec field", func() {
 						vpa = New(c, namespace, sm, Values{
 							ClusterType:              component.ClusterTypeShoot,
-							Enabled:                  true,
 							SecretNameServerCA:       secretNameCA,
 							RuntimeKubernetesVersion: runtimeKubernetesVersion,
 							AdmissionController:      valuesAdmissionController,
@@ -2303,7 +2299,6 @@ var _ = Describe("VPA", func() {
 					It("should successfully deploy with expected vpa-webhook service annotation, label and spec field", func() {
 						vpa = New(c, namespace, sm, Values{
 							ClusterType:              component.ClusterTypeShoot,
-							Enabled:                  true,
 							SecretNameServerCA:       secretNameCA,
 							RuntimeKubernetesVersion: runtimeKubernetesVersion,
 							AdmissionController:      valuesAdmissionController,

--- a/pkg/component/shared/vpa.go
+++ b/pkg/component/shared/vpa.go
@@ -26,7 +26,6 @@ func NewVerticalPodAutoscaler(
 	gardenNamespaceName string,
 	runtimeVersion *semver.Version,
 	secretsManager secretsmanager.Interface,
-	enabled bool,
 	maxAllowed corev1.ResourceList,
 	secretNameServerCA string,
 	priorityClassNameAdmissionController string,
@@ -60,7 +59,6 @@ func NewVerticalPodAutoscaler(
 		vpa.Values{
 			ClusterType:              component.ClusterTypeSeed,
 			IsGardenCluster:          isGardenCluster,
-			Enabled:                  enabled,
 			SecretNameServerCA:       secretNameServerCA,
 			RuntimeKubernetesVersion: runtimeVersion,
 			AdmissionController: vpa.ValuesAdmissionController{

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -752,7 +752,6 @@ func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSe
 		isGardenCluster,
 		featureGates,
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -408,7 +408,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 
 		// When the seed is the garden cluster then the following components are reconciled by the gardener-operator.
 		_ = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes vertical pod autoscaler",
+			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           c.verticalPodAutoscaler.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 			SkipIf:       seedIsGarden,

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -514,7 +514,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes vertical pod autoscaler",
+			Name:         "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:           flow.TaskFn(botanist.DeployVerticalPodAutoscaler).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilGardenerResourceManagerReady),

--- a/pkg/gardenlet/operation/botanist/vpa.go
+++ b/pkg/gardenlet/operation/botanist/vpa.go
@@ -83,7 +83,6 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 		b.SecretsManager,
 		vpa.Values{
 			ClusterType:              component.ClusterTypeShoot,
-			Enabled:                  true,
 			SecretNameServerCA:       v1beta1constants.SecretNameCACluster,
 			RuntimeKubernetesVersion: b.Seed.KubernetesVersion,
 			AdmissionController:      valuesAdmissionController,

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -465,7 +465,6 @@ func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, s
 		true,
 		featureGates,
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -217,7 +217,7 @@ func (r *Reconciler) reconcile(
 			Fn:   c.nginxIngressController.Deploy,
 		})
 		deployVPA = g.Add(flow.Task{
-			Name: "Deploying Kubernetes vertical pod autoscaler",
+			Name: "Reconciling Kubernetes vertical pod autoscaler",
 			Fn:   c.verticalPodAutoscaler.Deploy,
 		})
 		deployEtcdDruid = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Previously, even when disabled, VPA's `Deploy` function would still be called and a check of the `Enabled` field would determine whether its resources should be populated and created. However this would lead to the creation of an empty secret to be referenced in the VPA MR in the case of a disabled seed VPA, as mentioned in #12779.

With an additional check in `newVerticalPodAutoscaler` we can make sure that no VPA MR referencing an empty secret will be created after disabling it. Additionally we can remove the `Enabled` field and the logic surrounding it, since the proper check would be done on a higher level - even before going into the `Deploy` function.

**Which issue(s) this PR fixes**:
Fixes #12779

**Special notes for your reviewer**:
/cc @Kostov6 @plkokanov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The VPA ManagedResource and the Secret it references are now removed when VPA is disabled in the Shoot, Seed or Garden specification. Previously, when VPA was disabled a ManagedResource with an empty Secret would be created. Now, no ManagedResource is created.
```
