### PR TITLE
[GEP-28] `gardenadm bootstrap`: Initialize control plane

### DIFF
--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -24,11 +24,15 @@ spec:
             namespace: garden
       machine:
         type: local
+        image:
+          name: local
       minimum: 1
       maximum: 1
     - name: worker
       machine:
         type: local
+        image:
+          name: local
       minimum: 1
       maximum: 1
   kubernetes:

--- a/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
@@ -13,12 +13,8 @@ patches:
     kind: Shoot
   patch: |
     - op: add
-      path: /spec/provider/workers/0/machine/image
-      value:
-        name: local
-        version: 1.0.0
+      path: /spec/provider/workers/0/machine/image/version
+      value: 1.0.0
     - op: add
-      path: /spec/provider/workers/1/machine/image
-      value:
-        name: local
-        version: 1.0.0
+      path: /spec/provider/workers/1/machine/image/version
+      value: 1.0.0

--- a/docs/cli-reference/gardenadm/gardenadm_bootstrap.md
+++ b/docs/cli-reference/gardenadm/gardenadm_bootstrap.md
@@ -23,7 +23,8 @@ gardenadm bootstrap --config-dir /path/to/manifests
       --bastion-ingress-cidr strings   Restrict bastion host ingress to the given CIDRs. Defaults to your system's public IPs (IPv4 and/or IPv6) as detected using https://ipify.org/.
   -d, --config-dir string              Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
   -h, --help                           help for bootstrap
-  -k, --kubeconfig string              Path to the kubeconfig file pointing to the KinD cluster
+  -k, --kubeconfig string              Path to the kubeconfig file pointing to the bootstrap cluster
+      --kubeconfig-output string       Path where the kubeconfig file for the shoot cluster should be written to. If not set, the kubeconfig is not written to disk. Set to '-' to write to stdout.
 ```
 
 ### Options inherited from parent commands

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -33,15 +33,15 @@ This also includes the `gardenadm` CLI, which is installed on the machine pods b
 ## Setting Up the KinD Cluster
 
 ```shell
-make kind-up
+make kind-single-node-up
 ```
 
-Please see [this documentation section](getting_started_locally.md#setting-up-the-kind-cluster-garden-and-seed) for more details.
+Please see [this documentation section](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator) for more details.
 
 All following steps assume that you are using the kubeconfig for this KinD cluster:
 
 ```shell
-export KUBECONFIG=$PWD/example/gardener-local/kind/local/kubeconfig
+export KUBECONFIG=$PWD/example/gardener-local/kind/multi-zone/kubeconfig
 ```
 
 ## High-Touch Scenario
@@ -181,19 +181,16 @@ Based on the described setup, you can execute the e2e test suite for `gardenadm`
 
 ```shell
 make gardenadm-up SCENARIO=high-touch
+make gardenadm-up SCENARIO=connect
+make test-e2e-local-gardenadm-high-touch
+
+# or
 make gardenadm-up SCENARIO=medium-touch
-make test-e2e-local-gardenadm
-```
-
-You can also selectively run the e2e tests for one of the scenarios:
-
-```shell
-make gardenadm-up SCENARIO=high-touch
-./hack/test-e2e-local.sh gardenadm --label-filter="high-touch" ./test/e2e/gardenadm/...
+make test-e2e-local-gardenadm-medium-touch
 ```
 
 ## Tear Down the KinD Cluster
 
 ```shell
-make kind-down
+make kind-single-node-down
 ```

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -144,13 +144,45 @@ make gardenadm-up SCENARIO=medium-touch
 
 This will first build the needed images and then render the needed manifests for `gardenadm bootstrap` to the [`./dev-setup/gardenadm/resources/generated/medium-touch`](../../dev-setup/gardenadm/resources/generated/medium-touch) directory.
 
-Afterward, you can use `go run` to execute `gardenadm` commands on your machine:
+### Bootstrapping the Autonomous Shoot Cluster
+
+Use `go run` to execute `gardenadm` commands on your machine:
 
 ```shell
 $ export IMAGEVECTOR_OVERWRITE=$PWD/dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml
 $ go run ./cmd/gardenadm bootstrap -d ./dev-setup/gardenadm/resources/generated/medium-touch
 ...
-Command is work in progress
+[shoot--garden--root-control-plane-58ffc-2l6s7] Your Shoot cluster control-plane has initialized successfully!
+...
+```
+
+### Connecting to the Autonomous Shoot Cluster
+
+`gardenadm init` stores the kubeconfig of the autonomous shoot cluster in the `/etc/kubernetes/admin.conf` file on the control plane machine.
+To connect to the autonomous shoot cluster, set the `KUBECONFIG` environment variable and execute `kubectl` within a `bash` shell in the machine pod:
+
+```shell
+$ machine="$(kubectl -n shoot--garden--root get po -l app=machine -oname | head -1 | cut -d/ -f2)"
+$ kubectl -n shoot--garden--root exec -it $machine -- bash
+root@machine-shoot--garden--root-control-plane-58ffc-2l6s7:/# export KUBECONFIG=/etc/kubernetes/admin.conf
+root@machine-shoot--garden--root-control-plane-58ffc-2l6s7:/# kubectl get node
+NAME                                                    STATUS   ROLES    AGE     VERSION
+machine-shoot--garden--root-control-plane-58ffc-2l6s7   Ready    <none>   4m11s   v1.33.0
+```
+
+`gardenadm bootstrap` copies the kubeconfig from the control plane machine to the bootstrap cluster.
+You can also copy the kubeconfig to your local machine and use a port-forward to connect to the cluster's API server:
+
+```shell
+$ kubectl get secret -n shoot--garden--root kubeconfig -o jsonpath='{.data.kubeconfig}' | base64 --decode | sed 's/api.root.garden.local.gardener.cloud/localhost:6443/' > /tmp/shoot--garden--root.conf
+$ machine="$(kubectl -n shoot--garden--root get po -l app=machine -oname | head -1 | cut -d/ -f2)"
+$ kubectl -n shoot--garden--root port-forward pod/$machine 6443:443
+
+# in a new terminal
+$ export KUBECONFIG=/tmp/shoot--garden--root.conf
+$ kubectl get no
+NAME                                                    STATUS   ROLES    AGE     VERSION
+machine-shoot--garden--root-control-plane-58ffc-2l6s7   Ready    <none>   4m11s   v1.33.0
 ```
 
 ## Connecting the Autonomous Shoot Cluster to Gardener

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1065,7 +1065,8 @@ func KeyV2(
 	)
 
 	if worker.Machine.Image != nil {
-		data = append(data, worker.Machine.Image.Name+*worker.Machine.Image.Version)
+		// worker.Machine.Image.Version is unset for autonomous shoots with unmanaged infrastructure
+		data = append(data, worker.Machine.Image.Name+ptr.Deref(worker.Machine.Image.Version, ""))
 	}
 
 	if worker.Volume != nil {

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -1518,6 +1518,11 @@ var _ = Describe("OperatingSystemConfig", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should handle an empty machine image version", func() {
+			p.Machine.Image.Version = nil
+			Expect(CalculateKeyForVersion(2, kubernetesVersion, values, p, kubeletConfig, nil)).NotTo(BeEmpty())
+		})
+
 		Context("hash value should not change", func() {
 			AfterEach(func() {
 				kubeProxyConfig := &gardencorev1beta1.KubeProxyConfig{

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gardener/gardener/pkg/nodeagent"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	sshutils "github.com/gardener/gardener/pkg/utils/ssh"
 )
 
 // GardenadmBaseDir is the directory that gardenadm works with for storing information, transferring manifests, etc.
@@ -66,6 +67,9 @@ type AutonomousBotanist struct {
 
 	// controlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.
 	controlPlaneMachines []machinev1alpha1.Machine
+	// sshConnection is the SSH connection to the first control plane machine. It is set by ConnectToControlPlaneMachine
+	// during `gardenadm bootstrap`.
+	sshConnection *sshutils.Connection
 }
 
 // Extension contains the resources needed for an extension registration.

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -134,11 +134,11 @@ func NewAutonomousBotanist(
 		return nil, fmt.Errorf("failed creating autonomous botanist: %w", err)
 	}
 
-	if err := initializeShootResource(resources.Shoot, autonomousBotanist.FS, resources.Project.Name, runsControlPlane); err != nil {
+	if err := initializeShootResource(resources, autonomousBotanist.FS, runsControlPlane); err != nil {
 		return nil, fmt.Errorf("failed initializing shoot resource: %w", err)
 	}
 
-	initializeSeedResource(resources.Seed, resources.Shoot.Name, runsControlPlane)
+	initializeSeedResource(resources, runsControlPlane)
 
 	gardenClient := newFakeGardenClient()
 	if err := initializeFakeGardenResources(ctx, gardenClient, resources, extensions); err != nil {
@@ -264,6 +264,9 @@ func initializeFakeGardenResources(
 	if resources.CredentialsBinding != nil {
 		objects = append(objects, resources.CredentialsBinding.DeepCopy())
 	}
+	if resources.ShootState != nil {
+		objects = append(objects, resources.ShootState.DeepCopy())
+	}
 
 	for _, obj := range objects {
 		if err := gardenClient.Create(ctx, obj); client.IgnoreAlreadyExists(err) != nil {
@@ -315,7 +318,7 @@ func newShootObject(
 		b = b.WithoutShootCredentials()
 	}
 
-	obj, err := b.Build(ctx, nil)
+	obj, err := b.Build(ctx, gardenClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed building shoot object: %w", err)
 	}
@@ -363,8 +366,9 @@ func newFakeSeedClientSet(kubernetesVersion string) kubernetes.Interface {
 		Build()
 }
 
-func initializeShootResource(shoot *gardencorev1beta1.Shoot, fs afero.Afero, projectName string, runsControlPlane bool) error {
-	shoot.Status.TechnicalID = gardenerutils.ComputeTechnicalID(projectName, shoot)
+func initializeShootResource(resources gardenadm.Resources, fs afero.Afero, runsControlPlane bool) error {
+	shoot := resources.Shoot
+	shoot.Status.TechnicalID = gardenerutils.ComputeTechnicalID(resources.Project.Name, shoot)
 	shoot.Status.Gardener = gardencorev1beta1.Gardener{Name: "gardenadm", Version: version.Get().GitVersion}
 
 	if runsControlPlane {
@@ -375,6 +379,22 @@ func initializeShootResource(shoot *gardencorev1beta1.Shoot, fs afero.Afero, pro
 			return fmt.Errorf("failed fetching shoot UID: %w", err)
 		}
 		shoot.Status.UID = uid
+
+		if v1beta1helper.HasManagedInfrastructure(resources.Shoot) {
+			// When running `gardenadm init` for a shoot with managed infrastructure, we need to restore state (secrets,
+			// extensions, etc.) from the ShootState exported by `gardenadm bootstrap`.
+			if resources.ShootState == nil {
+				return fmt.Errorf("shoot has managed infrastructure, but ShootState is missing " +
+					"(the ShootState is usually exported by `gardenadm bootstrap` and read by `gardenadm init`): " +
+					"you should either use `gardenadm bootstrap` to create the autonomous shoot cluster with managed infrastructure or " +
+					"remove the `Shoot.spec.{secret,credentials}BindingName` field to mark the shoot as having unmanaged infrastructure")
+			}
+
+			// Instruct the botanist and shoot package to read the ShootState and restore the state of extensions, secrets, etc.
+			shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				Type: gardencorev1beta1.LastOperationTypeRestore,
+			}
+		}
 	} else {
 		// For `gardenadm bootstrap`, we don't need a stable UID. We generate a random one instead, because we might not be
 		// able to persist the generated UID in /var/lib/gardenadm (e.g., when running `gardenadm bootstrap` on macOS).
@@ -384,9 +404,10 @@ func initializeShootResource(shoot *gardencorev1beta1.Shoot, fs afero.Afero, pro
 	return nil
 }
 
-func initializeSeedResource(seed *gardencorev1beta1.Seed, shootName string, runsControlPlane bool) {
-	seed.Name = shootName
-	seed.Status = gardencorev1beta1.SeedStatus{ClusterIdentity: ptr.To(shootName)}
+func initializeSeedResource(resources gardenadm.Resources, runsControlPlane bool) {
+	seed := resources.Seed
+	seed.Name = resources.Shoot.Name
+	seed.Status = gardencorev1beta1.SeedStatus{ClusterIdentity: ptr.To(resources.Shoot.Name)}
 
 	if runsControlPlane {
 		// When running the control plane (`gardenadm init`), mark the seed as an autonomous shoot cluster.

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -5,8 +5,10 @@
 package botanist
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"os"
@@ -34,6 +36,7 @@ import (
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	resourcemanagerconstants "github.com/gardener/gardener/pkg/component/gardener/resourcemanager/constants"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenadm/staticpod"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -44,6 +47,10 @@ import (
 
 // PathKubeconfig is the path to a file on the control plane node containing an admin kubeconfig.
 var PathKubeconfig = filepath.Join(string(filepath.Separator), "etc", "kubernetes", "admin.conf")
+
+// KubeconfigSecretName is the name of the secret in the shoot namespace of the bootstrap cluster containing the
+// kubeconfig of the autonomous shoot.
+const KubeconfigSecretName = "kubeconfig"
 
 func (b *AutonomousBotanist) deployETCD(role string) func(context.Context) error {
 	var portClient, portPeer, portMetrics int32 = 2379, 2380, 2381
@@ -363,4 +370,38 @@ func (b *AutonomousBotanist) DiscoverKubernetesVersion(controlPlaneAddress strin
 	}
 
 	return version, nil
+}
+
+// FetchKubeconfig fetches the kubeconfig of the autonomous shoot from the control plane machine via SSH and stores it
+// in a secret in the shoot namespace of the bootstrap cluster for later retrieval. It also writes the kubeconfig to the
+// given output writer, if any.
+func (b *AutonomousBotanist) FetchKubeconfig(ctx context.Context, output io.Writer) error {
+	kubeconfigBuffer := &bytes.Buffer{}
+	if err := b.sshConnection.SCP.CopyFromRemotePassThru(ctx, kubeconfigBuffer, PathKubeconfig, nil); err != nil {
+		return fmt.Errorf("error fetching kubeconfig: %w", err)
+	}
+	kubeconfigBytes := kubeconfigBuffer.Bytes()
+
+	kubeconfigSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: KubeconfigSecretName, Namespace: b.Shoot.ControlPlaneNamespace}}
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, b.SeedClientSet.Client(), kubeconfigSecret, func() error {
+		kubeconfigSecret.Data = map[string][]byte{
+			secretsutils.DataKeyKubeconfig: kubeconfigBytes,
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error writing kubeconfig secret: %w", err)
+	}
+	b.Logger.Info("Stored kubeconfig of the autonomous shoot in secret", "namespace", kubeconfigSecret.Namespace, "name", kubeconfigSecret.Name)
+
+	if output != nil {
+		if outputFile, ok := output.(*os.File); ok {
+			b.Logger.Info("Writing kubeconfig of the autonomous shoot to file", "path", outputFile.Name())
+		}
+		if _, err := output.Write(kubeconfigBytes); err != nil {
+			return fmt.Errorf("error writing kubeconfig to output: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -79,7 +79,7 @@ var (
 
 // CopyManifests copies all manifests needed for `gardenadm init` to the remote machine under GardenadmBaseDir.
 func (b *AutonomousBotanist) CopyManifests(ctx context.Context, configDir fs.FS) error {
-	if err := prepareRemoteDirs(b.sshConnection); err != nil {
+	if err := prepareRemoteDirs(ctx, b.sshConnection); err != nil {
 		return err
 	}
 
@@ -100,12 +100,12 @@ func (b *AutonomousBotanist) CopyManifests(ctx context.Context, configDir fs.FS)
 	return b.copyShootState(ctx)
 }
 
-func prepareRemoteDirs(conn *sshutils.Connection) error {
+func prepareRemoteDirs(ctx context.Context, conn *sshutils.Connection) error {
 	// Empty manifests dir to start with a clean state on re-runs
-	if _, _, err := conn.Run("rm -rf " + ManifestsDir); err != nil {
+	if _, _, err := conn.Run(ctx, "rm -rf "+ManifestsDir); err != nil {
 		return fmt.Errorf("error removing manifests dir: %w", err)
 	}
-	if _, _, err := conn.Run("mkdir -p " + ManifestsDir); err != nil {
+	if _, _, err := conn.Run(ctx, "mkdir -p "+ManifestsDir); err != nil {
 		return fmt.Errorf("error ensuring manifests dir: %w", err)
 	}
 

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -141,6 +141,9 @@ func (b *AutonomousBotanist) copyShootState(ctx context.Context) error {
 		return fmt.Errorf("error getting ShootState: %w", err)
 	}
 
+	// Clear fields that must not be set on creation
+	shootState.SetResourceVersion("")
+
 	shootStateBytes, err := runtime.Encode(kubernetes.GardenCodec.EncoderForVersion(kubernetes.GardenSerializer, gardencorev1beta1.SchemeGroupVersion), shootState)
 	if err != nil {
 		return fmt.Errorf("error encoding ShootState: %w", err)

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -25,22 +25,23 @@ import (
 	sshutils "github.com/gardener/gardener/pkg/utils/ssh"
 )
 
-// ConnectToMachine opens an SSH connection via the Bastion to the n-th machine of the autonomous shoot.
-func (b *AutonomousBotanist) ConnectToMachine(ctx context.Context, index int) (*sshutils.Connection, error) {
-	machine, err := b.GetMachineByIndex(index)
+// ConnectToControlPlaneMachine opens an SSH connection via the Bastion to the first control plane machine of the
+// autonomous shoot. The connection is stored in the sshConnection field.
+func (b *AutonomousBotanist) ConnectToControlPlaneMachine(ctx context.Context) error {
+	machine, err := b.GetMachineByIndex(0)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	machineAddr, err := PreferredAddressForMachine(machine)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	sshAddr := net.JoinHostPort(machineAddr, "22")
 
 	sshKeypairSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameSSHKeyPair)
 	if !found {
-		return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameSSHKeyPair)
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameSSHKeyPair)
 	}
 
 	conn, err := sshutils.Dial(ctx, sshAddr,
@@ -49,12 +50,19 @@ func (b *AutonomousBotanist) ConnectToMachine(ctx context.Context, index int) (*
 		sshutils.WithPrivateKeyBytes(sshKeypairSecret.Data[secretsutils.DataKeyRSAPrivateKey]),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to machine %q at %q via bastion: %w", machine.Name, sshAddr, err)
+		return fmt.Errorf("failed to connect to machine %q at %q via bastion: %w", machine.Name, sshAddr, err)
 	}
 
 	// We need root permissions for running gardenadm commands on the machine.
 	// Also, add a line prefix to distinguish output from different machines.
-	return conn.RunAsUser("root").WithOutputPrefix(fmt.Sprintf("[%s] ", machine.Name)), nil
+	b.sshConnection = conn.RunAsUser("root").WithOutputPrefix(fmt.Sprintf("[%s] ", machine.Name))
+
+	return nil
+}
+
+// SSHConnection returns the SSH connection to the control plane machine opened by ConnectToControlPlaneMachine.
+func (b *AutonomousBotanist) SSHConnection() *sshutils.Connection {
+	return b.sshConnection
 }
 
 var (
@@ -70,14 +78,14 @@ var (
 )
 
 // CopyManifests copies all manifests needed for `gardenadm init` to the remote machine under GardenadmBaseDir.
-func (b *AutonomousBotanist) CopyManifests(ctx context.Context, conn *sshutils.Connection, configDir fs.FS) error {
-	if err := prepareRemoteDirs(conn); err != nil {
+func (b *AutonomousBotanist) CopyManifests(ctx context.Context, configDir fs.FS) error {
+	if err := prepareRemoteDirs(b.sshConnection); err != nil {
 		return err
 	}
 
 	// Copy all manifest files from --config-dir
 	if err := gardenadm.VisitManifestFiles(configDir, func(path string, file fs.File) error {
-		if err := conn.CopyFile(ctx, filepath.Join(ManifestsDir, path), manifestFilePermissions, file); err != nil {
+		if err := b.sshConnection.CopyFile(ctx, filepath.Join(ManifestsDir, path), manifestFilePermissions, file); err != nil {
 			return fmt.Errorf("failed copying file %s: %w", path, err)
 		}
 		return nil
@@ -85,11 +93,11 @@ func (b *AutonomousBotanist) CopyManifests(ctx context.Context, conn *sshutils.C
 		return fmt.Errorf("error copying manifests: %w", err)
 	}
 
-	if err := copyImageVectorOverride(ctx, conn); err != nil {
+	if err := copyImageVectorOverride(ctx, b.sshConnection); err != nil {
 		return err
 	}
 
-	return b.copyShootState(ctx, conn)
+	return b.copyShootState(ctx)
 }
 
 func prepareRemoteDirs(conn *sshutils.Connection) error {
@@ -127,7 +135,7 @@ func copyImageVectorOverride(ctx context.Context, conn *sshutils.Connection) (er
 	return nil
 }
 
-func (b *AutonomousBotanist) copyShootState(ctx context.Context, conn *sshutils.Connection) error {
+func (b *AutonomousBotanist) copyShootState(ctx context.Context) error {
 	shootState := &gardencorev1beta1.ShootState{}
 	if err := b.GardenClient.Get(ctx, client.ObjectKeyFromObject(b.Shoot.GetInfo()), shootState); err != nil {
 		return fmt.Errorf("error getting ShootState: %w", err)
@@ -138,7 +146,7 @@ func (b *AutonomousBotanist) copyShootState(ctx context.Context, conn *sshutils.
 		return fmt.Errorf("error encoding ShootState: %w", err)
 	}
 
-	if err := conn.Copy(ctx, filepath.Join(ManifestsDir, "shootstate.yaml"), manifestFilePermissions, shootStateBytes); err != nil {
+	if err := b.sshConnection.Copy(ctx, filepath.Join(ManifestsDir, "shootstate.yaml"), manifestFilePermissions, shootStateBytes); err != nil {
 		return fmt.Errorf("error copying ShootState: %w", err)
 	}
 

--- a/pkg/gardenadm/resources.go
+++ b/pkg/gardenadm/resources.go
@@ -52,6 +52,7 @@ type Resources struct {
 	Project                 *gardencorev1beta1.Project
 	Seed                    *gardencorev1beta1.Seed
 	Shoot                   *gardencorev1beta1.Shoot
+	ShootState              *gardencorev1beta1.ShootState
 	ControllerRegistrations []*gardencorev1beta1.ControllerRegistration
 	ControllerDeployments   []*gardencorev1.ControllerDeployment
 	ConfigMaps              []*corev1.ConfigMap
@@ -108,6 +109,12 @@ func ReadManifests(log logr.Logger, fsys fs.FS) (Resources, error) {
 					return fmt.Errorf("found more than one *gardencorev1beta1.Shoot resource, but only one is allowed")
 				}
 				resources.Shoot = typedObj
+
+			case *gardencorev1beta1.ShootState:
+				if resources.ShootState != nil {
+					return fmt.Errorf("found more than one *gardencorev1beta1.ShootState resource, but only one is allowed")
+				}
+				resources.ShootState = typedObj
 
 			case *gardencorev1beta1.ControllerRegistration:
 				resources.ControllerRegistrations = append(resources.ControllerRegistrations, typedObj)

--- a/pkg/gardenadm/resources_test.go
+++ b/pkg/gardenadm/resources_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Resources", func() {
 			createCloudProfile(fsys, "cpfl")
 			createProject(fsys, "project")
 			createShoot(fsys, "shoot")
+			createShootState(fsys, "shoot")
 			createControllerRegistration(fsys, "ext1")
 			createControllerRegistration(fsys, "ext2")
 			createControllerDeployment(fsys, "ext1")
@@ -50,6 +51,7 @@ var _ = Describe("Resources", func() {
 			Expect(resources.CloudProfile.Name).To(Equal("cpfl"))
 			Expect(resources.Project.Name).To(Equal("project"))
 			Expect(resources.Shoot.Name).To(Equal("shoot"))
+			Expect(resources.ShootState.Name).To(Equal("shoot"))
 			Expect(resources.ControllerRegistrations).To(HaveLen(4))
 			Expect(resources.ControllerRegistrations[0].Name).To(Equal("ext1"))
 			Expect(resources.ControllerRegistrations[1].Name).To(Equal("ext2"))
@@ -138,6 +140,16 @@ var _ = Describe("Resources", func() {
 			})
 		})
 
+		Describe("ShootState", func() {
+			It("should return an error", func() {
+				createShootState(fsys, "obj1")
+				createShootState(fsys, "obj2")
+
+				_, err := gardenadm.ReadManifests(log, fsys)
+				Expect(err).To(MatchError(ContainSubstring("found more than one *gardencorev1beta1.ShootState resource")))
+			})
+		})
+
 		Describe("SecretBinding", func() {
 			It("should return an error", func() {
 				createSecretBinding(fsys, "secretBinding1")
@@ -211,6 +223,14 @@ metadata:
 func createShoot(fsys fstest.MapFS, name string) {
 	fsys["shoot-"+name+".yaml"] = &fstest.MapFile{Data: []byte(`apiVersion: core.gardener.cloud/v1beta1
 kind: Shoot
+metadata:
+  name: ` + name + `
+`)}
+}
+
+func createShootState(fsys fstest.MapFS, name string) {
+	fsys["shootstate-"+name+".yaml"] = &fstest.MapFile{Data: []byte(`apiVersion: core.gardener.cloud/v1beta1
+kind: ShootState
 metadata:
   name: ` + name + `
 `)}

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -638,7 +638,7 @@ func ConstructExternalDomain(ctx context.Context, c client.Reader, shoot *garden
 		if primaryProvider.SecretName != nil {
 			secret := &corev1.Secret{}
 			if err := c.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *primaryProvider.SecretName}, secret); err != nil {
-				return nil, fmt.Errorf("could not get dns provider secret %q: %+v", *shoot.Spec.DNS.Providers[0].SecretName, err)
+				return nil, fmt.Errorf("could not get dns provider secret %q: %+v", *primaryProvider.SecretName, err)
 			}
 			externalDomain.SecretData = secret.Data
 		} else {

--- a/pkg/utils/ssh/prefixed_writer.go
+++ b/pkg/utils/ssh/prefixed_writer.go
@@ -14,7 +14,7 @@ import (
 // PrefixedWriter wraps an io.Writer, emitting the passed in prefix at the beginning of each new line.
 // This can be useful when running multiple ssh.Connections concurrently - you can prefix the log output of each
 // session by passing in a PrefixedWriter.
-// This is used by Connection.OutputPrefix.
+// This is used by Connection.WithOutputPrefix.
 type PrefixedWriter struct {
 	prefix        []byte
 	writer        io.Writer

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -188,6 +188,7 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 		It("should write the shoot kubeconfig to the specified file", func(ctx SpecContext) {
 			Eventually(ctx, session.Err).Should(gbytes.Say("Writing kubeconfig of the autonomous shoot to file"))
 
+			// #nosec G304 -- kubeconfigOutputFile is controlled by the test
 			Expect(os.ReadFile(kubeconfigOutputFile)).To(ContainSubstring("server: https://api.root.garden.local.gardener.cloud"))
 		}, SpecTimeout(time.Minute))
 

--- a/test/e2e/gardenadm/mediumtouch/gardenadm.go
+++ b/test/e2e/gardenadm/mediumtouch/gardenadm.go
@@ -96,7 +96,7 @@ var _ = Describe("gardenadm medium-touch scenario tests", Label("gardenadm", "me
 
 		It("should stop machine-controller-manager", func(ctx SpecContext) {
 			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameMachineControllerManager, Namespace: technicalID}}
-			Eventually(ctx, Get(deployment)).Should(BeNotFoundError())
+			Eventually(ctx, Object(deployment)).Should(HaveField("Replicas", HaveValue(BeEquivalentTo(0))))
 		}, SpecTimeout(time.Minute))
 
 		It("should deploy the DNSRecord", func(ctx SpecContext) {

--- a/test/e2e/gardener/shoot/internal/bastion/bastion.go
+++ b/test/e2e/gardener/shoot/internal/bastion/bastion.go
@@ -191,7 +191,7 @@ func VerifyBastion(s *ShootContext) {
 			}).Should(Succeed())
 			closers = append(closers, nodeConnection)
 
-			Eventually(ctx, execute(nodeConnection, "hostname")).Should(gbytes.Say(nodeName))
+			Eventually(ctx, execute(ctx, nodeConnection, "hostname")).Should(gbytes.Say(nodeName))
 		}
 
 		It("should connect to the Node via Bastion on Hostname", func(ctx SpecContext) {
@@ -214,11 +214,12 @@ func VerifyBastion(s *ShootContext) {
 	})
 }
 
-func execute(c *sshutils.Connection, command string) *gbytes.Buffer {
+func execute(ctx context.Context, c *sshutils.Connection, command string) *gbytes.Buffer {
 	GinkgoHelper()
 
 	combinedBuffer := gbytes.NewBuffer()
 	Expect(c.RunWithStreams(
+		ctx,
 		nil,
 		io.MultiWriter(combinedBuffer, gexec.NewPrefixedWriter("[out] ", GinkgoWriter)),
 		io.MultiWriter(combinedBuffer, gexec.NewPrefixedWriter("[err] ", GinkgoWriter)),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR continues the implementation of the `gardenadm bootstrap` flow by executing `gardenadm init` on the first control plane machine.
`gardenadm init` is adapted to read the `ShootState` together with the other manifests. It sets the `lastOperation.Type` to `Restore` to restore state like secrets, extensions, etc., in the autonomous shoot (similar to the `Restore` part of a Shoot control plane migration). By this, we ensure we don't lose any important state, e.g., that the SSH keypair for accessing the shoot machines is not overwritten with a newly generated one.

After `gardenadm init` has successfully initialized the control plane on the machine, `gardenadm bootstrap` fetches the kubeconfig, stores it in the bootstrap cluster, and optionally in a file specified via `--kubeconfig-output`.

I.e., with this PR, we can connect to a medium-touch autonomous shoot cluster for the first time 🎉 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

Opened as draft PR for early CI feedback. 
- [x] rebase once https://github.com/gardener/gardener/pull/12981 has been merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
