### PR TITLE
apply coredns-custom cm also for the node local dns coredns server

### DIFF
--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -74,10 +74,13 @@ const (
 
 	daemonSetPollInterval = 5 * time.Second
 
-	volumeMountNameCleanUp     = "cleanup-script"
-	volumeMountPathCleanUp     = "/scripts"
-	volumeMountNameXtablesLock = "xtables-lock"
-	volumeMountPathXtablesLock = "/run/xtables.lock"
+	volumeMountNameCleanUp      = "cleanup-script"
+	volumeMountPathCleanUp      = "/scripts"
+	volumeMountNameXtablesLock  = "xtables-lock"
+	volumeMountPathXtablesLock  = "/run/xtables.lock"
+	volumeMountPathCustomConfig = "/etc/custom"
+	volumeMountNameCustomConfig = "custom-config-volume"
+	customConfigMapName         = "coredns-custom"
 )
 
 var (

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -315,6 +315,7 @@ data:
         }
         reload
         loop
+        import custom/*.override
         bind ` + bindIP(values) + `
         forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
                 ` + forceTcpToClusterDNS + `
@@ -349,12 +350,14 @@ data:
         cache 30
         reload
         loop
+        import custom/*.override
         bind ` + bindIP(values) + `
         forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
                 ` + forceTcpToUpstreamDNS + `
         }
         prometheus :` + strconv.Itoa(prometheusPort) + `
         }
+        import custom/*.server
 immutable: true
 kind: ConfigMap
 metadata:
@@ -534,6 +537,11 @@ status:
 												MountPath: "/etc/kube-dns",
 												Name:      "kube-dns-config",
 											},
+											{
+												Name:      "custom-config-volume",
+												MountPath: "/etc/custom",
+												ReadOnly:  true,
+											},
 										},
 									},
 								},
@@ -571,6 +579,18 @@ status:
 														Path: "Corefile.base",
 													},
 												},
+											},
+										},
+									},
+									{
+										Name: "custom-config-volume",
+										VolumeSource: corev1.VolumeSource{
+											ConfigMap: &corev1.ConfigMapVolumeSource{
+												LocalObjectReference: corev1.LocalObjectReference{
+													Name: "coredns-custom",
+												},
+												DefaultMode: ptr.To[int32](420),
+												Optional:    ptr.To(true),
 											},
 										},
 									},
@@ -669,6 +689,7 @@ status: {}
     }
     reload
     loop
+    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
             ` + forceTcpToClusterDNS + `
@@ -703,12 +724,14 @@ ip6.arpa:53 {
     cache 30
     reload
     loop
+    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
             ` + forceTcpToUpstreamDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
+    import custom/*.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]
@@ -941,6 +964,7 @@ ip6.arpa:53 {
     }
     reload
     loop
+    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
             ` + forceTcpToClusterDNS + `
@@ -975,12 +999,14 @@ ip6.arpa:53 {
     cache 30
     reload
     loop
+    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
             ` + forceTcpToUpstreamDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
+    import custom/*.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -308,20 +308,20 @@ metadata:
 data:
   Corefile: |
     cluster.local:53 {
-        errors
-        cache {
-                success 9984 30
-                denial 9984 5
-        }
-        reload
         loop
-        import custom/*.override
         bind ` + bindIP(values) + `
         forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
                 ` + forceTcpToClusterDNS + `
         }
         prometheus :` + strconv.Itoa(prometheusPort) + `
         health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
+        import custom/*.override
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
         }
     in-addr.arpa:53 {
         errors
@@ -346,16 +346,16 @@ data:
         prometheus :` + strconv.Itoa(prometheusPort) + `
         }
     .:53 {
-        errors
-        cache 30
-        reload
         loop
-        import custom/*.override
         bind ` + bindIP(values) + `
         forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
                 ` + forceTcpToUpstreamDNS + `
         }
         prometheus :` + strconv.Itoa(prometheusPort) + `
+        import custom/*.override
+        errors
+        cache 30
+        reload
         }
         import custom/*.server
 immutable: true
@@ -682,20 +682,20 @@ status: {}
 				JustBeforeEach(func() {
 					configMapData := map[string]string{
 						"Corefile": `cluster.local:53 {
-    errors
-    cache {
-            success 9984 30
-            denial 9984 5
-    }
-    reload
     loop
-    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
             ` + forceTcpToClusterDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
+    import custom/*.override
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
     }
 in-addr.arpa:53 {
     errors
@@ -720,16 +720,16 @@ ip6.arpa:53 {
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
 .:53 {
-    errors
-    cache 30
-    reload
     loop
-    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
             ` + forceTcpToUpstreamDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
+    import custom/*.override
+    errors
+    cache 30
+    reload
     }
     import custom/*.server
 `,
@@ -957,20 +957,20 @@ ip6.arpa:53 {
 				JustBeforeEach(func() {
 					configMapData := map[string]string{
 						"Corefile": `cluster.local:53 {
-    errors
-    cache {
-            success 9984 30
-            denial 9984 5
-    }
-    reload
     loop
-    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(values.ClusterDNS, " ") + ` {
             ` + forceTcpToClusterDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     health ` + healthAddress(values) + `:` + strconv.Itoa(livenessProbePort) + `
+    import custom/*.override
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
     }
 in-addr.arpa:53 {
     errors
@@ -995,16 +995,16 @@ ip6.arpa:53 {
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
 .:53 {
-    errors
-    cache 30
-    reload
     loop
-    import custom/*.override
     bind ` + bindIP(values) + `
     forward . ` + strings.Join(upstreamDNSAddress, " ") + ` {
             ` + forceTcpToUpstreamDNS + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
+    import custom/*.override
+    errors
+    cache 30
+    reload
     }
     import custom/*.server
 `,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -51,20 +51,20 @@ func (n *nodeLocalDNS) computeResourcesData() (*corev1.ServiceAccount, *corev1.C
 			},
 			Data: map[string]string{
 				configDataKey: domain + `:53 {
-    errors
-    cache {
-            success 9984 30
-            denial 9984 5
-    }
-    reload
     loop
-    import custom/*.override
     bind ` + n.bindIP() + `
     forward . ` + strings.Join(n.values.ClusterDNS, " ") + ` {
             ` + n.forceTcpToClusterDNS() + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     health ` + n.getHealthAddress() + `:` + strconv.Itoa(livenessProbePort) + `
+    import custom/*.override
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
     }
 in-addr.arpa:53 {
     errors
@@ -89,16 +89,16 @@ ip6.arpa:53 {
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
 .:53 {
-    errors
-    cache 30
-    reload
     loop
-    import custom/*.override
     bind ` + n.bindIP() + `
     forward . ` + n.upstreamDNSAddress() + ` {
             ` + n.forceTcpToUpstreamDNS() + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
+    import custom/*.override
+    errors
+    cache 30
+    reload
     }
     import custom/*.server
 `,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -58,6 +58,7 @@ func (n *nodeLocalDNS) computeResourcesData() (*corev1.ServiceAccount, *corev1.C
     }
     reload
     loop
+    import custom/*.override
     bind ` + n.bindIP() + `
     forward . ` + strings.Join(n.values.ClusterDNS, " ") + ` {
             ` + n.forceTcpToClusterDNS() + `
@@ -92,12 +93,14 @@ ip6.arpa:53 {
     cache 30
     reload
     loop
+    import custom/*.override
     bind ` + n.bindIP() + `
     forward . ` + n.upstreamDNSAddress() + ` {
             ` + n.forceTcpToUpstreamDNS() + `
     }
     prometheus :` + strconv.Itoa(prometheusPort) + `
     }
+    import custom/*.server
 `,
 			},
 		}
@@ -282,6 +285,11 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 										MountPath: "/etc/kube-dns",
 										Name:      "kube-dns-config",
 									},
+									{
+										Name:      volumeMountNameCustomConfig,
+										MountPath: volumeMountPathCustomConfig,
+										ReadOnly:  true,
+									},
 								},
 							},
 						},
@@ -319,6 +327,18 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 												Path: "Corefile.base",
 											},
 										},
+									},
+								},
+							},
+							{
+								Name: volumeMountNameCustomConfig,
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: customConfigMapName,
+										},
+										DefaultMode: ptr.To[int32](420),
+										Optional:    ptr.To(true),
 									},
 								},
 							},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
The pull request aims to ensure that enabling `node-local-dns` for all shoot clusters does not alter DNS behaviour. To maintain consistency, it proposes mounting the custom CoreDNS configmap into the `node-local-dns` pods and applying the custom overwrite rules defined in the custom CoreDNS configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ensure that enabling `node-local-dns` for all shoot clusters does not alter DNS behaviour. To maintain consistency the custom CoreDNS configmap is mounted into the `node-local-dns` pods and the custom overwrite rules defined in the custom CoreDNS configuration is applied onto the `node-local-dns` pods.
```
