### PR TITLE
Add the `distroless-v` tag to `envoyfilter/envoy` only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -289,7 +289,7 @@
       postUpgradeTasks: {
         commands: [
           'go install github.com/mikefarah/yq/v4@latest',
-          'bash -c "yq -i \'(.images[] | select(.sourceRepository == \\"{{{depName}}}\\") | key) as \\$imagePos | .images[\\$imagePos].tag = \\"distroless-{{{currentValue}}}\\"\' imagevector/containers.yaml"',
+          'bash -c "yq -i \'(.images[] | select(.sourceRepository == \\"github.com/envoyproxy/envoy\\") | key) as \\$imagePos | .images[\\$imagePos].tag = \\"distroless-{{{newValue}}}\\"\' imagevector/containers.yaml"',
         ],
         executionMode: 'update',
       },


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
After PR #12892 renovate updated the tags of all images and used the old version, when `envoyproxy/envoy` was updated.
This is fixed now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
