### PR TITLE
Fix race conditions occurring when removing finalizers from resources watched by multiple controllers

### DIFF
--- a/pkg/controllermanager/controller/credentialsbinding/reconciler.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler.go
@@ -83,7 +83,7 @@ func (r *Reconciler) reconcile(ctx context.Context, credentialsBinding *security
 	kind := credential.GetObjectKind().GroupVersionKind().Kind
 
 	if !controllerutil.ContainsFinalizer(credential, finalizerName) {
-		log.Info("Adding finalizer", kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
+		log.Info("Adding finalizer", "finalizer", finalizerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 		if err := controllerutils.AddFinalizers(ctx, r.Client, credential, finalizerName); err != nil {
 			return fmt.Errorf("could not add finalizer to %s: %w", kind, err)
 		}
@@ -91,7 +91,7 @@ func (r *Reconciler) reconcile(ctx context.Context, credentialsBinding *security
 
 	// TODO(dimityrmirchev): Remove the ExternalGardenerName finalizer handling in a future release
 	if controllerutil.ContainsFinalizer(credential, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Removing finalizer", kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
+		log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 		if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, gardencorev1beta1.ExternalGardenerName); err != nil {
 			return fmt.Errorf("could not remove finalizer from %s: %w", kind, err)
 		}
@@ -160,14 +160,14 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 	} else if errCredentials == nil {
 		// TODO(dimityrmirchev): remove this handling in a future release, the finalizer should be added by the reconcile function
 		// ensure the new finalizer is present on the referenced secret/workload identity before removing the old finalizer
-		if !controllerutil.ContainsFinalizer(credential, finalizerName) {
-			log.Info("Adding finalizer", kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
+		if !controllerutil.ContainsFinalizer(credential, finalizerName) && credential.GetDeletionTimestamp() == nil {
+			log.Info("Adding finalizer", "finalizer", finalizerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 			if err := controllerutils.AddFinalizers(ctx, r.Client, credential, finalizerName); err != nil {
 				return fmt.Errorf("could not add finalizer to %s: %w", kind, err)
 			}
 		}
 		if controllerutil.ContainsFinalizer(credential, gardencorev1beta1.ExternalGardenerName) {
-			log.Info("Removing finalizer", kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
+			log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 			if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, gardencorev1beta1.ExternalGardenerName); err != nil {
 				return fmt.Errorf("failed to remove finalizer from %s: %w", kind, err)
 			}
@@ -213,7 +213,7 @@ func (r *Reconciler) delete(ctx context.Context, credentialsBinding *securityv1a
 
 		// Remove finalizer from referenced secret
 		if controllerutil.ContainsFinalizer(credential, finalizerName) {
-			log.Info("Removing finalizer", kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
+			log.Info("Removing finalizer", "finalizer", finalizerName, kind, client.ObjectKeyFromObject(credential)) //nolint:logcheck
 			if err := controllerutils.RemoveFinalizers(ctx, r.Client, credential, finalizerName); err != nil {
 				return fmt.Errorf("failed to remove finalizer from %s: %w", kind, err)
 			}

--- a/pkg/controllermanager/controller/credentialsbinding/reconciler.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler.go
@@ -29,9 +29,7 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-const (
-	finalizerName = "gardener.cloud/credentialsbinding"
-)
+const finalizerName = "gardener.cloud/credentialsbinding"
 
 // Reconciler reconciles CredentialsBinding.
 type Reconciler struct {

--- a/pkg/controllermanager/controller/credentialsbinding/reconciler.go
+++ b/pkg/controllermanager/controller/credentialsbinding/reconciler.go
@@ -245,6 +245,13 @@ func (r *Reconciler) mayReleaseCredentials(ctx context.Context, binding *securit
 		if cb.Namespace == binding.Namespace && cb.Name == binding.Name {
 			continue
 		}
+
+		if cb.DeletionTimestamp != nil {
+			// credentials bindings that are already marked for deletion
+			// are not considered to be protecting the referenced credentials
+			continue
+		}
+
 		if cb.CredentialsRef.APIVersion == binding.CredentialsRef.APIVersion &&
 			cb.CredentialsRef.Kind == binding.CredentialsRef.Kind &&
 			cb.CredentialsRef.Namespace == binding.CredentialsRef.Namespace &&

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -221,6 +221,13 @@ func (r *Reconciler) mayReleaseSecret(ctx context.Context, secretBindingNamespac
 		if secretBinding.Namespace == secretBindingNamespace && secretBinding.Name == secretBindingName {
 			continue
 		}
+
+		if secretBinding.DeletionTimestamp != nil {
+			// secret bindings that are already marked for deletion
+			// are not considered to be protecting the referenced secret
+			continue
+		}
+
 		if secretBinding.SecretRef.Namespace == secretNamespace && secretBinding.SecretRef.Name == secretName {
 			return false, nil
 		}

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -26,9 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
-const (
-	finalizerName = "gardener.cloud/secretbinding"
-)
+const finalizerName = "gardener.cloud/secretbinding"
 
 // Reconciler reconciles SecretBindings.
 type Reconciler struct {

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		} else if errSecret == nil {
 			// TODO(dimityrmirchev): remove this handling in a future release, the finalizer should be added by the reconcile function
 			// ensure the new finalizer is present on the referenced secret before removing the old finalizer
-			if !controllerutil.ContainsFinalizer(secret, finalizerName) {
+			if !controllerutil.ContainsFinalizer(secret, finalizerName) && secret.GetDeletionTimestamp() == nil {
 				log.Info("Adding finalizer", "finalizer", finalizerName) //nolint:logcheck
 				if err := controllerutils.AddFinalizers(ctx, r.Client, secret, finalizerName); err != nil {
 					return reconcile.Result{}, fmt.Errorf("could not add finalizer to secret: %w", err)

--- a/pkg/controllermanager/controller/secretbinding/reconciler.go
+++ b/pkg/controllermanager/controller/secretbinding/reconciler.go
@@ -26,6 +26,10 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
+const (
+	finalizerName = "gardener.cloud/secretbinding"
+)
+
 // Reconciler reconciles SecretBindings.
 type Reconciler struct {
 	Client   client.Client
@@ -57,6 +61,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, nil
 		}
 
+		secret := &corev1.Secret{}
+		errSecret := r.Client.Get(ctx, client.ObjectKey{Namespace: secretBinding.SecretRef.Namespace, Name: secretBinding.SecretRef.Name}, secret)
+		if errSecret != nil && !apierrors.IsNotFound(errSecret) {
+			return reconcile.Result{}, errSecret
+		} else if errSecret == nil {
+			// TODO(dimityrmirchev): remove this handling in a future release, the finalizer should be added by the reconcile function
+			// ensure the new finalizer is present on the referenced secret before removing the old finalizer
+			if !controllerutil.ContainsFinalizer(secret, finalizerName) {
+				log.Info("Adding finalizer", "finalizer", finalizerName) //nolint:logcheck
+				if err := controllerutils.AddFinalizers(ctx, r.Client, secret, finalizerName); err != nil {
+					return reconcile.Result{}, fmt.Errorf("could not add finalizer to secret: %w", err)
+				}
+			}
+			if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
+				log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName) //nolint:logcheck
+				if err := controllerutils.RemoveFinalizers(ctx, r.Client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+					return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
+				}
+			}
+			// end TODO
+		}
+
 		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.Client, secretBinding)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -70,35 +96,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 				return reconcile.Result{}, err
 			}
 
-			if mayReleaseSecret {
-				secret := &corev1.Secret{}
-				if err := r.Client.Get(ctx, client.ObjectKey{Namespace: secretBinding.SecretRef.Namespace, Name: secretBinding.SecretRef.Name}, secret); err == nil {
-					// Remove shoot provider label and 'referred by a secret binding' label
-					hasProviderLabel, providerLabel := getProviderLabel(secret.Labels)
-					if hasProviderLabel || metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelSecretBindingReference) {
-						patch := client.MergeFrom(secret.DeepCopy())
-						delete(secret.Labels, v1beta1constants.LabelSecretBindingReference)
+			if mayReleaseSecret && errSecret == nil {
+				// Remove shoot provider label and 'referred by a secret binding' label
+				hasProviderLabel, providerLabel := getProviderLabel(secret.Labels)
+				if hasProviderLabel || metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelSecretBindingReference) {
+					patch := client.MergeFrom(secret.DeepCopy())
+					delete(secret.Labels, v1beta1constants.LabelSecretBindingReference)
 
-						// The secret can be still referenced by a credentialsbinding so
-						// only remove the provider label if there is no credentialsbinding reference label
-						if !metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelCredentialsBindingReference) {
-							delete(secret.Labels, providerLabel)
-						}
+					// We rely on the sync-provider-secret-labels.gardener.cloud webhook to re-add the provider label if needed
+					delete(secret.Labels, providerLabel)
 
-						if err := r.Client.Patch(ctx, secret, patch); err != nil {
-							return reconcile.Result{}, fmt.Errorf("failed to remove referred label from Secret: %w", err)
-						}
+					if err := r.Client.Patch(ctx, secret, patch); err != nil {
+						return reconcile.Result{}, fmt.Errorf("failed to remove referred label from Secret: %w", err)
 					}
-					// Remove finalizer from referenced secret
-					// only if the secret does not have a credentialsbinding reference label
-					if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) && !metav1.HasLabel(secret.ObjectMeta, v1beta1constants.LabelCredentialsBindingReference) {
-						log.Info("Removing finalizer from secret", "secret", client.ObjectKeyFromObject(secret))
-						if err := controllerutils.RemoveFinalizers(ctx, r.Client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-							return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
-						}
+				}
+
+				if controllerutil.ContainsFinalizer(secret, finalizerName) {
+					log.Info("Removing finalizer", "finalizer", finalizerName)
+					if err := controllerutils.RemoveFinalizers(ctx, r.Client, secret, finalizerName); err != nil {
+						return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from secret: %w", err)
 					}
-				} else if !apierrors.IsNotFound(err) {
-					return reconcile.Result{}, err
 				}
 			}
 
@@ -136,9 +153,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if !controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
-		log.Info("Adding finalizer to secret", "secret", client.ObjectKeyFromObject(secret))
-		if err := controllerutils.AddFinalizers(ctx, r.Client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+	if !controllerutil.ContainsFinalizer(secret, finalizerName) {
+		log.Info("Adding finalizer", "finalizer", finalizerName)
+		if err := controllerutils.AddFinalizers(ctx, r.Client, secret, finalizerName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not add finalizer to secret: %w", err)
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
+		log.Info("Removing finalizer", "finalizer", gardencorev1beta1.ExternalGardenerName)
+		if err := controllerutils.RemoveFinalizers(ctx, r.Client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer to secret: %w", err)
 		}
 	}

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -114,10 +114,17 @@ func (r *Reconciler) reconcileBackupBucket(
 		return err
 	}
 
-	if !controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
+	if !controllerutil.ContainsFinalizer(backupCredentials, finalizerName) {
 		log.Info("Adding finalizer to backup credentials", "gvk", backupCredentials.GetObjectKind().GroupVersionKind().String(), "key", client.ObjectKeyFromObject(backupCredentials))
-		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+		if err := controllerutils.AddFinalizers(gardenCtx, r.GardenClient, backupCredentials, finalizerName); err != nil {
 			return fmt.Errorf("failed to add finalizer to backup credentials: %w", err)
+		}
+	}
+	// TODO(dimityrmirchev): Remove this handling in a future release
+	if controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
+		log.Info("Removing finalizer from backup credentials", "gvk", backupCredentials.GetObjectKind().GroupVersionKind().String(), "key", client.ObjectKeyFromObject(backupCredentials))
+		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+			return fmt.Errorf("failed to remove finalizer from backup credentials: %w", err)
 		}
 	}
 
@@ -330,9 +337,9 @@ func (r *Reconciler) deleteBackupBucket(
 
 	log.Info("Successfully deleted")
 
-	if controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) {
+	if controllerutil.ContainsFinalizer(backupCredentials, gardencorev1beta1.ExternalGardenerName) || controllerutil.ContainsFinalizer(backupCredentials, finalizerName) {
 		log.Info("Removing finalizer from credentials", "gvk", backupCredentials.GetObjectKind().GroupVersionKind().String(), "credentials", client.ObjectKeyFromObject(backupCredentials))
-		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName); err != nil {
+		if err := controllerutils.RemoveFinalizers(gardenCtx, r.GardenClient, backupCredentials, gardencorev1beta1.ExternalGardenerName, finalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to remove finalizer from credentials: %w", err)
 		}
 	}

--- a/pkg/gardenlet/controller/backupbucket/reconciler_test.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler_test.go
@@ -226,6 +226,9 @@ var _ = Describe("Controller", func() {
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionSecret), extensionSecret)).To(Succeed())
 			Expect(extensionSecret.Data).To(Equal(gardenSecret.Data))
 
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(gardenSecret), gardenSecret)).To(Succeed())
+			Expect(gardenSecret.Finalizers).To(Equal([]string{"core.gardener.cloud/backupbucket"}))
+
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
 			Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{
 				DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -356,6 +359,9 @@ var _ = Describe("Controller", func() {
 			Expect(extensionSecret.Annotations).To(HaveKeyWithValue("workloadidentity.security.gardener.cloud/namespace", workloadIdentity.Namespace))
 			Expect(extensionSecret.Annotations).To(HaveKey("gardener.cloud/timestamp"))
 			Expect(extensionSecret.Type).To(BeEquivalentTo("Opaque"))
+
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(workloadIdentity), workloadIdentity)).To(Succeed())
+			Expect(workloadIdentity.Finalizers).To(Equal([]string{"core.gardener.cloud/backupbucket"}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(extensionBackupBucket), extensionBackupBucket)).To(Succeed())
 			Expect(extensionBackupBucket.Spec).To(Equal(extensionsv1alpha1.BackupBucketSpec{

--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -171,7 +171,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			By("Ensure finalizer and labels got added to Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/credentialsbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/credentialsbinding", "true"),
@@ -194,7 +194,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			By("Ensure finalizer and labels got removed from Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).NotTo(ContainElement("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).NotTo(ContainElement("gardener.cloud/credentialsbinding"))
 				g.Expect(secret.Labels).NotTo(HaveKeyWithValue("reference.gardener.cloud/credentialsbinding", "true"))
 			}).Should(Succeed())
 
@@ -208,7 +208,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			By("Ensure finalizer and labels got added to Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/credentialsbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/credentialsbinding", "true"),
@@ -239,7 +239,7 @@ var _ = Describe("CredentialsBinding controller test", func() {
 			By("Ensure finalizer and labels are still present on Secret and Quota")
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/credentialsbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/credentialsbinding", "true"),

--- a/test/integration/controllermanager/secretbinding/secretbinding_test.go
+++ b/test/integration/controllermanager/secretbinding/secretbinding_test.go
@@ -164,7 +164,7 @@ var _ = Describe("SecretBinding controller test", func() {
 			By("Ensure finalizer and labels got added to Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/secretbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/secretbinding", "true"),
@@ -187,7 +187,7 @@ var _ = Describe("SecretBinding controller test", func() {
 			By("Ensure finalizer and labels got removed from Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).NotTo(ContainElement("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).NotTo(ContainElement("gardener.cloud/secretbinding"))
 				g.Expect(secret.Labels).NotTo(HaveKeyWithValue("reference.gardener.cloud/secretbinding", "true"))
 			}).Should(Succeed())
 
@@ -201,7 +201,7 @@ var _ = Describe("SecretBinding controller test", func() {
 			By("Ensure finalizer and labels got added to Secret and Quota")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/secretbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/secretbinding", "true"),
@@ -232,7 +232,7 @@ var _ = Describe("SecretBinding controller test", func() {
 			By("Ensure finalizer and labels are still present on Secret and Quota")
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(secret.Finalizers).To(ConsistOf("gardener.cloud/secretbinding"))
 				g.Expect(secret.Labels).To(And(
 					HaveKeyWithValue("provider.shoot.gardener.cloud/"+providerType, "true"),
 					HaveKeyWithValue("reference.gardener.cloud/secretbinding", "true"),

--- a/test/integration/gardenlet/backupbucket/backupbucket_test.go
+++ b/test/integration/gardenlet/backupbucket/backupbucket_test.go
@@ -201,7 +201,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 				g.Expect(backupBucket.Annotations).NotTo(HaveKey("gardener.cloud/operation"))
 
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenSecret), gardenSecret)).To(Succeed())
-				g.Expect(gardenSecret.Finalizers).To(ConsistOf("gardener.cloud/gardener"))
+				g.Expect(gardenSecret.Finalizers).To(ConsistOf("core.gardener.cloud/backupbucket"))
 			}).Should(Succeed())
 		})
 
@@ -267,7 +267,7 @@ var _ = Describe("BackupBucket controller tests", func() {
 			By("Ensure finalizers are removed and BackupBucket is released")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenSecret), gardenSecret)).To(Succeed())
-				g.Expect(gardenSecret.Finalizers).NotTo(ContainElement("gardener.cloud/gardener"))
+				g.Expect(gardenSecret.Finalizers).NotTo(ContainElement("core.gardener.cloud/backupbucket"))
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(backupBucket), backupBucket)).To(BeNotFoundError())
 			}).Should(Succeed())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Various controllers now use their own unique finalizers to prevent race conditions when removing them from a resource in deletion.

/invite @vpnachev 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13036

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug causing finalizers to not be removed from `Secret`s when such are deleted and referenced by both a `CredentialsBinding` and a `SecretBinding` is fixed.
```
