### PR TITLE
Add archive suffixes to `gardenadm` artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -230,14 +230,16 @@ jobs:
 
           if [ ${os} == 'windows' ]; then
             exe_suffix='.exe'
+            archive_suffix='.zip'
           else
             exe_suffix=''
+            archive_suffix='.tar.gz'
           fi
 
           mkdir -p /tmp/blobs.d
           prefix=/tmp/blobs.d/gardenadm
           platform_suffix="-${os}-${arch}"
-          outpath="${prefix}${platform_suffix}${exe_suffix}"
+          outpath="${prefix}${platform_suffix}${exe_suffix}${archive_suffix}"
           archive="${prefix}${platform_suffix}.archive"
 
           GOOS=${os} \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

Currently, the release artifacts of `gardenadm` for each of the builds are archives, but the artifacts are not suffixed as such in the release.
Let us add the suffixes to make it clear to the user, that the artifacts are in fact, archives

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/invite @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
