### PR TITLE
feat: configurable advertised addresses for shoot ingress endpoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -185,6 +185,7 @@
 * [Checklist For Adding New Components](development/component-checklist.md)
 * [Defaulting Strategy and Developer Guideline](development/defaulting.md)
 * [Autoscaling Specifics for Components](development/autoscaling-specifics-for-components.md)
+* [Shoot Advertised Addresses](development/shoot-advertised-addresses.md)
 
 ## Extensions
 

--- a/docs/development/shoot-advertised-addresses.md
+++ b/docs/development/shoot-advertised-addresses.md
@@ -1,0 +1,56 @@
+# Shoot Advertised Addresses
+
+Upon reconciliation, the `gardenlet` populates the list of advertised addresses
+for the shoot cluster in the `.status.advertisedAddresses` field of the `Shoot`
+resource.
+
+This list provides endpoints for various services, such as the Kubernetes API
+server of the shoot, the OIDC service account issuer, etc.
+
+The example command below shows the list of advertised endpoints for a local
+shoot cluster.
+
+``` shell
+$ kubectl --namespace garden-local get shoots local -o yaml | yq '.status.advertisedAddresses'
+- name: external
+  url: https://api.local.local.external.local.gardener.cloud
+- name: internal
+  url: https://api.local.local.internal.local.gardener.cloud
+- name: service-account-issuer
+  url: https://discovery.local.gardener.cloud/projects/local/shoots/41a0cdaa-6ad5-4846-9f6b-b7a7716538cb/issuer
+```
+
+The `external`, `internal` and `service-account-issuer` endpoints (amongst
+others) are always present by default for a shoot cluster. Besides these,
+additional endpoints from the shoot control-plane namespace may be advertised,
+e.g. observability-related components such as `plutono`, `vali`, `prometheus`,
+etc.
+
+> [!NOTE]
+> As of now, only `Ingress` resources support may be advertised using this label.
+> In the future, support for `Gateway` resources will be added as well.
+
+In order to advertise such endpoints, their respective `Ingress` resource needs
+to be labeled with `endpoint.shoot.gardener.cloud/advertise=true`.
+
+For example, if we want to advertise the `plutono` endpoint for our local shoot
+cluster, we would label its respective `Ingress` resource like this:
+
+``` shell
+kubectl --namespace shoot--local--local \
+    label ingress plutono endpoint.shoot.gardener.cloud/advertise=true
+```
+
+After successful reconciliation of the `Shoot` by the `gardenlet`, we should see a
+new advertised endpoint for our cluster.
+
+``` shell
+- name: external
+  url: https://api.local.local.external.local.gardener.cloud
+- name: internal
+  url: https://api.local.local.internal.local.gardener.cloud
+- name: service-account-issuer
+  url: https://discovery.local.gardener.cloud/projects/local/shoots/41a0cdaa-6ad5-4846-9f6b-b7a7716538cb/issuer
+- name: ingress/plutono/0/0
+  url: https://gu-local--local.ingress.local.seed.local.gardener.cloud
+```

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1064,4 +1064,14 @@ const (
 	// GardenerInfoConfigMapDataKeyGardenerAPIServer is the data key in the gardener-info ConfigMap that contains
 	// information about gardener-apiserver.
 	GardenerInfoConfigMapDataKeyGardenerAPIServer = "gardenerAPIServer"
+
+	// LabelShootEndpointPrefix is the prefix used for labels related to
+	// advertised shoot endpoints.
+	LabelShootEndpointPrefix = "endpoint.shoot.gardener.cloud/"
+	// LabelShootEndpointAdvertise is the name of the label which controls
+	// whether an endpoint is advertised for a shoot.
+	LabelShootEndpointAdvertise = LabelShootEndpointPrefix + "advertise"
+	// LabelShootEndpointName is the name of the label, which sets the name
+	// of a shoot advertised endpoint.
+	LabelShootEndpointName = LabelShootEndpointPrefix + "name"
 )

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1071,7 +1071,4 @@ const (
 	// LabelShootEndpointAdvertise is the name of the label which controls
 	// whether an endpoint is advertised for a shoot.
 	LabelShootEndpointAdvertise = LabelShootEndpointPrefix + "advertise"
-	// LabelShootEndpointName is the name of the label, which sets the name
-	// of a shoot advertised endpoint.
-	LabelShootEndpointName = LabelShootEndpointPrefix + "name"
 )

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -120,9 +120,12 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 	// [gardencorev1beta1.ShootAdvertisedAddress] is constrained to https://
 	// endpoints only.
 	for _, ingress := range ingressList.Items {
+		addrName := ingress.Name
 		for _, tlsItem := range ingress.Spec.TLS {
 			for _, hostItem := range tlsItem.Hosts {
-				addrName := fmt.Sprintf("%s", ingress.Name)
+				if strings.Contains(hostItem, "*") {
+					continue
+				}
 				addrLabelName, ok := ingress.GetLabels()[v1beta1constants.LabelShootEndpointName]
 				if ok && addrLabelName != "" {
 					addrName = addrLabelName

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -10,12 +10,12 @@ import (
 	"slices"
 	"strings"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // UpdateAdvertisedAddresses updates the shoot.status.advertisedAddresses with the list of
@@ -105,15 +105,14 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 	result := make([]gardencorev1beta1.ShootAdvertisedAddress, 0)
 	var ingressList networkingv1.IngressList
 
-	err := b.SeedClientSet.Client().List(
+	if err := b.SeedClientSet.Client().List(
 		ctx,
 		&ingressList,
-		client.InNamespace(b.Shoot.GetInfo().Status.TechnicalID),
+		client.InNamespace(b.Shoot.ControlPlaneNamespace),
 		client.MatchingLabels(map[string]string{
 			v1beta1constants.LabelShootEndpointAdvertise: "true",
 		}),
-	)
-	if err != nil {
+	); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -90,7 +90,7 @@ func (b *Botanist) ToAdvertisedAddresses(ctx context.Context) ([]gardencorev1bet
 
 	ingressItems, err := b.GetIngressAdvertisedEndpoints(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get ingress advertised endpoints: %w", err)
 	}
 	addresses = append(addresses, ingressItems...)
 
@@ -113,7 +113,7 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 			v1beta1constants.LabelShootEndpointAdvertise: "true",
 		}),
 	); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list ingress resources: %w", err)
 	}
 
 	// Only the TLS items are processed, since
@@ -125,11 +125,10 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 				if strings.Contains(hostItem, "*") {
 					continue
 				}
-				addr := gardencorev1beta1.ShootAdvertisedAddress{
+				result = append(result, gardencorev1beta1.ShootAdvertisedAddress{
 					Name: fmt.Sprintf("ingress/%s/%d/%d", ingress.Name, tlsIdx, hostIdx),
 					URL:  fmt.Sprintf("https://%s", hostItem),
-				}
-				result = append(result, addr)
+				})
 			}
 		}
 	}

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -122,7 +122,7 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 	for _, ingress := range ingressList.Items {
 		for _, tlsItem := range ingress.Spec.TLS {
 			for _, hostItem := range tlsItem.Hosts {
-				addrName := fmt.Sprintf("ingress/%s", ingress.Name)
+				addrName := fmt.Sprintf("%s", ingress.Name)
 				addrLabelName, ok := ingress.GetLabels()[v1beta1constants.LabelShootEndpointName]
 				if ok && addrLabelName != "" {
 					addrName = addrLabelName

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -120,19 +120,13 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 	// [gardencorev1beta1.ShootAdvertisedAddress] is constrained to https://
 	// endpoints only.
 	for _, ingress := range ingressList.Items {
-		addrName := ingress.Name
-		for _, tlsItem := range ingress.Spec.TLS {
-			for _, hostItem := range tlsItem.Hosts {
+		for tlsIdx, tlsItem := range ingress.Spec.TLS {
+			for hostIdx, hostItem := range tlsItem.Hosts {
 				if strings.Contains(hostItem, "*") {
 					continue
 				}
-				addrLabelName, ok := ingress.GetLabels()[v1beta1constants.LabelShootEndpointName]
-				if ok && addrLabelName != "" {
-					addrName = addrLabelName
-				}
-
 				addr := gardencorev1beta1.ShootAdvertisedAddress{
-					Name: addrName,
+					Name: fmt.Sprintf("ingress/%s/%d/%d", ingress.Name, tlsIdx, hostIdx),
 					URL:  fmt.Sprintf("https://%s", hostItem),
 				}
 				result = append(result, addr)

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -7,6 +7,8 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -135,6 +137,10 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 			}
 		}
 	}
+
+	slices.SortStableFunc(result, func(a, b gardencorev1beta1.ShootAdvertisedAddress) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return result, nil
 }

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
@@ -292,42 +292,12 @@ var _ = Describe("AdvertisedAddresses", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(items).To(HaveExactElements([]gardencorev1beta1.ShootAdvertisedAddress{
 				{
-					Name: "ingress-1",
+					Name: "ingress/ingress-1/0/0",
 					URL:  "https://foo.example.org",
 				},
 				{
-					Name: "ingress-2",
+					Name: "ingress/ingress-2/0/0",
 					URL:  "https://bar.example.org",
-				},
-			}))
-		})
-
-		It("returns valid endpoint with custom name", func() {
-			ingress := &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ingress-1",
-					Namespace: shootNamespace.Name,
-					Labels: map[string]string{
-						v1beta1constants.LabelShootEndpointAdvertise: "true",
-						v1beta1constants.LabelShootEndpointName:      "my-custom-name",
-					},
-				},
-				Spec: networkingv1.IngressSpec{
-					TLS: []networkingv1.IngressTLS{
-						{
-							Hosts: []string{"foo.example.org"},
-						},
-					},
-				},
-			}
-
-			Expect(botanist.SeedClientSet.Client().Create(ctx, ingress)).To(Succeed())
-			items, err := botanist.GetIngressAdvertisedEndpoints(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(items).To(HaveExactElements([]gardencorev1beta1.ShootAdvertisedAddress{
-				{
-					Name: "my-custom-name",
-					URL:  "https://foo.example.org",
 				},
 			}))
 		})

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
@@ -292,11 +292,11 @@ var _ = Describe("AdvertisedAddresses", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(items).To(HaveExactElements([]gardencorev1beta1.ShootAdvertisedAddress{
 				{
-					Name: "ingress/ingress-1",
+					Name: "ingress-1",
 					URL:  "https://foo.example.org",
 				},
 				{
-					Name: "ingress/ingress-2",
+					Name: "ingress-2",
 					URL:  "https://bar.example.org",
 				},
 			}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area control-plane
/area usability
/kind enhancement

**What this PR does / why we need it**:

This PR adds support for exposing ingress resource endpoints from shoot control plane namespaces via the `.status.advertisedAddresses` of the shoot resource.

See #13027 for more details about the initial proposal and background info.

Example list of advertised addresses for a test shoot running locally.

```
> kubectl --namespace garden-local get shoots local  -o yaml | yq '.status.advertisedAddresses'
- name: external
  url: https://api.local.local.external.local.gardener.cloud
- name: internal
  url: https://api.local.local.internal.local.gardener.cloud
- name: service-account-issuer
  url: https://discovery.local.gardener.cloud/projects/local/shoots/dcdf7a6c-a55b-4797-9f58-971c1b97efae/issuer
```

And these are the ingress resources for the local shoot cluster.

```
> kubectl --namespace shoot--local--local get ingress
NAME               CLASS                    HOSTS                                                     ADDRESS       PORTS     AGE
plutono            nginx-ingress-gardener   gu-local--local.ingress.local.seed.local.gardener.cloud   10.2.175.43   80, 443   7h
prometheus-shoot   nginx-ingress-gardener   p-local--local.ingress.local.seed.local.gardener.cloud    10.2.175.43   80, 443   6h59m
vali               nginx-ingress-gardener   v-local--local.ingress.local.seed.local.gardener.cloud    10.2.175.43   80, 443   7h2m
```

In order to expose any of the ingress resources from the shoot control-plane namespace and make it part of the `.status.advertisedAddresses`, the respective ingress resource may be labeled, e.g.

```
kubectl --namespace shoot--local--local label ingress plutono endpoint.shoot.gardener.cloud/advertise=true
```

Once the shoot has been reconciled a new endpoint should be listed under the `.status.advertisedAddresses` for the shoot.

```
> kubectl --namespace garden-local get shoots local  -o yaml | yq '.status.advertisedAddresses'
- name: external
  url: https://api.local.local.external.local.gardener.cloud
- name: internal
  url: https://api.local.local.internal.local.gardener.cloud
- name: service-account-issuer
  url: https://discovery.local.gardener.cloud/projects/local/shoots/e21c0178-85ec-4223-8069-d299dfd47b56/issuer
- name: plutono
  url: https://gu-local--local.ingress.local.seed.local.gardener.cloud
```

The name of the advertised address may also be customized by the `endpoint.shoot.gardener.cloud/name` label, e.g.

```
kubectl --namespace shoot--local--local label ingress plutono endpoint.shoot.gardener.cloud/name=my-plutono-endpoint
```

**Which issue(s) this PR fixes**:
Fixes #13027 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```feature developer
Shoot advertised addresses are now configurable by extension components for Shoot Ingress resources. For more details, see [Shoot Advertised Addresses](https://github.com/gardener/gardener/blob/v1.130.0/docs/development/shoot-advertised-addresses.md).
```