### PR TITLE
revert server block import of coredns-custom configmap for node-local…

### DIFF
--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -357,7 +357,6 @@ data:
         cache 30
         reload
         }
-        import custom/*.server
 immutable: true
 kind: ConfigMap
 metadata:
@@ -731,7 +730,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-    import custom/*.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]
@@ -1006,7 +1004,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-    import custom/*.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -100,7 +100,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-    import custom/*.server
 `,
 			},
 		}


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Revert server block import of coredns-custom configmap for node-local-dns. 
As the initial change (https://github.com/gardener/gardener/pull/12893) will lead to node-local-dns pods in CrashLoopBackOff with a conflicting coredns configuration. E.g.:
 
```
  istio.server: |
    istio.server:53 {
       ...
    }
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Revert server block import of coredns-custom configmap for node-local-dns.
```
