### PR TITLE
Provide WebsocketAllowedOrigins configuration

### DIFF
--- a/pkg/component/gardener/dashboard/config/config.go
+++ b/pkg/component/gardener/dashboard/config/config.go
@@ -17,13 +17,14 @@ type Config struct {
 	APIServerCAData    *string `yaml:"apiServerCaData,omitempty"`
 	MaxRequestBodySize string  `yaml:"maxRequestBodySize"`
 
-	ReadinessProbe        ReadinessProbe         `yaml:"readinessProbe"`
-	UnreachableSeeds      UnreachableSeeds       `yaml:"unreachableSeeds"`
-	ContentSecurityPolicy *ContentSecurityPolicy `yaml:"contentSecurityPolicy,omitempty"`
-	Terminal              *Terminal              `yaml:"terminal,omitempty"`
-	OIDC                  *OIDC                  `yaml:"oidc,omitempty"`
-	GitHub                *GitHub                `yaml:"gitHub,omitempty"`
-	Frontend              map[string]any         `yaml:"frontend,omitempty"`
+	ReadinessProbe          ReadinessProbe         `yaml:"readinessProbe"`
+	UnreachableSeeds        UnreachableSeeds       `yaml:"unreachableSeeds"`
+	WebsocketAllowedOrigins []string               `yaml:"websocketAllowedOrigins,omitempty"`
+	ContentSecurityPolicy   *ContentSecurityPolicy `yaml:"contentSecurityPolicy,omitempty"`
+	Terminal                *Terminal              `yaml:"terminal,omitempty"`
+	OIDC                    *OIDC                  `yaml:"oidc,omitempty"`
+	GitHub                  *GitHub                `yaml:"gitHub,omitempty"`
+	Frontend                map[string]any         `yaml:"frontend,omitempty"`
 }
 
 // ReadinessProbe is the readiness probe configuration.

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -48,15 +48,24 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 	}
 
 	var (
+		websocketAllowedOrigins []string
+	)
+
+	for _, host := range g.ingressHosts() {
+		websocketAllowedOrigins = append(websocketAllowedOrigins, "https://"+host)
+	}
+
+	var (
 		cfg = &config.Config{
-			Port:               portServer,
-			LogFormat:          "text",
-			LogLevel:           g.values.LogLevel,
-			APIServerURL:       "https://" + g.values.APIServerURL,
-			APIServerCAData:    g.values.APIServerCABundle,
-			MaxRequestBodySize: "500kb",
-			ReadinessProbe:     config.ReadinessProbe{PeriodSeconds: readinessProbePeriodSeconds},
-			UnreachableSeeds:   config.UnreachableSeeds{MatchLabels: map[string]string{v1beta1constants.LabelSeedNetwork: v1beta1constants.LabelSeedNetworkPrivate}},
+			Port:                    portServer,
+			LogFormat:               "text",
+			LogLevel:                g.values.LogLevel,
+			APIServerURL:            "https://" + g.values.APIServerURL,
+			APIServerCAData:         g.values.APIServerCABundle,
+			MaxRequestBodySize:      "500kb",
+			ReadinessProbe:          config.ReadinessProbe{PeriodSeconds: readinessProbePeriodSeconds},
+			UnreachableSeeds:        config.UnreachableSeeds{MatchLabels: map[string]string{v1beta1constants.LabelSeedNetwork: v1beta1constants.LabelSeedNetworkPrivate}},
+			WebsocketAllowedOrigins: websocketAllowedOrigins,
 		}
 		loginCfg = &config.LoginConfig{}
 	)

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -207,7 +207,13 @@ readinessProbe:
 unreachableSeeds:
   matchLabels:
     seed.gardener.cloud/network: private
-`
+websocketAllowedOrigins:`
+
+			for _, domain := range ingressDomains {
+				configRaw += `
+  - https://dashboard.` + domain
+			}
+			configRaw += "\n"
 
 			if terminal != nil {
 				configRaw += `contentSecurityPolicy:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The Gardener Dashboard now restricts the origins allowed for WebSocket connections ([ref](https://github.com/gardener/dashboard/pull/2588)). Gardener Operator must explicitly configure these allowed origins in the dashboard settings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
