### PR TITLE
[GEP-28] Implement custom verb for marking `Shoot`s as autonomous, and implement validation for `.spec.provider.workers[].controlPlane`

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -9,10 +9,6 @@ metadata:
 rules:
 - apiGroups:
   - core.gardener.cloud
-  - seedmanagement.gardener.cloud
-  - dashboard.gardener.cloud
-  - settings.gardener.cloud
-  - operations.gardener.cloud
   resources:
   - '*'
   verbs:
@@ -29,6 +25,23 @@ rules:
   - modify-spec-kubernetes
   - modify-spec-machineimages
   - modify-spec-providerconfig
+  - mark-autonomous
+- apiGroups:
+  - seedmanagement.gardener.cloud
+  - dashboard.gardener.cloud
+  - settings.gardener.cloud
+  - operations.gardener.cloud
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - watch
+  - patch
+  - update
 - apiGroups:
   - security.gardener.cloud
   resources:

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -63,6 +63,8 @@ Usually, regular project members are not bound to this custom verb, allowing the
 For `NamespacedCloudProfile`s, the modification of specific fields also require the user to be bound to an RBAC role with custom verbs.
 Please see [this document](../usage/project/namespaced-cloud-profiles.md#field-modification-restrictions) for more information.
 
+For `Shoot`s, the `mark-autonomous` verb is required to set the `spec.provider.workers[].controlPlane` field (which marks a `Shoot`as "autonomous shoot").
+
 ## `DeletionConfirmation`
 
 **Type**: Validating and Mutating. **Enabled by default**: Yes.

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -63,7 +63,7 @@ Usually, regular project members are not bound to this custom verb, allowing the
 For `NamespacedCloudProfile`s, the modification of specific fields also require the user to be bound to an RBAC role with custom verbs.
 Please see [this document](../usage/project/namespaced-cloud-profiles.md#field-modification-restrictions) for more information.
 
-For `Shoot`s, the `mark-autonomous` verb is required to set the `spec.provider.workers[].controlPlane` field (which marks a `Shoot`as "autonomous shoot").
+For `Shoot`s, the `mark-autonomous` verb is required to set the `spec.provider.workers[].controlPlane` field (which marks a `Shoot` as "autonomous shoot").
 
 ## `DeletionConfirmation`
 

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -419,7 +419,7 @@ func (a *actuator) delete(ctx context.Context, log logr.Logger, cp *extensionsv1
 }
 
 func (a *actuator) hasShootWebhooks(shoot *gardencorev1beta1.Shoot) bool {
-	return a.atomicShootWebhookConfig != nil && !v1beta1helper.IsShootAutonomous(shoot)
+	return a.atomicShootWebhookConfig != nil && !v1beta1helper.IsShootAutonomous(shoot.Spec.Provider.Workers)
 }
 
 // computeChecksums computes and returns all needed checksums. This includes the checksums for the given deployed secrets,

--- a/pkg/apis/core/helper/shoot.go
+++ b/pkg/apis/core/helper/shoot.go
@@ -319,10 +319,6 @@ func IsShootAutonomous(workers []core.Worker) bool {
 
 // ControlPlaneWorkerPoolForShoot returns the worker pool running the control plane in case the shoot is autonomous.
 func ControlPlaneWorkerPoolForShoot(workers []core.Worker) *core.Worker {
-	if !IsShootAutonomous(workers) {
-		return nil
-	}
-
 	idx := slices.IndexFunc(workers, func(worker core.Worker) bool {
 		return worker.ControlPlane != nil
 	})

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -664,8 +664,13 @@ var _ = Describe("Helper", func() {
 	})
 
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
-		It("should return nil because shoot is not autonomous", func() {
+		It("should return nil because shoot has no workers", func() {
 			shoot := &core.Shoot{}
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
+		})
+
+		It("should return nil because shoot has no worker marked for control plane", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{Provider: core.Provider{Workers: []core.Worker{{}}}}}
 			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
 		})
 

--- a/pkg/apis/core/helper/shoot_test.go
+++ b/pkg/apis/core/helper/shoot_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -629,4 +630,52 @@ var _ = Describe("Helper", func() {
 		Entry("with KubeProxy in IPVS mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPVS)}, true),
 		Entry("with KubeProxy in IPTables mode", &core.KubeProxyConfig{Enabled: ptr.To(true), Mode: ptr.To(core.ProxyModeIPTables)}, false),
 	)
+
+	Describe("#IsShootAutonomous", func() {
+		It("should return true (single worker pool with control plane configuration)", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{Provider: core.Provider{Workers: []core.Worker{
+				{ControlPlane: &core.WorkerControlPlane{}},
+			}}}}
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeTrue())
+		})
+
+		It("should return true (multiple worker pools, one with control plane configuration)", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{Provider: core.Provider{Workers: []core.Worker{
+				{},
+				{ControlPlane: &core.WorkerControlPlane{}},
+				{},
+			}}}}
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeTrue())
+		})
+
+		It("should return false (no worker pools)", func() {
+			shoot := &core.Shoot{}
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeFalse())
+		})
+
+		It("should return false (worker pools, but none with control plane configuration)", func() {
+			shoot := &core.Shoot{Spec: core.ShootSpec{Provider: core.Provider{Workers: []core.Worker{
+				{},
+				{},
+				{},
+			}}}}
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeFalse())
+		})
+	})
+
+	Describe("#ControlPlaneWorkerPoolForShoot", func() {
+		It("should return nil because shoot is not autonomous", func() {
+			shoot := &core.Shoot{}
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
+		})
+
+		It("should return the worker pool", func() {
+			worker := core.Worker{
+				ControlPlane: &core.WorkerControlPlane{},
+				Name:         "cp",
+			}
+			shoot := &core.Shoot{Spec: core.ShootSpec{Provider: core.Provider{Workers: []core.Worker{worker}}}}
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(PointTo(Equal(worker)))
+		})
+	})
 })

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -645,10 +645,6 @@ func IsShootAutonomous(workers []gardencorev1beta1.Worker) bool {
 
 // ControlPlaneWorkerPoolForShoot returns the worker pool running the control plane in case the shoot is autonomous.
 func ControlPlaneWorkerPoolForShoot(workers []gardencorev1beta1.Worker) *gardencorev1beta1.Worker {
-	if !IsShootAutonomous(workers) {
-		return nil
-	}
-
 	idx := slices.IndexFunc(workers, func(worker gardencorev1beta1.Worker) bool {
 		return worker.ControlPlane != nil
 	})

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1461,8 +1461,13 @@ var _ = Describe("Helper", func() {
 	})
 
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
-		It("should return nil because shoot is not autonomous", func() {
+		It("should return nil because shoot has no workers", func() {
 			shoot := &gardencorev1beta1.Shoot{}
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
+		})
+
+		It("should return nil because shoot has no worker marked for control plane", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{{}}}}}
 			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
 		})
 

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1433,7 +1433,7 @@ var _ = Describe("Helper", func() {
 			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
 				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
 			}}}}
-			Expect(IsShootAutonomous(shoot)).To(BeTrue())
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeTrue())
 		})
 
 		It("should return true (multiple worker pools, one with control plane configuration)", func() {
@@ -1442,12 +1442,12 @@ var _ = Describe("Helper", func() {
 				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
 				{},
 			}}}}
-			Expect(IsShootAutonomous(shoot)).To(BeTrue())
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeTrue())
 		})
 
 		It("should return false (no worker pools)", func() {
 			shoot := &gardencorev1beta1.Shoot{}
-			Expect(IsShootAutonomous(shoot)).To(BeFalse())
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeFalse())
 		})
 
 		It("should return false (worker pools, but none with control plane configuration)", func() {
@@ -1456,14 +1456,14 @@ var _ = Describe("Helper", func() {
 				{},
 				{},
 			}}}}
-			Expect(IsShootAutonomous(shoot)).To(BeFalse())
+			Expect(IsShootAutonomous(shoot.Spec.Provider.Workers)).To(BeFalse())
 		})
 	})
 
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
 		It("should return nil because shoot is not autonomous", func() {
 			shoot := &gardencorev1beta1.Shoot{}
-			Expect(ControlPlaneWorkerPoolForShoot(shoot)).To(BeNil())
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(BeNil())
 		})
 
 		It("should return the worker pool", func() {
@@ -1472,7 +1472,7 @@ var _ = Describe("Helper", func() {
 				Name:         "cp",
 			}
 			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{worker}}}}
-			Expect(ControlPlaneWorkerPoolForShoot(shoot)).To(PointTo(Equal(worker)))
+			Expect(ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)).To(PointTo(Equal(worker)))
 		})
 	})
 

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -363,7 +363,6 @@ func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *fi
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup, oldSeedSpec.Backup, fldPath.Child("backup"))...)
 		}
 	}
-	// If oldSeedSpec doesn't have backup configured, we allow to add it; but not the vice versa.
 
 	if oldSeedSpec.DNS.Internal != nil && newSeedSpec.DNS.Internal == nil {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("dns", "internal"), "removing internal DNS configuration is not allowed"))

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -245,7 +246,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	)
 
 	allErrs = append(allErrs, ValidateCloudProfileReference(spec.CloudProfile, spec.CloudProfileName, k8sVersion, fldPath)...)
-	allErrs = append(allErrs, validateProvider(spec.Provider, spec.Kubernetes, spec.Networking, workerless, fldPath.Child("provider"), inTemplate)...)
+	allErrs = append(allErrs, validateProvider(meta.Namespace, spec.Provider, spec.Kubernetes, spec.Networking, workerless, fldPath.Child("provider"), inTemplate)...)
 	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Purpose, workerless, fldPath.Child("addons"))...)
 	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
@@ -303,6 +304,10 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 		for _, err := range validation.IsDNS1123Subdomain(*spec.ExposureClassName) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("exposureClassName"), *spec.ExposureClassName, fmt.Sprintf("exposureClassName is not a valid DNS subdomain: %q", err)))
 		}
+	}
+
+	if helper.IsShootAutonomous(spec.Provider.Workers) && spec.SeedName != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), *spec.SeedName, "cannot set seedName for autonomous shoots"))
 	}
 
 	return allErrs
@@ -456,6 +461,25 @@ func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *fi
 			if !apiequality.Semantic.DeepEqual(oldWorker.Volume, newWorker.Volume) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("volume"), newWorker.Volume, "volume cannot be changed if update strategy is AutoInPlaceUpdate/ManualInPlaceUpdate"))
 			}
+		}
+
+		if oldWorker.ControlPlane != nil && oldWorker.ControlPlane.Backup != nil {
+			if newWorker.ControlPlane != nil && newWorker.ControlPlane.Backup != nil {
+				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.ControlPlane.Backup.Provider, oldWorker.ControlPlane.Backup.Provider, idxPath.Child("controlPlane").Child("backup", "provider"))...)
+				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.ControlPlane.Backup.Region, oldWorker.ControlPlane.Backup.Region, idxPath.Child("controlPlane").Child("backup", "region"))...)
+			} else {
+				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.ControlPlane.Backup, oldWorker.ControlPlane.Backup, idxPath.Child("controlPlane", "backup"))...)
+			}
+		}
+		// If oldWorker.ControlPlane doesn't have backup configured, we allow to add it; but not the vice versa.
+	}
+
+	if helper.IsShootAutonomous(oldProvider.Workers) != helper.IsShootAutonomous(newProvider.Workers) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("workers"), "cannot switch a Shoot between autonomous and non-autonomous mode"))
+	} else if helper.IsShootAutonomous(newProvider.Workers) {
+		oldControlPlaneWorkerPool, newControlPlaneWorkerPool := helper.ControlPlaneWorkerPoolForShoot(oldProvider.Workers), helper.ControlPlaneWorkerPoolForShoot(newProvider.Workers)
+		if oldControlPlaneWorkerPool.Name != newControlPlaneWorkerPool.Name {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("workers"), "cannot change control plane worker pool"))
 		}
 	}
 
@@ -1840,7 +1864,7 @@ func validateMaintenance(maintenance *core.Maintenance, fldPath *field.Path, wor
 	return allErrs
 }
 
-func validateProvider(provider core.Provider, kubernetes core.Kubernetes, networking *core.Networking, workerless bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func validateProvider(shootNamespace string, provider core.Provider, kubernetes core.Kubernetes, networking *core.Networking, workerless bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	var (
 		allErrs = field.ErrorList{}
 		maxPod  int32
@@ -1866,7 +1890,7 @@ func validateProvider(provider core.Provider, kubernetes core.Kubernetes, networ
 		}
 
 		for i, worker := range provider.Workers {
-			allErrs = append(allErrs, ValidateWorker(worker, kubernetes, fldPath.Child("workers").Index(i), inTemplate)...)
+			allErrs = append(allErrs, ValidateWorker(worker, kubernetes, shootNamespace, provider.Type, fldPath.Child("workers").Index(i), inTemplate)...)
 
 			if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil && worker.Kubernetes.Kubelet.MaxPods != nil && *worker.Kubernetes.Kubelet.MaxPods > maxPod {
 				maxPod = *worker.Kubernetes.Kubelet.MaxPods
@@ -1900,7 +1924,7 @@ const (
 var volumeSizeRegex = regexp.MustCompile(`^(\d)+Gi$`)
 
 // ValidateWorker validates the worker object.
-func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespace, shootProviderType string, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	kubernetesVersion := kubernetes.Version
 	allErrs := field.ErrorList{}
 
@@ -2037,6 +2061,36 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, fldPath *fie
 	}
 	if worker.Priority != nil && *worker.Priority < -1 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("priority"), *worker.Priority, "can not be less than -1"))
+	}
+
+	if worker.ControlPlane != nil {
+		if worker.Minimum != worker.Maximum || worker.Minimum != 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "autonomous shoots only support minimum=maximum=1 for the control plane worker pool (might change in the future)"))
+		}
+
+		if backup := worker.ControlPlane.Backup; backup != nil {
+			if len(backup.Provider) == 0 {
+				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "provider"), "must provide a backup cloud provider name"))
+			}
+
+			if shootProviderType != backup.Provider && (backup.Region == nil || len(*backup.Region) == 0) {
+				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "region"), "region must be specified for if backup provider is different from seed provider used in `spec.provider.type`"))
+			}
+
+			if backup.CredentialsRef == nil {
+				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "credentialsRef"), "must be set to refer a Secret or WorkloadIdentity"))
+			} else {
+				allErrs = append(allErrs, ValidateCredentialsRef(*backup.CredentialsRef, fldPath.Child("controlPlane", "backup", "credentialsRef"))...)
+				if backup.CredentialsRef.Namespace != shootNamespace {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("controlPlane", "backup", "credentialsRef", "namespace"), "must reference credentials in the same namespace as the Shoot"))
+				}
+
+				// TODO(vpnachev): Allow WorkloadIdentities once the support in the controllers and components is fully implemented.
+				if backup.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() && backup.CredentialsRef.Kind == "WorkloadIdentity" {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("controlPlane", "backup", "credentialsRef"), "support for WorkloadIdentity as backup credentials is not yet implemented"))
+				}
+			}
+		}
 	}
 
 	return allErrs
@@ -2393,8 +2447,9 @@ func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *f
 // ValidateWorkers validates worker objects.
 func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs     = field.ErrorList{}
-		workerNames = sets.New[string]()
+		allErrs               = field.ErrorList{}
+		workerNames           = sets.New[string]()
+		foundControlPlanePool bool
 	)
 
 	for i, worker := range workers {
@@ -2404,7 +2459,10 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 		workerNames.Insert(worker.Name)
 
 		if worker.ControlPlane != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Index(i).Child("controlPlane"), "setting controlPlane is not allowed in worker configuration currently"))
+			if foundControlPlanePool {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("controlPlane"), worker.ControlPlane, "cannot have more than one worker pool marked for control plane components"))
+			}
+			foundControlPlanePool = true
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -471,7 +471,6 @@ func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *fi
 				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.ControlPlane.Backup, oldWorker.ControlPlane.Backup, idxPath.Child("controlPlane", "backup"))...)
 			}
 		}
-		// If oldWorker.ControlPlane doesn't have backup configured, we allow to add it; but not the vice versa.
 	}
 
 	if helper.IsShootAutonomous(oldProvider.Workers) != helper.IsShootAutonomous(newProvider.Workers) {
@@ -2073,8 +2072,8 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "provider"), "must provide a backup cloud provider name"))
 			}
 
-			if shootProviderType != backup.Provider && (backup.Region == nil || len(*backup.Region) == 0) {
-				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "region"), "region must be specified for if backup provider is different from seed provider used in `spec.provider.type`"))
+			if shootProviderType != backup.Provider && ptr.Deref(backup.Region, "") == "" {
+				allErrs = append(allErrs, field.Required(fldPath.Child("controlPlane", "backup", "region"), "region must be specified for if backup provider is different from shoot provider used in `spec.provider.type`"))
 			}
 
 			if backup.CredentialsRef == nil {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1781,7 +1781,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Expect(ValidateShoot(shoot)).To(ConsistOfFields(Fields{
 							"Type":   Equal(field.ErrorTypeRequired),
 							"Field":  Equal("spec.provider.workers[0].controlPlane.backup.region"),
-							"Detail": Equal("region must be specified for if backup provider is different from seed provider used in `spec.provider.type`"),
+							"Detail": Equal("region must be specified for if backup provider is different from shoot provider used in `spec.provider.type`"),
 						}))
 					})
 				})

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -146,15 +146,19 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{"*"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update", "manage-members", "modify-spec-tolerations-whitelist", "modify-spec-kubernetes", "modify-spec-machineimages", "modify-spec-providerconfig", "mark-autonomous"},
+				},
+				{
 					APIGroups: []string{
-						gardencorev1beta1.GroupName,
 						seedmanagementv1alpha1.GroupName,
 						"dashboard.gardener.cloud",
 						settingsv1alpha1.GroupName,
 						operationsv1alpha1.GroupName,
 					},
 					Resources: []string{"*"},
-					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update", "manage-members", "modify-spec-tolerations-whitelist", "modify-spec-kubernetes", "modify-spec-machineimages", "modify-spec-providerconfig"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
 					APIGroups: []string{securityv1alpha1.GroupName},

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -168,15 +168,19 @@ var _ = Describe("Virtual", func() {
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
+					APIGroups: []string{"core.gardener.cloud"},
+					Resources: []string{"*"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update", "manage-members", "modify-spec-tolerations-whitelist", "modify-spec-kubernetes", "modify-spec-machineimages", "modify-spec-providerconfig", "mark-autonomous"},
+				},
+				{
 					APIGroups: []string{
-						"core.gardener.cloud",
 						"seedmanagement.gardener.cloud",
 						"dashboard.gardener.cloud",
 						"settings.gardener.cloud",
 						"operations.gardener.cloud",
 					},
 					Resources: []string{"*"},
-					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update", "manage-members", "modify-spec-tolerations-whitelist", "modify-spec-kubernetes", "modify-spec-machineimages", "modify-spec-providerconfig"},
+					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
 					APIGroups: []string{"security.gardener.cloud"},

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider.go
@@ -28,7 +28,7 @@ const (
 // implementations when the standard sidecar container is required.
 // The shoot object can be read from the `Cluster` object, e.g., using the GardenContext.GetCluster method in webhooks.
 func ProviderSidecarContainer(shoot *gardencorev1beta1.Shoot, controlPlaneNamespace, providerName, image string) corev1.Container {
-	autonomousShoot := v1beta1helper.IsShootAutonomous(shoot)
+	autonomousShoot := v1beta1helper.IsShootAutonomous(shoot.Spec.Provider.Workers)
 
 	c := corev1.Container{
 		Name:            providerSidecarContainerName(providerName),

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -93,7 +93,7 @@ func (b *AutonomousBotanist) deployOperatingSystemConfig(ctx context.Context) (*
 		return nil, "", fmt.Errorf("failed deploying OperatingSystemConfig resource: %w", err)
 	}
 
-	controlPlaneWorkerPool := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo())
+	controlPlaneWorkerPool := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers)
 	if controlPlaneWorkerPool == nil {
 		return nil, "", fmt.Errorf("failed fetching the control plane worker pool for the shoot")
 	}
@@ -236,7 +236,7 @@ func (b *AutonomousBotanist) ControlPlaneBootstrapOperatingSystemConfig() (opera
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	worker := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo())
+	worker := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers)
 	if worker == nil {
 		return nil, fmt.Errorf("did not find the control plane worker pool of the shoot")
 	}

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -32,7 +32,7 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 	// In `gardenadm bootstrap` we only deploy the control plane worker pool. When running `gardenadm init` on the
 	// medium-touch control plane, the full `Worker` with all pools will be deployed.
 	if b.Shoot.IsAutonomous() && !b.Shoot.RunsControlPlane() {
-		workers = []gardencorev1beta1.Worker{*v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().DeepCopy())}
+		workers = []gardencorev1beta1.Worker{*v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().DeepCopy().Spec.Provider.Workers)}
 	}
 
 	return worker.New(

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -669,7 +669,7 @@ func copyUniqueCIDRs(src []string, dst []net.IPNet, networkType string) ([]net.I
 
 // IsAutonomous returns true in case of an autonomous shoot cluster.
 func (s *Shoot) IsAutonomous() bool {
-	return v1beta1helper.IsShootAutonomous(s.GetInfo())
+	return v1beta1helper.IsShootAutonomous(s.GetInfo().Spec.Provider.Workers)
 }
 
 // RunsControlPlane returns true in case the Kubernetes control plane runs inside the cluster.

--- a/pkg/scheduler/controller/shoot/add.go
+++ b/pkg/scheduler/controller/shoot/add.go
@@ -85,7 +85,7 @@ func (r *Reconciler) ShootSpecChangedPredicate() predicate.Predicate {
 func (r *Reconciler) ShootIsNotAutonomous() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		if shoot, ok := obj.(*gardencorev1beta1.Shoot); ok {
-			return !helper.IsShootAutonomous(shoot)
+			return !helper.IsShootAutonomous(shoot.Spec.Provider.Workers)
 		}
 		return false
 	})

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -886,7 +886,7 @@ var _ = Describe("customverbauthorizer", func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
 					})
 
-					It("should forbid creating an autonomous shot", func() {
+					It("should forbid creating an autonomous shoot", func() {
 						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})
 
 						attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -807,6 +807,104 @@ var _ = Describe("customverbauthorizer", func() {
 				})
 			})
 		})
+
+		Context("Shoots", func() {
+			var (
+				shoot *core.Shoot
+			)
+
+			BeforeEach(func() {
+				shoot = &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy",
+						Namespace: "dummy-namespace",
+					},
+				}
+
+				authorizeAttributes = authorizer.AttributesRecord{
+					User:            userInfo,
+					APIGroup:        "core.gardener.cloud",
+					Namespace:       shoot.Namespace,
+					Name:            shoot.Name,
+					ResourceRequest: true,
+				}
+
+				authorizeAttributes.Resource = "shoots"
+			})
+
+			It("should do nothing because the resource is not Shoot", func() {
+				attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Validate(ctx, attrs, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("mark autonomous", func() {
+				BeforeEach(func() {
+					authorizeAttributes.Verb = "mark-autonomous"
+				})
+
+				It("should always allow creating a shoot without whitelist tolerations", func() {
+					attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+				})
+
+				Describe("permissions granted", func() {
+					BeforeEach(func() {
+						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
+					})
+
+					It("should allow creating an autonomous shoot", func() {
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})
+
+						attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+
+					It("should allow marking an existing shoot as 'autonomous'", func() {
+						// NB: This is already forbidden by validation, but this admission plugin does not know about it, so let's test it for completeness.
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{})
+						oldShoot := shoot.DeepCopy()
+						shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+						attrs = admission.NewAttributesRecord(shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+
+					It("should allow removing the control plane field of autonomous shoots", func() {
+						// NB: This is already forbidden by validation, but this admission plugin does not know about it, so let's test it for completeness.
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})
+						oldShoot := shoot.DeepCopy()
+						shoot.Spec.Provider.Workers[0].ControlPlane = nil
+
+						attrs = admission.NewAttributesRecord(shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+					})
+				})
+
+				Describe("permissions not granted", func() {
+					BeforeEach(func() {
+						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
+					})
+
+					It("should forbid creating an autonomous shot", func() {
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})
+
+						attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+					})
+
+					It("should allow removing the control plane field of autonomous shoots", func() {
+						// NB: This is already forbidden by validation, but this admission plugin does not know about it, so let's test it for completeness.
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})
+						oldShoot := shoot.DeepCopy()
+						shoot.Spec.Provider.Workers[0].ControlPlane = nil
+
+						attrs = admission.NewAttributesRecord(shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+					})
+				})
+			})
+		})
 	})
 
 	Describe("#Register", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
- Hardens the validation for autonomous `Shoot`s
- Introduces a new `mark-autonomous` custom RBAC verb that enables marking `Shoot`s as autonomous (granted to Gardener operators only since GEP-28 does exclude end-users).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
