### PR TITLE
Cleanup TODO

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1979,15 +1979,14 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
 	allErrs = append(allErrs, IsNotMoreThan100Percent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)
 
-	// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
-	// if ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
-	// 	if worker.MaxSurge != nil {
-	// 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
-	// 	}
-	// 	if worker.MaxUnavailable != nil {
-	// 		allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
-	// 	}
-	// }
+	if ptr.Deref(worker.UpdateStrategy, "") == core.ManualInPlaceUpdate {
+		if worker.MaxSurge != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxSurge"), worker.MaxSurge, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+		}
+		if worker.MaxUnavailable != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("maxUnavailable"), worker.MaxUnavailable, "should not be set when `updateStrategy` is `ManualInPlaceUpdate`"))
+		}
+	}
 
 	if (worker.MaxUnavailable == nil || getIntOrPercentValue(*worker.MaxUnavailable) == 0) && (worker.MaxSurge == nil || getIntOrPercentValue(*worker.MaxSurge) == 0) && ptr.Deref(worker.UpdateStrategy, "") != core.ManualInPlaceUpdate {
 		// Both MaxSurge and MaxUnavailable cannot be zero.

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -6503,8 +6503,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 					newShoot := prepareShootForUpdate(shoot)
 
 					newShoot.Spec.Provider.Workers[0].UpdateStrategy = ptr.To(core.ManualInPlaceUpdate)
-					newShoot.Spec.Provider.Workers[0].MaxSurge = ptr.To(intstr.FromInt32(0))
-					newShoot.Spec.Provider.Workers[0].MaxUnavailable = ptr.To(intstr.FromInt32(0))
+					newShoot.Spec.Provider.Workers[0].MaxSurge = nil
+					newShoot.Spec.Provider.Workers[0].MaxUnavailable = nil
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 				})
@@ -7007,9 +7007,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Entry("percentage is not less than zero", core.AutoRollingUpdate, ptr.To(intstr.FromString("-90%")), ptr.To(intstr.FromString("90%")), field.ErrorTypeInvalid),
 
 			// manual in-place update tests
-			// TODO(acumino): Uncomment this after the Gardener v1.127 is released.
-			// Entry("maxSurge is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, nil, ptr.To(intstr.FromInt32(1)), field.ErrorTypeInvalid),
-			// Entry("maxUnavailable is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, ptr.To(intstr.FromInt32(0)), nil, field.ErrorTypeInvalid),
+			Entry("maxSurge is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, nil, ptr.To(intstr.FromInt32(1)), field.ErrorTypeInvalid),
+			Entry("maxUnavailable is not nil in case of ManualInplaceUpdate update strategy", core.ManualInPlaceUpdate, ptr.To(intstr.FromInt32(0)), nil, field.ErrorTypeInvalid),
 		)
 
 		DescribeTable("reject when labels are invalid",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Cleanup TODO

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ary1992 @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
