### PR TITLE
Remove node reboot feature from `gardener-node-agent`

### DIFF
--- a/pkg/nodeagent/controller/healthcheck/kubelet.go
+++ b/pkg/nodeagent/controller/healthcheck/kubelet.go
@@ -210,9 +210,9 @@ func (k *KubeletHealthChecker) ensureNodeInternalIP(ctx context.Context, node *c
 // verifyNodeReady verifies the NodeReady condition of a node.
 func (k *KubeletHealthChecker) verifyNodeReady(log logr.Logger, node *corev1.Node) error {
 	if isNodeReady(node) && !k.NodeReady {
-		needsReboot := k.ToggleKubeletState()
+		createEvent := k.ToggleKubeletState()
 		log.Info("Kubelet became Ready", "readinessChanges", len(k.KubeletReadinessToggles), "timespan", toggleTimeSpan)
-		if needsReboot {
+		if createEvent {
 			// Do not reboot the node, but create an event instead.
 			k.recorder.Eventf(node, corev1.EventTypeWarning, "kubelet", "Kubelet toggled between NotReady and Ready at least %d times in a %s time window. Rebooting the node might help", maxToggles, toggleTimeSpan)
 		}

--- a/pkg/nodeagent/controller/healthcheck/kubelet.go
+++ b/pkg/nodeagent/controller/healthcheck/kubelet.go
@@ -211,17 +211,8 @@ func (k *KubeletHealthChecker) ensureNodeInternalIP(ctx context.Context, node *c
 // If the condition changes 5 times within 10 minutes from NotReady->Ready the node will be rebooted.
 func (k *KubeletHealthChecker) verifyNodeReady(log logr.Logger, node *corev1.Node) error {
 	if isNodeReady(node) && !k.NodeReady {
-		needsReboot := k.ToggleKubeletState()
+		_ = k.ToggleKubeletState()
 		log.Info("Kubelet became Ready", "readinessChanges", len(k.KubeletReadinessToggles), "timespan", toggleTimeSpan)
-		if needsReboot {
-			log.Info("Kubelet toggled between NotReady and Ready too often. Rebooting the node now")
-			k.recorder.Eventf(node, corev1.EventTypeWarning, "kubelet", "Kubelet toggled between NotReady and Ready at least %d times in a %s time window. Rebooting the node now", maxToggles, toggleTimeSpan)
-			if err := k.dbus.Reboot(); err != nil {
-				k.RevertToggleKubeletState()
-				k.recorder.Event(node, corev1.EventTypeWarning, "kubelet", "Rebooting the node failed")
-				return fmt.Errorf("rebooting the node failed %w", err)
-			}
-		}
 	}
 	k.NodeReady = isNodeReady(node)
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Remove node reboot feature from `gardener-node-agent`.

Long time ago, Gardener faced issues with nodes flapping between ready/non-ready state. A reboot seem to have solved these issues back then.
More recently some nodes got rebooted unnecessarily because the control plane was temporarily overloaded causing some nodes to flap between ready/non-ready as not all requests made it through. It seems reasonable to remove the node reboot for now until we see problems again. Then we may be able to tackle them in either the same way as previously done or find a better solution.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The original implementation for the node readiness check was done in https://github.com/gardener/gardener/commit/cc7c0bf8e55b37b3ba9e55e2b38ba19b262e9299.

The code keeping track of the number of flaps was left intentionally in so that the log messages still include the amount of flaps.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-node-agent no longer reboots a node if it flaps too often between ready/non-ready in a short period of time.
```
