### PR TITLE
Add cluster url to seed failing alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -294,6 +294,7 @@ spec:
         severity: critical
         topology: seed
         mute_on_weekends: "true"
+        project: garden
       annotations:
         summary: >-
           Seed Condition Failing
@@ -317,6 +318,7 @@ spec:
         severity: critical
         topology: seed
         mute_on_weekends: "true"
+        project: garden
       annotations:
         summary: >-
           Seed Condition Failing

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/seed.prometheusrule.test.yaml
@@ -15,16 +15,20 @@ tests:
     interval: 1m
     input_series:
       - series: garden_seed_condition{condition = "ExtensionsReady",
-                                      name      = "seed-flapping"}
+                                      name      = "seed-flapping",
+                                      project   = "garden"}
         values: 0x2 0 0 2 -1 2 0x24
       - series: garden_seed_condition{condition = "ExtensionsReady",
-                                      name      = "seed-progressing-for-long"}
+                                      name      = "seed-progressing-for-long",
+                                      project   = "garden"}
         values: 0x2 2 2 0 2 2 2 0x23
       - series: garden_seed_condition{condition = "GardenletReady",
-                                      name      = "seed-flapping"}
+                                      name      = "seed-flapping",
+                                      project   = "garden"}
         values: 0 0 2 -1 2 0 0 0 0 0
       - series: garden_seed_condition{condition = "GardenletReady",
-                                      name      = "seed-progressing-for-long"}
+                                      name      = "seed-progressing-for-long",
+                                      project   = "garden"}
         values: 2 2 0 0 2 2 0 0 0 0
       - series: garden_shoot_condition{condition = "APIServerUnavailable",
                                        is_seed   = "true",
@@ -48,6 +52,7 @@ tests:
               condition: ExtensionsReady
               name: seed-flapping
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -63,6 +68,7 @@ tests:
               condition: GardenletReady
               name: seed-flapping
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -75,6 +81,7 @@ tests:
               condition: APIServerUnavailable
               name: seed-flapping
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -109,6 +116,7 @@ tests:
               condition: SystemComponentsHealthy
               name: seed-one
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -121,6 +129,7 @@ tests:
               condition: SeedSystemComponentsHealthy
               name: seed-two
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -136,6 +145,7 @@ tests:
               condition: GardenletReady
               name: seed-three
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing
@@ -148,6 +158,7 @@ tests:
               condition: APIServerUnavailable
               name: seed-four
               mute_on_weekends: "true"
+              project: garden
             exp_annotations:
               summary: >-
                 Seed Condition Failing

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1413,6 +1413,12 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden/shoots/$1"),
 				TargetLabel:  "shoot_dashboard_url",
 			},
+			{
+				SourceLabels: []monitoringv1.LabelName{"project", "name"},
+				Regex:        "garden;soil.*",
+				Action:       "labeldrop",
+				TargetLabel:  "shoot_dashboard_url",
+			},
 		},
 		Ingress: &prometheus.IngressValues{
 			Host:                   "prometheus-garden." + ingressDomain,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
To the critical alerts about the shoot cluster are including the label `shoot_dashboard_url`, but the alerts of the seeds don't have this label, adding this label to seed failing alert for better convenience. 

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
