### PR TITLE
use template to avoid double-maintenance of resource-version

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -801,7 +801,7 @@ images:
     resourceId:
       version-template:
         type: 'jq'
-        expr: '.tag | ltrimstr("distroless")' # must yield single, semver-compliant, str
+        expr: '.tag | ltrimstr("distroless-")' # must yield single, semver-compliant, str
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -799,7 +799,9 @@ images:
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/envoyproxy/envoy
     tag: "distroless-v1.35.3"
     resourceId:
-      version: "v1.35.3-distroless" # keep in sync with tag; must be semver-compliant
+      version-template:
+        type: 'jq'
+        expr: '.tag | ltrimstr("distroless")' # must yield single, semver-compliant, str
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind technical-debt

**What this PR does / why we need it**:

use template to avoid double-maintenance of resource-version

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Depends on [this](https://github.com/gardener/cc-utils/pull/1380) pullrequest.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
