### PR TITLE
Swap the order of required deployments and etcd checks in shoot health check

### DIFF
--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -342,6 +342,10 @@ var _ = Describe("Garden health", func() {
 
 			Context("when there are issues with deployments for virtual garden", func() {
 				It("should set VirtualComponentsHealthy conditions to false when the deployments are missing", func() {
+					for _, name := range virtualGardenETCDs {
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
+					}
+
 					updatedConditions := NewHealth(
 						garden,
 						runtimeClient,
@@ -358,6 +362,9 @@ var _ = Describe("Garden health", func() {
 				})
 
 				It("should set VirtualComponentsHealthy conditions to false when the deployments are existing but unhealthy", func() {
+					for _, name := range virtualGardenETCDs {
+						Expect(runtimeClient.Create(ctx, newEtcd(gardenNamespace, name, true))).To(Succeed())
+					}
 					for _, name := range virtualGardenDeployments {
 						Expect(runtimeClient.Create(ctx, newDeployment(gardenNamespace, name, false))).To(Succeed())
 					}

--- a/pkg/utils/kubernetes/health/checker/checker.go
+++ b/pkg/utils/kubernetes/health/checker/checker.go
@@ -302,17 +302,17 @@ func (h *HealthChecker) CheckControlPlane(
 		return nil, err
 	}
 
-	if exitCondition := h.checkRequiredDeployments(condition, requiredControlPlaneDeployments, deploymentList.Items); exitCondition != nil {
-		return exitCondition, nil
-	}
-	if exitCondition := h.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
-		return exitCondition, nil
-	}
-
 	if exitCondition := h.checkRequiredEtcds(condition, requiredControlPlaneEtcds, etcdList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 	if exitCondition := h.checkEtcds(condition, etcdList.Items); exitCondition != nil {
+		return exitCondition, nil
+	}
+
+	if exitCondition := h.checkRequiredDeployments(condition, requiredControlPlaneDeployments, deploymentList.Items); exitCondition != nil {
+		return exitCondition, nil
+	}
+	if exitCondition := h.checkDeployments(condition, deploymentList.Items); exitCondition != nil {
 		return exitCondition, nil
 	}
 

--- a/test/integration/operator/garden/care/care_test.go
+++ b/test/integration/operator/garden/care/care_test.go
@@ -231,8 +231,8 @@ var _ = Describe("Garden Care controller tests", func() {
 			}).Should(ContainCondition(
 				OfType(operatorv1alpha1.VirtualComponentsHealthy),
 				WithStatus(gardencorev1beta1.ConditionFalse),
-				WithReason("DeploymentMissing"),
-				WithMessageSubstrings("Missing required deployments"),
+				WithReason("EtcdMissing"),
+				WithMessageSubstrings("Missing required etcds: [virtual-garden-etcd-events virtual-garden-etcd-main]"),
 			))
 		})
 	})
@@ -244,6 +244,11 @@ var _ = Describe("Garden Care controller tests", func() {
 		})
 
 		It("should set condition to False because status of all deployments are outdated", func() {
+			createETCDs(requiredControlPlaneETCDs)
+			for _, name := range requiredControlPlaneETCDs {
+				updateETCDStatusToHealthy(name)
+			}
+
 			By("Expect VirtualComponentsHealthy condition to be False")
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(garden), garden)).To(Succeed())
@@ -257,6 +262,11 @@ var _ = Describe("Garden Care controller tests", func() {
 		})
 
 		It("should set condition to False because status of some deployments are outdated", func() {
+			createETCDs(requiredControlPlaneETCDs)
+			for _, name := range requiredControlPlaneETCDs {
+				updateETCDStatusToHealthy(name)
+			}
+
 			for _, name := range requiredControlPlaneDeployments[1:] {
 				updateDeploymentStatusToHealthy(name)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind impediment

**What this PR does / why we need it**:
If etcd is not healthy, checking the health of KAPI and other deployments is needless. This PR swaps the order of required deployments and etcd checks to ensure the correct health check sequence.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
