### PR TITLE
Add `distroless-` prefix to tag when updating `envoyproxy`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -275,6 +275,25 @@
         '/github\\.com/fluent/.+/',
       ],
     },
+    // Add `distroless-` prefix to tag when updating `envoyproxy`.
+    {
+      matchDatasources: [
+        'github-releases'
+      ],
+      matchPackageNames: [
+        'github.com/envoyproxy/envoy'
+      ],
+      matchFileNames: [
+        'imagevector/containers.yaml'
+      ],
+      postUpgradeTasks: {
+        commands: [
+          'go install github.com/mikefarah/yq/v4@latest',
+          'bash -c "yq -i \'(.images[] | select(.sourceRepository == \\"{{{depName}}}\\") | key) as \\$imagePos | .images[\\$imagePos].tag = \\"distroless-{{{currentValue}}}\\"\' imagevector/containers.yaml"',
+        ],
+        executionMode: 'update',
+      },
+    },
     {
       // Ask for manual approval to create PRs for minor and major updates of container images which most likely
       // require manual adaptations of the code.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -281,7 +281,7 @@
         'github-releases'
       ],
       matchPackageNames: [
-        'github.com/envoyproxy/envoy'
+        'envoyproxy/envoy'
       ],
       matchFileNames: [
         'imagevector/containers.yaml'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Distroless container images for envoyproxy use a `distroless-<version>` tag. Their Github releases do not have the `distroless-` prefix. Thus, we have to add the prefix as an `postUpgradeTask` that we are still able to update this dependency via Github releases (and we prefer this way, because this adds release notes).

This change uses a similar approach we already use when we copy container images ([ref](https://github.com/gardener/ci-infra/blob/6f7b3b70e6d884d06d8b4f04ab6c18ee1808177f/.github/renovate.json5#L151-L157)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
