### PR TITLE
Skip `(Admin|Viewer)Kubeconfig` migration when MR secret is not found

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -143,7 +143,7 @@ func removePrometheusFolderCleanedupAnnotation(ctx context.Context, log logr.Log
 	return flow.Parallel(tasks...)(ctx)
 }
 
-// TODO(@vpnachev): Remove this after v1.127.0 has been released
+// TODO(vpnachev): Remove this after v1.128.0 has been released.
 func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log logr.Logger, seedClient client.Client) error {
 	namespaceList := &corev1.NamespaceList{}
 	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
@@ -181,6 +181,10 @@ func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log lo
 
 			objects, err := managedresources.GetObjects(ctx, seedClient, managedResource.Namespace, managedResource.Name)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Managed resource secret not found, skipping migration", "managedResource", key)
+					return nil
+				}
 				return fmt.Errorf("failed to get objects for ManagedResource %q: %w", key, err)
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind bug

**What this PR does / why we need it**:
Skip `(Admin|Viewer)Kubeconfig` migration when MR secret is not found

**Which issue(s) this PR fixes**:
Follow-up on #12673

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the gardenlet start-up migration of the Admin and Viewer Kubeconfig ClusterRoleBindings where a ManagedResource secret could be deleted leading to gardenlet being unable to startup is fixed.
```
