### PR TITLE
Reduce istio-ingressgateway CPU requests

### DIFF
--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -78,7 +78,7 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 
 		cpuRequests := "300m"
 		if enableAPIServerTLSTermination {
-			cpuRequests = "500m"
+			cpuRequests = "450m"
 		}
 
 		values := map[string]any{

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -705,7 +705,7 @@ var _ = Describe("istiod", func() {
 		Context("With IstioTLSTermination feature gate enabled", func() {
 			BeforeEach(func() {
 				expectAPIServerTLSTermination = true
-				expectedCPURequests = "500m"
+				expectedCPURequests = "450m"
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.IstioTLSTermination, true))
 			})
 
@@ -717,7 +717,7 @@ var _ = Describe("istiod", func() {
 		Context("With IstioTLSTermination feature gate disabled but with shoots still using the feature", func() {
 			BeforeEach(func() {
 				expectAPIServerTLSTermination = true
-				expectedCPURequests = "500m"
+				expectedCPURequests = "450m"
 
 				envoyFilter := istionetworkingv1alpha3.EnvoyFilter{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR reduces the CPU requests for istio-ingressgateway (which were increased with https://github.com/gardener/gardener/pull/11866 recently), because a value of `500m` can cause issues with VMs which have only 2 cores available. In some cases, it could happen that three istio instances (two zonal and one regional ingressgateway) end up on the same node, leaving not enough room for all the necessary DaemonSets.
For robustness reasons, some DS have a lower priority than istio (e.g. `fluent-bit`), but this causes the Pods to be preempted.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reduce the CPU resource requests of istio-ingressgateway to `450m` for the case with enabled L7 loadbalancing.
```
