### PR TITLE
Remove workaround for legacy `ScrapeConfig` roles in `monitoring.coreos.com`

### DIFF
--- a/dev-setup/extensions/networking-calico/components/extension/extension.yaml
+++ b/dev-setup/extensions/networking-calico/components/extension/extension.yaml
@@ -13,12 +13,12 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-calico-runtime:v1.48.1
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-calico-runtime:v1.50.0
       virtualCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-calico-application:v1.48.1
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-calico-application:v1.50.0
     extension:
       helm:
         ociRepository:
-          ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-calico:v1.48.1
+          ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-calico:v1.50.0

--- a/dev-setup/extensions/networking-cilium/components/extension/extension.yaml
+++ b/dev-setup/extensions/networking-cilium/components/extension/extension.yaml
@@ -13,12 +13,12 @@ spec:
       runtimeCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-runtime:v1.41.2
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-runtime:v1.42.2
       virtualCluster:
         helm:
           ociRepository:
-            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-application:v1.41.2
+            ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/admission-cilium-application:v1.42.2
     extension:
       helm:
         ociRepository:
-          ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-cilium:v1.41.2
+          ref: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions/networking-cilium:v1.42.2

--- a/example/seed-crds/10-crd-monitoring.coreos.com_scrapeconfigs.yaml
+++ b/example/seed-crds/10-crd-monitoring.coreos.com_scrapeconfigs.yaml
@@ -7363,17 +7363,11 @@ spec:
                         Role `Endpointslice` requires Prometheus >= v2.21.0
                       enum:
                       - Pod
-                      - pod
                       - Endpoints
-                      - endpoints
                       - Ingress
-                      - ingress
                       - Service
-                      - service
                       - Node
-                      - node
                       - EndpointSlice
-                      - endpointslice
                       type: string
                     selectors:
                       description: |-
@@ -7400,17 +7394,11 @@ spec:
                               Accepted values are: Node, Pod, Endpoints, EndpointSlice, Service, Ingress.
                             enum:
                             - Pod
-                            - pod
                             - Endpoints
-                            - endpoints
                             - Ingress
-                            - ingress
                             - Service
-                            - service
                             - Node
-                            - node
                             - EndpointSlice
-                            - endpointslice
                             type: string
                         required:
                         - role

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -132,20 +132,6 @@ generate_group () {
     generate="controller-gen crd"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate &> "$generator_output" ||:
     grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'usage' "$generator_output" && { echo "Failed to generate CRD YAMLs."; exit 1; }
-  elif [[ "$group" == "monitoring.coreos.com_v1alpha1" ]]; then
-    # ScrapeConfig roles change recently, see https://github.com/prometheus-operator/prometheus-operator/commit/38900ced627fdde49f3136795a678fbb8f79de05#diff-95caef4dacf48c47bf56afc00c513822feba29a5d2f6354b75c97a25a353d52fL75-R77
-    # The old roles (starting with lower case letters) are still working (because later roles are converted to lower case anyway). Yet, they are forbidden by the new enum.
-    # Some extensions still use the old roles, so we patch the CRD to give time for updating them.
-    # TODO(oliver-goetz): Remove this workaround when https://github.com/gardener/gardener/issues/12401 has been closed.
-    monitoring_dir="$(go list -f '{{ .Dir }}' "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring")"
-    scrapeconfig_types_file="${monitoring_dir}/v1alpha1/scrapeconfig_types.go"
-    # Create a local copy outside the mod cache path in order to patch the types file via sed.
-    scrapeconfig_types_backup="$(mktemp -d)/scrapeconfig_types.go"
-    cp "$scrapeconfig_types_file" "$scrapeconfig_types_backup"
-    chmod +w "$scrapeconfig_types_file" "$monitoring_dir/v1alpha1/"
-    trap 'cp "$scrapeconfig_types_backup" "$scrapeconfig_types_file" && chmod -w "$monitoring_dir/v1alpha1/"' EXIT
-    sed -i 's/\+kubebuilder:validation:Enum=Pod;Endpoints;Ingress;Service;Node;EndpointSlice/\+kubebuilder:validation:Enum=Pod;pod;Endpoints;endpoints;Ingress;ingress;Service;service;Node;node;EndpointSlice;endpointslice/g' "$scrapeconfig_types_file"
-    $generate
   elif [[ "$group" == "perses.dev_v1alpha1" ]]; then
     generate="controller-gen crd:ignoreUnexportedFields=true"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate

--- a/pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_scrapeconfigs.yaml
+++ b/pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_scrapeconfigs.yaml
@@ -7363,17 +7363,11 @@ spec:
                         Role `Endpointslice` requires Prometheus >= v2.21.0
                       enum:
                       - Pod
-                      - pod
                       - Endpoints
-                      - endpoints
                       - Ingress
-                      - ingress
                       - Service
-                      - service
                       - Node
-                      - node
                       - EndpointSlice
-                      - endpointslice
                       type: string
                     selectors:
                       description: |-
@@ -7400,17 +7394,11 @@ spec:
                               Accepted values are: Node, Pod, Endpoints, EndpointSlice, Service, Ingress.
                             enum:
                             - Pod
-                            - pod
                             - Endpoints
-                            - endpoints
                             - Ingress
-                            - ingress
                             - Service
-                            - service
                             - Node
-                            - node
                             - EndpointSlice
-                            - endpointslice
                             type: string
                         required:
                         - role


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
Since #12401 has been close we can remove the legacy `ScrapeConfig` roles now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I also updated calico and cilium extensions in dev-setup since they have been too old for this cleanup.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The long time deprecated legacy `ScrapeConfig` roles in `monitoring.coreos.com` have been removed from CRD.
```
