### PR TITLE
[GEP-26] Allow WorkloadIdentities to be used as backup credentials in Seed and BackupBucket APIs

### DIFF
--- a/docs/usage/shoot/shoot-workload-identity.md
+++ b/docs/usage/shoot/shoot-workload-identity.md
@@ -18,7 +18,7 @@ The issuer URL can be read from the [Gardener Info ConfigMap](../gardener/garden
 
 ## JWT Claims
 
-The Gardener API server, as JWT issuer, sets the following standard claims as per [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519):
+The Gardener API server, as JWT issuer, sets the following standard claims as per [RFC-7519](https://datatracker.ietf.org/doc/html/rfc7519):
 
 - **aud**: contains the audiences set in `WorkloadIdentity`'s `.spec.audiences` field.
 - **iss**: issuer of the JWT, see above how to find its value for your Garden installation.

--- a/pkg/apis/core/validation/backupbucket.go
+++ b/pkg/apis/core/validation/backupbucket.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 )
 
 // ValidateBackupBucket validates a BackupBucket object.
@@ -60,12 +59,6 @@ func validateCredentials(spec *core.BackupBucketSpec, fldPath *field.Path) field
 		allErrs = append(allErrs, field.Required(fldPath.Child("credentialsRef"), "must be set and refer a Secret or WorkloadIdentity"))
 	} else {
 		allErrs = append(allErrs, ValidateCredentialsRef(*spec.CredentialsRef, fldPath.Child("credentialsRef"))...)
-
-		// TODO(vpnachev): Allow WorkloadIdentities once the support in the controllers and components is fully implemented.
-		if spec.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() &&
-			spec.CredentialsRef.Kind == "WorkloadIdentity" {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsRef"), "support for WorkloadIdentity as backup credentials is not yet fully implemented"))
-		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/backupbucket_test.go
+++ b/pkg/apis/core/validation/backupbucket_test.go
@@ -149,22 +149,16 @@ var _ = Describe("validation", func() {
 				))
 			})
 
-			It("should forbid credentialsRef to refer a WorkloadIdentity", func() {
+			It("should allow credentialsRef to refer a WorkloadIdentity", func() {
 				backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Namespace: "garden", Name: "backup"}
 
-				Expect(ValidateBackupBucket(backupBucket)).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("spec.credentialsRef"),
-						"Detail": Equal("support for WorkloadIdentity as backup credentials is not yet fully implemented"),
-					})),
-				))
+				Expect(ValidateBackupBucket(backupBucket)).To(BeEmpty())
 			})
 
 			It("should allow credentialsRef to refer a Secret", func() {
 				backupBucket.Spec.CredentialsRef = &corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "garden", Name: "backup"}
 
-				Expect(ValidateBackupBucket(backupBucket)).To((BeEmpty()))
+				Expect(ValidateBackupBucket(backupBucket)).To(BeEmpty())
 			})
 
 			It("should forbid invalid values objectReference fields", func() {

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	featuresvalidation "github.com/gardener/gardener/pkg/utils/validation/features"
@@ -282,12 +281,6 @@ func validateSeedBackup(seedBackup *core.Backup, seedProviderType string, fldPat
 		allErrs = append(allErrs, field.Required(fldPath.Child("credentialsRef"), "must be set to refer a Secret or WorkloadIdentity"))
 	} else {
 		allErrs = append(allErrs, ValidateCredentialsRef(*seedBackup.CredentialsRef, fldPath.Child("credentialsRef"))...)
-
-		// TODO(vpnachev): Allow WorkloadIdentities once the support in the controllers and components is fully implemented.
-		if seedBackup.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() &&
-			seedBackup.CredentialsRef.Kind == "WorkloadIdentity" {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsRef"), "support for WorkloadIdentity as backup credentials is not yet fully implemented"))
-		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -422,22 +422,16 @@ var _ = Describe("Seed Validation Tests", func() {
 				))
 			})
 
-			It("should forbid credentialsRef to refer a WorkloadIdentity", func() {
+			It("should allow credentialsRef to refer a WorkloadIdentity", func() {
 				seed.Spec.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Namespace: "garden", Name: "backup"}
 
-				Expect(ValidateSeed(seed)).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("spec.backup.credentialsRef"),
-						"Detail": Equal("support for WorkloadIdentity as backup credentials is not yet fully implemented"),
-					})),
-				))
+				Expect(ValidateSeed(seed)).To(BeEmpty())
 			})
 
 			It("should allow credentialsRef to refer a Secret", func() {
 				seed.Spec.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "garden", Name: "backup"}
 
-				Expect(ValidateSeed(seed)).To((BeEmpty()))
+				Expect(ValidateSeed(seed)).To(BeEmpty())
 			})
 
 			It("should forbid invalid values objectReference fields", func() {


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/label ipcei/workload-identity 

**What this PR does / why we need it**:
Allow WorkloadIdentities to be used as credentials in `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef` 

**Which issue(s) this PR fixes**:
Part of #9586 

**Special notes for your reviewer**:
Provider extensions are expected to further verify the credentialsRef field and disallow unsupported credentials types, currently such checks are under implementation, refs:
- https://github.com/gardener/gardener-extension-provider-aws/pull/1461
- https://github.com/gardener/gardener-extension-provider-azure/pull/1277
- https://github.com/gardener/gardener-extension-provider-gcp/pull/1163
- https://github.com/gardener/gardener-extension-provider-alicloud/pull/837
- https://github.com/gardener/gardener-extension-provider-openstack/pull/1150
- https://github.com/ironcore-dev/gardener-extension-provider-ironcore/pull/803
- https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pull/240
- https://github.com/metal-stack/gardener-extension-provider-metal/pull/474
- https://github.com/23technologies/gardener-extension-provider-hcloud/pull/248

cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now allowed backups to use `WorkloadIdentity` as credentials via the `seed.spec.backup.credentialsRef` and `backupBucket.spec.credentialsRef` APIs. In order to make use of this feature, the infrastructure and provider extension must support `WorkloadIdentity` credentials. 
```


