### PR TITLE
Temporarily disable monitoring for Istio Ingress Gateways

### DIFF
--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -380,9 +380,14 @@ var _ = Describe("istiod", func() {
 				istioIngressServiceInternal(),
 				istioIngressServiceAccount(),
 				istioIngressDeployment(minReplicas),
-				istioIngressServiceMonitor(),
-				istioIngressTelemetry(),
 				istioIngressEnvoyFilter(),
+			}
+
+			if "" == "TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved" {
+				expectedIstioManifests = append(expectedIstioManifests,
+					istioIngressServiceMonitor(),
+					istioIngressTelemetry(),
+				)
 			}
 
 			expectedIstioSystemManifests := []string{

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -383,7 +383,8 @@ var _ = Describe("istiod", func() {
 				istioIngressEnvoyFilter(),
 			}
 
-			if "" == "TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved" {
+			// TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved
+			if false {
 				expectedIstioManifests = append(expectedIstioManifests,
 					istioIngressServiceMonitor(),
 					istioIngressTelemetry(),

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -265,7 +265,8 @@ func (i *istiod) Deploy(ctx context.Context) error {
 
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 	for _, istioIngressGateway := range i.values.IngressGateway {
-		if "" != "TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved" {
+		// TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved
+		if true {
 			continue
 		}
 		if err := registry.Add(&monitoringv1.ServiceMonitor{

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -265,6 +265,9 @@ func (i *istiod) Deploy(ctx context.Context) error {
 
 	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 	for _, istioIngressGateway := range i.values.IngressGateway {
+		if "" != "TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved" {
+			continue
+		}
 		if err := registry.Add(&monitoringv1.ServiceMonitor{
 			ObjectMeta: monitoringutils.ConfigObjectMeta("istio-ingressgateway", istioIngressGateway.Namespace, prometheusName),
 			Spec: monitoringv1.ServiceMonitorSpec{


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring networking
/kind bug

**What this PR does / why we need it**:

- Temporarily disable monitoring for the Istio Ingress Gateways to mitigate the metrics leak issue until #12699 is resolved.

We noticed several problems with the metrics exposed by the Istio Ingress Gateways, which eventually led to this proposal to disable these metrics altogether and to re-enable them later, once we are confident that they are accurate, meaningful, and do not leak.

These metrics are not used by the shoot owner facing monitoring stack, so this change has no impact for shoot owners.
There are a few dashboards in the seed Plutono that Gardener landscape operators can access, that will temporarily stay blank after this change.
However, in the current state, the Istio metrics are partially confusing, so enabling them again when the configuration was improved might be a meaningful approach.

The immediate motivation for disabling these metrics is that they leak, and with that they cause a substantial cross availability zone traffic when the aggregate Prometheus scrapes them.
They also significantly increase the memory and disk usage of the aggregate Prometheus, and with that they reduce the time that Prometheus can retain data.
See #12699 for more details.

Furthermore, for the HTTP routed VPN traffic, it would be meaningful to expose TCP metrics in addition to the HTTP metrics.
The HTTP metrics in their current form are confusing and not so meaningful for the VPN use case.
See #12699 and [Istio Discussion entry](https://github.com/istio/istio/discussions/56959) for more details.

In a minimalistic test setup, we observed that the Istio metrics do not always return the expected values.
Although this might be a small bug, this reduces our confidence in the accuracy of these metrics.
See https://github.com/istio/istio/issues/57576 for more details.

- Once #12699 is resolved, this PR and also #12142 should be reverted.

**Which issue(s) this PR fixes**:

Temporary mitigation for #12699.

**Special notes for your reviewer**:

/cc @oliver-goetz

With @vicwicker and @chrkl.

<details>

<summary>Details</summary>

In a local setup, with an HA seed and 1 shoot:

```bash
make kind-multi-zone-up
make operator-up
make operator-seed-up
kubectl apply -f example/provider-local/shoot.yaml
```

There are 5 service monitors for the various Istio Ingress Gateways:

```bash
k get servicemonitors -A | grep gateway | nl
```

```text
1  istio-ingress--0               aggregate-istio-ingressgateway
2  istio-ingress--1               aggregate-istio-ingressgateway
3  istio-ingress--2               aggregate-istio-ingressgateway
4  istio-ingress                  aggregate-istio-ingressgateway
5  virtual-garden-istio-ingress   garden-istio-ingressgateway
```

After deploying this PR, these service monitors will be deleted, and with that, the monitoring for the Istio Ingress Gateways will be disabled.

Operators can still use curl the metrics endpoint to access the current value of these metrics directly from the Istio Ingress Gateway pods.

</details>

**Release note**:

```other operator
Monitoring the Istio Ingress Gateways is temporarily disabled to mitigate a metric leak issue. This does not affect the monitoring of the shoot control planes where these metrics are not used.
```
