### PR TITLE
Allow migration from dual-stack [IPv4, IPv6] to single-stack [IPv4].

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -833,11 +833,20 @@ func validateNetworkingUpdate(newNetworking, oldNetworking *core.Networking, fld
 func validateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []core.IPFamily, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	// Allow migration from IPv4 to dual-stack
 	if len(oldIPFamilies) == 1 &&
 		oldIPFamilies[0] == core.IPFamilyIPv4 &&
 		len(newIPFamilies) == 2 &&
 		newIPFamilies[0] == core.IPFamilyIPv4 &&
 		newIPFamilies[1] == core.IPFamilyIPv6 {
+		return allErrs
+	}
+
+	// Allow migration from dual-stack to IPv4
+	if len(oldIPFamilies) == 2 &&
+		oldIPFamilies[0] == core.IPFamilyIPv4 &&
+		oldIPFamilies[1] == core.IPFamilyIPv6 &&
+		len(newIPFamilies) == 1 && newIPFamilies[0] == core.IPFamilyIPv4 {
 		return allErrs
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4558,7 +4558,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})
 			})
 
-			It("should allow updating ipfamilies from IPv4 to dual-stack [IPv4 IPv6]", func() {
+			It("should allow updating ipfamilies from IPv4 to dual-stack [IPv4, IPv6]", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
 
 				newShoot := prepareShootForUpdate(shoot)
@@ -4567,7 +4567,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 				Expect(errorList).To(BeEmpty())
 			})
-			It("should forbid changing ipfamilies from IPv6 to dual-stack [IPv6 IPv4]", func() {
+			It("should forbid changing ipfamilies from IPv6 to dual-stack [IPv6, IPv4]", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6, core.IPFamilyIPv4}
@@ -4575,10 +4575,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv6], newIPFamilies=[IPv6 IPv4]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv6], newIPFamilies=[IPv6, IPv4]"),
 				}))))
 			})
-			It("should forbid changing ipfamilies from single-stack IPv4 to dual-stack [IPv6 IPv4]", func() {
+			It("should forbid changing ipfamilies from single-stack IPv4 to dual-stack [IPv6, IPv4]", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4}
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6, core.IPFamilyIPv4}
@@ -4586,10 +4586,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4], newIPFamilies=[IPv6 IPv4]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4], newIPFamilies=[IPv6, IPv4]"),
 				}))))
 			})
-			It("should forbid changing ipfamilies from dual-stack [IPv4 IPv6] to single-stack [IPv6]", func() {
+			It("should forbid changing ipfamilies from dual-stack [IPv4, IPv6] to single-stack [IPv6]", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 
 				newShoot := prepareShootForUpdate(shoot)
@@ -4598,10 +4598,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4 IPv6], newIPFamilies=[IPv6]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4, IPv6], newIPFamilies=[IPv6]"),
 				}))))
 			})
-			It("should allow changing ipfamilies from dual-stack [IPv4 IPv6] to single-stack [IPv4]", func() {
+			It("should allow changing ipfamilies from dual-stack [IPv4, IPv6] to single-stack [IPv4]", func() {
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 
 				newShoot := prepareShootForUpdate(shoot)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4575,7 +4575,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv6], newIPFamilies=[IPv6, IPv4]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv6], newIPFamilies=[IPv6 IPv4]"),
 				}))))
 			})
 			It("should forbid changing ipfamilies from single-stack IPv4 to dual-stack [IPv6, IPv4]", func() {
@@ -4586,7 +4586,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4], newIPFamilies=[IPv6, IPv4]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4], newIPFamilies=[IPv6 IPv4]"),
 				}))))
 			})
 			It("should forbid changing ipfamilies from dual-stack [IPv4, IPv6] to single-stack [IPv6]", func() {
@@ -4598,7 +4598,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.networking.ipFamilies"),
-					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4, IPv6], newIPFamilies=[IPv6]"),
+					"Detail": Equal("unsupported IP family update: oldIPFamilies=[IPv4 IPv6], newIPFamilies=[IPv6]"),
 				}))))
 			})
 			It("should allow changing ipfamilies from dual-stack [IPv4, IPv6] to single-stack [IPv4]", func() {

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -141,6 +141,14 @@ func ValidateIPFamiliesUpdate(newIPFamilies, oldIPFamilies []extensionsv1alpha1.
 		return allErrs
 	}
 
+	if len(oldIPFamilies) == 2 &&
+		oldIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 &&
+		oldIPFamilies[1] == extensionsv1alpha1.IPFamilyIPv6 &&
+		len(newIPFamilies) == 1 &&
+		newIPFamilies[0] == extensionsv1alpha1.IPFamilyIPv4 {
+		return allErrs
+	}
+
 	if !apiequality.Semantic.DeepEqual(newIPFamilies, oldIPFamilies) {
 		allErrs = append(allErrs, field.Forbidden(fldPath,
 			fmt.Sprintf("unsupported IP family update: oldIPFamilies=%v, newIPFamilies=%v", oldIPFamilies, newIPFamilies)))

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -314,10 +314,10 @@ var _ = Describe("Network validation tests", func() {
 			))
 		})
 
-		It("should not allow removing an address family", func() {
+		It("should not allow to update from [IPv4 IPv6] to [IPv6]", func() {
 			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
 			newNetwork := prepareNetworkForUpdate(network)
-			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4}
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
 
 			errorList := ValidateNetworkUpdate(newNetwork, network)
 
@@ -326,7 +326,27 @@ var _ = Describe("Network validation tests", func() {
 					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("spec.ipFamilies"),
 				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.podCIDR"),
+					"Detail": Equal("must be a valid IPv6 address"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.serviceCIDR"),
+					"Detail": Equal("must be a valid IPv6 address"),
+				})),
 			))
+		})
+
+		It("should allow to update from [IPv4 IPv6] to [IPv4]", func() {
+			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
+			newNetwork := prepareNetworkForUpdate(network)
+			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4}
+
+			errorList := ValidateNetworkUpdate(newNetwork, network)
+
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -314,7 +314,7 @@ var _ = Describe("Network validation tests", func() {
 			))
 		})
 
-		It("should not allow to update from [IPv4 IPv6] to [IPv6]", func() {
+		It("should not allow to update from [IPv4, IPv6] to [IPv6]", func() {
 			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
 			newNetwork := prepareNetworkForUpdate(network)
 			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv6}
@@ -339,7 +339,7 @@ var _ = Describe("Network validation tests", func() {
 			))
 		})
 
-		It("should allow to update from [IPv4 IPv6] to [IPv4]", func() {
+		It("should allow to update from [IPv4, IPv6] to [IPv4]", func() {
 			network.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4, extensionsv1alpha1.IPFamilyIPv6}
 			newNetwork := prepareNetworkForUpdate(network)
 			newNetwork.Spec.IPFamilies = []extensionsv1alpha1.IPFamily{extensionsv1alpha1.IPFamilyIPv4}

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -198,9 +198,9 @@ func (b *Botanist) UpdateDualStackMigrationConditionIfNeeded(ctx context.Context
 	}
 
 	if constraint := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady); constraint == nil {
-		network, err := b.Shoot.Components.Extensions.Network.Get(ctx)
-		if err != nil {
-			return nil
+		network, _ := b.Shoot.Components.Extensions.Network.Get(ctx)
+		if network == nil {
+			return nil // Network not yet created, nothing to do
 		}
 		networkReadyForDualStackMigration := len(network.Status.IPFamilies) == len(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 		updateFunction := b.DetermineUpdateFunction(networkReadyForDualStackMigration, nodeList)

--- a/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration_test.go
@@ -38,6 +38,22 @@ var _ = Describe("DualStackMigration", func() {
 			},
 			Clock: mockClock,
 		}}
+
+		// Initialize the shoot with proper IP families for dual-stack tests
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-shoot",
+				Namespace: "test-namespace",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				Networking: &gardencorev1beta1.Networking{
+					IPFamilies: []gardencorev1beta1.IPFamily{
+						gardencorev1beta1.IPFamilyIPv4,
+						gardencorev1beta1.IPFamilyIPv6,
+					},
+				},
+			},
+		})
 	})
 
 	Describe("#DetermineUpdateFunction", func() {
@@ -53,6 +69,14 @@ var _ = Describe("DualStackMigration", func() {
 					Name:        "test-shoot",
 					Namespace:   "test-namespace",
 					Annotations: map[string]string{},
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{
+							gardencorev1beta1.IPFamilyIPv4,
+							gardencorev1beta1.IPFamilyIPv6,
+						},
+					},
 				},
 				Status: gardencorev1beta1.ShootStatus{
 					Constraints: []gardencorev1beta1.Condition{
@@ -80,6 +104,14 @@ var _ = Describe("DualStackMigration", func() {
 			}
 
 			shoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{
+							gardencorev1beta1.IPFamilyIPv4,
+							gardencorev1beta1.IPFamilyIPv6,
+						},
+					},
+				},
 				Status: gardencorev1beta1.ShootStatus{
 					Constraints: []gardencorev1beta1.Condition{},
 				},
@@ -93,7 +125,7 @@ var _ = Describe("DualStackMigration", func() {
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionTrue))
 			Expect(condition.Reason).To(Equal("NodesMigrated"))
-			Expect(condition.Message).To(Equal("All nodes were migrated to dual-stack networking."))
+			Expect(condition.Message).To(Equal("All node pod CIDRs migrated to target network stack.")) // Updated message
 		})
 
 		It("Updates the constraint to ConditionFalse when not all nodes are dual-stack", func() {
@@ -105,6 +137,14 @@ var _ = Describe("DualStackMigration", func() {
 			}
 
 			shoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{
+							gardencorev1beta1.IPFamilyIPv4,
+							gardencorev1beta1.IPFamilyIPv6,
+						},
+					},
+				},
 				Status: gardencorev1beta1.ShootStatus{
 					Constraints: []gardencorev1beta1.Condition{},
 				},
@@ -118,7 +158,7 @@ var _ = Describe("DualStackMigration", func() {
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(gardencorev1beta1.ConditionProgressing))
 			Expect(condition.Reason).To(Equal("NodesNotMigrated"))
-			Expect(condition.Message).To(Equal("The shoot is migrating to dual-stack networking."))
+			Expect(condition.Message).To(Equal("Migrating node pod CIDRs to match target network stack.")) // Updated message
 		})
 		It("Updates the constraint to ConditionProgressing if coredns pods not are migrated", func() {
 

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -522,20 +522,31 @@ func (s *Shoot) IsShootControlPlaneLoggingEnabled(c *gardenletconfigv1alpha1.Gar
 }
 
 func sortByIPFamilies(ipfamilies []gardencorev1beta1.IPFamily, cidrs []net.IPNet) []net.IPNet {
+	if len(ipfamilies) == 0 || len(cidrs) == 0 {
+		return cidrs
+	}
+
 	var result []net.IPNet
-	for _, ipfamily := range ipfamilies {
-		switch ipfamily {
-		case gardencorev1beta1.IPFamilyIPv4:
-			for _, cidr := range cidrs {
-				if cidr.IP.To4() != nil {
-					result = append(result, cidr)
-				}
+
+	// Process each IP family in order
+	for _, family := range ipfamilies {
+		for _, cidr := range cidrs {
+			isIPv4 := cidr.IP.To4() != nil
+			if (family == gardencorev1beta1.IPFamilyIPv4 && isIPv4) ||
+				(family == gardencorev1beta1.IPFamilyIPv6 && !isIPv4) {
+				result = append(result, cidr)
 			}
-		case gardencorev1beta1.IPFamilyIPv6:
-			for _, cidr := range cidrs {
-				if cidr.IP.To4() == nil {
-					result = append(result, cidr)
-				}
+		}
+	}
+
+	// For single-stack, append non-matching CIDRs at the end
+	if len(ipfamilies) == 1 {
+		primary := ipfamilies[0]
+		for _, cidr := range cidrs {
+			isIPv4 := cidr.IP.To4() != nil
+			if (primary == gardencorev1beta1.IPFamilyIPv4 && !isIPv4) ||
+				(primary == gardencorev1beta1.IPFamilyIPv6 && isIPv4) {
+				result = append(result, cidr)
 			}
 		}
 	}
@@ -616,7 +627,11 @@ func ToNetworks(shoot *gardencorev1beta1.Shoot, workerless bool) (*Networks, err
 
 	// During dual-stack migration, until nodes are migrated to  dual-stack, we only use the primary addresses.
 	condition := v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-	if condition != nil && condition.Status != gardencorev1beta1.ConditionTrue {
+	if condition != nil &&
+		((condition.Status != gardencorev1beta1.ConditionTrue && len(shoot.Spec.Networking.IPFamilies) == 2) ||
+			(condition.Status == gardencorev1beta1.ConditionTrue && len(shoot.Spec.Networking.IPFamilies) == 1)) {
+
+		// if condition != nil && condition.Status != gardencorev1beta1.ConditionTrue {
 		nodes = getPrimaryCIDRs(nodes, shoot.Spec.Networking.IPFamilies)
 		services = getPrimaryCIDRs(services, shoot.Spec.Networking.IPFamilies)
 		pods = getPrimaryCIDRs(pods, shoot.Spec.Networking.IPFamilies)

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -106,8 +106,8 @@ func (c *mutationContext) addMetadataAnnotations(a admission.Attributes) {
 		addDNSRecordDeploymentTasks(c.shoot)
 	}
 
-	if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
-		c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && !reflect.DeepEqual(c.oldShoot.Spec.Networking.IPFamilies, c.shoot.Spec.Networking.IPFamilies) {
+		if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
+		c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && len(c.oldShoot.Spec.Networking.IPFamilies) < len(c.shoot.Spec.Networking.IPFamilies) {
 		addInfrastructureDeploymentTask(c.shoot)
 	}
 

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -106,7 +106,7 @@ func (c *mutationContext) addMetadataAnnotations(a admission.Attributes) {
 		addDNSRecordDeploymentTasks(c.shoot)
 	}
 
-		if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
+	if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
 		c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && len(c.oldShoot.Spec.Networking.IPFamilies) < len(c.shoot.Spec.Networking.IPFamilies) {
 		addInfrastructureDeploymentTask(c.shoot)
 	}


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
In case unforeseen issues arise during or after the migration of a shoot to dual-stack networking, it should be possible to revert to single-stack. Not all changes made during the migration can be reversed. Depending on the infrastructure, VPCs and subnets may still have IPv6 addresses. However, from Kubernetes' point of view, the cluster will be single-stack after the migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Changes to infrastructure providers need to be released before merging this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Migration from dual-stack [IPv4, IPv6] to [IPv4] networking is now allowed.
```
