### PR TITLE
Edit extra port mappings of `local2` seed

### DIFF
--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -9,14 +9,7 @@
 {{- if .Values.gardener.seed.deployed -}}
 {{- range $i, $listenAddress := (required ".Values.gardener.seed.istio.listenAddresses is required" .Values.gardener.seed.istio.listenAddresses) }}
 - containerPort: {{ add 30443 $i }}
-{{- if $.Values.gardener.controlPlane.deployed }}
   hostPort: 443
-{{- else }}
-  # TODO (plkokanov): when using skaffold to deploy, 172.18.255.2 is not used as listenAddress (unlike the local
-  #  deployment) because secondary IPs cannot be easily added to inside the `prow` containers. Additionally, there is no
-  #  way currently to swap the dns record of the shoot's `kube-apiserver` once it is migrated to this seed.
-  hostPort: 9443
-{{- end }}
   listenAddress: {{ $listenAddress }}
 - containerPort: {{ add 32132 $i }}
   hostPort: 8132


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration dev-productivity
/kind cleanup

**What this PR does / why we need it**:
For quite a while the `172.18.255.2` ip alias is automatically added to the developer's localhost interface when [setting up a second local seed cluster](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#optional-setting-up-a-second-seed-cluster) and is used to port forward connections to services in the `local2` seed used for control plane migration tests. The `TODO` text removed in this PR became outdated as it did not reflect that automatic addition of local ip aliases.

This PR changes the extra port mappings for the `local2` seed so that the `istio-ingressgateway` service of the `local2` seed is exposed on `172.18.255.2:443`, instead of `172.18.255.2:9443`  as it no-longer clashes with the port forwarding rules for the `istio-ingressgateway` service of the `local` seed, which is exposed on `172.18.255.1:443` .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `istio-ingressgateway` service of the `local2` seed is now exposed on `172.18.255.2:443` instead of `172.18.255.2:9443` on the developer's host machine.
```
