### PR TITLE
Support processing field/label selectors in `SeedAuthorizer`

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
@@ -77,4 +77,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 {{- end }}

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -98,21 +98,21 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 		switch requestResource {
 		case backupBucketResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeBackupBucket, attrs,
-				[]string{"update", "patch", "delete"},
-				[]string{"create", "get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch", "delete"),
+				withAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case backupEntryResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeBackupEntry, attrs,
-				[]string{"update", "patch", "delete"},
-				[]string{"create", "get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch", "delete"),
+				withAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case bastionResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeBastion, attrs,
-				[]string{"update", "patch"},
-				[]string{"create", "get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch"),
+				withAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case certificateSigningRequestResource:
 			if userType == seedidentity.UserTypeExtension {
@@ -120,9 +120,9 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			}
 
 			return a.authorize(requestLog, seedName, graph.VertexTypeCertificateSigningRequest, attrs,
-				[]string{"get", "list", "watch"},
-				[]string{"create"},
-				[]string{"seedclient"},
+				withAllowedVerbs("get", "list", "watch"),
+				withAlwaysAllowedVerbs("create"),
+				withAllowedSubresources("seedclient"),
 			)
 		case cloudProfileResource:
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeCloudProfile, attrs)
@@ -133,9 +133,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 				// We don't use authorizeRead here, as it would also grant list and watch permissions, which gardenlet doesn't
 				// have. We want to grant the read-only subset of gardenlet's permissions.
 				return a.authorize(requestLog, seedName, graph.VertexTypeClusterRoleBinding, attrs,
-					[]string{"get"},
-					nil,
-					nil,
+					withAllowedVerbs("get"),
 				)
 			}
 
@@ -146,39 +144,38 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeControllerDeployment, attrs)
 		case controllerInstallationResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeControllerInstallation, attrs,
-				[]string{"update", "patch"},
-				[]string{"get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch"),
+				withAlwaysAllowedVerbs("get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case controllerRegistrationResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeControllerRegistration, attrs,
-				nil,
-				[]string{"get", "list", "watch"},
-				nil,
+				withAlwaysAllowedVerbs("get", "list", "watch"),
 			)
+		case credentialsBindingResource:
+			return a.authorizeRead(requestLog, seedName, graph.VertexTypeCredentialsBinding, attrs)
 		case eventCoreResource, eventResource:
 			return a.authorizeEvent(requestLog, attrs)
 		case exposureClassResource:
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeExposureClass, attrs)
 		case internalSecretResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeInternalSecret, attrs,
-				[]string{"get", "update", "patch", "delete", "list", "watch"},
-				[]string{"create"},
-				nil,
+				withAllowedVerbs("get", "update", "patch", "delete", "list", "watch"),
+				withAlwaysAllowedVerbs("create"),
 			)
 		case leaseResource:
 			return a.authorizeLease(requestLog, seedName, userType, attrs)
 		case gardenletResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeGardenlet, attrs,
-				[]string{"update", "patch"},
-				[]string{"get", "list", "watch", "create"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch"),
+				withAlwaysAllowedVerbs("get", "list", "watch", "create"),
+				withAllowedSubresources("status"),
 			)
 		case managedSeedResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeManagedSeed, attrs,
-				[]string{"update", "patch"},
-				[]string{"get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch"),
+				withAlwaysAllowedVerbs("get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case namespaceResource:
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeNamespace, attrs)
@@ -186,45 +183,44 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeProject, attrs)
 		case secretBindingResource:
 			return a.authorizeRead(requestLog, seedName, graph.VertexTypeSecretBinding, attrs)
-		case credentialsBindingResource:
-			return a.authorizeRead(requestLog, seedName, graph.VertexTypeCredentialsBinding, attrs)
 		case secretResource:
 			return a.authorizeSecret(requestLog, seedName, attrs)
 		case workloadIdentityResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeWorkloadIdentity, attrs,
-				[]string{"get", "list", "watch", "create", "patch"},
-				nil,
-				[]string{"token"},
+				withAllowedVerbs("get", "list", "watch", "create", "patch"),
+				withAllowedSubresources("token"),
 			)
 		case seedResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeSeed, attrs,
-				[]string{"update", "patch", "delete"},
-				[]string{"create", "get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch", "delete"),
+				withAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case serviceAccountResource:
 			if userType == seedidentity.UserTypeExtension {
 				// We don't use authorizeRead here, as it would also grant list and watch permissions, which gardenlet doesn't
 				// have. We want to grant the read-only subset of gardenlet's permissions.
 				return a.authorize(requestLog, seedName, graph.VertexTypeServiceAccount, attrs,
-					[]string{"get"},
-					nil,
-					nil,
+					withAllowedVerbs("get"),
 				)
 			}
 
 			return a.authorizeServiceAccount(requestLog, seedName, attrs)
 		case shootResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeShoot, attrs,
-				[]string{"update", "patch"},
-				[]string{"get", "list", "watch"},
-				[]string{"status"},
+				withAllowedVerbs("update", "patch"),
+				withAlwaysAllowedVerbs("get", "list", "watch"),
+				withAllowedSubresources("status"),
 			)
 		case shootStateResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeShootState, attrs,
-				[]string{"get", "update", "patch", "delete", "list", "watch"},
-				[]string{"create"},
-				nil,
+				withAllowedVerbs("get", "update", "patch", "delete", "list", "watch"),
+				withAlwaysAllowedVerbs("create"),
+			)
+		case workloadIdentityResource:
+			return a.authorize(requestLog, seedName, graph.VertexTypeWorkloadIdentity, attrs,
+				withAllowedVerbs("get", "list", "watch", "create"),
+				withAllowedSubresources("token"),
 			)
 		default:
 			a.logger.Info(
@@ -253,9 +249,8 @@ func (a *authorizer) authorizeClusterRoleBinding(log logr.Logger, seedName strin
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeClusterRoleBinding, attrs,
-		[]string{"get", "patch", "update"},
-		[]string{"create"},
-		nil,
+		withAllowedVerbs("get", "patch", "update"),
+		withAlwaysAllowedVerbs("create"),
 	)
 }
 
@@ -292,9 +287,8 @@ func (a *authorizer) authorizeLease(log logr.Logger, seedName string, userType s
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeLease, attrs,
-		[]string{"get", "update", "patch", "list", "watch"},
-		[]string{"create"},
-		nil,
+		withAllowedVerbs("get", "update", "patch", "list", "watch"),
+		withAlwaysAllowedVerbs("create"),
 	)
 }
 
@@ -314,9 +308,8 @@ func (a *authorizer) authorizeSecret(log logr.Logger, seedName string, attrs aut
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeSecret, attrs,
-		[]string{"get", "patch", "update", "delete"},
-		[]string{"create"},
-		nil,
+		withAllowedVerbs("get", "patch", "update", "delete"),
+		withAlwaysAllowedVerbs("create"),
 	)
 }
 
@@ -328,9 +321,8 @@ func (a *authorizer) authorizeConfigMap(log logr.Logger, seedName string, attrs 
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeConfigMap, attrs,
-		[]string{"get", "patch", "update", "delete", "list", "watch"},
-		[]string{"create"},
-		nil,
+		withAllowedVerbs("get", "patch", "update", "delete", "list", "watch"),
+		withAlwaysAllowedVerbs("create"),
 	)
 }
 
@@ -350,49 +342,75 @@ func (a *authorizer) authorizeServiceAccount(log logr.Logger, seedName string, a
 	}
 
 	return a.authorize(log, seedName, graph.VertexTypeServiceAccount, attrs,
-		[]string{"get", "patch", "update"},
-		[]string{"create"},
-		nil,
+		withAllowedVerbs("get", "patch", "update"),
+		withAlwaysAllowedVerbs("create"),
 	)
 }
 
 func (a *authorizer) authorizeRead(log logr.Logger, seedName string, fromType graph.VertexType, attrs auth.Attributes) (auth.Decision, string, error) {
 	return a.authorize(log, seedName, fromType, attrs,
-		[]string{"get", "list", "watch"},
-		nil,
-		nil,
+		withAllowedVerbs("get", "list", "watch"),
 	)
 }
+
+type authzRequest struct {
+	allowedVerbs        []string
+	alwaysAllowedVerbs  []string
+	allowedSubresources []string
+}
+
+type configFunc func(req *authzRequest)
 
 func (a *authorizer) authorize(
 	log logr.Logger,
 	seedName string,
 	fromType graph.VertexType,
 	attrs auth.Attributes,
-	allowedVerbs []string,
-	alwaysAllowedVerbs []string,
-	allowedSubresources []string,
+	fns ...configFunc,
 ) (
 	auth.Decision,
 	string,
 	error,
 ) {
-	if ok, reason := a.checkSubresource(log, attrs, allowedSubresources...); !ok {
+	req := &authzRequest{}
+	for _, f := range fns {
+		f(req)
+	}
+
+	if ok, reason := a.checkSubresource(log, attrs, req.allowedSubresources...); !ok {
 		return auth.DecisionNoOpinion, reason, nil
 	}
 
 	// When a new object is created then it doesn't yet exist in the graph, so usually such requests are always allowed
 	// as the 'create case' is typically handled in the SeedRestriction admission handler. Similarly, resources for
 	// which the gardenlet has a controller need to be listed/watched, so those verbs would also be allowed here.
-	if slices.Contains(alwaysAllowedVerbs, attrs.GetVerb()) {
+	if slices.Contains(req.alwaysAllowedVerbs, attrs.GetVerb()) {
 		return auth.DecisionAllow, "", nil
 	}
 
-	if ok, reason := a.checkVerb(log, attrs, append(alwaysAllowedVerbs, allowedVerbs...)...); !ok {
+	if ok, reason := a.checkVerb(log, attrs, append(req.alwaysAllowedVerbs, req.allowedVerbs...)...); !ok {
 		return auth.DecisionNoOpinion, reason, nil
 	}
 
 	return a.hasPathFrom(log, seedName, fromType, attrs)
+}
+
+func withAllowedVerbs(verbs ...string) configFunc {
+	return func(req *authzRequest) {
+		req.allowedVerbs = verbs
+	}
+}
+
+func withAlwaysAllowedVerbs(verbs ...string) configFunc {
+	return func(req *authzRequest) {
+		req.alwaysAllowedVerbs = verbs
+	}
+}
+
+func withAllowedSubresources(resources ...string) configFunc {
+	return func(req *authzRequest) {
+		req.allowedSubresources = resources
+	}
 }
 
 func (a *authorizer) hasPathFrom(log logr.Logger, seedName string, fromType graph.VertexType, attrs auth.Attributes) (auth.Decision, string, error) {

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Seed", func() {
 
 		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		graph = mockgraph.NewMockInterface(ctrl)
-		authorizer = NewAuthorizer(log, graph)
+		authorizer = NewAuthorizer(log, graph, nil)
 
 		seedName = "seed"
 		gardenletUser = &user.DefaultInfo{

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Seed", func() {
 
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get patch update delete list watch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 					},
 
 					Entry("deletecollection", "deletecollection"),
@@ -561,7 +561,7 @@ var _ = Describe("Seed", func() {
 
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch create patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list patch watch]"))
 					},
 
 					Entry("update", "update"),
@@ -674,7 +674,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get update patch delete list watch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 					},
 
 					Entry("deletecollection", "deletecollection"),
@@ -974,7 +974,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch delete]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 					},
 
 					Entry("deletecollection", "deletecollection"),
@@ -1071,7 +1071,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch delete]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 
 					},
 
@@ -1249,7 +1249,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list patch update watch]"))
 
 					},
 
@@ -1332,7 +1332,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch update patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
 
 					},
 
@@ -1417,7 +1417,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch create update patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list patch update watch]"))
 
 					},
 
@@ -1499,7 +1499,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch update patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
 
 					},
 
@@ -1709,7 +1709,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch update patch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
 
 					},
 
@@ -1831,7 +1831,7 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch delete]"))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 				})
 
 				It("should have no opinion because no allowed subresource", func() {
@@ -2039,7 +2039,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get patch update delete]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get patch update]"))
 
 					},
 
@@ -2169,7 +2169,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get update patch delete list watch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list patch update watch]"))
 					},
 
 					Entry("deletecollection", "deletecollection"),
@@ -2446,7 +2446,7 @@ var _ = Describe("Seed", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get update patch list watch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list patch update watch]"))
 
 					},
 					Entry("delete", "delete"),

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -878,10 +878,8 @@ func clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"operations.gardener.cloud"},
-				Resources: []string{
-					"bastions",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"bastions"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{""},
@@ -895,24 +893,23 @@ func clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"coordination.k8s.io"},
-				Resources: []string{
-					"leases",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"certificates.k8s.io"},
-				Resources: []string{
-					"certificatesigningrequests",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"certificatesigningrequests"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"security.gardener.cloud"},
-				Resources: []string{
-					"credentialsbindings",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"credentialsbindings"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"authorization.k8s.io"},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
 			},
 		},
 	}

--- a/pkg/component/gardener/admissioncontroller/rbac.go
+++ b/pkg/component/gardener/admissioncontroller/rbac.go
@@ -5,6 +5,7 @@
 package admissioncontroller
 
 import (
+	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,10 +53,8 @@ func (a *gardenerAdmissionController) clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{operationsv1alpha1.GroupName},
-				Resources: []string{
-					"bastions",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"bastions"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
@@ -69,24 +68,23 @@ func (a *gardenerAdmissionController) clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{coordinationv1beta1.GroupName},
-				Resources: []string{
-					"leases",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{certificatesv1.GroupName},
-				Resources: []string{
-					"certificatesigningrequests",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"certificatesigningrequests"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{securityv1alpha1.GroupName},
-				Resources: []string{
-					"credentialsbindings",
-				},
-				Verbs: []string{"get", "list", "watch"},
+				Resources: []string{"credentialsbindings"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{authorizationv1.GroupName},
+				Resources: []string{"subjectaccessreviews"},
+				Verbs:     []string{"create"},
 			},
 		},
 	}

--- a/pkg/webhook/authorizer/withselectors.go
+++ b/pkg/webhook/authorizer/withselectors.go
@@ -23,6 +23,7 @@ import (
 
 // WithSelectorsChecker checks whether the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
 // TODO(rfranzke): Remove this interface once the lowest supported Kubernetes version is 1.34.
+//
 // Deprecated: This interface will be removed once the lowest supported Kubernetes version is 1.34.
 type WithSelectorsChecker interface {
 	// IsPossible returns true if the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
@@ -62,7 +63,7 @@ func (w *withSelectorsChecker) IsPossible() (bool, error) {
 		w.isPossible = enabled
 		if mustCheckAgain {
 			w.nextCheckTime = ptr.To(w.clock.Now().UTC().Add(10 * time.Minute))
-			w.log.Info("Must check again, caching result", "nextCheckTime", w.nextCheckTime.String())
+			w.log.Info("Must check again, caching result", "nextCheckTime", w.nextCheckTime.UTC().String())
 		} else {
 			w.nextCheckTime = nil
 			w.log.Info("No need not check again")
@@ -101,7 +102,7 @@ func (w *withSelectorsChecker) isAuthorizeWithSelectorsFeatureEnabled() (enabled
 					Namespace:     "default",
 					Verb:          "get",
 					Resource:      "shoots",
-					LabelSelector: &authorizationv1.LabelSelectorAttributes{RawSelector: "foo=bar"},
+					LabelSelector: &authorizationv1.LabelSelectorAttributes{RawSelector: "is-kubernetes-feature-gate-AuthorizeWithSelectors=enabled?"},
 				},
 			},
 		}

--- a/pkg/webhook/authorizer/withselectors.go
+++ b/pkg/webhook/authorizer/withselectors.go
@@ -52,19 +52,19 @@ type withSelectorsChecker struct {
 }
 
 func (w *withSelectorsChecker) IsPossible() (bool, error) {
-	if w.nextCheckTime != nil && !w.clock.Now().UTC().Before(w.nextCheckTime.UTC()) {
+	if w.nextCheckTime != nil && w.clock.Now().UTC().After(w.nextCheckTime.UTC()) {
 		enabled, mustCheckAgain, err := w.isAuthorizeWithSelectorsFeatureEnabled()
 		if err != nil {
 			return false, fmt.Errorf("failed checking whether 'AuthorizeWithSelectors' feature is enabled: %w", err)
 		}
 
 		w.isPossible = enabled
-		if !mustCheckAgain {
-			w.nextCheckTime = nil
-			w.log.Info("No need not check again")
-		} else {
+		if mustCheckAgain {
 			w.nextCheckTime = ptr.To(w.clock.Now().UTC().Add(10 * time.Minute))
 			w.log.Info("Must check again, caching result", "nextCheckTime", w.nextCheckTime.String())
+		} else {
+			w.nextCheckTime = nil
+			w.log.Info("No need not check again")
 		}
 	}
 

--- a/pkg/webhook/authorizer/withselectors.go
+++ b/pkg/webhook/authorizer/withselectors.go
@@ -23,6 +23,7 @@ import (
 
 // WithSelectorsChecker checks whether the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
 // TODO(rfranzke): Remove this interface once the lowest supported Kubernetes version is 1.34.
+// Deprecated: This interface will be removed once the lowest supported Kubernetes version is 1.34.
 type WithSelectorsChecker interface {
 	// IsPossible returns true if the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
 	IsPossible() (bool, error)

--- a/pkg/webhook/authorizer/withselectors.go
+++ b/pkg/webhook/authorizer/withselectors.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
+)
+
+// WithSelectorsChecker checks whether the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
+// TODO(rfranzke): Remove this interface once the lowest supported Kubernetes version is 1.34.
+type WithSelectorsChecker interface {
+	// IsPossible returns true if the 'AuthorizeWithSelectors' feature is enabled in the kube-apiserver.
+	IsPossible() (bool, error)
+}
+
+// NewWithSelectorsChecker creates a new WithSelectorsChecker.
+func NewWithSelectorsChecker(ctx context.Context, log logr.Logger, clientSet kubernetes.Interface, clock clock.Clock) WithSelectorsChecker {
+	return &withSelectorsChecker{
+		ctx:       ctx,
+		log:       log.WithName("authorize-with-selectors-checker"),
+		clientSet: clientSet,
+		clock:     clock,
+
+		isPossible:    false,
+		nextCheckTime: ptr.To(clock.Now()),
+	}
+}
+
+type withSelectorsChecker struct {
+	ctx       context.Context
+	log       logr.Logger
+	clientSet kubernetes.Interface
+	clock     clock.Clock
+
+	isPossible    bool
+	nextCheckTime *time.Time
+}
+
+func (w *withSelectorsChecker) IsPossible() (bool, error) {
+	if w.nextCheckTime != nil && !w.clock.Now().UTC().Before(w.nextCheckTime.UTC()) {
+		enabled, mustCheckAgain, err := w.isAuthorizeWithSelectorsFeatureEnabled()
+		if err != nil {
+			return false, fmt.Errorf("failed checking whether 'AuthorizeWithSelectors' feature is enabled: %w", err)
+		}
+
+		w.isPossible = enabled
+		if !mustCheckAgain {
+			w.nextCheckTime = nil
+			w.log.Info("No need not check again")
+		} else {
+			w.nextCheckTime = ptr.To(w.clock.Now().UTC().Add(10 * time.Minute))
+			w.log.Info("Must check again, caching result", "nextCheckTime", w.nextCheckTime.String())
+		}
+	}
+
+	return w.isPossible, nil
+}
+
+func (w *withSelectorsChecker) isAuthorizeWithSelectorsFeatureEnabled() (enabled bool, mustCheckAgain bool, err error) {
+	version, err := semver.NewVersion(w.clientSet.Version())
+	if err != nil {
+		return false, true, fmt.Errorf("failed parsing Kubernetes version %q to semver: %w", w.clientSet.Version(), err)
+	}
+
+	switch {
+	case versionutils.ConstraintK8sLess131.Check(version):
+		w.log.Info("Kubernetes version is lower than 1.31 -> feature gate did not exist", "authorizationWithSelectorsPossible", false)
+		return false, false, nil
+
+	case versionutils.ConstraintK8sGreaterEqual134.Check(version):
+		w.log.Info("Kubernetes version is at least 1.34 -> feature gate is GA and locked to 'enabled'", "authorizationWithSelectorsPossible", true)
+		return true, false, nil
+
+	default:
+		// Feature gate exists but is alpha/beta and may be disabled - we have to check whether it is enabled by making
+		// a dry-run call with a label selector field. If it is still present in the output, then the
+		// 'AuthorizeWithSelectors' feature is enabled. If it was disabled, kube-apiserver would have removed it in its
+		// response.
+		w.log.Info("Kubernetes version is between 1.31 and 1.33 -> feature gate is alpha/beta and may be disabled, must check")
+
+		sar := &authorizationv1.SubjectAccessReview{
+			Spec: authorizationv1.SubjectAccessReviewSpec{
+				User: "gardener-admission-controller",
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace:     "default",
+					Verb:          "get",
+					Resource:      "shoots",
+					LabelSelector: &authorizationv1.LabelSelectorAttributes{RawSelector: "foo=bar"},
+				},
+			},
+		}
+
+		ctx, cancel := context.WithTimeout(w.ctx, 10*time.Second)
+		defer cancel()
+
+		if err := w.clientSet.Client().Create(ctx, sar, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
+			return false, true, fmt.Errorf("failed creating dry-run SubjectAccessReview: %w", err)
+		}
+
+		// If the label selector field is still present in the output, then the AuthorizeWithSelectors feature is enabled.
+		// If it was disabled, kube-apiserver would have removed it in its response.
+		authorizationWithSelectorsPossible := sar.Spec.ResourceAttributes.LabelSelector != nil
+		w.log.Info("Check completed", "authorizationWithSelectorsPossible", authorizationWithSelectorsPossible)
+
+		return authorizationWithSelectorsPossible, true, nil
+	}
+}

--- a/pkg/webhook/authorizer/withselectors_test.go
+++ b/pkg/webhook/authorizer/withselectors_test.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authorizer_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	. "github.com/gardener/gardener/pkg/webhook/authorizer"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+)
+
+var _ = Describe("WithSelectors", func() {
+	Describe("WithSelectorsChecker", func() {
+		var (
+			ctx = context.Background()
+			log = logr.Discard()
+
+			ctrl          *gomock.Controller
+			mockClient    *mockclient.MockClient
+			fakeClientSet kubernetes.Interface
+			fakeClock     *testclock.FakeClock
+
+			checker WithSelectorsChecker
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			DeferCleanup(func() { ctrl.Finish() })
+
+			mockClient = mockclient.NewMockClient(ctrl)
+			fakeClock = testclock.NewFakeClock(time.Now())
+		})
+
+		JustBeforeEach(func() {
+			fakeClock.Step(time.Second)
+		})
+
+		Describe("#IsPossible", func() {
+			When("Kubernetes version is less then 1.31", func() {
+				BeforeEach(func() {
+					fakeClientSet = fakekubernetes.NewClientSetBuilder().
+						WithClient(mockClient).
+						WithVersion("1.30.0").
+						Build()
+					checker = NewWithSelectorsChecker(ctx, log, fakeClientSet, fakeClock)
+				})
+
+				It("should return false", func() {
+					possible, err := checker.IsPossible()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(possible).To(BeFalse())
+				})
+
+				It("should never query the API server to check if the feature gate is turned on", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
+
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+				})
+			})
+
+			When("Kubernetes version is at least 1.34", func() {
+				BeforeEach(func() {
+					fakeClientSet = fakekubernetes.NewClientSetBuilder().
+						WithClient(mockClient).
+						WithVersion("1.34.0").
+						Build()
+					checker = NewWithSelectorsChecker(ctx, log, fakeClientSet, fakeClock)
+				})
+
+				It("should return true", func() {
+					possible, err := checker.IsPossible()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(possible).To(BeTrue())
+				})
+
+				It("should never query the API server to check if the feature gate is turned on", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.Any()).Times(0)
+
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+				})
+			})
+
+			When("Kubernetes version is between 1.31 and 1.33", func() {
+				BeforeEach(func() {
+					fakeClientSet = fakekubernetes.NewClientSetBuilder().
+						WithClient(mockClient).
+						WithVersion("1.33.0").
+						Build()
+					checker = NewWithSelectorsChecker(ctx, log, fakeClientSet, fakeClock)
+				})
+
+				It("should return true when the feature is turned on", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{}), gomock.Any()).Do(func(_ context.Context, _ client.Object, _ ...client.CreateOption) {
+						// we do not modify the .spec.resourceAttributes.labelSelector here, hence, it is part of the
+						// returned object --> feature gate is turned on
+					})
+
+					possible, err := checker.IsPossible()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(possible).To(BeTrue())
+				})
+
+				It("should return false when the feature gate is turned off", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{}), gomock.Any()).Do(func(_ context.Context, obj client.Object, _ ...client.CreateOption) {
+						// we remove the .spec.resourceAttributes.labelSelector here, hence, it is not part of the
+						// returned object --> feature gate is turned off
+						obj.(*authorizationv1.SubjectAccessReview).Spec.ResourceAttributes.LabelSelector = nil
+					})
+
+					possible, err := checker.IsPossible()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(possible).To(BeFalse())
+				})
+
+				It("should cache the result for 10 minutes", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{}), gomock.Any()).Times(1)
+
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+				})
+
+				It("should re-check the feature gate after 10 minutes", func() {
+					mockClient.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{}), gomock.Any()).Times(2)
+
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5 * time.Minute)
+					_, _ = checker.IsPossible()
+					fakeClock.Step(5*time.Minute + time.Second)
+					_, _ = checker.IsPossible()
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This topic was started in [2024/12 Hackathon](https://github.com/gardener-community/hackathon/tree/main/2024-12_Schelklingen#%EF%B8%8F-enhanced-seed-authorizer-with-labelfield-selectors), but it was not finished. In the context of #2906, we need it to restrict the read permissions of "shoot `gardenlet`s".

The possibility to check selectors depends on the Kubernetes version of the garden cluster, and whether the `AuthorizeWithSelectors` feature gate is enabled. It was introduced as alpha with 1.31, and got promoted to GA (and locked to 'enabled') with 1.34. `gardener-admission-controller` checks if the feature is enabled by checking the Kubernetes version and dry-running a `SubjectAccessReview` creation with a label selector (see implementation).

If the feature is turned on, `list`/`watch` requests can be put under selector constraints. This is not part of this PR but can be worked on separately/as follow-up (see https://github.com/gardener/gardener/issues/12959). For example, to restrict the `gardenlet`s to only list/watch `Shoot`s that are related to the `Seed` it is responsible for, the following diff could be used:

```diff
diff --git a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
index 4a670eabac..a1894b6db7 100644
--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -24,6 +24,7 @@ import (
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"

 	"github.com/gardener/gardener/pkg/admissioncontroller/seedidentity"
+	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
@@ -213,9 +214,10 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeServiceAccount(requestLog, seedName, attrs)
 		case shootResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeShoot, attrs,
-				withAllowedVerbs("update", "patch"),
-				withAlwaysAllowedVerbs("get", "list", "watch"),
+				withAllowedVerbs("update", "patch", "get", "list", "watch"),
 				withAllowedSubresources("status"),
+				withSeedFieldSelectorFields(core.ShootSeedName, core.ShootStatusSeedName),
+				withSeedLabelSelectorKeys(v1beta1constants.LabelPrefixSeedName+seedName),
 			)
 		case shootStateResource:
 			return a.authorize(requestLog, seedName, graph.VertexTypeShootState, attrs,
```

**Special notes for your reviewer**:
FYI @maboehm @dimityrmirchev @vpnachev 
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
