### PR TITLE
provider-local: fix `NetworkPolicy` for coredns ingress on `nodePort`

### DIFF
--- a/charts/gardener/provider-local/templates/coredns/networkpolicy.yaml
+++ b/charts/gardener/provider-local/templates/coredns/networkpolicy.yaml
@@ -1,14 +1,4 @@
 {{- if eq (include "coredns.enabled" .) "true" -}}
-# This NetworkPolicy allows ingress traffic from all IPs in the kind cluster pod network (10.1.0.0/16) to coredns.
-# The shoot machine pods use a dedicated calico IPPool with a CIDR outside the kind pod network
-# (see https://github.com/gardener/gardener/pull/9752).
-# With this, routing of traffic from machine pods doesn't work correctly in all cases. E.g., kube-proxy treats such
-# traffic as external and SNATs it, even though it actually originates from inside the cluster.
-# In combination with calico's IPIP tunneling, this breaks NetworkPolicies for cross-node traffic, because traffic
-# doesn't appear to come from a pod IP anymore but a node IP on the tunl0 interface (which is actually an IP within
-# the kind pod network).
-# I.e., this NetworkPolicy is a workaround to allow cross-node traffic from machine pods to the local coredns.
-# TODO(timebertt): remove this workaround once the shoot machine pods use pod IPs from the kind pod network
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,8 +7,17 @@ metadata:
 spec:
   ingress:
   - from:
+    # Allow traffic from the docker kind network's gateway IP. This is the source IP seen by NetworkPolicies
+    # when using the nodePort port-mapping on the kind control-node node (5353:30053) used by e2e tests and if the
+    # coredns pod runs on the control-plane node.
     - ipBlock:
-        cidr: 10.1.0.0/16 # kind pod network
+        cidr: 172.18.0.1/32
+    # If the coredns pod runs on another node than the control-plane node, incoming traffic on the nodePort gets SNATed
+    # by kube-proxy and is then sent over the tunl0 interface to the node where the coredns pod runs. In this case, the
+    # source IP seen by NetworkPolicies on the destination node is the node IP of the control-plane node (on the tunl0
+    # interface). This IP is allocated from the calico default IPPool (10.1.0.0/16).
+    - ipBlock:
+        cidr: 10.1.0.0/16
     ports:
     - port: 9053
       protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking dev-productivity
/kind flake

**What this PR does / why we need it**:

After https://github.com/gardener/gardener/pull/12836, I encountered flakes, where e2e tests could not resolve API domains using the provider-local coredns:
```
error discovering kubernetes version: Get "https://api.e2e-mngdseed-op.garden.external.local.gardener.cloud/version": dial tcp: lookup api.e2e-mngdseed-op.garden.external.local.gardener.cloud: i/o timeout
```

In that PR, I forgot that e2e tests use the port-mapping on the control-plane node to resolve API domains from outside the cluster. 
When doing so, the source IP seen by NetworkPolicies depends on where the coredns pod runs:
- running on the control-plane node (where the port-mapping is): docker network gateway IP (`172.18.0.1/32`)
- running on another node (control-plane node forwards traffic via tunl0): IP of the control-plane node on the tunl0 interface (from the calico default IPPool)

This PR resolves the flake by adapting the NetworkPolicy to cover all cases, regardless of where the coredns pod runs.

**Which issue(s) this PR fixes**:
Fixes https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12873/pull-gardener-e2e-kind-operator-seed/1962979939795865600#1:build-log.txt%3A964

**Special notes for your reviewer**:

/cc @ScheererJ 

Should be merged before https://github.com/gardener/gardener/pull/12864 or cherry-picked onto release-v1.128 (cc @rfranzke)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
