### PR TITLE
Include current version for in-place update filtering in maintenance controller

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/helper/helper.go
@@ -215,9 +215,17 @@ func filterForInPlaceUpdateConstraint(machineImageFromCloudProfile *gardencorev1
 	}
 
 	for _, cloudProfileVersion := range machineImageFromCloudProfile.Versions {
-		if workerImageVersion != nil && cloudProfileVersion.InPlaceUpdates != nil && cloudProfileVersion.InPlaceUpdates.Supported && cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate != nil {
-			if validVersion, _ := versionutils.CompareVersions(*cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate, "<=", *workerImageVersion); validVersion {
+		if workerImageVersion != nil && cloudProfileVersion.InPlaceUpdates != nil && cloudProfileVersion.InPlaceUpdates.Supported {
+			// add the current version also in the list of possible versions
+			if *workerImageVersion == cloudProfileVersion.Version {
 				filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+				continue
+			}
+
+			if cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate != nil {
+				if validVersion, _ := versionutils.CompareVersions(*cloudProfileVersion.InPlaceUpdates.MinVersionForUpdate, "<=", *workerImageVersion); validVersion {
+					filteredMachineImages.Versions = append(filteredMachineImages.Versions, cloudProfileVersion)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Enhances the filterForInPlaceUpdateConstraint function to also include the current worker image version if it supports in-place updates; otherwise, it can trigger an update because of [this](https://github.com/gardener/gardener/blob/a80facba33ad394a88f17571f661d61f73e97efe/pkg/controllermanager/controller/shoot/maintenance/reconciler.go#L729-L732) reason.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
