### PR TITLE
provider-local: move shoot node CIDR into kind pod CIDR

### DIFF
--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -20,6 +20,7 @@ spec:
       nodes:
       - 172.18.0.0/16
       pods:
+      # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
       - 10.1.0.0/16
       services:
       - 10.2.0.0/16

--- a/dev-setup/garden/components/ipv6/kustomization.yaml
+++ b/dev-setup/garden/components/ipv6/kustomization.yaml
@@ -11,6 +11,7 @@ patches:
       - op: replace
         path: /spec/runtimeCluster/networking/pods
         value:
+        # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
         - fd00:10:1::/56
       - op: replace
         path: /spec/runtimeCluster/networking/services

--- a/dev-setup/gardenadm/machines/ippool.yaml
+++ b/dev-setup/gardenadm/machines/ippool.yaml
@@ -1,0 +1,13 @@
+apiVersion: crd.projectcalico.org/v1
+kind: IPPool
+metadata:
+  name: gardenadm-high-touch
+spec:
+  cidr: 10.0.0.0/16
+  ipipMode: Always
+  natOutgoing: true
+  # Without this, calico defaults nodeSelector to "all()" and can randomly pick this pool for
+  # IPAM for pods even if the pod does not explicitly request an IP from this pool via the
+  # cni.projectcalico.org/IPv{4,6}Pools annotation.
+  # See https://github.com/projectcalico/calico/issues/7299#issuecomment-1446834103
+  nodeSelector: "!all()"

--- a/dev-setup/gardenadm/machines/kustomization.yaml
+++ b/dev-setup/gardenadm/machines/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - namespace.yaml
 - service.yaml
 - machine.yaml
+- ippool.yaml

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: machine
+      annotations:
+        cni.projectcalico.org/ipv4pools: '["gardenadm-high-touch"]'
     spec:
       containers:
       - name: node

--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -43,4 +43,5 @@ spec:
     type: calico
     pods: 10.3.0.0/16
     services: 10.4.0.0/16
-    nodes: 10.1.0.0/16 # pod network range of the kind cluster
+    # Must be within 10.0.0.0/16 (subnet of kind pod CIDR 10.0.0.0/15, but disjoint with seed pod CIDR 10.1.0.0/16).
+    nodes: 10.0.0.0/16

--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -66,7 +66,7 @@ spec:
             kind: nginx
         networks:
           nodes: 172.18.0.0/16
-          # Those CIDRs must match those specified in the kind Cluster configuration.
+          # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
           pods: 10.1.0.0/16
           services: 10.2.0.0/16
           shootDefaults:

--- a/dev-setup/gardenlet/components/ipv6/kustomization.yaml
+++ b/dev-setup/gardenlet/components/ipv6/kustomization.yaml
@@ -17,6 +17,7 @@ patches:
         value: fd00:10::/64
       - op: replace
         path: /spec/config/seedConfig/spec/networks/pods
+        # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
         value: fd00:10:1::/56
       - op: replace
         path: /spec/config/seedConfig/spec/networks/services

--- a/example/gardener-local/calico/dual/kustomization.yaml
+++ b/example/gardener-local/calico/dual/kustomization.yaml
@@ -17,3 +17,4 @@ configMapGenerator:
 patches:
 - path: patch-calico-node-daemonset.yaml
 - path: ../ipv4/patch-calico-default-ippool.yaml
+- path: ../ipv6/patch-calico-default-ippool.yaml

--- a/example/gardener-local/calico/dual/kustomization.yaml
+++ b/example/gardener-local/calico/dual/kustomization.yaml
@@ -14,5 +14,6 @@ configMapGenerator:
   files:
   - cni_network_config=cni_network_config.json
 
-patchesStrategicMerge:
-- patch-calico-node-daemonset.yaml
+patches:
+- path: patch-calico-node-daemonset.yaml
+- path: ../ipv4/patch-calico-default-ippool.yaml

--- a/example/gardener-local/calico/ipv4/kustomization.yaml
+++ b/example/gardener-local/calico/ipv4/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 resources:
 - ../base
+
+patches:
+- path: patch-calico-default-ippool.yaml

--- a/example/gardener-local/calico/ipv4/patch-calico-default-ippool.yaml
+++ b/example/gardener-local/calico/ipv4/patch-calico-default-ippool.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: calico-node
+        env:
+        # NB: this is not the full kind pod network (10.0.0.0/15).
+        # This /16 subnet is used for automatic pod IP assignment (calico default IPPool), as the seed/runtime pod CIDR.
+        # This allows us to create dedicated IPPools for shoot machine pods, that are also subnets of the kind pod
+        # network but don't overlap with the seed pod CIDR.
+        # If we used another IPPool CIDR that is outside the kind pod network for shoot machine pods, then routing of
+        # traffic from machine pods would not work correctly in all cases. E.g., kube-proxy would treat such traffic as
+        # external and SNAT it, even though actually originates from inside the cluster. In combination with calico's
+        # IPIP tunneling, this can break NetworkPolicies for cross-node traffic, because traffic doesn't appear to come
+        # from the machine pod IPs anymore.
+        - name: CALICO_IPV4POOL_CIDR
+          value: "10.1.0.0/16"

--- a/example/gardener-local/calico/ipv6/kustomization.yaml
+++ b/example/gardener-local/calico/ipv6/kustomization.yaml
@@ -16,3 +16,4 @@ configMapGenerator:
 
 patches:
 - path: patch-calico-node-daemonset.yaml
+- path: patch-calico-default-ippool.yaml

--- a/example/gardener-local/calico/ipv6/patch-calico-default-ippool.yaml
+++ b/example/gardener-local/calico/ipv6/patch-calico-default-ippool.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: calico-node
+        env:
+        # NB: this is not the full kind pod network (fd00:10:1::/48).
+        # This /56 subnet is used for automatic pod IP assignment (calico default IPPool), as the seed/runtime pod CIDR.
+        # Also see the comment for CALICO_IPV4POOL_CIDR in ../ipv4/patch-calico-default-ippool.yaml.
+        - name: CALICO_IPV6POOL_CIDR
+          value: "fd00:10:1::/56"

--- a/example/gardener-local/gardenlet/values-dual.yaml
+++ b/example/gardener-local/gardenlet/values-dual.yaml
@@ -6,7 +6,7 @@ config:
         - IPv6
         - IPv4
         nodes: fd00:10::/64
-        # Those CIDRs must match those specified in the kind Cluster configuration.
+        # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
         pods: fd00:10:1::/56
         services: fd00:10:2::/112
         shootDefaults:
@@ -15,4 +15,3 @@ config:
           - IPv4
           pods: fd00:10:3::/56
           services: fd00:10:4::/112
-

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -94,7 +94,7 @@ config:
           kind: nginx
       networks:
         nodes: 172.18.0.0/16
-        # Those CIDRs must match those specified in the kind Cluster configuration.
+        # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
         pods: 10.1.0.0/16
         services: 10.2.0.0/16
         shootDefaults:

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -11,5 +11,5 @@ gardener:
 
 networking:
   ipFamily: dual
-  podSubnet: "fd00:10:1::/56,10.0.0.0/15"
+  podSubnet: "fd00:10:1::/48,10.0.0.0/15"
   serviceSubnet: "fd00:10:2::/112,10.2.0.0/16"

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -11,5 +11,5 @@ gardener:
 
 networking:
   ipFamily: dual
-  podSubnet: "fd00:10:1::/56,10.1.0.0/16"
+  podSubnet: "fd00:10:1::/56,10.0.0.0/15"
   serviceSubnet: "fd00:10:2::/112,10.2.0.0/16"

--- a/example/gardener-local/kind/cluster/values-ipv6.yaml
+++ b/example/gardener-local/kind/cluster/values-ipv6.yaml
@@ -12,5 +12,5 @@ gardener:
 
 networking:
   ipFamily: ipv6
-  podSubnet: "fd00:10:1::/56"
+  podSubnet: "fd00:10:1::/48"
   serviceSubnet: "fd00:10:2::/112"

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -31,7 +31,7 @@ registry:
 
 networking:
   ipFamily: ipv4
-  podSubnet: 10.1.0.0/16
+  podSubnet: 10.0.0.0/15
   serviceSubnet: 10.2.0.0/16
 
 #workers:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -47,6 +47,7 @@ spec:
       nodes:
       - 172.18.0.0/16
       pods:
+      # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
       - 10.1.0.0/16
       services:
       - 10.2.0.0/16

--- a/example/provider-local/managedseeds/shoot-managedseed.yaml
+++ b/example/provider-local/managedseeds/shoot-managedseed.yaml
@@ -12,7 +12,8 @@ spec:
   region: local
   networking:
     type: calico
-    nodes: 10.10.0.0/16
+    # Must be within 10.0.0.0/16 (subnet of kind pod CIDR 10.0.0.0/15, but disjoint with seed pod CIDR 10.1.0.0/16).
+    nodes: 10.0.0.0/16
   provider:
     type: local
     workers:

--- a/example/provider-local/seed-kind/local-dual/patch-seed.yaml
+++ b/example/provider-local/seed-kind/local-dual/patch-seed.yaml
@@ -5,6 +5,7 @@
       - IPv6
       - IPv4
     nodes: fd00:10::/64
+    # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
     pods: fd00:10:1::/56
     services: fd00:10:2::/112
     shootDefaults:

--- a/example/provider-local/seed-kind/local-ipv6/patch-seed.yaml
+++ b/example/provider-local/seed-kind/local-ipv6/patch-seed.yaml
@@ -4,6 +4,7 @@
     ipFamilies:
       - IPv6
     nodes: fd00:10::/64
+    # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
     pods: fd00:10:1::/56
     services: fd00:10:2::/112
     shootDefaults:

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -14,7 +14,8 @@ spec:
     type: calico
     ipFamilies:
     - IPv6
-    nodes: fd00:10:a::/64
+    # Must be within fd00:10:1:100::/56 (subnet of kind pod CIDR fd00:10:1::/48, but disjoint with seed pod CIDR fd00:10:1::/56).
+    nodes: fd00:10:1:100::/56
     providerConfig:
       ipv6:
         sourceNATEnabled: true

--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -13,7 +13,8 @@ spec:
   region: local
   networking:
     type: calico
-    nodes: 10.10.0.0/16
+    # Must be within 10.0.0.0/16 (subnet of kind pod CIDR 10.0.0.0/15, but disjoint with seed pod CIDR 10.1.0.0/16).
+    nodes: 10.0.0.0/16
   provider:
     type: local
     workers:

--- a/pkg/provider-local/admission/validator/shoot.go
+++ b/pkg/provider-local/admission/validator/shoot.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+)
+
+// We require that local shoots specify a nodes CIDR within the following ranges. This ensures that:
+//   - the nodes CIDR is a subnet of the kind pod network (cluster CIDR) so that machine pods get IPs from the pod
+//     network and are treated as internal traffic by kube-proxy
+//   - the nodes CIDR is disjoint with the seed/runtime pod CIDR (calico default IPPool)
+var (
+	shootAllowedNodesCIDRIPv4 = netip.MustParsePrefix("10.0.0.0/16")
+	// Technically, there are other CIDRs that are subnets of the kind pod network (fd00:10:1::/48) that don't overlap
+	// with the seed pod CIDR (fd00:10:1::/56), but we restrict the allowed CIDRs to a single /56 prefix for simplicity.
+	shootAllowedNodesCIDRIPv6 = netip.MustParsePrefix("fd00:10:1:100::/56")
+)
+
+type shootValidator struct{}
+
+// NewShootValidator returns a new instance of a Shoot validator.
+func NewShootValidator() extensionswebhook.Validator {
+	return &shootValidator{}
+}
+
+// Validate validates the given Shoot object.
+func (s *shootValidator) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	newShoot, ok := newObj.(*core.Shoot)
+	if !ok {
+		return fmt.Errorf("expected Shoot, but got %T", newObj)
+	}
+	var oldShoot *core.Shoot
+	if oldObj != nil {
+		oldShoot, ok = oldObj.(*core.Shoot)
+		if !ok {
+			return fmt.Errorf("expected Shoot, but got %T", oldObj)
+		}
+	}
+
+	if newShoot.DeletionTimestamp != nil {
+		return nil
+	}
+
+	allErrs := field.ErrorList{}
+	if !helper.IsWorkerless(newShoot) {
+		allErrs = append(allErrs, s.ValidateShootNodesCIDR(newShoot, oldShoot)...)
+	}
+
+	return allErrs.ToAggregate()
+}
+
+func (s *shootValidator) ValidateShootNodesCIDR(newShoot, oldShoot *core.Shoot) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// only validate shoot nodes CIDR on creation or if it is changed
+	if oldShoot != nil && apiequality.Semantic.DeepEqual(oldShoot.Spec.Networking.Nodes, newShoot.Spec.Networking.Nodes) {
+		return allErrs
+	}
+
+	nodesPath := field.NewPath("spec.networking.nodes")
+	if newShoot.Spec.Networking.Nodes == nil {
+		allErrs = append(allErrs, field.Required(nodesPath, "nodes CIDR must not be empty"))
+		return allErrs
+	}
+
+	cidr, err := netip.ParsePrefix(*newShoot.Spec.Networking.Nodes)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(nodesPath, *newShoot.Spec.Networking.Nodes, "nodes CIDR must be a valid CIDR"))
+		return allErrs
+	}
+
+	if cidr.Addr().Is4() {
+		if !shootAllowedNodesCIDRIPv4.Contains(cidr.Addr()) {
+			allErrs = append(allErrs, field.Invalid(nodesPath, *newShoot.Spec.Networking.Nodes, fmt.Sprintf("nodes CIDR must be a subnet of %s", shootAllowedNodesCIDRIPv4.String())))
+		}
+	} else {
+		if !shootAllowedNodesCIDRIPv6.Contains(cidr.Addr()) {
+			allErrs = append(allErrs, field.Invalid(nodesPath, *newShoot.Spec.Networking.Nodes, fmt.Sprintf("nodes CIDR must be a subnet of %s", shootAllowedNodesCIDRIPv6.String())))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/provider-local/admission/validator/shoot_test.go
+++ b/pkg/provider-local/admission/validator/shoot_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/provider-local/admission/validator"
+)
+
+var _ = Describe("Shoot Validator", func() {
+	var (
+		ctx = context.Background()
+
+		shootValidator extensionswebhook.Validator
+		shoot          *core.Shoot
+	)
+
+	BeforeEach(func() {
+		shootValidator = validator.NewShootValidator()
+		shoot = &core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot-1",
+				Namespace: "garden-dev",
+			},
+			Spec: core.ShootSpec{
+				Networking: &core.Networking{},
+				Provider: core.Provider{
+					Workers: []core.Worker{{Name: "worker-1"}},
+				},
+			},
+		}
+	})
+
+	Describe("#Validate", func() {
+		It("should succeed for valid IPv4 nodes CIDR", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("10.0.0.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+
+		It("should fail for invalid IPv4 nodes CIDR", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("192.168.0.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of 10.0.0.0/16")))
+		})
+
+		It("should succeed for valid IPv6 nodes CIDR", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("fd00:10:1:100::/64")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+
+		It("should fail for invalid IPv6 nodes CIDR", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("fd00:20:1:100::/64")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of fd00:10:1:100::/56")))
+		})
+
+		It("should fail for empty nodes CIDR", func() {
+			shoot.Spec.Networking.Nodes = nil
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must not be empty")))
+		})
+
+		It("should fail for invalid CIDR format", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("not-a-cidr")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a valid CIDR")))
+		})
+
+		It("should succeed if nodes CIDR is added on update", func() {
+			oldShoot := shoot.DeepCopy()
+			shoot.Spec.Networking.Nodes = ptr.To("10.0.0.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(Succeed())
+		})
+
+		It("should fail if invalid nodes CIDR is added on update", func() {
+			oldShoot := shoot.DeepCopy()
+			shoot.Spec.Networking.Nodes = ptr.To("192.168.0.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of 10.0.0.0/16")))
+		})
+
+		It("should succeed if nodes CIDR is unchanged on update", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("192.168.0.0/24")
+			oldShoot := shoot.DeepCopy()
+			Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(Succeed())
+		})
+
+		It("should succeed if nodes CIDR is changed to valid value on update", func() {
+			oldShoot := shoot.DeepCopy()
+			oldShoot.Spec.Networking.Nodes = ptr.To("10.0.0.0/24")
+			shoot.Spec.Networking.Nodes = ptr.To("10.0.1.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(Succeed())
+		})
+
+		It("should fail if nodes CIDR is changed to invalid value on update", func() {
+			oldShoot := shoot.DeepCopy()
+			oldShoot.Spec.Networking.Nodes = ptr.To("10.0.0.0/24")
+			shoot.Spec.Networking.Nodes = ptr.To("192.168.0.0/24")
+			Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of 10.0.0.0/16")))
+		})
+
+		It("should succeed if Shoot is in deletion phase", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("192.168.0.0/24")
+			shoot.DeletionTimestamp = ptr.To(metav1.Now())
+			Expect(shootValidator.Validate(ctx, shoot, shoot.DeepCopy())).To(Succeed())
+		})
+
+		It("should accept empty nodes CIDR for workerless shoot", func() {
+			shoot.Spec.Provider.Workers = nil
+			shoot.Spec.Networking.Nodes = nil
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+		})
+	})
+})

--- a/pkg/provider-local/admission/validator/shoot_test.go
+++ b/pkg/provider-local/admission/validator/shoot_test.go
@@ -52,6 +52,11 @@ var _ = Describe("Shoot Validator", func() {
 			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of 10.0.0.0/16")))
 		})
 
+		It("should fail for invalid IPv4 nodes CIDR with shorter prefix", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("10.0.0.0/15")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of 10.0.0.0/16")))
+		})
+
 		It("should succeed for valid IPv6 nodes CIDR", func() {
 			shoot.Spec.Networking.Nodes = ptr.To("fd00:10:1:100::/64")
 			Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
@@ -59,6 +64,11 @@ var _ = Describe("Shoot Validator", func() {
 
 		It("should fail for invalid IPv6 nodes CIDR", func() {
 			shoot.Spec.Networking.Nodes = ptr.To("fd00:20:1:100::/64")
+			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of fd00:10:1:100::/56")))
+		})
+
+		It("should fail for invalid IPv6 nodes CIDR with shorter prefix", func() {
+			shoot.Spec.Networking.Nodes = ptr.To("fd00:10:1::/48")
 			Expect(shootValidator.Validate(ctx, shoot, nil)).To(MatchError(ContainSubstring("nodes CIDR must be a subnet of fd00:10:1:100::/56")))
 		})
 

--- a/pkg/provider-local/admission/validator/webhook.go
+++ b/pkg/provider-local/admission/validator/webhook.go
@@ -35,6 +35,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
+			NewShootValidator():                     {{Obj: &core.Shoot{}}},
 			NewWorkloadIdentityValidator():          {{Obj: &securityv1alpha1.WorkloadIdentity{}}},
 		},
 		Target: extensionswebhook.TargetSeed,

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -67,8 +67,9 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 		RegistryBurst:       ptr.To[int32](20),
 	}
 	shoot.Spec.Networking = &gardencorev1beta1.Networking{
-		Type:  ptr.To("calico"),
-		Nodes: ptr.To("10.10.0.0/16"),
+		Type: ptr.To("calico"),
+		// Must be within 10.0.0.0/16 (subnet of kind pod CIDR 10.0.0.0/15, but disjoint with seed pod CIDR 10.1.0.0/16).
+		Nodes: ptr.To("10.0.0.0/16"),
 	}
 	shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, DefaultWorker("local", nil))
 	shoot.Spec.Extensions = append(shoot.Spec.Extensions, gardencorev1beta1.Extension{Type: "local-ext-shoot-after-worker"})

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -76,7 +76,8 @@ func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 
 	if os.Getenv("IPFAMILY") == "ipv6" {
 		shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
-		shoot.Spec.Networking.Nodes = ptr.To("fd00:10:a::/64")
+		// Must be within fd00:10:1:100::/56 (subnet of kind pod CIDR fd00:10:1::/48, but disjoint with seed pod CIDR fd00:10:1::/56).
+		shoot.Spec.Networking.Nodes = ptr.To("fd00:10:1:100::/56")
 		shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"ipv6":{"sourceNATEnabled":true}}`)}
 	}
 

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -47,6 +47,7 @@ func defaultGarden(backupSecret *corev1.Secret, specifyBackupBucket bool) *opera
 			}},
 			RuntimeCluster: operatorv1alpha1.RuntimeCluster{
 				Networking: operatorv1alpha1.RuntimeNetworking{
+					// Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
 					Pods:     []string{"10.1.0.0/16"},
 					Services: []string{"10.2.0.0/16"},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking dev-productivity
/kind technical-debt

**What this PR does**:

This PR moves the provider-local shoot node CIDR into the kind cluster's pod network and adds according validation to admission-local. The ranges are changed as follows:

IPv4:
-    kind pod CIDR: 10.0.0.0/15 (previously: 10.1.0.0/16)
-    seed pod CIDR (calico default IPPool): 10.1.0.0/16 (unchanged) – keeping this unchanged should allow upgrade tests to succeed
-    shoot node CIDR (dedicated IPPool): 10.0.0.0/16 or any smaller subnet (previously: 10.10.0.0/16)

IPv6:
-    kind pod CIDR: fd00:10:1::/48 (previously: fd00:10:1::/56)
-    seed pod CIDR (calico default IPPool): fd00:10:1::/56 (unchanged)
-    shoot node CIDR (dedicated IPPool): fd00:10:1:100::/56 or any smaller subnet (previously: fd00:10:a::/64)

**Why we need it**:

In https://github.com/gardener/gardener/pull/9752, we added dedicated Calico `IPPools` to the kind cluster using `Shoot.spec.networking.nodes`. The issue is that the default value (`10.10.0.0/16`) was outside the kind pod network (`10.1.0.0/16`). This causes kube-proxy to treat traffic from machine pods as external traffic (non-pod traffic).
If the traffic crosses node boundaries, Calico encapsulates this traffic (IPIP). The traffic then reaches its target with the source IP set to the IP of the tunl0 interface of the source node.
Ultimately, `NetworkPolicies` didn't work for cross-node traffic from machine pods – much like they don't work for cluster-external traffic.
This was discovered in https://github.com/gardener/gardener/pull/12836 when adding generated `NetworkPolicies` to the `gardener-extension-provider-local-coredns` namespace.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/gardener/pull/12836#issuecomment-3242499803

**Special notes for your reviewer**:

Thanks again to @ScheererJ and @hown3d for your help on this!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
