### PR TITLE
Update logging stack

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -547,7 +547,7 @@ images:
   - name: fluent-bit
     sourceRepository: github.com/fluent/fluent-operator
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-    tag: "v3.2.5"
+    tag: "v4.0.9"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -566,7 +566,7 @@ images:
       name: fluent-bit-to-vali
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-    tag: "v0.65.0"
+    tag: "v0.66.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -601,7 +601,7 @@ images:
   - name: vali-curator
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-    tag: "v0.65.0"
+    tag: "v0.66.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -657,7 +657,7 @@ images:
       name: telegraf-iptables
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-    tag: "v0.65.0"
+    tag: "v0.66.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -677,7 +677,7 @@ images:
   - name: event-logger
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-    tag: "v0.65.0"
+    tag: "v0.66.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -694,7 +694,7 @@ images:
   - name: tune2fs
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-    tag: "v0.65.0"
+    tag: "v0.66.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
**How to categorize this PR?**
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR brings latest releases of fluent-bit (4.0.9).
It brings number of CVE fixes and updated dependencies.

- release notes fluent-bit [v4.0.9](https://fluentbit.io/announcements/v4.0.9/)

> [!NOTE]  
> Removed release for logging plugin due to revert in https://github.com/gardener/gardener/pull/13051.

**Release note**:
```other dependency
The following dependencies have been updated:
- `fluent/fluent-operator` from `v3.2.5` to `v4.0.9`
```
