### PR TITLE
Support enabling the `OwnerReferencesPermissionEnforcement` plugin for the virtual kube-apiserver

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -114,7 +114,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return requestAuthorizer.Check(graph.VertexTypeBackupBucket, attrs,
 				authwebhook.WithAllowedVerbs("update", "patch", "delete"),
 				authwebhook.WithAlwaysAllowedVerbs("create", "get", "list", "watch"),
-				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithAllowedSubresources("status", "finalizers"),
 			)
 		case backupEntryResource:
 			return requestAuthorizer.Check(graph.VertexTypeBackupEntry, attrs,

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -224,7 +224,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return requestAuthorizer.Check(graph.VertexTypeShoot, attrs,
 				authwebhook.WithAllowedVerbs("update", "patch"),
 				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
-				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithAllowedSubresources("status", "finalizers"),
 			)
 		case shootStateResource:
 			return requestAuthorizer.Check(graph.VertexTypeShootState, attrs,

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -1724,7 +1724,7 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [finalizers status]"))
 				})
 
 				DescribeTable("should return correct result if path exists",
@@ -1746,9 +1746,11 @@ var _ = Describe("Seed", func() {
 					},
 
 					Entry("patch w/o subresource", "patch", ""),
-					Entry("patch w/ subresource", "patch", "status"),
+					Entry("patch w/ status subresource", "patch", "status"),
+					Entry("patch w/ finalizers subresource", "patch", "finalizers"),
 					Entry("update w/o subresource", "update", ""),
-					Entry("update w/ subresource", "update", "status"),
+					Entry("update w/ status subresource", "update", "status"),
+					Entry("update w/ finalizers subresource", "update", "finalizers"),
 				)
 			})
 

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -986,7 +986,7 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [finalizers status]"))
 				})
 
 				It("should allow when verb is delete and resource does not exist", func() {
@@ -1022,9 +1022,11 @@ var _ = Describe("Seed", func() {
 					},
 
 					Entry("patch w/o subresource", "patch", ""),
-					Entry("patch w/ subresource", "patch", "status"),
+					Entry("patch w/ status subresource", "patch", "status"),
+					Entry("patch w/ finalizers subresource", "patch", "finalizers"),
 					Entry("update w/o subresource", "update", ""),
-					Entry("update w/ subresource", "update", "status"),
+					Entry("update w/ status subresource", "update", "status"),
+					Entry("update w/ finalizers subresource", "update", "finalizers"),
 					Entry("delete", "delete", ""),
 				)
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
From [`OwnerReferencesPermissionEnforcement` admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) docs:
> This admission controller protects the access to the `metadata.ownerReferences` of an object
so that only users with **delete** permission to the object can change it.
This admission controller also protects the access to `metadata.ownerReferences[x].blockOwnerDeletion`
of an object, so that only users with **update** permission to the `finalizers`
subresource of the referenced *owner* can change it.

There is no real `/finalizers` subresource. It is only used by the admission plugin to check if the requestor has the needed permission to set an `ownerReference` with `blockOwnerDeletion: true`. 

We have the following usages that need adaptations so that the enablement of the admission plugin for the virtual kube-apiserver does not break existing lifecycle operations:
- gardenlet syncs Shoot Secrets and ConfigMaps to the Project namespace. These Secrets and ConfigMaps have `ownerReference` with `blockOwnerDeletion: true` to the corresponding Shoot resource. Hence, according to the upstream docs, gardenlet needs to have update permissions for the `shoots/finalizers` subresource.
- gardenlet syncs the generated BackupBucket Secret to the garden namespace in the virtual cluster. This Secret has `ownerReference` with `blockOwnerDeletion: true` to the corresponding BackupBucket. Hence, according to the upstream docs, gardenlet needs to have update permissions for the `backupbuckets/finalizers` subresource.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13006

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
gardener-admission-controller now supports enabling the [`OwnerReferencesPermissionEnforcement` admission plugin](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) for the virtual kube-apiserver. Previously, it was rejecting requests from gardenlet because the `shoots/finalizers` and `backupbuckets/finalizers` subresources were not allowed.
```
