### PR TITLE
Cleanup usages of `ShouldNot(ContainElements())`

### DIFF
--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -74,8 +74,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				if should {
 					asyncAssertion(1, assertedFunc).Should(ContainElements(expectation))
 				} else {
-					// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-					asyncAssertion(1, assertedFunc).ShouldNot(ContainElements(expectation))
+					asyncAssertion(1, assertedFunc).ShouldNot(ContainAnyOf(expectation...))
 				}
 			}
 		}
@@ -100,8 +99,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				if should {
 					asyncAssertion(1, assertedFunc).Should(ContainElements(expectation))
 				} else {
-					// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-					asyncAssertion(1, assertedFunc).ShouldNot(ContainElements(expectation))
+					asyncAssertion(1, assertedFunc).ShouldNot(ContainAnyOf(expectation...))
 				}
 
 				// egress rules
@@ -118,8 +116,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				if should {
 					asyncAssertion(1, assertedFunc).Should(ContainElements(expectation))
 				} else {
-					// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-					asyncAssertion(1, assertedFunc).ShouldNot(ContainElements(expectation))
+					asyncAssertion(1, assertedFunc).ShouldNot(ContainAnyOf(expectation...))
 				}
 			}
 		}
@@ -148,8 +145,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				if should {
 					asyncAssertion(1, assertedFunc).Should(ContainElements(expectation))
 				} else {
-					// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-					asyncAssertion(1, assertedFunc).ShouldNot(ContainElements(expectation))
+					asyncAssertion(1, assertedFunc).ShouldNot(ContainAnyOf(expectation...))
 				}
 			}
 		}
@@ -170,8 +166,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				if should {
 					asyncAssertion(1, assertedFunc).Should(ContainElements(expectation))
 				} else {
-					// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-					asyncAssertion(1, assertedFunc).ShouldNot(ContainElements(expectation))
+					asyncAssertion(1, assertedFunc).ShouldNot(ContainAnyOf(expectation...))
 				}
 			}
 		}
@@ -348,8 +343,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(service.Namespace))).To(Succeed())
 				return test.ObjectNames(networkPolicyList)
 			}).Should(And(
-				// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-				Not(ContainElements(
+				Not(ContainAnyOf(
 					"ingress-to-"+service.Name+port1Suffix,
 					"egress-to-"+service.Name+port1Suffix,
 				)),
@@ -582,8 +576,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				g.Expect(testClient.List(ctx, networkPolicyList, client.InNamespace(otherNamespace.Name))).To(Succeed())
 				return test.ObjectNames(networkPolicyList)
 			}).Should(And(
-				// TODO(tobschli): Change this to the `ShouldNot(ContainAnyOf())` matcher, once https://github.com/gardener/gardener/pull/12317 is merged.
-				Not(ContainElements(
+				Not(ContainAnyOf(
 					"egress-to-"+service.Namespace+"-"+service.Name+port1Suffix,
 				)),
 				ContainElements(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind task

**What this PR does / why we need it**:

These are some leftovers I forgot 😅

**Which issue(s) this PR fixes**:
Part of #11787

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
