### PR TITLE
Fix alertmanager peer discovery

### DIFF
--- a/pkg/component/observability/monitoring/alertmanager/alertmanager.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager.go
@@ -67,8 +67,8 @@ func (a *alertManager) alertManager() *monitoringv1.Alertmanager {
 	if a.values.Replicas > 1 {
 		// The `alertmanager-operated` service is automatically created by `prometheus-operator` and not managed by our
 		// code. It is used to enable peer/mesh communication when more than 1 replica is used.
-		obj.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-tcp-9094"] = v1beta1constants.LabelNetworkPolicyAllowed
-		obj.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-udp-9094"] = v1beta1constants.LabelNetworkPolicyAllowed
+		obj.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-tcp-mesh-tcp"] = v1beta1constants.LabelNetworkPolicyAllowed
+		obj.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-udp-mesh-udp"] = v1beta1constants.LabelNetworkPolicyAllowed
 	}
 
 	if a.values.ClusterType == component.ClusterTypeShoot {

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -536,8 +536,8 @@ var _ = Describe("Alertmanager", func() {
 				})
 
 				It("should successfully deploy all resources", func() {
-					alertManager.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-tcp-9094"] = "allowed"
-					alertManager.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-udp-9094"] = "allowed"
+					alertManager.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-tcp-mesh-tcp"] = "allowed"
+					alertManager.Spec.PodMetadata.Labels["networking.resources.gardener.cloud/to-alertmanager-operated-udp-mesh-udp"] = "allowed"
 					alertManager.Spec.Replicas = ptr.To[int32](2)
 
 					Expect(managedResource).To(consistOf(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
An [upstream change](https://github.com/prometheus-operator/prometheus-operator/pull/7517) introduced named ports for the service created by the prometheus operator. In turn, that caused the Gardener NetworkPolicy controller to generate network policies with a different name and pod selector, while the alertmanager instances still only had the old label. This commit adapts the alertmanager custom resource to use the new label.

**Special notes for your reviewer**:
cc @DockToFuture

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed the `alertmanager-garden` peer discovery service port names
```
