### PR TITLE
Refine `gardener/gardener` reviewer groups

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ reviewers:
 - gardener-reviewers-core
 - gardener-reviewers-etcd
 - gardener-reviewers-logging
+- gardener-reviewers-machine-controller-manager
 - gardener-reviewers-monitoring
 - gardener-reviewers-networking
 - gardener-reviewers-security

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,8 @@
 
 reviewers:
 - gardener-reviewers-auditlog
-- gardener-reviewers-autoscaling
+- gardener-reviewers-autoscaling-cluster
+- gardener-reviewers-autoscaling-pod
 - gardener-reviewers-control-plane-migration
 - gardener-reviewers-core
 - gardener-reviewers-etcd

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- gardener-reviewers
+- gardener-reviewers-auditlog
+- gardener-reviewers-autoscaling
+- gardener-reviewers-control-plane-migration
+- gardener-reviewers-core
+- gardener-reviewers-etcd
+- gardener-reviewers-logging
+- gardener-reviewers-monitoring
+- gardener-reviewers-networking
+- gardener-reviewers-security
+- gardener-reviewers-ui
 approvers:
 - gardener-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,9 @@ aliases:
   - plkokanov
   - vitanovs
   gardener-reviewers-control-plane-migration: # This group is primarily responsible for control plane migration.
+  - ary1992
   - plkokanov
+  - shafeeqes
   gardener-reviewers-core: # This group is interdisciplinary might review PRs touching multiple components and adjacent areas.
   - acumino
   - ary1992

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,11 +41,11 @@ aliases:
   - rrhubenov
   gardener-reviewers-machine-controller-manager: # This group is primarily responsible for the machine-controller-manager component.
   - aaronfern
+  - elankath
   - unmarshall
   gardener-reviewers-monitoring: # This group is primarily responsible for monitoring topics.
   - chrkl
   - istvanballok
-  - nickytd
   - rickardsjp
   - vicwicker
   gardener-reviewers-networking: # This group is primarily responsible for networking topics.

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,9 +4,10 @@ aliases:
   gardener-reviewers-auditlog: # This group is primarily responsible for the auditlog component.
   - dimityrmirchev
   - vpnachev
-  gardener-reviewers-autoscaling: # This group is primarily responsible for autoscaling topics.
+  gardener-reviewers-autoscaling-cluster: # This group is primarily responsible for autoscaling topics.
   - aaronfern
   - elankath
+  gardener-reviewers-autoscaling-pod: # This group is primarily responsible for autoscaling topics.
   - ialidzhikov
   - plkokanov
   - vitanovs

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,24 +1,59 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS docs at https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview and Gardener community roles at https://github.com/gardener/documentation/blob/master/website/documentation/contribute/code/roles/_index.md
 
 aliases:
-  gardener-reviewers:
+  gardener-reviewers-auditlog: # This group is primarily responsible for the auditlog component.
+  - dimityrmirchev
+  - vpnachev
+  gardener-reviewers-autoscaling: # This group is primarily responsible for autoscaling topics.
+  - aaronfern
+  - elankath
+  - ialidzhikov
+  - plkokanov
+  - vitanovs
+  gardener-reviewers-control-plane-migration: # This group is primarily responsible for control plane migration.
+  - plkokanov
+  gardener-reviewers-core: # This group is interdisciplinary might review PRs touching multiple components and adjacent areas.
   - acumino
   - ary1992
-  - dimitar-kostadinov
   - ialidzhikov
   - Kostov6
   - LucaBernstein
+  - MartinWeindel
   - marc1404
   - oliver-goetz
-  - plkokanov
   - rfranzke
   - ScheererJ
   - shafeeqes
   - timebertt
   - timuthy
   - tobschli
-  - vitanovs
-  gardener-approvers:
+  gardener-reviewers-etcd: # This group is primarily responsible for the etcd component.
+  - ishan16696
+  - shreyas-s-rao
+  - unmarshall
+  gardener-reviewers-logging: # This group is primarily responsible for logging topics.
+  - nickytd
+  - rrhubenov
+  gardener-reviewers-monitoring: # This group is primarily responsible for monitoring topics.
+  - chrkl
+  - istvanballok
+  - nickytd
+  - rickardsjp
+  - vicwicker
+  gardener-reviewers-networking: # This group is primarily responsible for networking topics.
+  - axel7born
+  - docktofuture
+  - domdom82
+  - ScheererJ
+  gardener-reviewers-security: # This group is primarily responsible for security topics.
+  - AleksandarSavchev
+  - dimityrmirchev
+  - theoddora
+  - vpnachev
+  gardener-reviewers-ui: # This group is primarily responsible for the Gardener Dashboard and related UI components.
+  - grolu
+  - petersutter
+  gardener-approvers: # This group has the authority to review and approve changes across various components and areas.
   - acumino
   - ary1992
   - ialidzhikov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,18 +15,20 @@ aliases:
   gardener-reviewers-core: # This group is interdisciplinary might review PRs touching multiple components and adjacent areas.
   - acumino
   - ary1992
+  - dimitar-kostadinov
   - ialidzhikov
   - Kostov6
   - LucaBernstein
-  - MartinWeindel
   - marc1404
   - oliver-goetz
+  - plkokanov
   - rfranzke
   - ScheererJ
   - shafeeqes
   - timebertt
   - timuthy
   - tobschli
+  - vitanovs
   gardener-reviewers-etcd: # This group is primarily responsible for the etcd component.
   - ishan16696
   - shreyas-s-rao

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,6 +39,9 @@ aliases:
   gardener-reviewers-logging: # This group is primarily responsible for logging topics.
   - nickytd
   - rrhubenov
+  gardener-reviewers-machine-controller-manager: # This group is primarily responsible for the machine-controller-manager component.
+  - aaronfern
+  - unmarshall
   gardener-reviewers-monitoring: # This group is primarily responsible for monitoring topics.
   - chrkl
   - istvanballok


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
The `gardener/gardener` repository consists of various components and areas, each contributed to and reviewed by different expert groups. This PR establishes the main reviewer groups and assigns individuals to reviewer roles (see [definition](https://github.com/gardener/documentation/blob/master/website/documentation/contribute/code/roles/_index.md#reviewer)).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please review your assigned areas @aaronfern @acumino @AleksandarSavchev @ary1992 @axel7born @chrkl @dimityrmirchev @docktofuture @domdom82 @elankath @grolu @ialidzhikov @ishan16696 @istvanballok @Kostov6 @LucaBernstein @marc1404 @MartinWeindel @nickytd @oliver-goetz @petersutter @plkokanov @rfranzke @rickardsjp @rrhubenov @ScheererJ @shafeeqes @shreyas-s-rao @theoddora @timebertt @tobschli @unmarshall @vicwicker @vitanovs @vpnachev

ℹ️ **The file and assignments reflect areas people are usually working in and isn't to be understood as a organizational team assignment.**

ℹ️ One of the next steps involves creating a Prow plugin that notifies the appropriate reviewers about new PRs in their areas.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The Gardener reviewer groups have been refined and can be found in the [`OWNERS_ALIASES`](https://github.com/gardener/gardener/blob/master/OWNERS_ALIASES) file. This will serve as the foundation for finding appropriate reviewers for the respective areas in the future.
```
