### PR TITLE
[GEP-28] `gardenadm bootstrap`: Deploy bootstrap `DNSRecord`

### DIFF
--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: false
       hostAliases:
         - hostnames:
-          - api.root.garden.external.local.gardener.cloud
+          - api.root.garden.local.gardener.cloud
           ip: 10.2.0.99
       securityContext:
         seccompProfile:

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: false
       hostAliases:
         - hostnames:
-          - api.root.garden.internal.gardenadm.local
+          - api.root.garden.external.local.gardener.cloud
           ip: 10.2.0.99
       securityContext:
         seccompProfile:

--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -7,6 +7,8 @@ spec:
   cloudProfile:
     kind: CloudProfile
     name: local
+  dns:
+    domain: root.garden.external.local.gardener.cloud
   region: local
   provider:
     type: local

--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -8,7 +8,7 @@ spec:
     kind: CloudProfile
     name: local
   dns:
-    domain: root.garden.external.local.gardener.cloud
+    domain: root.garden.local.gardener.cloud
   region: local
   provider:
     type: local

--- a/dev-setup/gardenadm/resources/overlays/medium-touch/patch-shoot-medium-touch.yaml
+++ b/dev-setup/gardenadm/resources/overlays/medium-touch/patch-shoot-medium-touch.yaml
@@ -5,3 +5,8 @@ metadata:
   namespace: garden
 spec:
   secretBindingName: local
+  dns:
+    providers:
+    - type: local
+      primary: true
+      # secretName omitted, using secret of the secret binding

--- a/docs/cli-reference/gardenadm/gardenadm_discover.md
+++ b/docs/cli-reference/gardenadm/gardenadm_discover.md
@@ -23,7 +23,7 @@ gardenadm discover <path-to-shoot-manifest>
   -d, --config-dir string        Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
   -h, --help                     help for discover
   -k, --kubeconfig string        Path to the kubeconfig file pointing to the garden cluster
-      --managed-infrastructure   Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using "gardenadm bootstrap" for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener. (default true)
+      --managed-infrastructure   Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener. (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/gardenadm/gardenadm_discover.md
+++ b/docs/cli-reference/gardenadm/gardenadm_discover.md
@@ -20,10 +20,10 @@ gardenadm discover <path-to-shoot-manifest>
 ### Options
 
 ```
-  -d, --config-dir string                        Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-  -h, --help                                     help for discover
-  -k, --kubeconfig string                        Path to the kubeconfig file pointing to the garden cluster
-      --runs-control-plane gardenadm bootstrap   Indicates whether the control plane is run in the same cluster. This should be set to false if gardenadm bootstrap will be used for bootstrapping the shoot cluster. (default true)
+  -d, --config-dir string        Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+  -h, --help                     help for discover
+  -k, --kubeconfig string        Path to the kubeconfig file pointing to the garden cluster
+      --managed-infrastructure   Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using "gardenadm bootstrap" for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener. (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/gardenadm/gardenadm_discover.md
+++ b/docs/cli-reference/gardenadm/gardenadm_discover.md
@@ -23,7 +23,7 @@ gardenadm discover <path-to-shoot-manifest>
   -d, --config-dir string        Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
   -h, --help                     help for discover
   -k, --kubeconfig string        Path to the kubeconfig file pointing to the garden cluster
-      --managed-infrastructure   Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener. (default true)
+      --managed-infrastructure   Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.). Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener. (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -98,7 +98,7 @@ machine-0   Ready    <none>   4m11s   v1.32.0
 You can also copy the kubeconfig to your local machine and use a port-forward to connect to the cluster's API server:
 
 ```shell
-$ kubectl -n gardenadm-high-touch exec -it machine-0 -- cat /etc/kubernetes/admin.conf | sed 's/api.root.garden.external.local.gardener.cloud/localhost:6443/' > /tmp/shoot--garden--root.conf
+$ kubectl -n gardenadm-high-touch exec -it machine-0 -- cat /etc/kubernetes/admin.conf | sed 's/api.root.garden.local.gardener.cloud/localhost:6443/' > /tmp/shoot--garden--root.conf
 $ kubectl -n gardenadm-high-touch port-forward pod/machine-0 6443:443
 
 # in a new terminal

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -98,7 +98,7 @@ machine-0   Ready    <none>   4m11s   v1.32.0
 You can also copy the kubeconfig to your local machine and use a port-forward to connect to the cluster's API server:
 
 ```shell
-$ kubectl -n gardenadm-high-touch exec -it machine-0 -- cat /etc/kubernetes/admin.conf | sed 's/api.root.garden.internal.gardenadm.local/localhost:6443/' > /tmp/shoot--garden--root.conf
+$ kubectl -n gardenadm-high-touch exec -it machine-0 -- cat /etc/kubernetes/admin.conf | sed 's/api.root.garden.external.local.gardener.cloud/localhost:6443/' > /tmp/shoot--garden--root.conf
 $ kubectl -n gardenadm-high-touch port-forward pod/machine-0 6443:443
 
 # in a new terminal

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -74,14 +74,27 @@ Additionally, it creates a few (currently unused) dummy secrets (CA, server and 
 
 #### `DNSRecord`
 
-The controller adapts the cluster internal DNS configuration by extending the `coredns` configuration for every observed `DNSRecord`. It will add two corresponding entries in the custom DNS configuration per shoot cluster:
+The controller adapts the cluster internal DNS configuration by extending the custom CoreDNS configuration for every observed `DNSRecord`.
+It adds two corresponding entries in the custom DNS configuration per shoot cluster containing a `rewrite` rule:
 
-```text
+```yaml
 data:
   api.local.local.external.local.gardener.cloud.override: |
     rewrite stop name regex api.local.local.external.local.gardener.cloud istio-ingressgateway.istio-ingress.svc.cluster.local answer auto
   api.local.local.internal.local.gardener.cloud.override: |
     rewrite stop name regex api.local.local.internal.local.gardener.cloud istio-ingressgateway.istio-ingress.svc.cluster.local answer auto
+```
+
+For autonomous shoots, the controller configures the CoreDNS `template` plugin instead of using a `rewrite` rule for each `DNSRecord`:
+
+```yaml
+data:
+  api.root.garden.external.local.gardener.cloud.override: |
+    template IN A local.gardener.cloud {
+      match "^api\.root\.garden\.external\.local\.gardener\.cloud\.$"
+      answer "{{ .Name }} 120 IN A 10.0.130.192"
+      fallthrough
+    }
 ```
 
 #### `Infrastructure`

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -89,9 +89,9 @@ For autonomous shoots, the controller configures the CoreDNS `template` plugin i
 
 ```yaml
 data:
-  api.root.garden.external.local.gardener.cloud.override: |
+  api.root.garden.local.gardener.cloud.override: |
     template IN A local.gardener.cloud {
-      match "^api\.root\.garden\.external\.local\.gardener\.cloud\.$"
+      match "^api\.root\.garden\.local\.gardener\.cloud\.$"
       answer "{{ .Name }} 120 IN A 10.0.130.192"
       fallthrough
     }

--- a/pkg/apis/core/v1beta1/helper/shoot.go
+++ b/pkg/apis/core/v1beta1/helper/shoot.go
@@ -643,6 +643,12 @@ func IsShootAutonomous(workers []gardencorev1beta1.Worker) bool {
 	})
 }
 
+// HasManagedInfrastructure returns true if the shoot's infrastructure (network, machines, etc.) is managed by Gardener.
+// I.e., it returns false for high-touch autonomous shoots, where the infrastructure is managed by the user.
+func HasManagedInfrastructure(shoot *gardencorev1beta1.Shoot) bool {
+	return shoot.Spec.CredentialsBindingName != nil || shoot.Spec.SecretBindingName != nil
+}
+
 // ControlPlaneWorkerPoolForShoot returns the worker pool running the control plane in case the shoot is autonomous.
 func ControlPlaneWorkerPoolForShoot(workers []gardencorev1beta1.Worker) *gardencorev1beta1.Worker {
 	idx := slices.IndexFunc(workers, func(worker gardencorev1beta1.Worker) bool {

--- a/pkg/apis/core/v1beta1/helper/shoot_test.go
+++ b/pkg/apis/core/v1beta1/helper/shoot_test.go
@@ -1460,6 +1460,23 @@ var _ = Describe("Helper", func() {
 		})
 	})
 
+	Describe("#HasManagedInfrastructure", func() {
+		It("should return false when both CredentialsBindingName and SecretBindingName are nil", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{CredentialsBindingName: nil, SecretBindingName: nil}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeFalse())
+		})
+
+		It("should return true when CredentialsBindingName is set", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{CredentialsBindingName: ptr.To("binding")}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeTrue())
+		})
+
+		It("should return true when SecretBindingName is set", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SecretBindingName: ptr.To("binding")}}
+			Expect(HasManagedInfrastructure(shoot)).To(BeTrue())
+		})
+	})
+
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
 		It("should return nil because shoot has no workers", func() {
 			shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AllExtensionKinds contains all supported extension kinds.
-var AllExtensionKinds = sets.New(
+var AllExtensionKinds = sets.New[string](
 	BackupBucketResource,
 	BackupEntryResource,
 	BastionResource,

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AllExtensionKinds contains all supported extension kinds.
-var AllExtensionKinds = sets.New[string](
+var AllExtensionKinds = sets.New(
 	BackupBucketResource,
 	BackupEntryResource,
 	BastionResource,

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -26,6 +26,7 @@ import (
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/component/extensions/bastion"
@@ -95,7 +96,7 @@ func NewAutonomousBotanistFromManifests(
 		return nil, fmt.Errorf("failed reading Kubernetes resources from config directory %s: %w", dir, err)
 	}
 
-	extensions, err := ComputeExtensions(resources, runsControlPlane)
+	extensions, err := ComputeExtensions(resources, runsControlPlane, v1beta1helper.HasManagedInfrastructure(resources.Shoot))
 	if err != nil {
 		return nil, fmt.Errorf("failed computing extensions: %w", err)
 	}

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -58,13 +58,14 @@ type AutonomousBotanist struct {
 
 	// Bastion is only set for `gardenadm bootstrap`.
 	Bastion *bastion.Bastion
-	// ControlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.
-	ControlPlaneMachines []machinev1alpha1.Machine
 
 	operatingSystemConfigSecret       *corev1.Secret
 	gardenerResourceManagerServiceIPs []string
 	staticPodNameToHash               map[string]string
 	useEtcdManagedByDruid             bool
+
+	// controlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.
+	controlPlaneMachines []machinev1alpha1.Machine
 }
 
 // Extension contains the resources needed for an extension registration.

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -299,8 +299,7 @@ func newShootObject(
 		NewBuilder().
 		WithProjectName(resources.Project.Name).
 		WithCloudProfileObject(resources.CloudProfile).
-		WithShootObject(resources.Shoot).
-		WithInternalDomain(&gardenerutils.Domain{Domain: "gardenadm.local"})
+		WithShootObject(resources.Shoot)
 
 	if resources.Shoot.Spec.SecretBindingName != nil || resources.Shoot.Spec.CredentialsBindingName != nil {
 		b = b.WithShootCredentialsFrom(gardenClient)

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +58,8 @@ type AutonomousBotanist struct {
 
 	// Bastion is only set for `gardenadm bootstrap`.
 	Bastion *bastion.Bastion
+	// ControlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.
+	ControlPlaneMachines []machinev1alpha1.Machine
 
 	operatingSystemConfigSecret       *corev1.Secret
 	gardenerResourceManagerServiceIPs []string

--- a/pkg/gardenadm/botanist/dnsrecord.go
+++ b/pkg/gardenadm/botanist/dnsrecord.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
+	"github.com/gardener/gardener/pkg/component"
+)
+
+// DeployBootstrapDNSRecord deploys the external DNSRecord pointing to the first control plane machine for bootstrapping
+// the autonomous shoot cluster. The DNSRecord might be publicly resolvable but not publicly accessible, depending on
+// shoot's infrastructure provider and network setup. It should be resolvable and accessible from within the shoot
+// cluster's network including the machines, so it `gardenadm init` can use it to bootstrap the cluster.
+func (b *AutonomousBotanist) DeployBootstrapDNSRecord(ctx context.Context) error {
+	machine, err := b.GetMachineByIndex(0)
+	if err != nil {
+		return err
+	}
+
+	machineAddr, err := PreferredAddressForMachine(machine)
+	if err != nil {
+		return err
+	}
+
+	b.Shoot.Components.Extensions.ExternalDNSRecord.SetRecordType(extensionsv1alpha1helper.GetDNSRecordType(machineAddr))
+	b.Shoot.Components.Extensions.ExternalDNSRecord.SetValues([]string{machineAddr})
+
+	return component.OpWait(b.Shoot.Components.Extensions.ExternalDNSRecord).Deploy(ctx)
+}

--- a/pkg/gardenadm/botanist/dnsrecord.go
+++ b/pkg/gardenadm/botanist/dnsrecord.go
@@ -14,7 +14,7 @@ import (
 // DeployBootstrapDNSRecord deploys the external DNSRecord pointing to the first control plane machine for bootstrapping
 // the autonomous shoot cluster. The DNSRecord might be publicly resolvable but not publicly accessible, depending on
 // shoot's infrastructure provider and network setup. It should be resolvable and accessible from within the shoot
-// cluster's network including the machines, so it `gardenadm init` can use it to bootstrap the cluster.
+// cluster's network including the machines, so `gardenadm init` can use it to bootstrap the cluster.
 func (b *AutonomousBotanist) DeployBootstrapDNSRecord(ctx context.Context) error {
 	machine, err := b.GetMachineByIndex(0)
 	if err != nil {

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -97,13 +97,13 @@ func wantedExtensionKinds(runsControlPlane, managedInfrastructure bool) sets.Set
 		return sets.New[string](extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource, extensionsv1alpha1.DNSRecordResource)
 	}
 
-	// In `gardenadm init`, we deploy all extensions referenced by the shoot in the medium-touch scenario.
 	// In the high-touch scenario, we don't deploy Infrastructure, Worker, and DNSRecord extensions because they are
 	// managed outside of Gardener.
 	if !managedInfrastructure {
 		return extensionsv1alpha1.AllExtensionKinds.Clone().Delete(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.WorkerResource, extensionsv1alpha1.DNSRecordResource)
 	}
 
+	// In `gardenadm init`, we deploy all extensions referenced by the shoot in the medium-touch scenario.
 	return extensionsv1alpha1.AllExtensionKinds.Clone()
 }
 

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -31,13 +31,12 @@ import (
 
 // ComputeExtensions takes a list of ControllerRegistrations and ControllerDeployments and computes a corresponding list
 // of Extensions.
-func ComputeExtensions(resources gardenadm.Resources, runsControlPlane bool) ([]Extension, error) {
+func ComputeExtensions(resources gardenadm.Resources, runsControlPlane, managedInfrastructure bool) ([]Extension, error) {
 	var extensions []Extension
 
 	wantedControllerRegistrationNames, err := computeWantedControllerRegistrationNames(
-		resources.Shoot,
-		resources.ControllerRegistrations,
-		wantedExtensionKinds(runsControlPlane),
+		resources,
+		wantedExtensionKinds(runsControlPlane, managedInfrastructure),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing the names of the wanted ControllerRegistrations: %w", err)
@@ -88,32 +87,37 @@ func ComputeExtensions(resources gardenadm.Resources, runsControlPlane bool) ([]
 // wantedExtensionKinds returns the set of extension kinds that are needed and supported for autonomous shoot clusters.
 // runsControlPlane indicates whether we are bootstrapping the control plane of the cluster (i.e., when executing
 // `gardenadm init`).
-func wantedExtensionKinds(runsControlPlane bool) sets.Set[string] {
-	if runsControlPlane {
-		// In `gardenadm init`, we deploy all extensions referenced by the shoot, except for Infrastructure and Worker
-		// (we only support the high-touch scenario here for now).
-		// TODO(timebertt): distinguish between high-touch and medium-touch scenario in `gardenadm init`
-		return extensionsv1alpha1.AllExtensionKinds.Clone().Delete(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.WorkerResource)
+// managedInfrastructure indicates whether the infrastructure of the shoot cluster is managed by Gardener (medium-touch
+// scenario) or not (high-touch scenario).
+func wantedExtensionKinds(runsControlPlane, managedInfrastructure bool) sets.Set[string] {
+	if !runsControlPlane {
+		// When running `gardenadm bootstrap` against the bootstrap cluster, we create Infrastructure, OSC, Worker, and
+		// DNSRecord for the control plane of the autonomous shoot cluster, so we only need to deploy a subset of the
+		// extensions required for the shoot.
+		return sets.New[string](extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource, extensionsv1alpha1.DNSRecordResource)
 	}
 
-	// In `gardenadm bootstrap`, we create Infrastructure, OSC, and Worker for the control plane of the autonomous shoot
-	// cluster, so we only need these extensions.
-	return sets.New(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.OperatingSystemConfigResource, extensionsv1alpha1.WorkerResource)
+	// In `gardenadm init`, we deploy all extensions referenced by the shoot in the medium-touch scenario.
+	// In the high-touch scenario, we don't deploy Infrastructure, Worker, and DNSRecord extensions because they are
+	// managed outside of Gardener.
+	if !managedInfrastructure {
+		return extensionsv1alpha1.AllExtensionKinds.Clone().Delete(extensionsv1alpha1.InfrastructureResource, extensionsv1alpha1.WorkerResource, extensionsv1alpha1.DNSRecordResource)
+	}
+
+	return extensionsv1alpha1.AllExtensionKinds.Clone()
 }
 
 // computeWantedControllerRegistrationNames returns the names of all ControllerRegistrations relevant for the autonomous
 // botanist based on the parsed manifests and the wanted extension kinds.
-func computeWantedControllerRegistrationNames(
-	shoot *gardencorev1beta1.Shoot,
-	controllerRegistrations []*gardencorev1beta1.ControllerRegistration,
-	wantedExtensionKinds sets.Set[string],
-) (sets.Set[string], error) {
+func computeWantedControllerRegistrationNames(resources gardenadm.Resources, wantedExtensionKinds sets.Set[string]) (sets.Set[string], error) {
 	var (
 		result                                   = sets.New[string]()
+		requiredExtensionIDs                     = sets.New[string]()
 		extensionIDToControllerRegistrationNames = make(map[string][]string)
 	)
 
-	for _, controllerRegistration := range controllerRegistrations {
+	// collect available extension IDs from ControllerRegistrations, and add always-deployed extensions to result
+	for _, controllerRegistration := range resources.ControllerRegistrations {
 		for _, resource := range controllerRegistration.Spec.Resources {
 			id := gardenerutils.ExtensionsID(resource.Kind, resource.Type)
 			extensionIDToControllerRegistrationNames[id] = append(extensionIDToControllerRegistrationNames[id], controllerRegistration.Name)
@@ -124,16 +128,20 @@ func computeWantedControllerRegistrationNames(
 		}
 	}
 
-	for _, extensionID := range gardenerutils.ComputeRequiredExtensionsForShoot(shoot, nil, controllerRegistrationSliceToList(controllerRegistrations), nil, nil).UnsortedList() {
+	// collect extension IDs required by the shoot
+	for _, extensionID := range gardenerutils.ComputeRequiredExtensionsForShoot(resources.Shoot, nil, controllerRegistrationSliceToList(resources.ControllerRegistrations), nil, nil).UnsortedList() {
 		extensionKind, _, err := gardenerutils.ExtensionKindAndTypeForID(extensionID)
 		if err != nil {
 			return nil, err
 		}
 
-		if !wantedExtensionKinds.Has(extensionKind) {
-			continue
+		if wantedExtensionKinds.Has(extensionKind) {
+			requiredExtensionIDs.Insert(extensionID)
 		}
+	}
 
+	// map required extension IDs back to ControllerRegistration names
+	for extensionID := range requiredExtensionIDs {
 		names, ok := extensionIDToControllerRegistrationNames[extensionID]
 		if !ok {
 			return nil, fmt.Errorf("need to install an extension controller for %q but no appropriate ControllerRegistration found", extensionID)

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ListControlPlaneMachines stores all control plane machines in ControlPlaneMachines for later retrieval.
+// Listing the machines only once ensures consistent ordering when accessing them by index.
+func (b *AutonomousBotanist) ListControlPlaneMachines(ctx context.Context) error {
+	machineList := &machinev1alpha1.MachineList{}
+	if err := b.SeedClientSet.Client().List(ctx, machineList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
+		return fmt.Errorf("failed to list machines: %w", err)
+	}
+	b.ControlPlaneMachines = machineList.Items
+	return nil
+}
+
+// GetMachineByIndex returns the control plane machine with the given index or an error if the index is out of bounds.
+func (b *AutonomousBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machine, error) {
+	if len(b.ControlPlaneMachines) <= index {
+		return nil, fmt.Errorf("only %q machines founds, but wanted machine with index %d", len(b.ControlPlaneMachines), index)
+	}
+	return &b.ControlPlaneMachines[index], nil
+}
+
+// addressTypePreference when retrieving the SSH Address of a machine. Higher value means higher priority.
+// Unknown address types have the lowest priority (0).
+var addressTypePreference = map[corev1.NodeAddressType]int{
+	// internal names have priority, as we jump via a bastion host
+	corev1.NodeInternalIP:  5,
+	corev1.NodeInternalDNS: 4,
+	corev1.NodeExternalIP:  3,
+	corev1.NodeExternalDNS: 2,
+	// this should be returned by all providers, and is actually locally resolvable in many infrastructures
+	corev1.NodeHostName: 1,
+}
+
+// PreferredAddressForMachine returns the preferred address of the given machine based on addressTypePreference.
+// If the machine has no addresses, an error is returned.
+func PreferredAddressForMachine(machine *machinev1alpha1.Machine) (string, error) {
+	if len(machine.Status.Addresses) == 0 {
+		return "", fmt.Errorf("no addresses found in status of machine %s", machine.Name)
+	}
+
+	address := slices.MaxFunc(machine.Status.Addresses, func(a, b corev1.NodeAddress) int {
+		return addressTypePreference[a.Type] - addressTypePreference[b.Type]
+	})
+
+	return address.Address, nil
+}

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -27,7 +27,10 @@ func (b *AutonomousBotanist) ListControlPlaneMachines(ctx context.Context) error
 
 // GetMachineByIndex returns the control plane machine with the given index or an error if the index is out of bounds.
 func (b *AutonomousBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machine, error) {
-	if len(b.controlPlaneMachines) <= index {
+	if index < 0 {
+		return nil, fmt.Errorf("machine index must be non-negative, got %d", index)
+	}
+	if index >= len(b.controlPlaneMachines) {
 		return nil, fmt.Errorf("only %q machines founds, but wanted machine with index %d", len(b.controlPlaneMachines), index)
 	}
 	return &b.controlPlaneMachines[index], nil

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -14,23 +14,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ListControlPlaneMachines stores all control plane machines in ControlPlaneMachines for later retrieval.
+// ListControlPlaneMachines stores all control plane machines in controlPlaneMachines for later retrieval.
 // Listing the machines only once ensures consistent ordering when accessing them by index.
 func (b *AutonomousBotanist) ListControlPlaneMachines(ctx context.Context) error {
 	machineList := &machinev1alpha1.MachineList{}
 	if err := b.SeedClientSet.Client().List(ctx, machineList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
 		return fmt.Errorf("failed to list machines: %w", err)
 	}
-	b.ControlPlaneMachines = machineList.Items
+	b.controlPlaneMachines = machineList.Items
 	return nil
 }
 
 // GetMachineByIndex returns the control plane machine with the given index or an error if the index is out of bounds.
 func (b *AutonomousBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machine, error) {
-	if len(b.ControlPlaneMachines) <= index {
-		return nil, fmt.Errorf("only %q machines founds, but wanted machine with index %d", len(b.ControlPlaneMachines), index)
+	if len(b.controlPlaneMachines) <= index {
+		return nil, fmt.Errorf("only %q machines founds, but wanted machine with index %d", len(b.controlPlaneMachines), index)
 	}
-	return &b.ControlPlaneMachines[index], nil
+	return &b.controlPlaneMachines[index], nil
 }
 
 // addressTypePreference when retrieving the SSH Address of a machine. Higher value means higher priority.

--- a/pkg/gardenadm/botanist/machines_test.go
+++ b/pkg/gardenadm/botanist/machines_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
+)
+
+var _ = Describe("Machines", func() {
+	Describe("#PreferredAddressForMachine", func() {
+		var machine *machinev1alpha1.Machine
+
+		BeforeEach(func() {
+			machine = &machinev1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-machine"},
+				Status:     machinev1alpha1.MachineStatus{},
+			}
+		})
+
+		It("should return error if no addresses are present", func() {
+			Expect(PreferredAddressForMachine(machine)).Error().To(MatchError(ContainSubstring("no addresses found")))
+		})
+
+		It("should return the only address present", func() {
+			machine.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}}
+			Expect(PreferredAddressForMachine(machine)).To(Equal("1.2.3.4"))
+		})
+
+		It("should return the address with the highest preference", func() {
+			machine.Status.Addresses = []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				{Type: corev1.NodeHostName, Address: "host.local"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+			}
+			Expect(PreferredAddressForMachine(machine)).To(Equal("10.0.0.2"))
+		})
+
+		It("should prefer InternalDNS over ExternalIP", func() {
+			machine.Status.Addresses = []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				{Type: corev1.NodeInternalDNS, Address: "internal.dns"},
+			}
+			Expect(PreferredAddressForMachine(machine)).To(Equal("internal.dns"))
+		})
+
+		It("should return unknown type if only unknown is present", func() {
+			machine.Status.Addresses = []corev1.NodeAddress{{Type: "UnknownType", Address: "unknown.addr"}}
+			Expect(PreferredAddressForMachine(machine)).To(Equal("unknown.addr"))
+		})
+
+		It("should prefer known type over unknown type", func() {
+			machine.Status.Addresses = []corev1.NodeAddress{
+				{Type: "UnknownType", Address: "unknown.addr"},
+				{Type: corev1.NodeExternalDNS, Address: "external.dns"},
+			}
+			Expect(PreferredAddressForMachine(machine)).To(Equal("external.dns"))
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -215,7 +215,7 @@ func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev
 		return nil, fmt.Errorf("failed adding ControllerDeployments: %w", err)
 	}
 
-	return botanist.ComputeExtensions(resources, runsControlPlane)
+	return botanist.ComputeExtensions(resources, true, runsControlPlane)
 }
 
 func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, opts *Options, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -134,7 +134,7 @@ func run(ctx context.Context, opts *Options) error {
 		return getAndExportObject(ctx, clientSet.Client(), fs, opts, "Project", project)
 	})
 
-	extensions, err := requiredExtensions(ctx, clientSet.Client(), shoot, opts.RunsControlPlane)
+	extensions, err := requiredExtensions(ctx, clientSet.Client(), shoot, opts.ManagedInfrastructure)
 	if err != nil {
 		return fmt.Errorf("failed computing required extensions: %w", err)
 	}
@@ -189,7 +189,7 @@ func secretBindingForShoot(ctx context.Context, c client.Client, shoot *gardenco
 	}
 }
 
-func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot, runsControlPlane bool) ([]botanist.Extension, error) {
+func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot, managedInfrastructure bool) ([]botanist.Extension, error) {
 	resources := gardenadm.Resources{Shoot: shoot}
 
 	controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
@@ -215,7 +215,7 @@ func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev
 		return nil, fmt.Errorf("failed adding ControllerDeployments: %w", err)
 	}
 
-	return botanist.ComputeExtensions(resources, true, runsControlPlane)
+	return botanist.ComputeExtensions(resources, true, managedInfrastructure)
 }
 
 func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, opts *Options, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/discover_test.go
+++ b/pkg/gardenadm/cmd/discover/discover_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -66,20 +67,23 @@ var _ = Describe("Discover", func() {
 
 	Describe("#RunE", func() {
 		var (
-			ctx            = context.Background()
-			namespaceName  = "garden-test-project"
-			extensionType1 = "test-extension-type-1"
-			extensionType2 = "test-extension-type-2"
+			ctx                   = context.Background()
+			namespaceName         = "garden-test-project"
+			extensionTypeProvider = "test-extension-type-provider"
+			extensionTypeNetwork  = "test-extension-type-network"
+			extensionTypeDNS      = "test-extension-type-dns"
 
-			project                 *gardencorev1beta1.Project
-			namespace               *corev1.Namespace
-			secretBinding           *gardencorev1beta1.SecretBinding
-			secret                  *corev1.Secret
-			cloudProfile            *gardencorev1beta1.CloudProfile
-			controllerDeployment1   *gardencorev1.ControllerDeployment
-			controllerRegistration1 *gardencorev1beta1.ControllerRegistration
-			controllerDeployment2   *gardencorev1.ControllerDeployment
-			controllerRegistration2 *gardencorev1beta1.ControllerRegistration
+			project                        *gardencorev1beta1.Project
+			namespace                      *corev1.Namespace
+			secretBinding                  *gardencorev1beta1.SecretBinding
+			secret, secretDNS              *corev1.Secret
+			cloudProfile                   *gardencorev1beta1.CloudProfile
+			controllerDeploymentProvider   *gardencorev1.ControllerDeployment
+			controllerRegistrationProvider *gardencorev1beta1.ControllerRegistration
+			controllerDeploymentNetwork    *gardencorev1.ControllerDeployment
+			controllerRegistrationNetwork  *gardencorev1beta1.ControllerRegistration
+			controllerDeploymentDNS        *gardencorev1.ControllerDeployment
+			controllerRegistrationDNS      *gardencorev1beta1.ControllerRegistration
 
 			shoot             *gardencorev1beta1.Shoot
 			shootRaw          []byte
@@ -106,6 +110,12 @@ var _ = Describe("Discover", func() {
 					Namespace: namespaceName,
 				},
 			}
+			secretDNS = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret-dns",
+					Namespace: namespaceName,
+				},
+			}
 			secretBinding = &gardencorev1beta1.SecretBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-secret-binding",
@@ -121,41 +131,59 @@ var _ = Describe("Discover", func() {
 					Name: "test-cloud-profile",
 				},
 			}
-			controllerDeployment1 = &gardencorev1.ControllerDeployment{
+			controllerDeploymentProvider = &gardencorev1.ControllerDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-controller-deployment-1",
+					Name: "test-controller-deployment-provider",
 				},
 			}
-			controllerRegistration1 = &gardencorev1beta1.ControllerRegistration{
+			controllerRegistrationProvider = &gardencorev1beta1.ControllerRegistration{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-controller-registration-1",
+					Name: "test-controller-registration-provider",
 				},
 				Spec: gardencorev1beta1.ControllerRegistrationSpec{
 					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: "ControlPlane", Type: extensionType1},
-						{Kind: "Infrastructure", Type: extensionType1},
-						{Kind: "Worker", Type: extensionType1},
+						{Kind: "ControlPlane", Type: extensionTypeProvider},
+						{Kind: "Infrastructure", Type: extensionTypeProvider},
+						{Kind: "Worker", Type: extensionTypeProvider},
 					},
 					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
-						DeploymentRefs: []gardencorev1beta1.DeploymentRef{{Name: controllerDeployment1.Name}},
+						DeploymentRefs: []gardencorev1beta1.DeploymentRef{{Name: controllerDeploymentProvider.Name}},
 					},
 				},
 			}
-			controllerDeployment2 = &gardencorev1.ControllerDeployment{
+			controllerDeploymentNetwork = &gardencorev1.ControllerDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-controller-deployment-2",
+					Name: "test-controller-deployment-network",
 				},
 			}
-			controllerRegistration2 = &gardencorev1beta1.ControllerRegistration{
+			controllerRegistrationNetwork = &gardencorev1beta1.ControllerRegistration{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-controller-registration-2",
+					Name: "test-controller-registration-network",
 				},
 				Spec: gardencorev1beta1.ControllerRegistrationSpec{
 					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: "Network", Type: extensionType2},
+						{Kind: "Network", Type: extensionTypeNetwork},
 					},
 					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
-						DeploymentRefs: []gardencorev1beta1.DeploymentRef{{Name: controllerDeployment2.Name}},
+						DeploymentRefs: []gardencorev1beta1.DeploymentRef{{Name: controllerDeploymentNetwork.Name}},
+					},
+				},
+			}
+			controllerDeploymentDNS = &gardencorev1.ControllerDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-controller-deployment-dns",
+				},
+			}
+			controllerRegistrationDNS = &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-controller-registration-dns",
+				},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "DNSRecord", Type: extensionTypeDNS},
+					},
+					Deployment: &gardencorev1beta1.ControllerRegistrationDeployment{
+						DeploymentRefs: []gardencorev1beta1.DeploymentRef{{Name: controllerDeploymentDNS.Name}},
 					},
 				},
 			}
@@ -163,12 +191,15 @@ var _ = Describe("Discover", func() {
 			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
 			Expect(fakeClient.Create(ctx, project)).To(Succeed())
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, secretDNS)).To(Succeed())
 			Expect(fakeClient.Create(ctx, secretBinding)).To(Succeed())
 			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
-			Expect(fakeClient.Create(ctx, controllerDeployment1)).To(Succeed())
-			Expect(fakeClient.Create(ctx, controllerRegistration1)).To(Succeed())
-			Expect(fakeClient.Create(ctx, controllerDeployment2)).To(Succeed())
-			Expect(fakeClient.Create(ctx, controllerRegistration2)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerDeploymentProvider)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerRegistrationProvider)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerDeploymentNetwork)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerRegistrationNetwork)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerDeploymentDNS)).To(Succeed())
+			Expect(fakeClient.Create(ctx, controllerRegistrationDNS)).To(Succeed())
 
 			shoot = &gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
@@ -182,11 +213,24 @@ var _ = Describe("Discover", func() {
 						Name: cloudProfile.Name,
 					},
 					Provider: gardencorev1beta1.Provider{
-						Type:    extensionType1,
+						Type:    extensionTypeProvider,
 						Workers: []gardencorev1beta1.Worker{{}},
 					},
 					Networking: &gardencorev1beta1.Networking{
-						Type: &extensionType2,
+						Type: &extensionTypeNetwork,
+					},
+					DNS: &gardencorev1beta1.DNS{
+						Providers: []gardencorev1beta1.DNSProvider{
+							{
+								Type:       ptr.To(extensionTypeDNS),
+								Primary:    ptr.To(true),
+								SecretName: ptr.To(secretDNS.Name),
+							},
+							{
+								Type:       ptr.To("unused"),
+								SecretName: ptr.To("dns-credentials-unused"),
+							},
+						},
 					},
 				},
 			}
@@ -207,24 +251,30 @@ var _ = Describe("Discover", func() {
 				ContainSubstring("Exported Namespace/"+namespace.Name),
 				ContainSubstring("Exported Project/"+project.Name),
 				ContainSubstring("Exported Secret/"+secret.Name),
+				ContainSubstring("Exported Secret/"+secretDNS.Name),
 				ContainSubstring("Exported SecretBinding/"+secretBinding.Name),
 				ContainSubstring("Exported CloudProfile/"+cloudProfile.Name),
-				ContainSubstring("Exported ControllerDeployment/"+controllerDeployment1.Name),
-				ContainSubstring("Exported ControllerRegistration/"+controllerRegistration1.Name),
-				ContainSubstring("Exported ControllerDeployment/"+controllerDeployment2.Name),
-				ContainSubstring("Exported ControllerRegistration/"+controllerRegistration2.Name),
+				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentProvider.Name),
+				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationProvider.Name),
+				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentNetwork.Name),
+				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationNetwork.Name),
+				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentDNS.Name),
+				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationDNS.Name),
 			))
 
 			for _, path := range []string{
 				fmt.Sprintf("namespace-%s.yaml", namespace.Name),
 				fmt.Sprintf("project-%s.yaml", project.Name),
 				fmt.Sprintf("secret-%s.yaml", secret.Name),
+				fmt.Sprintf("secret-%s.yaml", secretDNS.Name),
 				fmt.Sprintf("secretbinding-%s.yaml", secretBinding.Name),
 				fmt.Sprintf("cloudprofile-%s.yaml", cloudProfile.Name),
-				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeployment1.Name),
-				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistration1.Name),
-				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeployment2.Name),
-				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistration2.Name),
+				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentProvider.Name),
+				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationProvider.Name),
+				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentNetwork.Name),
+				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationNetwork.Name),
+				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentDNS.Name),
+				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationDNS.Name),
 			} {
 				exists, err := fs.Exists(path)
 				Expect(err).NotTo(HaveOccurred(), "for path "+path)

--- a/pkg/gardenadm/cmd/discover/options.go
+++ b/pkg/gardenadm/cmd/discover/options.go
@@ -24,7 +24,7 @@ type Options struct {
 	// ShootManifest is the path to the shoot manifest file.
 	ShootManifest string
 	// ManagedInfrastructure indicates whether Gardener will manage the shoot's infrastructure (network, domains,
-	// machines, etc.) Set this to true if using "gardenadm bootstrap" for bootstrapping the shoot cluster. Set this to
+	// machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to
 	// false if managing the infrastructure outside of Gardener.
 	ManagedInfrastructure bool
 }
@@ -65,5 +65,5 @@ func (o *Options) Complete() error { return o.ManifestOptions.Complete() }
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.StringVarP(&o.Kubeconfig, "kubeconfig", "k", "", "Path to the kubeconfig file pointing to the garden cluster")
-	fs.BoolVar(&o.ManagedInfrastructure, "managed-infrastructure", true, "Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using \"gardenadm bootstrap\" for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener.")
+	fs.BoolVar(&o.ManagedInfrastructure, "managed-infrastructure", true, "Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener.")
 }

--- a/pkg/gardenadm/cmd/discover/options.go
+++ b/pkg/gardenadm/cmd/discover/options.go
@@ -23,9 +23,10 @@ type Options struct {
 	Kubeconfig string
 	// ShootManifest is the path to the shoot manifest file.
 	ShootManifest string
-	// RunsControlPlane indicates whether the control plane is run in the same cluster. This should be set to false
-	// if `gardenadm bootstrap` will be used for bootstrapping the shoot cluster.
-	RunsControlPlane bool
+	// ManagedInfrastructure indicates whether Gardener will manage the shoot's infrastructure (network, domains,
+	// machines, etc.) Set this to true if using "gardenadm bootstrap" for bootstrapping the shoot cluster. Set this to
+	// false if managing the infrastructure outside of Gardener.
+	ManagedInfrastructure bool
 }
 
 // ParseArgs parses the arguments to the options.
@@ -64,5 +65,5 @@ func (o *Options) Complete() error { return o.ManifestOptions.Complete() }
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.StringVarP(&o.Kubeconfig, "kubeconfig", "k", "", "Path to the kubeconfig file pointing to the garden cluster")
-	fs.BoolVar(&o.RunsControlPlane, "runs-control-plane", true, "Indicates whether the control plane is run in the same cluster. This should be set to false if `gardenadm bootstrap` will be used for bootstrapping the shoot cluster.")
+	fs.BoolVar(&o.ManagedInfrastructure, "managed-infrastructure", true, "Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using \"gardenadm bootstrap\" for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener.")
 }

--- a/pkg/gardenadm/cmd/discover/options.go
+++ b/pkg/gardenadm/cmd/discover/options.go
@@ -24,7 +24,7 @@ type Options struct {
 	// ShootManifest is the path to the shoot manifest file.
 	ShootManifest string
 	// ManagedInfrastructure indicates whether Gardener will manage the shoot's infrastructure (network, domains,
-	// machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to
+	// machines, etc.). Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to
 	// false if managing the infrastructure outside of Gardener.
 	ManagedInfrastructure bool
 }
@@ -65,5 +65,5 @@ func (o *Options) Complete() error { return o.ManifestOptions.Complete() }
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.StringVarP(&o.Kubeconfig, "kubeconfig", "k", "", "Path to the kubeconfig file pointing to the garden cluster")
-	fs.BoolVar(&o.ManagedInfrastructure, "managed-infrastructure", true, "Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.) Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener.")
+	fs.BoolVar(&o.ManagedInfrastructure, "managed-infrastructure", true, "Indicates whether Gardener will manage the shoot's infrastructure (network, domains, machines, etc.). Set this to true if using 'gardenadm bootstrap' for bootstrapping the shoot cluster. Set this to false if managing the infrastructure outside of Gardener.")
 }

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -33,7 +33,7 @@ func (b *Botanist) ToAdvertisedAddresses() ([]gardencorev1beta1.ShootAdvertisedA
 		return addresses, nil
 	}
 
-	if b.Shoot.ExternalClusterDomain != nil && len(*b.Shoot.ExternalClusterDomain) > 0 {
+	if b.Shoot.ExternalClusterDomain != nil {
 		addresses = append(addresses, gardencorev1beta1.ShootAdvertisedAddress{
 			Name: v1beta1constants.AdvertisedAddressExternal,
 			URL:  "https://" + v1beta1helper.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
@@ -47,10 +47,10 @@ func (b *Botanist) ToAdvertisedAddresses() ([]gardencorev1beta1.ShootAdvertisedA
 		})
 	}
 
-	if len(b.Shoot.InternalClusterDomain) > 0 {
+	if b.Shoot.InternalClusterDomain != nil {
 		addresses = append(addresses, gardencorev1beta1.ShootAdvertisedAddress{
 			Name: v1beta1constants.AdvertisedAddressInternal,
-			URL:  "https://" + v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
+			URL:  "https://" + v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
 		})
 	}
 
@@ -68,7 +68,7 @@ func (b *Botanist) ToAdvertisedAddresses() ([]gardencorev1beta1.ShootAdvertisedA
 			shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.Issuer != nil
 	}
 
-	if len(b.Shoot.InternalClusterDomain) > 0 ||
+	if b.Shoot.InternalClusterDomain != nil ||
 		hasCustomIssuer(b.Shoot.GetInfo()) ||
 		v1beta1helper.HasManagedIssuer(b.Shoot.GetInfo()) {
 		externalHostname := b.Shoot.ComputeOutOfClusterAPIServerAddress(true)

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
@@ -50,7 +50,7 @@ var _ = Describe("AdvertisedAddresses", func() {
 		})
 
 		It("returns internal and service-account-issuer addresses", func() {
-			botanist.Shoot.InternalClusterDomain = "baz.foo"
+			botanist.Shoot.InternalClusterDomain = ptr.To("baz.foo")
 
 			addresses, err := botanist.ToAdvertisedAddresses()
 			Expect(err).ToNot(HaveOccurred())
@@ -82,7 +82,7 @@ var _ = Describe("AdvertisedAddresses", func() {
 
 		It("returns external, internal, service-account-issuer addresses in correct order", func() {
 			botanist.Shoot.ExternalClusterDomain = ptr.To("foo.bar")
-			botanist.Shoot.InternalClusterDomain = "baz.foo"
+			botanist.Shoot.InternalClusterDomain = ptr.To("baz.foo")
 			botanist.APIServerAddress = "bar.foo"
 
 			addresses, err := botanist.ToAdvertisedAddresses()
@@ -105,7 +105,7 @@ var _ = Describe("AdvertisedAddresses", func() {
 
 		It("returns external, internal addresses with addition to custom service-account-issuer address", func() {
 			botanist.Shoot.ExternalClusterDomain = ptr.To("foo.bar")
-			botanist.Shoot.InternalClusterDomain = "baz.foo"
+			botanist.Shoot.InternalClusterDomain = ptr.To("baz.foo")
 			botanist.Shoot.GetInfo().Spec.Kubernetes = gardencorev1beta1.Kubernetes{
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
 					ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
@@ -135,7 +135,7 @@ var _ = Describe("AdvertisedAddresses", func() {
 
 		It("returns external, internal addresses with addition to managed service-account-issuer address", func() {
 			botanist.Shoot.ExternalClusterDomain = ptr.To("foo.bar")
-			botanist.Shoot.InternalClusterDomain = "baz.foo"
+			botanist.Shoot.InternalClusterDomain = ptr.To("baz.foo")
 			botanist.Shoot.ServiceAccountIssuerHostname = ptr.To("managed.foo.bar")
 			botanist.Garden = &garden.Garden{
 				Project: &gardencorev1beta1.Project{
@@ -175,7 +175,7 @@ var _ = Describe("AdvertisedAddresses", func() {
 
 		It("should return error because shoot wants managed issuer, but issuer hostname is not configured", func() {
 			botanist.Shoot.ExternalClusterDomain = ptr.To("foo.bar")
-			botanist.Shoot.InternalClusterDomain = "baz.foo"
+			botanist.Shoot.InternalClusterDomain = ptr.To("baz.foo")
 
 			botanist.Garden = &garden.Garden{
 				Project: &gardencorev1beta1.Project{

--- a/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy_test.go
@@ -73,7 +73,7 @@ var _ = Describe("APIServerProxy", func() {
 					Components: &shootpkg.Components{
 						SystemComponents: &shootpkg.SystemComponents{},
 					},
-					InternalClusterDomain: internalClusterDomain,
+					InternalClusterDomain: &internalClusterDomain,
 					ExternalClusterDomain: &externalClusterDomain,
 					ExternalDomain:        &gardenerutils.Domain{Provider: "some-external-provider"},
 				},

--- a/pkg/gardenlet/operation/botanist/blackboxexporter.go
+++ b/pkg/gardenlet/operation/botanist/blackboxexporter.go
@@ -10,7 +10,6 @@ import (
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/blackboxexporter"
@@ -40,7 +39,7 @@ func (b *Botanist) DefaultBlackboxExporterControlPlane() (component.DeployWaiter
 			},
 			PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
 			Config:            controlplaneblackboxexporter.Config(),
-			ScrapeConfigs:     controlplaneblackboxexporter.ScrapeConfig(b.Shoot.ControlPlaneNamespace, monitoringv1alpha1.Target("https://"+v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain)+"/healthz")),
+			ScrapeConfigs:     controlplaneblackboxexporter.ScrapeConfig(b.Shoot.ControlPlaneNamespace, monitoringv1alpha1.Target("https://"+b.Shoot.ComputeOutOfClusterAPIServerAddress(true)+"/healthz")),
 			Replicas:          b.Shoot.GetReplicas(1),
 		},
 	)

--- a/pkg/gardenlet/operation/botanist/dns_test.go
+++ b/pkg/gardenlet/operation/botanist/dns_test.go
@@ -187,7 +187,7 @@ var _ = Describe("dns", func() {
 		It("sets internal and external DNSRecords", func() {
 			b.Shoot.GetInfo().Status.ClusterIdentity = ptr.To("shoot-cluster-identity")
 			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: ptr.To("foo")}
-			b.Shoot.InternalClusterDomain = "bar"
+			b.Shoot.InternalClusterDomain = ptr.To("bar")
 			b.Shoot.ExternalClusterDomain = ptr.To("baz")
 			b.Shoot.ExternalDomain = &gardenerutils.Domain{Provider: "valid-provider"}
 			b.Garden.InternalDomain = &gardenerutils.Domain{Provider: "valid-provider"}

--- a/pkg/gardenlet/operation/botanist/dnsrecord.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord.go
@@ -67,7 +67,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 			values.Zone = &b.Garden.InternalDomain.Zone
 		}
 		values.SecretData = b.Garden.InternalDomain.SecretData
-		values.DNSName = v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain)
+		values.DNSName = v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain)
 	}
 
 	return extensionsdnsrecord.New(

--- a/pkg/gardenlet/operation/botanist/dnsrecord_test.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord_test.go
@@ -117,7 +117,7 @@ var _ = Describe("dnsrecord", func() {
 							"external-foo": []byte("external-bar"),
 						},
 					},
-					InternalClusterDomain: internalDomain,
+					InternalClusterDomain: ptr.To(internalDomain),
 					Components: &shoot.Components{
 						Extensions: &shoot.Extensions{
 							ExternalDNSRecord: externalDNSRecord,

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Etcd", func() {
 				},
 				ControlPlaneNamespace: namespace,
 				BackupEntryName:       namespace + "--" + string(shootUID),
-				InternalClusterDomain: "internal.example.com",
+				InternalClusterDomain: ptr.To("internal.example.com"),
 			}
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
 				Status: gardencorev1beta1.SeedStatus{

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -116,13 +116,16 @@ func (b *Botanist) computeKubeAPIServerServerCertificateConfig() kubeapiserver.S
 	var (
 		ipAddresses = []net.IP{}
 		dnsNames    = []string{
-			v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
 			b.Shoot.GetInfo().Status.TechnicalID,
 		}
 	)
 
 	if b.Shoot.Networks != nil {
 		ipAddresses = append(ipAddresses, b.Shoot.Networks.APIServer...)
+	}
+
+	if b.Shoot.InternalClusterDomain != nil {
+		dnsNames = append(dnsNames, v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain))
 	}
 
 	if b.Shoot.ExternalClusterDomain != nil {

--- a/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver_test.go
@@ -124,7 +124,7 @@ var _ = Describe("KubeAPIServer", func() {
 							KubeAPIServer: kubeAPIServer,
 						},
 					},
-					InternalClusterDomain: internalClusterDomain,
+					InternalClusterDomain: ptr.To(internalClusterDomain),
 					ExternalClusterDomain: &externalClusterDomain,
 					Networks: &shootpkg.Networks{
 						APIServer: apiServerNetwork,

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -158,7 +158,7 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 			values := &kubeapiserverexposure.SNIValues{
 				Hosts: []string{
 					v1beta1helper.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
-					v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
+					v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
 				},
 				APIServerProxy: &kubeapiserverexposure.APIServerProxy{
 					APIServerClusterIP: b.APIServerClusterIP,
@@ -192,7 +192,7 @@ func (b *Botanist) ReconcileIstioInternalLoadBalancingConfigMap(ctx context.Cont
 		b.Shoot.ControlPlaneNamespace,
 		b.IstioNamespace(),
 		[]string{
-			v1beta1helper.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
+			v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
 		},
 		features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 	)

--- a/pkg/gardenlet/operation/botanist/kubeproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeproxy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("KubeProxy", func() {
 				ShootClientSet:   fakeShootKubernetesInterface,
 				SecretsManager:   sm,
 				Shoot: &shootpkg.Shoot{
-					InternalClusterDomain: internalClusterDomain,
+					InternalClusterDomain: ptr.To(internalClusterDomain),
 					KubernetesVersion:     kubernetesVersionControlPlane,
 					ControlPlaneNamespace: namespace,
 				},

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -89,7 +89,7 @@ var _ = Describe("operatingsystemconfig", func() {
 							OperatingSystemConfig: operatingSystemConfig,
 						},
 					},
-					InternalClusterDomain: shootDomain,
+					InternalClusterDomain: ptr.To(shootDomain),
 					Purpose:               "development",
 					Networks: &shootpkg.Networks{
 						CoreDNS: []net.IP{net.ParseIP(coreDNS[0]), net.ParseIP(coreDNS[1])},

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -70,7 +70,8 @@ var _ = Describe("ResourceManager", func() {
 			botanist.Seed = &seedpkg.Seed{}
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
 			botanist.Shoot = &shootpkg.Shoot{
-				KubernetesVersion: semver.MustParse("1.32.1"),
+				KubernetesVersion:     semver.MustParse("1.32.1"),
+				ExternalClusterDomain: ptr.To("foo.local.gardener.cloud"),
 			}
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})

--- a/pkg/gardenlet/operation/botanist/vpnshoot_test.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot_test.go
@@ -49,6 +49,7 @@ var _ = Describe("VPNShoot", func() {
 					Services: []net.IPNet{{IP: []byte("10.0.0.0"), Mask: []byte("24")}},
 					Nodes:    []net.IPNet{{IP: []byte("10.181.0.0"), Mask: []byte("16")}},
 				},
+				ExternalClusterDomain: ptr.To("foo.local.gardener.cloud"),
 			}
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -500,13 +500,9 @@ func (s *Shoot) ComputeInClusterAPIServerAddress(runsInShootNamespace bool) stri
 
 // ComputeOutOfClusterAPIServerAddress returns the external address for the shoot API server depending on whether
 // the caller wants to use the internal cluster domain and whether DNS is disabled on this seed.
-func (s *Shoot) ComputeOutOfClusterAPIServerAddress(useInternalClusterDomain bool) string {
-	if v1beta1helper.ShootUsesUnmanagedDNS(s.GetInfo()) {
-		return v1beta1helper.GetAPIServerDomain(s.InternalClusterDomain)
-	}
-
-	if useInternalClusterDomain || s.ExternalClusterDomain == nil {
-		return v1beta1helper.GetAPIServerDomain(s.InternalClusterDomain)
+func (s *Shoot) ComputeOutOfClusterAPIServerAddress(preferInternalClusterDomain bool) string {
+	if s.InternalClusterDomain != nil && (preferInternalClusterDomain || s.ExternalClusterDomain == nil || v1beta1helper.ShootUsesUnmanagedDNS(s.GetInfo())) {
+		return v1beta1helper.GetAPIServerDomain(*s.InternalClusterDomain)
 	}
 
 	return v1beta1helper.GetAPIServerDomain(*s.ExternalClusterDomain)

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -678,3 +678,9 @@ func (s *Shoot) IsAutonomous() bool {
 func (s *Shoot) RunsControlPlane() bool {
 	return s.ControlPlaneNamespace == metav1.NamespaceSystem
 }
+
+// HasManagedInfrastructure returns true if the shoot's infrastructure (network, machines, etc.) is managed by Gardener.
+// I.e., it returns false for high-touch autonomous shoots, where the infrastructure is managed by the user.
+func (s *Shoot) HasManagedInfrastructure() bool {
+	return v1beta1helper.HasManagedInfrastructure(s.GetInfo())
+}

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -219,7 +219,7 @@ var _ = Describe("shoot", func() {
 				unmanaged := "unmanaged"
 				internalDomain := "foo"
 				s := &Shoot{
-					InternalClusterDomain: internalDomain,
+					InternalClusterDomain: ptr.To(internalDomain),
 				}
 				s.SetInfo(&gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
@@ -237,7 +237,7 @@ var _ = Describe("shoot", func() {
 			It("should return the internal domain as requested (shoot's external domain is not unmanaged)", func() {
 				internalDomain := "foo"
 				s := &Shoot{
-					InternalClusterDomain: internalDomain,
+					InternalClusterDomain: ptr.To(internalDomain),
 				}
 				s.SetInfo(&gardencorev1beta1.Shoot{})
 
@@ -247,7 +247,7 @@ var _ = Describe("shoot", func() {
 			It("should return the internal domain when shoot's external domain is not set (even if not requested)", func() {
 				internalDomain := "foo"
 				s := &Shoot{
-					InternalClusterDomain: internalDomain,
+					InternalClusterDomain: ptr.To(internalDomain),
 				}
 				s.SetInfo(&gardencorev1beta1.Shoot{})
 

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -303,5 +303,22 @@ var _ = Describe("shoot", func() {
 				Expect((&Shoot{ControlPlaneNamespace: "shoot--foo--bar"}).RunsControlPlane()).To(BeFalse())
 			})
 		})
+
+		Describe("#HasManagedInfrastructure", func() {
+			It("should return false when both CredentialsBindingName and SecretBindingName are nil", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{CredentialsBindingName: nil, SecretBindingName: nil}})
+				Expect(shoot.HasManagedInfrastructure()).To(BeFalse())
+			})
+
+			It("should return true when CredentialsBindingName is set", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{CredentialsBindingName: ptr.To("binding")}})
+				Expect(shoot.HasManagedInfrastructure()).To(BeTrue())
+			})
+
+			It("should return true when SecretBindingName is set", func() {
+				shoot.SetInfo(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SecretBindingName: ptr.To("binding")}})
+				Expect(shoot.HasManagedInfrastructure()).To(BeTrue())
+			})
+		})
 	})
 })

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -79,9 +79,12 @@ type Shoot struct {
 	ControlPlaneNamespace string
 	KubernetesVersion     *semver.Version
 
-	InternalClusterDomain string
+	// InternalClusterDomain is empty for autonomous shoots, which only have an external domain (Shoot.spec.dns.domain).
+	InternalClusterDomain *string
+	// ExternalClusterDomain is nil if Shoot.Spec.DNS.Domain is unset.
 	ExternalClusterDomain *string
-	ExternalDomain        *gardenerutils.Domain
+	// ExternalDomain is nil if Shoot.Spec.DNS.Domain is unset.
+	ExternalDomain *gardenerutils.Domain
 
 	Purpose                                 gardencorev1beta1.ShootPurpose
 	IsWorkerless                            bool

--- a/pkg/provider-local/controller/dnsrecord/actuator.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator.go
@@ -6,98 +6,118 @@ package dnsrecord
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
-type actuator struct {
-	client client.Client
+// Actuator implements the DNSRecord actuator for the local DNS provider.
+type Actuator struct {
+	Client client.Client
 }
 
-// NewActuator creates a new Actuator that updates the status of the handled DNSRecord resources.
-func NewActuator(mgr manager.Manager) dnsrecord.Actuator {
-	return &actuator{
-		client: mgr.GetClient(),
-	}
-}
-
-func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, dnsrecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
-	return a.reconcile(ctx, dnsrecord, cluster, updateCoreDNSRewriteRule)
-}
-
-func (a *actuator) Delete(ctx context.Context, _ logr.Logger, dnsrecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
-	return a.reconcile(ctx, dnsrecord, cluster, deleteCoreDNSRewriteRule)
-}
-
-func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, dnsrecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
-	return a.Delete(ctx, log, dnsrecord, cluster)
-}
-
-func (a *actuator) reconcile(ctx context.Context, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster, mutateCorednsRules func(corednsConfig *corev1.ConfigMap, dnsRecord *extensionsv1alpha1.DNSRecord, zone *string)) error {
-	return a.updateCoreDNSRewritingRules(ctx, dnsRecord, cluster, mutateCorednsRules)
-}
-
-func (a *actuator) Migrate(ctx context.Context, log logr.Logger, dnsrecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
-	return a.Delete(ctx, log, dnsrecord, cluster)
-}
-
-func (a *actuator) Restore(ctx context.Context, log logr.Logger, dnsrecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
-	return a.Reconcile(ctx, log, dnsrecord, cluster)
-}
-
-func (a *actuator) updateCoreDNSRewritingRules(
-	ctx context.Context,
-	dnsRecord *extensionsv1alpha1.DNSRecord,
-	cluster *extensionscontroller.Cluster,
-	mutateCorednsRules func(corednsConfig *corev1.ConfigMap, dnsRecord *extensionsv1alpha1.DNSRecord, zone *string),
-) error {
+// Reconcile ensures that the DNS record is correctly represented in the CoreDNS config map.
+func (a *Actuator) Reconcile(ctx context.Context, _ logr.Logger, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
 	// Only handle dns records for kube-apiserver
-	if dnsRecord == nil || !strings.HasPrefix(dnsRecord.Spec.Name, "api.") || !strings.HasSuffix(dnsRecord.Spec.Name, ".local.gardener.cloud") ||
-		(dnsRecord.Spec.Class != nil && *dnsRecord.Spec.Class == extensionsv1alpha1.ExtensionClassGarden) {
+	if !strings.HasPrefix(dnsRecord.Spec.Name, "api.") || !strings.HasSuffix(dnsRecord.Spec.Name, ".local.gardener.cloud") ||
+		ptr.Deref(dnsRecord.Spec.Class, "") == extensionsv1alpha1.ExtensionClassGarden {
 		return nil
 	}
 
+	config, err := a.configForDNSRecord(ctx, dnsRecord, cluster)
+	if err != nil {
+		return err
+	}
+
+	return a.patchCoreDNSConfigMap(ctx, func(configMap *corev1.ConfigMap) {
+		configMap.Data[keyForDNSRecord(dnsRecord)] = config
+	})
+}
+
+// Delete removes the DNS record from the CoreDNS config map.
+func (a *Actuator) Delete(ctx context.Context, _ logr.Logger, dnsRecord *extensionsv1alpha1.DNSRecord, _ *extensionscontroller.Cluster) error {
+	return a.patchCoreDNSConfigMap(ctx, func(configMap *corev1.ConfigMap) {
+		delete(configMap.Data, keyForDNSRecord(dnsRecord))
+	})
+}
+
+// ForceDelete is the same as Delete for the local DNS provider.
+func (a *Actuator) ForceDelete(ctx context.Context, log logr.Logger, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
+	return a.Delete(ctx, log, dnsRecord, cluster)
+}
+
+// Migrate removes the DNS record from the CoreDNS config map if the shoot is not autonomous.
+func (a *Actuator) Migrate(ctx context.Context, log logr.Logger, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
+	if v1beta1helper.IsShootAutonomous(cluster.Shoot.Spec.Provider.Workers) {
+		// Do nothing when migrating DNSRecord of autonomous shoot with managed infrastructure. The CoreDNS
+		// rewrite rules are still needed for the control plane machines to resolve the kube-apiserver domain.
+		return nil
+	}
+
+	return a.Delete(ctx, log, dnsRecord, cluster)
+}
+
+// Restore is the same as Reconcile for the local DNS provider.
+func (a *Actuator) Restore(ctx context.Context, log logr.Logger, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) error {
+	return a.Reconcile(ctx, log, dnsRecord, cluster)
+}
+
+func (a *Actuator) patchCoreDNSConfigMap(ctx context.Context, mutate func(configMap *corev1.ConfigMap)) error {
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns-custom", Namespace: "gardener-extension-provider-local-coredns"}}
+	_, err := controllerutil.CreateOrPatch(ctx, a.Client, configMap, func() error {
+		mutate(configMap)
+		return nil
+	})
+	return err
+}
+
+func keyForDNSRecord(dnsRecord *extensionsv1alpha1.DNSRecord) string {
+	return dnsRecord.Spec.Name + ".override"
+}
+
+func (a *Actuator) configForDNSRecord(ctx context.Context, dnsRecord *extensionsv1alpha1.DNSRecord, cluster *extensionscontroller.Cluster) (string, error) {
+	if v1beta1helper.IsShootAutonomous(cluster.Shoot.Spec.Provider.Workers) {
+		switch dnsRecord.Spec.RecordType {
+		case extensionsv1alpha1.DNSRecordTypeA, extensionsv1alpha1.DNSRecordTypeAAAA:
+			// We need to use the `template` plugin because the `hosts` plugin can only be used once per server block.
+			config := fmt.Sprintf(`template IN %[1]s local.gardener.cloud {
+  match "^%[2]s\.$"
+  answer "{{ .Name }} %[3]d IN %[1]s %[4]s"
+  fallthrough
+}
+`, dnsRecord.Spec.RecordType, regexp.QuoteMeta(dnsRecord.Spec.Name), ptr.Deref(dnsRecord.Spec.TTL, 120), strings.Join(dnsRecord.Spec.Values, " "))
+
+			return config, nil
+		default:
+			return "", fmt.Errorf("unsupported record type %q for autonomous shoot, only A and AAAA are supported", dnsRecord.Spec.RecordType)
+		}
+	}
+
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dnsRecord.Namespace}}
-	if err := a.client.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-		return err
+	if err := a.Client.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+		return "", err
 	}
 
-	var zone *string
+	var zone string
 	if zones, ok := namespace.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones]; ok && !strings.Contains(zones, ",") && len(cluster.Seed.Spec.Provider.Zones) > 1 {
-		zone = &zones
+		zone = zones
 	}
-
-	corednsConfig := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns-custom", Namespace: "gardener-extension-provider-local-coredns"}}
-	if err := a.client.Get(ctx, client.ObjectKeyFromObject(corednsConfig), corednsConfig); err != nil {
-		return err
-	}
-
-	originalConfig := corednsConfig.DeepCopy()
-	mutateCorednsRules(corednsConfig, dnsRecord, zone)
-
-	return a.client.Patch(ctx, corednsConfig, client.MergeFrom(originalConfig))
-}
-
-func deleteCoreDNSRewriteRule(corednsConfig *corev1.ConfigMap, dnsRecord *extensionsv1alpha1.DNSRecord, _ *string) {
-	delete(corednsConfig.Data, dnsRecord.Spec.Name+".override")
-}
-
-func updateCoreDNSRewriteRule(corednsConfig *corev1.ConfigMap, dnsRecord *extensionsv1alpha1.DNSRecord, zone *string) {
 	istioNamespaceSuffix := ""
-	if zone != nil {
-		istioNamespaceSuffix = "--" + *zone
+	if zone != "" {
+		istioNamespaceSuffix = "--" + zone
 	}
-	corednsConfig.Data[dnsRecord.Spec.Name+".override"] =
-		"rewrite stop name regex " + regexp.QuoteMeta(dnsRecord.Spec.Name) + " istio-ingressgateway.istio-ingress" + istioNamespaceSuffix + ".svc.cluster.local answer auto"
+
+	return "rewrite stop name regex " + regexp.QuoteMeta(dnsRecord.Spec.Name) + " istio-ingressgateway.istio-ingress" + istioNamespaceSuffix + ".svc.cluster.local answer auto", nil
 }

--- a/pkg/provider-local/controller/dnsrecord/actuator_test.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator_test.go
@@ -7,43 +7,64 @@ package dnsrecord_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
-	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 )
 
 var _ = Describe("Actuator", func() {
 	Describe("DNS Rewriting", func() {
 		var (
-			actuator dnsrecord.Actuator
-			c        client.Client
-			ctrl     *gomock.Controller
-			mgr      *mockmanager.MockManager
+			log        logr.Logger
+			fakeClient client.Client
 
-			ctx     = context.TODO()
+			actuator dnsrecord.Actuator
+
+			namespace           string
+			cluster             *extensionscontroller.Cluster
+			singleZoneNamespace *corev1.Namespace
+			multiZoneNamespace  *corev1.Namespace
+			apiDNSRecord        *extensionsv1alpha1.DNSRecord
+			otherDNSRecord      *extensionsv1alpha1.DNSRecord
+
+			extensionNamespace *corev1.Namespace
+			emptyConfigMap     *corev1.ConfigMap
+			configMapWithRule  *corev1.ConfigMap
+		)
+
+		BeforeEach(func() {
+			log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter))
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+			actuator = &Actuator{
+				Client: fakeClient,
+			}
+
+			namespace = "foo"
 			cluster = &extensionscontroller.Cluster{
-				Seed: &v1beta1.Seed{
-					Spec: v1beta1.SeedSpec{
-						Provider: v1beta1.SeedProvider{
+				Shoot: &gardencorev1beta1.Shoot{},
+				Seed: &gardencorev1beta1.Seed{
+					Spec: gardencorev1beta1.SeedSpec{
+						Provider: gardencorev1beta1.SeedProvider{
 							Zones: []string{"a", "b", "c"},
 						},
 					},
 				},
 			}
-			namespace           = "foo"
 			singleZoneNamespace = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
@@ -65,7 +86,9 @@ var _ = Describe("Actuator", func() {
 					Namespace: namespace,
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{
-					Name: "api.something.local.gardener.cloud",
+					Name:   "api.something.local.gardener.cloud",
+					Values: []string{"1.2.3.4", "5.6.7.8"},
+					TTL:    ptr.To[int64](123),
 				},
 			}
 			otherDNSRecord = &extensionsv1alpha1.DNSRecord{
@@ -95,83 +118,157 @@ var _ = Describe("Actuator", func() {
 					apiDNSRecord.Spec.Name + ".override": "some rule",
 				},
 			}
-			log = logf.Log.WithName("test")
-		)
-
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			mgr = mockmanager.NewMockManager(ctrl)
 		})
 
-		Describe("Successful reconciliation", func() {
-			It("Should add single zone rewrite rule", func() {
-				c = initializeClient(singleZoneNamespace, extensionNamespace, emptyConfigMap)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).NotTo(HaveOccurred())
+		Describe("Reconcile", func() {
+			It("should add single zone rewrite rule", func(ctx SpecContext) {
+				createObjects(fakeClient, singleZoneNamespace, extensionNamespace, emptyConfigMap)
+
+				Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
 				Expect(result.Data[apiDNSRecord.Spec.Name+".override"]).To(
 					Equal("rewrite stop name regex api\\.something\\.local\\.gardener\\.cloud istio-ingressgateway.istio-ingress--a.svc.cluster.local answer auto"))
 			})
 
-			It("Should add multi zone rewrite rule", func() {
-				c = initializeClient(multiZoneNamespace, extensionNamespace, emptyConfigMap)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).NotTo(HaveOccurred())
+			It("should add multi zone rewrite rule", func(ctx SpecContext) {
+				createObjects(fakeClient, multiZoneNamespace, extensionNamespace, emptyConfigMap)
+
+				Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
 				Expect(result.Data[apiDNSRecord.Spec.Name+".override"]).To(
 					Equal("rewrite stop name regex api\\.something\\.local\\.gardener\\.cloud istio-ingressgateway.istio-ingress.svc.cluster.local answer auto"))
 			})
 
-			It("Should ignore other dns entries", func() {
-				c = initializeClient(singleZoneNamespace, extensionNamespace, emptyConfigMap)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Reconcile(ctx, log, otherDNSRecord, cluster)).NotTo(HaveOccurred())
+			It("should ignore other dns entries", func(ctx SpecContext) {
+				createObjects(fakeClient, singleZoneNamespace, extensionNamespace, emptyConfigMap)
+
+				Expect(actuator.Reconcile(ctx, log, otherDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
 				Expect(result.Data).To(Equal(map[string]string{"test": "data"}))
 			})
 		})
 
-		Describe("Successful deletion", func() {
-			It("Should remove single zone rewrite rule", func() {
-				c = initializeClient(singleZoneNamespace, extensionNamespace, configMapWithRule)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Delete(ctx, log, apiDNSRecord, cluster)).NotTo(HaveOccurred())
+		Describe("Delete", func() {
+			It("should remove single zone rewrite rule", func(ctx SpecContext) {
+				createObjects(fakeClient, singleZoneNamespace, extensionNamespace, configMapWithRule)
+
+				Expect(actuator.Delete(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).To(Succeed())
 				Expect(result.Data).To(Equal(map[string]string{"test": "data"}))
 			})
 
-			It("Should remove multi zone rewrite rule", func() {
-				c = initializeClient(multiZoneNamespace, extensionNamespace, configMapWithRule)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Delete(ctx, log, apiDNSRecord, cluster)).NotTo(HaveOccurred())
+			It("should remove multi zone rewrite rule", func(ctx SpecContext) {
+				createObjects(fakeClient, multiZoneNamespace, extensionNamespace, configMapWithRule)
+
+				Expect(actuator.Delete(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).To(Succeed())
 				Expect(result.Data).To(Equal(map[string]string{"test": "data"}))
 			})
 
-			It("Should ignore other dns entries", func() {
-				c = initializeClient(singleZoneNamespace, extensionNamespace, configMapWithRule)
-				mgr.EXPECT().GetClient().Return(c)
-				actuator = NewActuator(mgr)
-				Expect(actuator.Delete(ctx, log, otherDNSRecord, cluster)).NotTo(HaveOccurred())
+			It("should ignore other dns entries", func(ctx SpecContext) {
+				createObjects(fakeClient, singleZoneNamespace, extensionNamespace, configMapWithRule)
+
+				Expect(actuator.Delete(ctx, log, otherDNSRecord, cluster)).To(Succeed())
+
 				result := &corev1.ConfigMap{}
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).NotTo(HaveOccurred())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).To(Succeed())
 				Expect(result.Data).To(Equal(map[string]string{"test": "data", apiDNSRecord.Spec.Name + ".override": "some rule"}))
+			})
+		})
+
+		Describe("Migrate", func() {
+			It("should remove the rewrite rule", func(ctx SpecContext) {
+				createObjects(fakeClient, extensionNamespace, configMapWithRule)
+
+				Expect(actuator.Migrate(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
+				result := &corev1.ConfigMap{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(configMapWithRule), result)).To(Succeed())
+				Expect(result.Data).To(Equal(map[string]string{"test": "data"}))
+			})
+		})
+
+		Context("autonomous shoots", func() {
+			BeforeEach(func() {
+				cluster.Shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{{
+					ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+				}}
+			})
+
+			Describe("Reconcile", func() {
+				It("should add config for A record", func(ctx SpecContext) {
+					createObjects(fakeClient, extensionNamespace, emptyConfigMap)
+
+					apiDNSRecord.Spec.RecordType = "A"
+					Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
+					result := &corev1.ConfigMap{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
+					Expect(result.Data[apiDNSRecord.Spec.Name+".override"]).To(
+						Equal(`template IN A local.gardener.cloud {
+  match "^api\.something\.local\.gardener\.cloud\.$"
+  answer "{{ .Name }} 123 IN A 1.2.3.4 5.6.7.8"
+  fallthrough
+}
+`))
+				})
+
+				It("should add config for AAAA record", func(ctx SpecContext) {
+					createObjects(fakeClient, extensionNamespace, emptyConfigMap)
+
+					apiDNSRecord.Spec.RecordType = "AAAA"
+					Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
+					result := &corev1.ConfigMap{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
+					Expect(result.Data[apiDNSRecord.Spec.Name+".override"]).To(
+						Equal(`template IN AAAA local.gardener.cloud {
+  match "^api\.something\.local\.gardener\.cloud\.$"
+  answer "{{ .Name }} 123 IN AAAA 1.2.3.4 5.6.7.8"
+  fallthrough
+}
+`))
+				})
+
+				It("should fail for CNAME record", func(ctx SpecContext) {
+					createObjects(fakeClient, extensionNamespace, emptyConfigMap)
+
+					apiDNSRecord.Spec.RecordType = "CNAME"
+					apiDNSRecord.Spec.Values = []string{"some.other.name.gardener.cloud"}
+					Expect(actuator.Reconcile(ctx, log, apiDNSRecord, cluster)).To(MatchError(ContainSubstring(`unsupported record type "CNAME" for autonomous shoot`)))
+				})
+			})
+
+			Describe("Migrate", func() {
+				It("should not delete rule from ConfigMap", func(ctx SpecContext) {
+					createObjects(fakeClient, extensionNamespace, configMapWithRule)
+
+					Expect(actuator.Migrate(ctx, log, apiDNSRecord, cluster)).To(Succeed())
+
+					result := &corev1.ConfigMap{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(emptyConfigMap), result)).To(Succeed())
+					Expect(result.Data[apiDNSRecord.Spec.Name+".override"]).To(
+						Equal("some rule"))
+				})
 			})
 		})
 	})
 })
 
-func initializeClient(objects ...client.Object) client.Client {
-	client := fakeclient.NewClientBuilder().WithObjects(objects...).WithScheme(scheme.Scheme).Build()
-	return client
+func createObjects(c client.Client, objs ...client.Object) {
+	GinkgoHelper()
+
+	for _, obj := range objs {
+		Expect(c.Create(context.Background(), obj)).To(Succeed())
+	}
 }

--- a/pkg/provider-local/controller/dnsrecord/add.go
+++ b/pkg/provider-local/controller/dnsrecord/add.go
@@ -31,10 +31,12 @@ type AddOptions struct {
 }
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
-// The opts.Reconciler is being set with a newly instantiated actuator.
+// The opts.Reconciler is being set with a newly instantiated Actuator.
 func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
 	return dnsrecord.Add(mgr, dnsrecord.AddArgs{
-		Actuator:          NewActuator(mgr),
+		Actuator: &Actuator{
+			Client: mgr.GetClient(),
+		},
 		ControllerOptions: opts.Controller,
 		Predicates:        dnsrecord.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:              local.Type,

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -622,6 +622,13 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 	)
 
 	switch {
+	case v1beta1helper.IsShootAutonomous(shoot.Spec.Provider.Workers) && !v1beta1helper.HasManagedInfrastructure(shoot):
+		// For high-touch autonomous shoots, the external domain is managed outside of Gardener, but must be specified
+		// in the Shoot resource. Therefore, we do not have to set any secret/zone data here.
+		// When removing the "unmanaged provider" (https://github.com/gardener/gardener/issues/12212), replace this value
+		// with a bool field on the Domain type that is considered by the NeedsExternalDNS func.
+		externalDomain.Provider = core.DNSUnmanaged
+
 	case defaultDomain != nil:
 		externalDomain.SecretData = defaultDomain.SecretData
 		externalDomain.Provider = defaultDomain.Provider

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -587,14 +587,14 @@ func IsIncompleteDNSConfigError(err error) bool {
 // already contains "internal", the result is constructed as "<shootName>.<shootProject>.<internalDomain>."
 // In case it does not, the word "internal" will be appended, resulting in
 // "<shootName>.<shootProject>.internal.<internalDomain>".
-func ConstructInternalClusterDomain(shootName, shootProject string, internalDomain *Domain) string {
+func ConstructInternalClusterDomain(shootName, shootProject string, internalDomain *Domain) *string {
 	if internalDomain == nil {
-		return ""
+		return nil
 	}
 	if strings.Contains(internalDomain.Domain, InternalDomainKey) {
-		return fmt.Sprintf("%s.%s.%s", shootName, shootProject, internalDomain.Domain)
+		return ptr.To(fmt.Sprintf("%s.%s.%s", shootName, shootProject, internalDomain.Domain))
 	}
-	return fmt.Sprintf("%s.%s.%s.%s", shootName, shootProject, InternalDomainKey, internalDomain.Domain)
+	return ptr.To(fmt.Sprintf("%s.%s.%s.%s", shootName, shootProject, InternalDomainKey, internalDomain.Domain))
 }
 
 // ConstructExternalClusterDomain constructs the external Shoot cluster domain, i.e. the domain which will be put

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -966,7 +966,7 @@ var _ = Describe("Shoot", func() {
 
 	DescribeTable("#ConstructInternalClusterDomain",
 		func(shootName, shootProject, internalDomain, expected string) {
-			Expect(ConstructInternalClusterDomain(shootName, shootProject, &Domain{Domain: internalDomain})).To(Equal(expected))
+			Expect(ConstructInternalClusterDomain(shootName, shootProject, &Domain{Domain: internalDomain})).To(HaveValue(Equal(expected)))
 		},
 
 		Entry("with internal domain key", "foo", "bar", "internal.example.com", "foo.bar.internal.example.com"),

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -1070,6 +1070,29 @@ var _ = Describe("Shoot", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("returns the unmanaged external domain for autonomous shoots", func(ctx SpecContext) {
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					DNS: &gardencorev1beta1.DNS{
+						Domain: &domain,
+					},
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{{
+							ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+						}},
+					},
+				},
+			}
+
+			Expect(ConstructExternalDomain(ctx, fakeClient, shoot, nil, nil)).To(Equal(&Domain{
+				Domain:   domain,
+				Provider: "unmanaged",
+			}))
+		})
+
 		It("returns the default domain secret", func() {
 			var (
 				ctx = context.TODO()

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -86,7 +86,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
 				g.Expect(err).NotTo(HaveOccurred())
 
-				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), "api.root.garden.external.local.gardener.cloud", fmt.Sprintf("localhost:%d", localPort))
+				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), "api.root.garden.local.gardener.cloud", fmt.Sprintf("localhost:%d", localPort))
 				return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
 			}).Should(Succeed())
 

--- a/test/e2e/gardenadm/hightouch/gardenadm.go
+++ b/test/e2e/gardenadm/hightouch/gardenadm.go
@@ -86,7 +86,7 @@ var _ = Describe("gardenadm high-touch scenario tests", Label("gardenadm", "high
 				stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
 				g.Expect(err).NotTo(HaveOccurred())
 
-				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), "api.root.garden.internal.gardenadm.local", fmt.Sprintf("localhost:%d", localPort))
+				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), "api.root.garden.external.local.gardener.cloud", fmt.Sprintf("localhost:%d", localPort))
 				return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
 			}).Should(Succeed())
 

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -99,10 +99,16 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 			Eventually(ctx, Get(deployment)).Should(BeNotFoundError())
 		}, SpecTimeout(time.Minute))
 
+		It("should deploy the DNSRecord", func(ctx SpecContext) {
+			dnsRecord := &extensionsv1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Name: shootName + "-external", Namespace: technicalID}}
+			Eventually(ctx, Object(dnsRecord)).Should(BeHealthy(health.CheckExtensionObject))
+		}, SpecTimeout(time.Minute))
+
 		It("should prepare extension resources for migration", func(ctx SpecContext) {
 			extensionKinds := map[string]client.ObjectList{
 				extensionsv1alpha1.InfrastructureResource: &extensionsv1alpha1.InfrastructureList{},
 				extensionsv1alpha1.WorkerResource:         &extensionsv1alpha1.WorkerList{},
+				extensionsv1alpha1.DNSRecordResource:      &extensionsv1alpha1.DNSRecordList{},
 			}
 
 			for kind, list := range extensionKinds {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR implements the main part of the DNS handling in `gardenadm`. 
Autonomous shoots only have an external domain (specified in `Shoot.spec.dns.domain`) and no internal domain. For high-touch shoots, the field has an informative character (needed for generating secrets and connecting to the API server). For medium-touch shoots, it will be used by `gardenadm` to create the DNS record pointing to the control plane (using the primary provider specified in `Shoot.spec.dns.providers` – default domain secrets are not considered).

In the `gardenadm bootstrap` process, the external `DNSRecord` is deployed to point to the (internal) address of the first control plane machine, where `gardenadm init` will be executed later on. With this, the machines (including `gardenadm init` running on it) can connect to the shoot API server.

This PR also introduces a helper for distinguishing the autonomous shoot scenarios (`HasManagedInfrastructure`).

Exposing the API server of medium-touch shoots for external access via the shoot domain will be implemented later on.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```