### PR TITLE
Metric for Gardener Operator `Extension` conditions

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
@@ -190,7 +190,7 @@ func newOperatorExtensionCustomResourceStateMetrics() customresourcestate.Resour
 			Kind:    "Extension",
 			Version: "v1alpha1",
 		},
-		MetricNamePrefix: ptr.To("gardener_operator"),
+		MetricNamePrefix: ptr.To("garden"),
 		Labels: customresourcestate.Labels{
 			LabelsFromPath: map[string][]string{
 				"name": {"metadata", "name"},

--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
@@ -183,7 +183,7 @@ func newGardenCustomResourceStateMetrics() customresourcestate.Resource {
 	return resource
 }
 
-func newOperatorExtesionCustomResourceStateMetrics() customresourcestate.Resource {
+func newOperatorExtensionCustomResourceStateMetrics() customresourcestate.Resource {
 	resource := customresourcestate.Resource{
 		GroupVersionKind: customresourcestate.GroupVersionKind{
 			Group:   "operator.gardener.cloud",
@@ -230,7 +230,7 @@ func WithGardenResourceMetrics(c *customresourcestate.Metrics) {
 
 // WithOperatorExtensionMetrics adds the custom resource state configuration for the Garden resource
 func WithOperatorExtensionMetrics(c *customresourcestate.Metrics) {
-	c.Spec.Resources = append(c.Spec.Resources, newOperatorExtesionCustomResourceStateMetrics())
+	c.Spec.Resources = append(c.Spec.Resources, newOperatorExtensionCustomResourceStateMetrics())
 }
 
 // WithVPAMetrics adds the custom resource state configuration for the VerticalPodAutoscaler resource

--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
@@ -12,9 +12,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.yaml.in/yaml/v2"
+	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
 
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/kubestatemetrics"
-	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
 )
 
 // Returns the expected CustomResourceState config and also asserts that the actual value is the same.

--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.yaml.in/yaml/v2"
 	"k8s.io/kube-state-metrics/v2/pkg/customresourcestate"
@@ -18,12 +17,8 @@ import (
 )
 
 // Returns the expected CustomResourceState config and also asserts that the actual value is the same.
-// This assertion is performed inside this function to allow to give more human readable errors when the
-// long config document actually differs. This also allows to keep the expectation in a standalone yaml
-// file and to easily update it when it needs to be changed
+// Assertion merges the yaml of the expected data together and compares is to the actual value.
 func expectedCustomResourceStateConfig(suffix string) string {
-	defer GinkgoRecover()
-
 	options := []Option{WithVPAMetrics}
 	relativePaths := []string{"testdata/custom-resource-state-vpa.expectation.yaml"}
 	if suffix == SuffixRuntime {

--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate_test.go
@@ -28,7 +28,7 @@ func expectedCustomResourceStateConfig(suffix string) string {
 	relativePaths := []string{"testdata/custom-resource-state-vpa.expectation.yaml"}
 	if suffix == SuffixRuntime {
 		options = append(options, WithGardenResourceMetrics, WithOperatorExtensionMetrics)
-		relativePaths = append(relativePaths, "testdata/custom-resource-state-garden.expectation.yaml", "testdata/custom-resource-state-operator-extension.expectation.yaml")
+		relativePaths = append(relativePaths, "testdata/custom-resource-state-garden.expectation.yaml", "testdata/custom-resource-state-garden-extension.expectation.yaml")
 	}
 
 	var expectedMetrics customresourcestate.Metrics

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -122,7 +122,7 @@ var _ = Describe("KubeStateMetrics", func() {
 					},
 					{
 						APIGroups: []string{"operator.gardener.cloud"},
-						Resources: []string{"gardens"},
+						Resources: []string{"gardens", "extensions"},
 						Verbs:     []string{"list", "watch"},
 					},
 				},
@@ -345,7 +345,8 @@ var _ = Describe("KubeStateMetrics", func() {
 							"^kube_customresource_verticalpodautoscaler_spec_resourcepolicy_containerpolicies_maxallowed_memory$," +
 							"^kube_customresource_verticalpodautoscaler_spec_updatepolicy_updatemode$," +
 							"^garden_garden_condition$," +
-							"^garden_garden_last_operation$",
+							"^garden_garden_last_operation$," +
+							"^gardener_operator_extension_condition$",
 						"--custom-resource-state-config-file=/config/custom-resource-state.yaml",
 					}
 				}
@@ -1077,7 +1078,6 @@ var _ = Describe("KubeStateMetrics", func() {
 				Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				Expect(managedResource).To(consistOf(expectedObjects...))
-
 			})
 		})
 

--- a/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/kubestatemetrics_test.go
@@ -346,7 +346,7 @@ var _ = Describe("KubeStateMetrics", func() {
 							"^kube_customresource_verticalpodautoscaler_spec_updatepolicy_updatemode$," +
 							"^garden_garden_condition$," +
 							"^garden_garden_last_operation$," +
-							"^gardener_operator_extension_condition$",
+							"^garden_extension_condition$",
 						"--custom-resource-state-config-file=/config/custom-resource-state.yaml",
 					}
 				}

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -405,7 +405,7 @@ var gardenMetricAllowlist = []string{
 	"^kube_customresource_verticalpodautoscaler_spec_updatepolicy_updatemode$",
 	"^garden_garden_condition$",
 	"^garden_garden_last_operation$",
-	"^gardener_operator_extension_condition$",
+	"^garden_extension_condition$",
 }
 
 var cacheMetricAllowlist = []string{

--- a/pkg/component/observability/monitoring/kubestatemetrics/resources.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/resources.go
@@ -90,7 +90,7 @@ func (k *kubeStateMetrics) clusterRole() *rbacv1.ClusterRole {
 		},
 		{
 			APIGroups: []string{"operator.gardener.cloud"},
-			Resources: []string{"gardens"},
+			Resources: []string{"gardens", "extensions"},
 			Verbs:     []string{"list", "watch"},
 		},
 	}
@@ -405,6 +405,7 @@ var gardenMetricAllowlist = []string{
 	"^kube_customresource_verticalpodautoscaler_spec_updatepolicy_updatemode$",
 	"^garden_garden_condition$",
 	"^garden_garden_last_operation$",
+	"^gardener_operator_extension_condition$",
 }
 
 var cacheMetricAllowlist = []string{
@@ -719,11 +720,10 @@ func (k *kubeStateMetrics) nameSuffix() string {
 func (k *kubeStateMetrics) customResourceStateConfigMap() (*corev1.ConfigMap, error) {
 	opts := []Option{WithVPAMetrics}
 	if k.values.NameSuffix == SuffixRuntime {
-		opts = append(opts, WithGardenResourceMetrics)
+		opts = append(opts, WithGardenResourceMetrics, WithOperatorExtensionMetrics)
 	}
 
 	customResourceStateConfig, err := yaml.Marshal(NewCustomResourceStateConfig(opts...))
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-garden-extension.expectation.yaml
+++ b/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-garden-extension.expectation.yaml
@@ -1,6 +1,6 @@
 spec:
   resources:
-    - metricNamePrefix: gardener_operator
+    - metricNamePrefix: garden
       groupVersionKind:
         group: operator.gardener.cloud
         version: v1alpha1

--- a/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-operator-extension.expectation.yaml
+++ b/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-operator-extension.expectation.yaml
@@ -1,18 +1,18 @@
 spec:
   resources:
-    - metricNamePrefix: garden
+    - metricNamePrefix: gardener_operator
       groupVersionKind:
         group: operator.gardener.cloud
         version: v1alpha1
-        kind: Garden
+        kind: Extension
       commonLabels: {}
       labelsFromPath:
         name:
           - metadata
           - name
       metrics:
-        - name: garden_condition
-          help: represents a condition of a Garden object
+        - name: extension_condition
+          help: represents a condition of an Operator Extension object
           each:
             type: stateset
             gauge: null
@@ -31,29 +31,6 @@ spec:
               labelName: status
               valueFrom:
                 - status
-            info: null
-          commonLabels: {}
-          labelsFromPath: {}
-          errorLogV: 0
-        - name: garden_last_operation
-          help: denotes the last operation performed on a Garden object
-          each:
-            type: stateset
-            gauge: null
-            stateSet:
-              labelsFromPath: {}
-              path:
-                - status
-                - lastOperation
-              list:
-                - Create
-                - Reconcile
-                - Delete
-                - Migrate
-                - Restore
-              labelName: last_operation
-              valueFrom:
-                - type
             info: null
           commonLabels: {}
           labelsFromPath: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Introduces a new metric `garden_extension_condition` as a custom resource metric through `kube-state-metrics` that reports conditions of `Extensions` by the Gardener Operator.
 
It follows the principle introduced in https://github.com/gardener/gardener/pull/10393 for reporting metrics of Gardener Operator resources.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Report Gardener Operator `Extension` conditions as metrics
```
