### PR TITLE
Improve validation for `kubeletConfig` in the `Shoot` API

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2121,6 +2121,14 @@ const PodPIDsLimitMinimum int64 = 100
 func ValidateKubeletConfig(kubeletConfig core.KubeletConfig, version string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if kubeletConfig.CPUManagerPolicy != nil {
+		// Ref: https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#configuration
+		supportedCPUManagerPolicies := sets.New("none", "static")
+		if !supportedCPUManagerPolicies.Has(*kubeletConfig.CPUManagerPolicy) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("cpuManagerPolicy"), *kubeletConfig.CPUManagerPolicy, sets.List(supportedCPUManagerPolicies)))
+		}
+	}
+
 	if kubeletConfig.MaxPods != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*kubeletConfig.MaxPods), fldPath.Child("maxPods"))...)
 	}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2192,6 +2192,9 @@ func ValidateKubeletConfig(kubeletConfig core.KubeletConfig, version string, fld
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("containerLogMaxFiles"), *v, "value must be >= 2."))
 		}
 	}
+	if v := kubeletConfig.ContainerLogMaxSize; v != nil {
+		allErrs = append(allErrs, kubernetescorevalidation.ValidateResourceQuantityValue("containerLogMaxSize", *v, fldPath.Child("containerLogMaxSize"))...)
+	}
 	if v := kubeletConfig.StreamingConnectionIdleTimeout; v != nil {
 		if v.Duration < time.Second*30 || time.Hour*4 < v.Duration {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("streamingConnectionIdleTimeout"), *v, "value must be between 30s and 4h"))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -7790,6 +7790,25 @@ var _ = Describe("Shoot Validation Tests", func() {
 		invalidPercentValueHigh := "110%"
 		invalidValue := "5X"
 
+		DescribeTable("CPUManagerPolicy",
+			func(cpuManagerPolicy *string, matcher gomegatypes.GomegaMatcher) {
+				kubeletConfig := core.KubeletConfig{
+					CPUManagerPolicy: cpuManagerPolicy,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, "", field.NewPath("kubelet"))
+				Expect(errList).To(matcher)
+			},
+			Entry("should allow empty cpuManagerPolicy", nil, BeEmpty()),
+			Entry("should allow cpuManagerPolicy to be 'none'", ptr.To("none"), BeEmpty()),
+			Entry("should allow cpuManagerPolicy to be 'static'", ptr.To("static"), BeEmpty()),
+			Entry("should not allow cpuManagerPolicy to be 'foo'", ptr.To("foo"), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeNotSupported),
+				"Field":  Equal("kubelet.cpuManagerPolicy"),
+				"Detail": Equal("supported values: \"none\", \"static\""),
+			})))),
+		)
+
 		DescribeTable("StreamingConnectionIdleTimeout",
 			func(streamingConnectionIdleTimeout *metav1.Duration, matcher gomegatypes.GomegaMatcher) {
 				kubeletConfig := core.KubeletConfig{

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -8324,6 +8324,40 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				Expect(errList).To(BeEmpty())
 			})
+
+			It("should not accept invalid containerLogMaxSize", func() {
+				maxSize := resource.MustParse("-1Mi")
+				kubeletConfig := core.KubeletConfig{
+					ContainerLogMaxSize: &maxSize,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, "", nil)
+				Expect(errList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal(field.NewPath("containerLogMaxSize").String()),
+					})),
+				))
+			})
+
+			It("should accept valid containerLogMaxSize", func() {
+				maxSize := resource.MustParse("100Mi")
+				kubeletConfig := core.KubeletConfig{
+					ContainerLogMaxSize: &maxSize,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, "", nil)
+				Expect(errList).To(BeEmpty())
+			})
+
+			It("should accept empty containerLogMaxSize and containerLogMaxFiles", func() {
+				kubeletConfig := core.KubeletConfig{
+					ContainerLogMaxSize:  nil,
+					ContainerLogMaxFiles: nil,
+				}
+				errList := ValidateKubeletConfig(kubeletConfig, "", nil)
+				Expect(errList).To(BeEmpty())
+			})
 		})
 
 		Describe("maxParallelImagePulls", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -8313,7 +8313,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				))
 			})
 
-			It("should accept valid containerLogMaxFiles and containerLogMaxSize", func() {
+			It("should accept valid containerLogMaxFiles", func() {
 				maxSize := resource.MustParse("100Mi")
 				kubeletConfig := core.KubeletConfig{
 					ContainerLogMaxFiles: ptr.To[int32](5),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -178,7 +178,8 @@ func setConfigDefaults(c *components.ConfigurableKubeletConfigParameters) {
 	}
 
 	if c.CpuManagerPolicy == nil {
-		c.CpuManagerPolicy = ptr.To(kubeletconfigv1beta1.NoneTopologyManagerPolicy)
+		// Ref: https://github.com/kubernetes/kubernetes/blob/cede96336a809a67546ca08df0748e4253ec270d/pkg/kubelet/cm/cpumanager/policy_none.go#L34
+		c.CpuManagerPolicy = ptr.To("none")
 	}
 
 	if c.EvictionHard == nil {

--- a/pkg/utils/validation/kubernetes/core/validation_test.go
+++ b/pkg/utils/validation/kubernetes/core/validation_test.go
@@ -22,110 +22,136 @@ package core_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/gardener/gardener/pkg/utils/validation/kubernetes/core"
 	. "github.com/gardener/gardener/pkg/utils/validation/kubernetes/core"
 )
 
-var _ = Describe("#Tolerations", func() {
-	var fieldPath *field.Path
+var _ = Describe("Validation", func() {
+	Describe("#ValidateTolerations", func() {
+		var fieldPath *field.Path
 
-	BeforeEach(func() {
-		fieldPath = field.NewPath("tolerations")
+		BeforeEach(func() {
+			fieldPath = field.NewPath("tolerations")
+		})
+
+		DescribeTable(
+			"#Success cases",
+			func(tolerations []corev1.Toleration) {
+				Expect(ValidateTolerations(tolerations, fieldPath)).To(BeEmpty())
+			},
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9646
+			Entry(
+				"populate forgiveness tolerations with exists operator in annotations.",
+				[]corev1.Toleration{{Key: "foo", Operator: "Exists", Value: "", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9653
+			Entry(
+				"populate forgiveness tolerations with equal operator in annotations.",
+				[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9660
+			Entry(
+				"populate tolerations equal operator in annotations.",
+				[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9674
+			Entry(
+				"empty key with Exists operator is OK for toleration, empty toleration key means match all taint keys.",
+				[]corev1.Toleration{{Operator: "Exists", Effect: "NoSchedule"}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9681
+			Entry(
+				"empty operator is OK for toleration, defaults to Equal.",
+				[]corev1.Toleration{{Key: "foo", Value: "bar", Effect: "NoSchedule"}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9688
+			Entry(
+				"empty effect is OK for toleration, empty toleration effect means match all taint effects.",
+				[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar"}},
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9695
+			Entry(
+				"negative tolerationSeconds is OK for toleration.",
+				[]corev1.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: &[]int64{-2}[0]}},
+			),
+		)
+
+		DescribeTable(
+			"#Error cases",
+			func(tolerations []corev1.Toleration, expectedError string) {
+				// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10950-L10959
+				errs := ValidateTolerations(tolerations, fieldPath)
+				Expect(errs).NotTo(BeEmpty())
+				Expect(errs.ToAggregate().Error()).To(ContainSubstring(expectedError))
+			},
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10465
+			Entry(
+				"invalid toleration key",
+				[]corev1.Toleration{{Key: "nospecialchars^=@", Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
+				"tolerations[0].key",
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10475
+			Entry(
+				"invalid toleration operator",
+				[]corev1.Toleration{{Key: "foo", Operator: "In", Value: "bar", Effect: "NoSchedule"}},
+				"tolerations[0].operator",
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10485
+			Entry(
+				"value must be empty when `operator` is 'Exists'",
+				[]corev1.Toleration{{Key: "foo", Operator: "Exists", Value: "bar", Effect: "NoSchedule"}},
+				"tolerations[0].operator",
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10496
+			Entry(
+				"operator must be 'Exists' when `key` is empty",
+				[]corev1.Toleration{{Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
+				"tolerations[0].operator",
+			),
+
+			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10506
+			Entry(
+				"effect must be 'NoExecute' when `TolerationSeconds` is set",
+				[]corev1.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: &[]int64{20}[0]}},
+				"tolerations[0].effect",
+			),
+		)
 	})
 
 	DescribeTable(
-		"#Success cases",
-		func(tolerations []corev1.Toleration) {
-			Expect(ValidateTolerations(tolerations, fieldPath)).To(BeEmpty())
+		"#ValidateResourceQuantityValue",
+		func(res string, value resource.Quantity, errMatcher types.GomegaMatcher) {
+			Expect(core.ValidateResourceQuantityValue(res, value, field.NewPath("resourceQuantity"))).To(errMatcher)
 		},
 
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9646
-		Entry(
-			"populate forgiveness tolerations with exists operator in annotations.",
-			[]corev1.Toleration{{Key: "foo", Operator: "Exists", Value: "", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9653
-		Entry(
-			"populate forgiveness tolerations with equal operator in annotations.",
-			[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoExecute", TolerationSeconds: &[]int64{60}[0]}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9660
-		Entry(
-			"populate tolerations equal operator in annotations.",
-			[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9674
-		Entry(
-			"empty key with Exists operator is OK for toleration, empty toleration key means match all taint keys.",
-			[]corev1.Toleration{{Operator: "Exists", Effect: "NoSchedule"}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9681
-		Entry(
-			"empty operator is OK for toleration, defaults to Equal.",
-			[]corev1.Toleration{{Key: "foo", Value: "bar", Effect: "NoSchedule"}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9688
-		Entry(
-			"empty effect is OK for toleration, empty toleration effect means match all taint effects.",
-			[]corev1.Toleration{{Key: "foo", Operator: "Equal", Value: "bar"}},
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L9695
-		Entry(
-			"negative tolerationSeconds is OK for toleration.",
-			[]corev1.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: &[]int64{-2}[0]}},
-		),
-	)
-
-	DescribeTable(
-		"#Error cases",
-		func(tolerations []corev1.Toleration, expectedError string) {
-			// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10950-L10959
-			errs := ValidateTolerations(tolerations, fieldPath)
-			Expect(errs).NotTo(BeEmpty())
-			Expect(errs.ToAggregate().Error()).To(ContainSubstring(expectedError))
-		},
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10465
-		Entry(
-			"invalid toleration key",
-			[]corev1.Toleration{{Key: "nospecialchars^=@", Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
-			"tolerations[0].key",
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10475
-		Entry(
-			"invalid toleration operator",
-			[]corev1.Toleration{{Key: "foo", Operator: "In", Value: "bar", Effect: "NoSchedule"}},
-			"tolerations[0].operator",
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10485
-		Entry(
-			"value must be empty when `operator` is 'Exists'",
-			[]corev1.Toleration{{Key: "foo", Operator: "Exists", Value: "bar", Effect: "NoSchedule"}},
-			"tolerations[0].operator",
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10496
-		Entry(
-			"operator must be 'Exists' when `key` is empty",
-			[]corev1.Toleration{{Operator: "Equal", Value: "bar", Effect: "NoSchedule"}},
-			"tolerations[0].operator",
-		),
-
-		// origin: https://github.com/kubernetes/kubernetes/blob/1467b588060812a11c3e556f645ce0a949bb4b36/pkg/apis/core/validation/validation_test.go#L10506
-		Entry(
-			"effect must be 'NoExecute' when `TolerationSeconds` is set",
-			[]corev1.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: &[]int64{20}[0]}},
-			"tolerations[0].effect",
-		),
-	)
+		Entry("valid quantity", "cpu", resource.MustParse("100m"), BeEmpty()),
+		Entry("zero quantity", "cpu", resource.MustParse("0"), BeEmpty()),
+		Entry("negative quantity", "cpu", resource.MustParse("-100m"), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":   Equal(field.ErrorTypeInvalid),
+			"Field":  Equal("resourceQuantity"),
+			"Detail": Equal("must be greater than or equal to 0"),
+		})))),
+		Entry("valid integer resource quantity", "pods", resource.MustParse("5"), BeEmpty()),
+		Entry("non-integer resource quantity", "pods", resource.MustParse("5.5"), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":   Equal(field.ErrorTypeInvalid),
+			"Field":  Equal("resourceQuantity"),
+			"Detail": Equal("must be an integer"),
+		})))))
 })

--- a/pkg/utils/validation/kubernetes/core/validation_test.go
+++ b/pkg/utils/validation/kubernetes/core/validation_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/gardener/gardener/pkg/utils/validation/kubernetes/core"
 	. "github.com/gardener/gardener/pkg/utils/validation/kubernetes/core"
 )
 
@@ -138,7 +137,7 @@ var _ = Describe("Validation", func() {
 	DescribeTable(
 		"#ValidateResourceQuantityValue",
 		func(res string, value resource.Quantity, errMatcher types.GomegaMatcher) {
-			Expect(core.ValidateResourceQuantityValue(res, value, field.NewPath("resourceQuantity"))).To(errMatcher)
+			Expect(ValidateResourceQuantityValue(res, value, field.NewPath("resourceQuantity"))).To(errMatcher)
 		},
 
 		Entry("valid quantity", "cpu", resource.MustParse("100m"), BeEmpty()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area robustness
/area security
/kind enhancement


**What this PR does / why we need it**:

In the Shoot API, 
- The `.spec.kubernetes.kubelet.cpuManagerPolicy` and `.spec.provider.workers[].kubelet.cpuManagerPolicy` fields are now validated to ensure they can only be set to static or none.
- The `.spec.kubernetes.kubelet.containerLogMaxSize` and `.spec.provider.workers[].kubelet.containerLogMaxSize` fields are now validated to ensure they contain a valid resource quantity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
In the Shoot API, the `.spec.kubernetes.kubelet.cpuManagerPolicy` and `.spec.provider.workers[].kubelet.cpuManagerPolicy` fields are now validated to ensure they can only be set to static or none.
```
```breaking user
In the Shoot API, the `.spec.kubernetes.kubelet.containerLogMaxSize` and `.spec.provider.workers[].kubelet.containerLogMaxSize` fields are now validated to ensure they contain a valid resource quantity.
```
