### PR TITLE
docs: Order gardener-apiserver admission plugins alphabetically

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -174,15 +174,6 @@ Generally, it checks whether referred resources stated in the specifications of 
 However, it also has some special behaviours for certain resources:
 * `CloudProfile`s: It rejects removing Kubernetes or machine image versions if there is at least one `Shoot` that refers to them.
 
-## `SeedValidator`
-
-**Type**: Validating. **Enabled by default**: Yes.
-
-This admission controller reacts on `CREATE`, `UPDATE`, and `DELETE` operations for `Seed`s.
-Rejects the deletion if `Shoot`(s) reference the seed cluster.
-While the seed is still used by `Shoot`(s), the plugin disallows removal of entries from the `seed.spec.provider.zones` field.
-When the seed is using `WorkloadIdentity` as backup credentials, the plugin ensures the seed backup and the workload identity have the same provider type, i.e. `seed.spec.backup.provider` and `workloadIdentity.spec.targetSystem.type` have the same value.
-
 ## `SeedMutator`
 
 **Type**: Mutating. **Enabled by default**: Yes.
@@ -192,6 +183,15 @@ It maintains the `name.seed.gardener.cloud/<name>` labels for it.
 More specifically, it adds that the `name.seed.gardener.cloud/<name>=true` label where `<name>` is
 - the name of the `Seed` resource (a `Seed` named `foo` will get label `name.seed.gardener.cloud/foo=true`).
 - the name of the parent `Seed` resource in case it is a `ManagedSeed` (a `Seed` named `foo` that is created by a `ManagedSeed` which references a `Shoot` running a `Seed` called `bar` will get label `name.seed.gardener.cloud/bar=true`).
+
+## `SeedValidator`
+
+**Type**: Validating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE`, `UPDATE`, and `DELETE` operations for `Seed`s.
+Rejects the deletion if `Shoot`(s) reference the seed cluster.
+While the seed is still used by `Shoot`(s), the plugin disallows removal of entries from the `seed.spec.provider.zones` field.
+When the seed is using `WorkloadIdentity` as backup credentials, the plugin ensures the seed backup and the workload identity have the same provider type, i.e. `seed.spec.backup.provider` and `workloadIdentity.spec.targetSystem.type` have the same value.
 
 ## `ShootDNS`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -136,6 +136,13 @@ This admission controller is defined in the generic API server library (`k8s.io/
 
 This admission controller is defined in the generic API server library (`k8s.io/apiserver`). See the [NamespaceLifecycle section](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#namespacelifecycle).
 
+## `NamespacedCloudProfileValidator`
+
+**Type**: Validating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
+It primarily validates if the referenced parent `CloudProfile` exists in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.
+
 ## `ProjectMutator`
 
 **Type**: Mutating. **Enabled by default**: Yes.
@@ -276,13 +283,6 @@ Already existing `Shoot`s will not be affected by this admission plugin.
 
 This admission controller reacts on `Create` operations for `Shoot`s.
 It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
-
-## `NamespacedCloudProfileValidator`
-
-**Type**: Validating. **Enabled by default**: Yes.
-
-This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
-It primarily validates if the referenced parent `CloudProfile` exists in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.
 
 ## `ValidatingAdmissionPolicy`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -257,6 +257,14 @@ If a shoot contains global resource reservations, then no per worker pool resour
 By default, `useGKEFormula: true` applies to all Shoots.
 Operators can provide an optional label selector via the `selector` field to limit which Shoots get worker specific resource reservations injected.
 
+## `ShootTolerationRestriction`
+
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
+It validates the `.spec.tolerations` used in `Shoot`s against the whitelist of its `Project`, or against the whitelist configured in the admission controller's configuration, respectively.
+Additionally, it defaults the `.spec.tolerations` in `Shoot`s with those configured in its `Project`, and those configured in the admission controller's configuration, respectively.
+
 ## `ShootVPAEnabledByDefault`
 
 **Type**: Mutating. **Enabled by default**: Yes.
@@ -266,14 +274,6 @@ If enabled, it will enable the managed `VerticalPodAutoscaler` components (for m
 by setting `spec.kubernetes.verticalPodAutoscaler.enabled=true` for newly created Shoots.
 Already existing Shoots and new Shoots that explicitly disable VPA (`spec.kubernetes.verticalPodAutoscaler.enabled=false`)
 will not be affected by this admission plugin.
-
-## `ShootTolerationRestriction`
-
-**Type**: Validating and Mutating. **Enabled by default**: Yes.
-
-This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
-It validates the `.spec.tolerations` used in `Shoot`s against the whitelist of its `Project`, or against the whitelist configured in the admission controller's configuration, respectively.
-Additionally, it defaults the `.spec.tolerations` in `Shoot`s with those configured in its `Project`, and those configured in the admission controller's configuration, respectively.
 
 ## `ShootValidator`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -216,6 +216,14 @@ Already existing `Shoot`s will not be affected by this admission plugin.
 This admission controller reacts on `Create` operations for `Shoot`s.
 It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
 
+## `ShootManagedSeed`
+
+**Type**: Validating. **Enabled by default**: Yes.
+
+This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
+It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
+It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
+
 ## `ShootNodeLocalDNSEnabledByDefault`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -275,14 +283,6 @@ This admission controller reacts on `CREATE`, `UPDATE` and `DELETE` operations f
 It validates certain configurations in the specification against the referred `CloudProfile` (e.g., machine images, machine types, used Kubernetes version, ...).
 Generally, it performs validations that cannot be handled by the static API validation due to their dynamic nature (e.g., when something needs to be checked against referred resources).
 Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools, default Kubernetes version) and setting the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
-
-## `ShootManagedSeed`
-
-**Type**: Validating. **Enabled by default**: Yes.
-
-This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
-It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
-It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
 
 ## `ValidatingAdmissionPolicy`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -111,6 +111,13 @@ It validates certain configuration values in the specification against the refer
 Similar to `ShootValidator`, it performs validations that cannot be handled by the static API validation due to their dynamic nature.
 Additionally, it performs certain defaulting tasks, making sure that configuration values that are not specified are defaulted to the values of the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
 
+## `ManagedSeedShoot`
+
+**Type**: Validating. **Enabled by default**: Yes.
+
+This admission controller reacts on `DELETE` operations for `ManagedSeed`s.
+It rejects the deletion if there are `Shoot`s that are scheduled onto the `Seed` that is registered by the `ManagedSeed`.
+
 ## `MutatingAdmissionPolicy`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -254,13 +261,6 @@ Additionally, it takes over certain defaulting tasks (e.g., default machine imag
 This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
-
-## `ManagedSeedShoot`
-
-**Type**: Validating. **Enabled by default**: Yes.
-
-This admission controller reacts on `DELETE` operations for `ManagedSeed`s.
-It rejects the deletion if there are `Shoot`s that are scheduled onto the `Seed` that is registered by the `ManagedSeed`.
 
 ## `ShootDNSRewriting`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -10,6 +10,8 @@ If you want to get an overview of the what and why of admission plugins then [th
 
 This document lists all existing admission plugins with a short explanation of what it is responsible for.
 
+<!-- Keep the list of admission plugins in (case-sensitive) lexicographical order. -->
+
 ## `BackupBucketValidator`
 
 **Type**: Validating. **Enabled by default**: Yes.

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -85,13 +85,6 @@ It makes sure that the `deletion.gardener.cloud/confirmed-by` annotation is prop
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
-## `ShootExposureClass`
-
-**Type**: Mutating. **Enabled by default**: Yes.
-
-This admission controller reacts on `Create` operations for `Shoot`s.
-It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
-
 ## `ExtensionValidator`
 
 **Type**: Validating. **Enabled by default**: Yes.
@@ -276,6 +269,13 @@ It rejects the deletion if there are `Shoot`s that are scheduled onto the `Seed`
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/networking/dns-search-path-optimization.md)).
 Already existing `Shoot`s will not be affected by this admission plugin.
+
+## `ShootExposureClass`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `Create` operations for `Shoot`s.
+It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
 
 ## `NamespacedCloudProfileValidator`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -102,6 +102,15 @@ It ensures that the finalizers of these resources are not removed by users, as l
 For `CredentialsBinding`s and `SecretBinding`s this means, that the `gardener` finalizer can only be removed if the binding is not referenced by any `Shoot`.
 In case of `Shoot`s, the `gardener` finalizer can only be removed if the last operation of the `Shoot` indicates a successful deletion. 
 
+## `ManagedSeed`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `ManagedSeeds`s.
+It validates certain configuration values in the specification against the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
+Similar to `ShootValidator`, it performs validations that cannot be handled by the static API validation due to their dynamic nature.
+Additionally, it performs certain defaulting tasks, making sure that configuration values that are not specified are defaulted to the values of the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
+
 ## `MutatingAdmissionPolicy`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -245,15 +254,6 @@ Additionally, it takes over certain defaulting tasks (e.g., default machine imag
 This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
-
-## `ManagedSeed`
-
-**Type**: Mutating. **Enabled by default**: Yes.
-
-This admission controller reacts on `CREATE` and `UPDATE` operations for `ManagedSeeds`s.
-It validates certain configuration values in the specification against the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
-Similar to `ShootValidator`, it performs validations that cannot be handled by the static API validation due to their dynamic nature.
-Additionally, it performs certain defaulting tasks, making sure that configuration values that are not specified are defaulted to the values of the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
 
 ## `ManagedSeedShoot`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -79,6 +79,12 @@ Find all information about it [in this document](../usage/project/projects.md#fo
 Furthermore, this admission controller reacts on `CREATE` or `UPDATE` operations for `Shoot`s.
 It makes sure that the `deletion.gardener.cloud/confirmed-by` annotation is properly maintained in case the `Shoot` deletion is confirmed with above mentioned annotation.
 
+## `ExtensionLabels`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
+
 ## `ShootExposureClass`
 
 **Type**: Mutating. **Enabled by default**: Yes.
@@ -93,12 +99,6 @@ It mutates `Shoot` resources which have an `ExposureClass` referenced by merging
 This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupEntry`s, `BackupBucket`s, `Seed`s, and `Shoot`s.
 For all the various extension types in the specifications of these objects, it validates whether there exists a `ControllerRegistration` in the system that is primarily responsible for the stated extension type(s).
 This prevents misconfigurations that would otherwise allow users to create such resources with extension types that don't exist in the cluster, effectively leading to failing reconciliation loops.
-
-## `ExtensionLabels`
-
-**Type**: Mutating. **Enabled by default**: Yes.
-
-This admission controller reacts on `CREATE` and `UPDATE` operations for `BackupBucket`s, `BackupEntry`s, `CloudProfile`s, `NamespacedCloudProfile`s, `Seed`s, `SecretBinding`s, `CredentialsBinding`s, `WorkloadIdentity`s and `Shoot`s. For all the various extension types in the specifications of these objects, it adds a corresponding label in the resource. This would allow extension admission webhooks to filter out the resources they are responsible for and ignore all others. This label is of the form `<extension-type>.extensions.gardener.cloud/<extension-name> : "true"`. For example, an extension label for provider extension type `aws`, looks like `provider.extensions.gardener.cloud/aws : "true"`.
 
 ## `FinalizerRemoval`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -201,6 +201,14 @@ This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`
 It tries to assign a default domain to the `Shoot`.
 It also validates the DNS configuration (`.spec.dns`) for shoots.
 
+## `ShootDNSRewriting`
+
+**Type**: Mutating. **Enabled by default**: No.
+
+This admission controller reacts on `CREATE` operations for `Shoot`s.
+If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/networking/dns-search-path-optimization.md)).
+Already existing `Shoot`s will not be affected by this admission plugin.
+
 ## `ShootNodeLocalDNSEnabledByDefault`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -268,14 +276,6 @@ Additionally, it takes over certain defaulting tasks (e.g., default machine imag
 This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
-
-## `ShootDNSRewriting`
-
-**Type**: Mutating. **Enabled by default**: No.
-
-This admission controller reacts on `CREATE` operations for `Shoot`s.
-If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/networking/dns-search-path-optimization.md)).
-Already existing `Shoot`s will not be affected by this admission plugin.
 
 ## `ShootExposureClass`
 

--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -209,6 +209,13 @@ This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it adds a set of common suffixes configured in its admission plugin configuration to the `Shoot` (`spec.systemComponents.coreDNS.rewriting.commonSuffixes`) (for more information, see [DNS Search Path Optimization](../usage/networking/dns-search-path-optimization.md)).
 Already existing `Shoot`s will not be affected by this admission plugin.
 
+## `ShootExposureClass`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `Create` operations for `Shoot`s.
+It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
+
 ## `ShootNodeLocalDNSEnabledByDefault`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -276,13 +283,6 @@ Additionally, it takes over certain defaulting tasks (e.g., default machine imag
 This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
-
-## `ShootExposureClass`
-
-**Type**: Mutating. **Enabled by default**: Yes.
-
-This admission controller reacts on `Create` operations for `Shoot`s.
-It mutates `Shoot` resources which have an `ExposureClass` referenced by merging both their `shootSelectors` and/or `tolerations` into the `Shoot` resource.
 
 ## `ValidatingAdmissionPolicy`
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The admission plugins in the upstream docs are ordered alphabetically: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#what-does-each-admission-controller-do

It seems that the intention was the same for our docs however over time this alphabetical order was not preserved - for example new admission plugins were added to the end.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
