### PR TITLE
Install openssh and openssl together, so that openssl version is matching.

### DIFF
--- a/example/provider-extensions/ssh-reverse-tunnel/base/ssh/files/entrypoint.sh
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/ssh/files/entrypoint.sh
@@ -5,7 +5,7 @@
 
 
 # Install openssh
-apk add --no-cache openssh
+apk add --no-cache openssh openssl
 
 host=$(cat /gardener-apiserver-ssh-keys/host)
 

--- a/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/entrypoint.sh
+++ b/example/provider-extensions/ssh-reverse-tunnel/base/sshd/files/entrypoint.sh
@@ -8,7 +8,7 @@ set -o nounset
 set -o pipefail
 
 # Install openssh
-apk add --no-cache openssh
+apk add --no-cache openssh openssl
 
 # Run sshd for gardener-apiserver reverse tunnel
 echo "Starting sshd"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Currently the extensions development setup is broken. ssh tunnel pods are crashing with the message:
```
Starting sshd
OpenSSL version mismatch. Built against 3050003f, you have 30500010
```

The problem can be fixed by installing `openssl` together with `openssh` to get matching versions. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue with the ssh tunnel in the extensions setup is fixed.
```
