### PR TITLE
Support `override_path` option for containerd

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -4502,6 +4502,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Capabilities determine what operations a host is
 capable of performing. Defaults to
 - pull
@@ -4516,7 +4517,21 @@ capable of performing. Defaults to
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>CACerts are paths to public key certificates used for TLS.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>overridePath</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>OverridePath sets the &lsquo;override_path&rsquo; field to allow defining the API endpoint in the URL.
+See <a href="https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field">https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field</a> for more information.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/extensions/resources/operatingsystemconfig.md
+++ b/docs/extensions/resources/operatingsystemconfig.md
@@ -287,6 +287,9 @@ spec:
 #       server: https://registry-1.docker.io
 #       hosts:
 #       - url: http://<service-ip>:<port>]
+#         capabilities: ["pull", "resolve"] # optional - defaults to ["pull", "resolve"]
+#         caCerts: ["/path/to/ca.crt"] # optional - see https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#ca-field 
+#         overridePath: false # optional - see https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field
 #     plugins:
 #     - op: add # add (default) or remove
 #       path: [io.containerd.grpc.v1.cri, containerd]

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -141,6 +141,11 @@ spec:
                                         action a client can perform against a registry.
                                       type: string
                                     type: array
+                                  overridePath:
+                                    description: |-
+                                      OverridePath sets the 'override_path' field to allow defining the API endpoint in the URL.
+                                      See https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field for more information.
+                                    type: boolean
                                   url:
                                     description: URL is the endpoint address of the
                                       registry mirror.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -334,9 +334,15 @@ type RegistryHost struct {
 	// capable of performing. Defaults to
 	//  - pull
 	//  - resolve
+	// +optional
 	Capabilities []RegistryCapability `json:"capabilities,omitempty"`
 	// CACerts are paths to public key certificates used for TLS.
+	// +optional
 	CACerts []string `json:"caCerts,omitempty"`
+	// OverridePath sets the 'override_path' field to allow defining the API endpoint in the URL.
+	// See https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field for more information.
+	// +optional
+	OverridePath *bool `json:"overridePath,omitempty"`
 }
 
 // CRIName is a type alias for the CRI name string.

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1859,6 +1859,11 @@ func (in *RegistryHost) DeepCopyInto(out *RegistryHost) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.OverridePath != nil {
+		in, out := &in.OverridePath, &out.OverridePath
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -143,6 +143,11 @@ spec:
                                         action a client can perform against a registry.
                                       type: string
                                     type: array
+                                  overridePath:
+                                    description: |-
+                                      OverridePath sets the 'override_path' field to allow defining the API endpoint in the URL.
+                                      See https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field for more information.
+                                    type: boolean
                                   url:
                                     description: URL is the endpoint address of the
                                       registry mirror.

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -283,6 +283,9 @@ func addRegistryToContainerdFunc(ctx context.Context, log logr.Logger, registryC
 		if len(host.CACerts) > 0 {
 			hostConfig["ca"] = host.CACerts
 		}
+		if host.OverridePath != nil {
+			hostConfig["overridePath"] = *host.OverridePath
+		}
 
 		values["hostConfigs"] = append(values["hostConfigs"].([]any), hostConfig)
 	}

--- a/pkg/nodeagent/controller/operatingsystemconfig/templates/containerd-hosts.toml.tpl
+++ b/pkg/nodeagent/controller/operatingsystemconfig/templates/containerd-hosts.toml.tpl
@@ -8,4 +8,7 @@ server = {{ .server | quote }}
   {{- if .ca }}
   ca = {{ .ca | toJson }}
   {{- end }}
+  {{- if .overridePath }}
+  override_path = {{ .overridePath }}
+  {{- end }}
 {{ end }}

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -361,7 +361,12 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			Upstream: "registry.k8s.io",
 			Server:   ptr.To("https://registry.k8s.io"),
 			Hosts: []extensionsv1alpha1.RegistryHost{
-				{URL: "https://10.10.10.101:8080", Capabilities: []extensionsv1alpha1.RegistryCapability{"pull"}, CACerts: []string{"/var/certs/ca.crt"}},
+				{
+					URL:          "https://10.10.10.101:8080",
+					Capabilities: []extensionsv1alpha1.RegistryCapability{"pull"},
+					CACerts:      []string{"/var/certs/ca.crt"},
+					OverridePath: ptr.To(true),
+				},
 			},
 		}
 
@@ -476,7 +481,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/"+containerdDropIn.DropIns[0].Name, containerdDropIn.DropIns[0].Content, 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n  override_path = true\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service", "#existingunit", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", "#existingdropin", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+existingUnitDropIn.Name+".d/"+existingUnitDropIn.DropIns[0].Name, "#unit11drop", 0600)
@@ -495,7 +500,7 @@ inPlaceUpdates:
   operatingSystem: false
   serviceAccountKeyRotation: false
 mustRestartNodeAgent: false
-operatingSystemConfigChecksum: 4330078242f98407daaaa8e755dbc054dc301233a6bab2bc7706801365711527
+operatingSystemConfigChecksum: 9f99a06a84314322dfbe80920a71938f4ac301874fc0e21c8fa5ad0d09baa98c
 units: {}
 `, 0600)
 
@@ -653,7 +658,7 @@ units: {}
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/30-env_config.conf", "[Service]\nEnvironment=\"PATH=/var/bin/containerruntimes:"+os.Getenv("PATH")+"\"\n", 0600)
 		test.AssertNoFileOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d/"+containerdDropIn.DropIns[0].Name)
 		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.hub.docker.com\"\n\n[host.\"https://10.10.10.100:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n[host.\"https://10.10.10.200:8080\"]\n  capabilities = [\"pull\",\"resolve\"]\n\n", 0644)
-		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n  override_path = true\n\n", 0644)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service", "#existingunit", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/existing-unit.service.d/existing-dropin.conf", "#existingdropin", 0600)
 		test.AssertNoFileOnDisk(fakeFS, "/etc/systemd/system/"+existingUnitDropIn.Name+".d/"+existingUnitDropIn.DropIns[0].Name)
@@ -715,7 +720,7 @@ units: {}
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/containerd/conf.d")
 		test.AssertDirectoryOnDisk(fakeFS, "/etc/systemd/system/containerd.service.d")
 		test.AssertNoFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig1.Upstream+"/hosts.toml")
-		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n\n", 0644)
+		test.AssertFileOnDisk(fakeFS, "/etc/containerd/certs.d/"+registryConfig2.Upstream+"/hosts.toml", "# managed by gardener-node-agent\nserver = \"https://registry.k8s.io\"\n\n[host.\"https://10.10.10.101:8080\"]\n  capabilities = [\"pull\"]\n  ca = [\"/var/certs/ca.crt\"]\n  override_path = true\n\n", 0644)
 
 		By("Assert that unit actions have been applied")
 		Expect(fakeDBus.Actions).To(ConsistOf(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Enhances the `OperatingSystemConfig` API to support the [`override_path`](https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field) option for containerd.

This option is needed if registry mirrors have a path based endpoint and thus only overriding the hostname isn't sufficient.

For example, earlier it was only possible to configure mirrors following the same image path:
**Upstream**: https://europe-docker.pkg.dev/gardener-project/releases/gardener/operator
**Mirror**: https://mirror.example.com/gardener-project/releases/gardener/operator

The `override_path` enables specifying the path (here **/v2/europe**)
**Mirror**: https://mirror.example.com/v2/europe/gardener-project/releases/gardener/operator

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @8R0WNI3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `OperatingSystemConfig` containerd config was enhanced to specify the [`override_path`](https://github.com/containerd/containerd/blob/cef8ce2ecb572bc8026323c0c3dfad9953b952f6/docs/hosts.md?override_path#override_path-field) option which is respected when generating the `hosts.toml` file for the respective upstream config.
```
