### PR TITLE
chore(mutator): add VPNServerstatefulset ensurer

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -287,6 +287,20 @@ func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerDeployment(ctx, gctx, new,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerDeployment), ctx, gctx, new, old)
 }
 
+// EnsureVPNSeedServerStatefulSet mocks base method.
+func (m *MockEnsurer) EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx context0.GardenContext, new, old *v1.StatefulSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureVPNSeedServerStatefulSet", ctx, gctx, new, old)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureVPNSeedServerStatefulSet indicates an expected call of EnsureVPNSeedServerStatefulSet.
+func (mr *MockEnsurerMockRecorder) EnsureVPNSeedServerStatefulSet(ctx, gctx, new, old any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVPNSeedServerStatefulSet", reflect.TypeOf((*MockEnsurer)(nil).EnsureVPNSeedServerStatefulSet), ctx, gctx, new, old)
+}
+
 // ShouldProvisionKubeletCloudProviderConfig mocks base method.
 func (m *MockEnsurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, gctx context0.GardenContext, kubeletVersion *semver.Version) bool {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -58,6 +58,9 @@ type Ensurer interface {
 	// EnsureVPNSeedServerDeployment ensures that the vpn-seed-server deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
 	EnsureVPNSeedServerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
+	// EnsureVPNSeedServerStatefulSet ensures that the vpn-seed-server deployment conforms to the provider requirements.
+	// "old" might be "nil" and must always be checked.
+	EnsureVPNSeedServerStatefulSet(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.StatefulSet) error
 	// EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
 	EnsureKubeletServiceUnitOptions(ctx context.Context, gctx extensionscontextwebhook.GardenContext, kubeletVersion *semver.Version, new, old []*unit.UnitOption) ([]*unit.UnitOption, error)
 	// EnsureKubeletConfiguration ensures that the kubelet configuration conforms to the provider requirements.
@@ -154,6 +157,21 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureVPNSeedServerDeployment(ctx, gctx, x, oldDep)
 		}
+	case *appsv1.StatefulSet:
+		var oldSet *appsv1.StatefulSet
+		if old != nil {
+			var ok bool
+			oldSet, ok = old.(*appsv1.StatefulSet)
+			if !ok {
+				return errors.New("could not cast old object to appsv1.StatefulSet")
+			}
+		}
+		switch x.Name {
+		case v1beta1constants.StatefulSetNameVPNSeedServer:
+			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
+			return m.ensurer.EnsureVPNSeedServerStatefulSet(ctx, gctx, x, oldSet)
+		}
+
 	case *vpaautoscalingv1.VerticalPodAutoscaler:
 		var oldVPA *vpaautoscalingv1.VerticalPodAutoscaler
 		if old != nil {

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -260,6 +260,21 @@ var _ = Describe("Mutator", func() {
 					ensurer.EXPECT().EnsureVPNSeedServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
+			Entry(
+				"EnsureVPNSeedServerStatefulSet with a vpn-seed-server statefulset",
+				func() {
+					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameVPNSeedServer}}
+					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureVPNSeedServerStatefulSet with a vpn-seed-server statefulset and existing statefulset",
+				func() {
+					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameVPNSeedServer}}
+					oldObj = newObj.DeepCopyObject().(client.Object)
+					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
 		)
 
 		DescribeTable("EnsureETCD", func(newObj, oldObj *druidcorev1alpha1.Etcd) {

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -63,6 +63,11 @@ func (e *NoopEnsurer) EnsureVPNSeedServerDeployment(_ context.Context, _ extensi
 	return nil
 }
 
+// EnsureVPNSeedServerStatefulSet ensures that the vpn-seed-server statefulset conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureVPNSeedServerStatefulSet(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.StatefulSet) error {
+	return nil
+}
+
 // EnsureKubeletServiceUnitOptions ensures that the kubelet.service unit options conform to the provider requirements.
 func (e *NoopEnsurer) EnsureKubeletServiceUnitOptions(_ context.Context, _ extensionscontextwebhook.GardenContext, _ *semver.Version, new, _ []*unit.UnitOption) ([]*unit.UnitOption, error) {
 	return new, nil

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -132,7 +132,7 @@ const (
 	DeploymentNameVPNSeedServer = "vpn-seed-server"
 	// StatefulSetNameVPNSeedServer is a constant for the name of a Kubernetes statefulset object that contains
 	// the vpn-seed-server pods.
-	StatefulSetNameVPNSeedServer = "vpn-seed-server"
+	StatefulSetNameVPNSeedServer = DeploymentNameVPNSeedServer
 
 	// DeploymentNameKubeScheduler is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-scheduler pod.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -130,6 +130,9 @@ const (
 	// DeploymentNameVPNSeedServer is a constant for the name of a Kubernetes deployment object that contains
 	// the vpn-seed-server pod.
 	DeploymentNameVPNSeedServer = "vpn-seed-server"
+	// StatefulSetNameVPNSeedServer is a constant for the name of a Kubernetes statefulset object that contains
+	// the vpn-seed-server pods.
+	StatefulSetNameVPNSeedServer = "vpn-seed-server"
 
 	// DeploymentNameKubeScheduler is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-scheduler pod.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivy
/kind enhancement

**What this PR does / why we need it**:
VPN seed server is deployed as statefulset in HA controlplane clusters
https://gardener-cloud.slack.com/archives/CAPMD6DCG/p1757677243558969

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add ensure capabilities for HA vpn statefulsets
```
