### PR TITLE
Fix faulty `WatchCacheSizes` validation

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1142,6 +1142,7 @@ func ValidateWatchCacheSizes(sizes *core.WatchCacheSizes, fldPath *field.Path) f
 	allErrs := field.ErrorList{}
 
 	invalidCharacters := ",. #"
+	APIGroupInvalidCharacters := ", #"
 
 	if sizes != nil {
 		if defaultSize := sizes.Default; defaultSize != nil {
@@ -1168,7 +1169,7 @@ func ValidateWatchCacheSizes(sizes *core.WatchCacheSizes, fldPath *field.Path) f
 				if strings.ToLower(*cacheAPIGroup) != *cacheAPIGroup {
 					allErrs = append(allErrs, field.Invalid(idxPath.Child("apiGroup"), *cacheAPIGroup, "must be lower case"))
 				}
-				if strings.ContainsAny(*cacheAPIGroup, invalidCharacters) {
+				if strings.ContainsAny(*cacheAPIGroup, APIGroupInvalidCharacters) {
 					allErrs = append(allErrs, field.Invalid(idxPath.Child("apiGroup"), *cacheAPIGroup, fmt.Sprintf("must not contain any of the following characters: %q", invalidCharacters)))
 				}
 			}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1141,8 +1141,8 @@ func validateNetworkingStatus(networking *core.NetworkingStatus, fldPath *field.
 func ValidateWatchCacheSizes(sizes *core.WatchCacheSizes, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	invalidCharacters := ",. #"
-	APIGroupInvalidCharacters := ", #"
+	resourceInvalidCharacters := ",. #"
+	apiGroupInvalidCharacters := ", #"
 
 	if sizes != nil {
 		if defaultSize := sizes.Default; defaultSize != nil {
@@ -1160,8 +1160,8 @@ func ValidateWatchCacheSizes(sizes *core.WatchCacheSizes, fldPath *field.Path) f
 				if strings.ToLower(cacheResource) != cacheResource {
 					allErrs = append(allErrs, field.Invalid(idxPath.Child("resource"), cacheResource, "must be lower case"))
 				}
-				if strings.ContainsAny(cacheResource, invalidCharacters) {
-					allErrs = append(allErrs, field.Invalid(idxPath.Child("resource"), cacheResource, fmt.Sprintf("must not contain any of the following characters: %q", invalidCharacters)))
+				if strings.ContainsAny(cacheResource, resourceInvalidCharacters) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("resource"), cacheResource, fmt.Sprintf("must not contain any of the following characters: %q", resourceInvalidCharacters)))
 				}
 			}
 
@@ -1169,8 +1169,8 @@ func ValidateWatchCacheSizes(sizes *core.WatchCacheSizes, fldPath *field.Path) f
 				if strings.ToLower(*cacheAPIGroup) != *cacheAPIGroup {
 					allErrs = append(allErrs, field.Invalid(idxPath.Child("apiGroup"), *cacheAPIGroup, "must be lower case"))
 				}
-				if strings.ContainsAny(*cacheAPIGroup, APIGroupInvalidCharacters) {
-					allErrs = append(allErrs, field.Invalid(idxPath.Child("apiGroup"), *cacheAPIGroup, fmt.Sprintf("must not contain any of the following characters: %q", invalidCharacters)))
+				if strings.ContainsAny(*cacheAPIGroup, apiGroupInvalidCharacters) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("apiGroup"), *cacheAPIGroup, fmt.Sprintf("must not contain any of the following characters: %q", apiGroupInvalidCharacters)))
 				}
 			}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2716,7 +2716,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 							CacheSize: 42,
 						}},
 					}, ConsistOf(
-						field.Invalid(field.NewPath("resources[0].apiGroup"), "apps#", `must not contain any of the following characters: ",. #"`),
+						field.Invalid(field.NewPath("resources[0].apiGroup"), "apps#", `must not contain any of the following characters: ", #"`),
 					)),
 				)
 			})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2675,6 +2675,13 @@ var _ = Describe("Shoot Validation Tests", func() {
 							CacheSize: 42,
 						}},
 					}, BeEmpty()),
+					Entry("valid (coordination.k8s.io/leases=0)", &core.WatchCacheSizes{
+						Resources: []core.ResourceWatchCacheSize{{
+							APIGroup:  ptr.To("coordination.k8s.io"),
+							Resource:  "leases",
+							CacheSize: 0,
+						}},
+					}, BeEmpty()),
 					Entry("invalid (apps/deployments=<0)", &core.WatchCacheSizes{
 						Resources: []core.ResourceWatchCacheSize{{
 							APIGroup:  ptr.To("apps"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
`.` is a valid character for APIGroup validation. This PR removes it from the invalid characters

Follow-up after https://github.com/gardener/gardener/pull/12839.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
