### PR TITLE
[GEP-28] Make `SeedConfig` optional in `gardenlet`'s component configuration

### DIFF
--- a/cmd/gardenlet/app/options.go
+++ b/cmd/gardenlet/app/options.go
@@ -74,7 +74,7 @@ func (o *options) Validate() error {
 	// ManagedSeed and Gardenlet resources in the seedmanagement API group. Here, the .metadata.name field is not
 	// required and might indeed be empty, since it will be defaulted to the name of the resource during gardenlet
 	// deployment.
-	if o.config.SeedConfig.Name == "" {
+	if o.config.SeedConfig == nil || o.config.SeedConfig.Name == "" {
 		return fmt.Errorf("seedConfig.metadata.name must be set in the gardenlet configuration")
 	}
 

--- a/cmd/gardenlet/app/options.go
+++ b/cmd/gardenlet/app/options.go
@@ -66,7 +66,7 @@ func (o *options) Complete() error {
 }
 
 func (o *options) Validate() error {
-	if errs := gardenletvalidation.ValidateGardenletConfiguration(o.config, nil, false); len(errs) > 0 {
+	if errs := gardenletvalidation.ValidateGardenletConfiguration(o.config, nil); len(errs) > 0 {
 		return errs.ToAggregate()
 	}
 

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -435,6 +435,9 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
+		if seedTemplate == nil {
+			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("seed template is nil for ManagedSeed %q", managedSeed.Name))
+		}
 
 		if seedTemplate.Spec.Backup != nil &&
 			seedTemplate.Spec.Backup.CredentialsRef.APIVersion == "v1" &&

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1839,7 +1839,7 @@ var _ = Describe("handler", func() {
 									Allowed: false,
 									Result: &metav1.Status{
 										Code:    int32(http.StatusInternalServerError),
-										Message: "no seed config found for managedseed ",
+										Message: `seed template is nil for ManagedSeed ""`,
 									},
 								},
 							}))

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_gardenlet_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Defaults", func() {
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{},
 				}}))
 		})
 

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -113,11 +113,6 @@ func setDefaultsGardenletConfiguration(obj *gardenletconfigv1alpha1.GardenletCon
 
 	// Set resources defaults
 	setDefaultsResources(obj.Resources)
-
-	// Initialize seed config
-	if obj.SeedConfig == nil {
-		obj.SeedConfig = &gardenletconfigv1alpha1.SeedConfig{}
-	}
 }
 
 func setDefaultsResources(obj *gardenletconfigv1alpha1.ResourcesConfiguration) {

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -56,7 +56,6 @@ var _ = Describe("Defaults", func() {
 							gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
 						},
 					},
-					SeedConfig: &gardenletconfigv1alpha1.SeedConfig{},
 				}}))
 			Expect(obj.Spec.Gardenlet.Bootstrap).To(PointTo(Equal(BootstrapToken)))
 			Expect(obj.Spec.Gardenlet.MergeWithParent).To(PointTo(Equal(true)))

--- a/pkg/apis/seedmanagement/v1alpha1/helper/gardenlet.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/gardenlet.go
@@ -17,21 +17,18 @@ import (
 // ExtractSeedTemplateAndGardenletConfig extracts SeedTemplate and GardenletConfig from the given `managedSeed`.
 // An error is returned if either SeedTemplate of GardenletConfig is not specified.
 func ExtractSeedTemplateAndGardenletConfig(name string, config *runtime.RawExtension) (*gardencorev1beta1.SeedTemplate, *gardenletconfigv1alpha1.GardenletConfiguration, error) {
-	var err error
-
 	if config == nil {
 		return nil, nil, fmt.Errorf("no gardenlet config provided in object: %q", name)
 	}
 
 	// Decode gardenlet configuration
-	var gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration
-	gardenletConfig, err = encoding.DecodeGardenletConfiguration(config, false)
+	gardenletConfig, err := encoding.DecodeGardenletConfiguration(config, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not decode gardenlet configuration: %w", err)
 	}
 
 	if gardenletConfig.SeedConfig == nil {
-		return nil, nil, fmt.Errorf("no seed config found for managedseed %s", name)
+		return nil, gardenletConfig, nil
 	}
 
 	return &gardenletConfig.SeedConfig.SeedTemplate, gardenletConfig, nil

--- a/pkg/apis/seedmanagement/v1alpha1/helper/gardenlet_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/helper/gardenlet_test.go
@@ -58,13 +58,13 @@ var _ = Describe("Helper", func() {
 				Expect(err).To(MatchError("could not decode gardenlet configuration: couldn't get version/kind; json parse error: unexpected end of JSON input"))
 			})
 
-			It("should return an error because seedTemplate is not specified", func() {
+			It("should not return an error because seedTemplate is not specified", func() {
 				managedSeed.Spec.Gardenlet.Config = runtime.RawExtension{Raw: encode(config)}
 
 				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)
 				Expect(seedTemplate).To(BeNil())
-				Expect(gardenletConfig).To(BeNil())
-				Expect(err).To(HaveOccurred())
+				Expect(gardenletConfig).To(Equal(config))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return the template from `.spec.gardenlet.seedConfig.seedTemplate", func() {
@@ -79,11 +79,16 @@ var _ = Describe("Helper", func() {
 		})
 
 		Context("w/o gardenlet config", func() {
-			It("should return an error if seed template cannot be determined", func() {
+			It("should not return an error if seed template cannot be determined", func() {
 				seedTemplate, gardenletConfig, err := ExtractSeedTemplateAndGardenletConfig(managedSeed.Name, &managedSeed.Spec.Gardenlet.Config)
 				Expect(seedTemplate).To(BeNil())
-				Expect(gardenletConfig).To(BeNil())
-				Expect(err).To(HaveOccurred())
+				Expect(gardenletConfig).To(Equal(&gardenletconfigv1alpha1.GardenletConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
+						Kind:       "GardenletConfiguration",
+					},
+				}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/apis/seedmanagement/validation/gardenlet.go
+++ b/pkg/apis/seedmanagement/validation/gardenlet.go
@@ -50,7 +50,7 @@ func ValidateGardenletSpec(spec *seedmanagement.GardenletSpec, fldPath *field.Pa
 	allErrs = append(allErrs, validation.ValidateOCIRepository(&spec.Deployment.Helm.OCIRepository, fldPath.Child("deployment", "helm", "ociRepository"))...)
 
 	if spec.Config != nil {
-		allErrs = append(allErrs, validateGardenletConfig(spec.Config, seedmanagement.BootstrapToken, false, fldPath.Child("config"), false)...)
+		allErrs = append(allErrs, validateGardenletConfig(spec.Config, seedmanagement.BootstrapToken, false, fldPath.Child("config"))...)
 	}
 
 	return allErrs

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -93,7 +93,7 @@ func ValidateManagedSeedSpec(spec *seedmanagement.ManagedSeedSpec, fldPath *fiel
 		allErrs = append(allErrs, validateShoot(spec.Shoot, fldPath.Child("shoot"), inTemplate)...)
 	}
 
-	allErrs = append(allErrs, validateGardenlet(&spec.Gardenlet, fldPath.Child("gardenlet"), inTemplate)...)
+	allErrs = append(allErrs, validateGardenlet(&spec.Gardenlet, fldPath.Child("gardenlet"))...)
 
 	return allErrs
 }
@@ -131,7 +131,7 @@ func validateShoot(shoot *seedmanagement.Shoot, fldPath *field.Path, inTemplate 
 	return allErrs
 }
 
-func validateGardenlet(gardenlet *seedmanagement.GardenletConfig, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func validateGardenlet(gardenlet *seedmanagement.GardenletConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if gardenlet.Deployment != nil {
@@ -139,7 +139,7 @@ func validateGardenlet(gardenlet *seedmanagement.GardenletConfig, fldPath *field
 	}
 
 	if gardenlet.Config != nil {
-		allErrs = append(allErrs, validateGardenletConfig(gardenlet.Config, ptr.Deref(gardenlet.Bootstrap, seedmanagement.BootstrapNone), ptr.Deref(gardenlet.MergeWithParent, false), fldPath.Child("config"), inTemplate)...)
+		allErrs = append(allErrs, validateGardenletConfig(gardenlet.Config, ptr.Deref(gardenlet.Bootstrap, seedmanagement.BootstrapNone), ptr.Deref(gardenlet.MergeWithParent, false), fldPath.Child("config"))...)
 	}
 
 	if gardenlet.Bootstrap != nil {
@@ -152,7 +152,7 @@ func validateGardenlet(gardenlet *seedmanagement.GardenletConfig, fldPath *field
 	return allErrs
 }
 
-func validateGardenletConfig(config runtime.Object, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func validateGardenletConfig(config runtime.Object, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	gardenletConfig, ok := config.(*gardenletconfigv1alpha1.GardenletConfiguration)
@@ -162,7 +162,7 @@ func validateGardenletConfig(config runtime.Object, bootstrap seedmanagement.Boo
 	}
 
 	// Validate gardenlet config
-	allErrs = append(allErrs, validateGardenletConfiguration(gardenletConfig, bootstrap, mergeWithParent, fldPath, inTemplate)...)
+	allErrs = append(allErrs, validateGardenletConfiguration(gardenletConfig, bootstrap, mergeWithParent, fldPath)...)
 
 	return allErrs
 }
@@ -251,7 +251,7 @@ func validateImage(image *seedmanagement.Image, fldPath *field.Path) field.Error
 	return allErrs
 }
 
-func validateGardenletConfiguration(gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func validateGardenletConfiguration(gardenletConfig *gardenletconfigv1alpha1.GardenletConfiguration, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure name is not specified since it will be set by the controller
@@ -260,7 +260,7 @@ func validateGardenletConfiguration(gardenletConfig *gardenletconfigv1alpha1.Gar
 	}
 
 	// Validate gardenlet config
-	allErrs = append(allErrs, gardenletvalidation.ValidateGardenletConfiguration(gardenletConfig, fldPath, inTemplate)...)
+	allErrs = append(allErrs, gardenletvalidation.ValidateGardenletConfiguration(gardenletConfig, fldPath)...)
 
 	if gardenletConfig.GardenClientConnection != nil {
 		allErrs = append(allErrs, validateGardenClientConnection(gardenletConfig.GardenClientConnection, bootstrap, mergeWithParent, fldPath.Child("gardenClientConnection"))...)

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ValidateGardenletConfiguration validates a GardenletConfiguration object.
-func ValidateGardenletConfiguration(cfg *gardenletconfigv1alpha1.GardenletConfiguration, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func ValidateGardenletConfiguration(cfg *gardenletconfigv1alpha1.GardenletConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if cfg.GardenClientConnection != nil {

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
@@ -75,19 +75,14 @@ func ValidateGardenletConfiguration(cfg *gardenletconfigv1alpha1.GardenletConfig
 		}
 	}
 
-	seedConfigPath := fldPath.Child("seedConfig")
-	if !inTemplate && cfg.SeedConfig == nil {
-		allErrs = append(allErrs, field.Invalid(seedConfigPath, cfg, "seed config must be set"))
-	}
-
 	if cfg.SeedConfig != nil {
 		seedTemplate, err := gardencorehelper.ConvertSeedTemplate(&cfg.SeedConfig.SeedTemplate)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(seedConfigPath, seedTemplate, fmt.Sprintf("could not convert gardenlet config: %v", err)))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), seedTemplate, fmt.Sprintf("could not convert gardenlet config: %v", err)))
 			return allErrs
 		}
 
-		allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplate(seedTemplate, seedConfigPath)...)
+		allErrs = append(allErrs, gardencorevalidation.ValidateSeedTemplate(seedTemplate, fldPath.Child("seedConfig"))...)
 	}
 
 	resourcesPath := fldPath.Child("resources")

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
@@ -110,7 +110,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 	Describe("#ValidateGardenletConfiguration", func() {
 		It("should allow valid configurations", func() {
-			errorList := ValidateGardenletConfiguration(cfg, nil, false)
+			errorList := ValidateGardenletConfiguration(cfg, nil)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -127,13 +127,13 @@ var _ = Describe("GardenletConfiguration", func() {
 
 			commonTests := func() {
 				It("should allow default client connection configuration", func() {
-					Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+					Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 				})
 
 				It("should return errors because some values are invalid", func() {
 					clientConnection.Burst = -1
 
-					Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+					Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeInvalid),
 							"Field": Equal(fldPath.Child("burst").String()),
@@ -152,7 +152,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 				Context("kubeconfig validity", func() {
 					It("should allow when config is not set", func() {
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 					})
 
 					It("should allow valid configurations", func() {
@@ -164,7 +164,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 					})
 
 					It("should forbid validity less than 10m", func() {
@@ -174,7 +174,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("gardenClientConnection.kubeconfigValidity.validity"),
 							"Detail": ContainSubstring("must be at least 10m"),
@@ -188,7 +188,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("gardenClientConnection.kubeconfigValidity.autoRotationJitterPercentageMin"),
 							"Detail": ContainSubstring("must be at least 1"),
@@ -202,7 +202,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("gardenClientConnection.kubeconfigValidity.autoRotationJitterPercentageMax"),
 							"Detail": ContainSubstring("must be at most 100"),
@@ -217,7 +217,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("gardenClientConnection.kubeconfigValidity.autoRotationJitterPercentageMin"),
 							"Detail": ContainSubstring("minimum percentage must be less than maximum percentage"),
@@ -232,7 +232,7 @@ var _ = Describe("GardenletConfiguration", func() {
 							},
 						}
 
-						Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("gardenClientConnection.kubeconfigValidity.autoRotationJitterPercentageMin"),
 							"Detail": ContainSubstring("minimum percentage must be less than maximum percentage"),
@@ -268,23 +268,23 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should allow not enabling leader election", func() {
 				cfg.LeaderElection.LeaderElect = nil
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should allow disabling leader election", func() {
 				cfg.LeaderElection.LeaderElect = ptr.To(false)
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should allow default leader election configuration with required fields", func() {
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should reject leader election config with missing required fields", func() {
 				cfg.LeaderElection.ResourceNamespace = ""
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("leaderElection.resourceNamespace"),
@@ -302,7 +302,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.Controllers.Shoot.SyncPeriod = &metav1.Duration{Duration: -1}
 				cfg.Controllers.Shoot.RetryDuration = &metav1.Duration{Duration: -1}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -327,7 +327,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid too low values for the DNS TTL", func() {
 				cfg.Controllers.Shoot.DNSEntryTTLSeconds = ptr.To(int64(-1))
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -338,7 +338,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid too high values for the DNS TTL", func() {
 				cfg.Controllers.Shoot.DNSEntryTTLSeconds = ptr.To[int64](601)
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -357,7 +357,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.Controllers.ShootCare.ManagedResourceProgressingThreshold = &metav1.Duration{Duration: -1}
 				cfg.Controllers.ShootCare.ConditionThresholds = []gardenletconfigv1alpha1.ConditionThreshold{{Duration: metav1.Duration{Duration: -1}}}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -393,7 +393,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.Controllers.ManagedSeed.WaitSyncPeriod = &metav1.Duration{Duration: -1}
 				cfg.Controllers.ManagedSeed.SyncJitterPeriod = &metav1.Duration{Duration: -1}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -420,7 +420,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid specifying purposes when not specifying hours", func() {
 				cfg.Controllers.BackupEntry.DeletionGracePeriodHours = nil
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeForbidden),
 						"Field": Equal("controllers.backupEntry.deletionGracePeriodShootPurposes"),
@@ -437,13 +437,13 @@ var _ = Describe("GardenletConfiguration", func() {
 					gardencorev1beta1.ShootPurposeProduction,
 				}
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should forbid invalid purposes", func() {
 				cfg.Controllers.BackupEntry.DeletionGracePeriodShootPurposes = []gardencorev1beta1.ShootPurpose{"does-not-exist"}
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotSupported),
 						"Field": Equal("controllers.backupEntry.deletionGracePeriodShootPurposes[0]"),
@@ -457,7 +457,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				invalidConcurrentSyncs := -1
 				cfg.Controllers.Bastion.ConcurrentSyncs = &invalidConcurrentSyncs
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -476,7 +476,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should return errors because concurrent syncs are < 0", func() {
 				cfg.Controllers.NetworkPolicy.ConcurrentSyncs = ptr.To(-1)
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("controllers.networkPolicy.concurrentSyncs"),
@@ -490,7 +490,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					metav1.LabelSelector{MatchLabels: map[string]string{"foo": "no/slash/allowed"}},
 				)
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("controllers.networkPolicy.additionalNamespaceSelectors[1].matchLabels"),
@@ -502,7 +502,7 @@ var _ = Describe("GardenletConfiguration", func() {
 		Context("seed config", func() {
 			It("should not require a seedConfig", func() {
 				cfg.SeedConfig = nil
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 		})
 
@@ -510,7 +510,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid invalid fields in seed template", func() {
 				cfg.SeedConfig.Spec.Networks.Nodes = ptr.To("")
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -532,7 +532,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					},
 				}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -547,7 +547,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					},
 				}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -564,14 +564,14 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should pass as sni config contains a valid external service ip", func() {
 				cfg.SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should forbid as sni config contains an empty external service ip", func() {
 				cfg.SNI.Ingress.ServiceExternalIP = ptr.To("")
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("sni.ingress.serviceExternalIP"),
@@ -581,7 +581,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid as sni config contains an invalid external service ip", func() {
 				cfg.SNI.Ingress.ServiceExternalIP = ptr.To("a.b.c.d")
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("sni.ingress.serviceExternalIP"),
@@ -603,14 +603,14 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should pass valid exposureClassHandler", func() {
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should fail as exposureClassHandler name is no DNS1123 label with zero length", func() {
 				cfg.ExposureClassHandlers[0].Name = ""
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -621,7 +621,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should fail as exposureClassHandler name is no DNS1123 label", func() {
 				cfg.ExposureClassHandlers[0].Name = "TE:ST"
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -633,7 +633,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				It("should allow to use an external service ip as loadbalancer ip is valid", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil, false)
+					errorList := ValidateGardenletConfiguration(cfg, nil)
 
 					Expect(errorList).To(BeEmpty())
 				})
@@ -641,7 +641,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				It("should allow to use an external service ip", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil, false)
+					errorList := ValidateGardenletConfiguration(cfg, nil)
 
 					Expect(errorList).To(BeEmpty())
 				})
@@ -649,7 +649,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				It("should forbid to use an empty external service ip", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil, false)
+					errorList := ValidateGardenletConfiguration(cfg, nil)
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("exposureClassHandlers[0].sni.ingress.serviceExternalIP"),
@@ -659,7 +659,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				It("should forbid to use an invalid external service ip", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("a.b.c.d")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil, false)
+					errorList := ValidateGardenletConfiguration(cfg, nil)
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("exposureClassHandlers[0].sni.ingress.serviceExternalIP"),
@@ -672,7 +672,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should pass with unset toleration options", func() {
 				cfg.NodeToleration = nil
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should pass with unset toleration seconds", func() {
@@ -681,7 +681,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					DefaultUnreachableTolerationSeconds: nil,
 				}
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should pass with valid toleration options", func() {
@@ -690,7 +690,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					DefaultUnreachableTolerationSeconds: ptr.To[int64](120),
 				}
 
-				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should fail with invalid toleration options", func() {
@@ -699,7 +699,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					DefaultUnreachableTolerationSeconds: ptr.To(int64(-2)),
 				}
 
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
@@ -500,15 +500,9 @@ var _ = Describe("GardenletConfiguration", func() {
 		})
 
 		Context("seed config", func() {
-			It("should require a seedConfig", func() {
+			It("should not require a seedConfig", func() {
 				cfg.SeedConfig = nil
-
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("seedConfig"),
-				}))))
+				Expect(ValidateGardenletConfiguration(cfg, nil, false)).To(BeEmpty())
 			})
 		})
 

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -105,6 +105,9 @@ func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) ga
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract seed template and gardenlet config: %w", err)
 			}
+			if seedTemplate == nil {
+				return nil, fmt.Errorf("seed template is unset in gardenlet config")
+			}
 
 			if seedTemplate.Spec.Backup == nil {
 				return nil, nil

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -162,6 +162,9 @@ func (v *ManagedSeed) validateUpdate(ctx context.Context, a admission.Attributes
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("cannot extract the seed template: %w", err))
 	}
+	if seedTemplate == nil {
+		return apierrors.NewInternalError(fmt.Errorf("seed template is unset in gardenlet config"))
+	}
 
 	allErrs = append(allErrs, v.validateZoneRemovalFromShoot(field.NewPath("spec", "providers", "workers"), oldShoot, shoot, seedTemplate)...)
 

--- a/plugin/pkg/shoot/managedseed/admission_test.go
+++ b/plugin/pkg/shoot/managedseed/admission_test.go
@@ -205,7 +205,7 @@ var _ = Describe("ManagedSeed", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeInternalServerError())
-				Expect(err).To(MatchError(ContainSubstring("cannot extract the seed template")))
+				Expect(err).To(MatchError(ContainSubstring("seed template is unset in gardenlet config")))
 			})
 
 			It("should forbid Shoot update when zones have changed but still configured in ManagedSeed", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
The `SeedConfig` field is now optional in `gardenlet`'s component configuration. This is a preparation for deploying a `gardenlet` into autonomous shoot clusters (here, we don't have any `Seed` specification whatsoever, hence, no such configuration is needed).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
