### PR TITLE
kind: setup lo addresses with docker

### DIFF
--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -75,14 +75,39 @@ if ! command -v ip &>/dev/null; then
   return
 fi
 
-LOOPBACK_DEVICE=$(ip address | grep LOOPBACK | sed "s/^[0-9]\+: //g" | awk '{print $1}' | sed "s/:$//g")
-echo "Checking loopback device ${LOOPBACK_DEVICE}..."
-for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do
-  if ip address show dev ${LOOPBACK_DEVICE} | grep -q $address/; then
-    echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
-  else
-    echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
-    ${SUDO}ip address add "$address" dev "${LOOPBACK_DEVICE}"
-  fi
+# In some scenarios a developer might run the kind cluster with a docker daemon that is running inside a VM.
+#
+# Most people are using Docker Desktop which is able to mirror the IP addresses 
+# added to the loopback device on the host into it's managed VM running the docker daemon.
+#
+# However if people are not using this approach,
+# docker might not be able to start the kind containers as the IP
+# is not visible for it since it's only attached to the loopback device on the host.
+#
+# We test the loopback devices by checking on the host directly as well as checking 
+# the loopback on the docker host using an container that is running in the host network.
+
+container_ip() {
+	docker run --rm --cap-add NET_ADMIN --network=host alpine ip $@
+}
+
+for ip_func in "ip" "container_ip"; do
+  LOOPBACK_DEVICE=$(${ip_func} address | grep LOOPBACK | sed "s/^[0-9]\+: //g" | awk '{print $1}' | sed "s/:$//g")
+  echo "Checking loopback device ${LOOPBACK_DEVICE} with ${ip_func}..."
+
+  for address in "${LOOPBACK_IP_ADDRESSES[@]}"; do
+    if ${ip_func} address show dev ${LOOPBACK_DEVICE} | grep -q $address/; then
+      echo "IP address $address already assigned to ${LOOPBACK_DEVICE}."
+    else
+      echo "Adding IP address $address to ${LOOPBACK_DEVICE}..."
+      if [[ ${ip_func} == "ip" ]]; then
+        sudo_ip_func=${SUDO}${ip_func}
+      else 
+        sudo_ip_func=${ip_func}
+      fi
+      ${sudo_ip_func} address add "$address" dev "${LOOPBACK_DEVICE}"
+    fi
+  done
+
+  echo "Setting up loopback device ${LOOPBACK_DEVICE} with ${ip_func} completed."
 done
-echo "Setting up loopback device ${LOOPBACK_DEVICE} completed."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
Setups kind loopback devices with a docker container running on the host network.
If a developer uses a virtual-machine like lima for their docker setup, the local ip command won't add the addresses to the correct lo interface where kind expects them to be.
Using a docker container will always add them to the loopback device where the actual kind containers hosting the control-plane will live.

**Which issue(s) this PR fixes**:
Fixes #13012

**Special notes for your reviewer**:
/cc @oliver-goetz @plkokanov 
