### PR TITLE
logging: revert logging plugin to v0.65.0

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -566,7 +566,7 @@ images:
       name: fluent-bit-to-vali
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-    tag: "v0.66.0"
+    tag: "v0.65.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -601,7 +601,7 @@ images:
   - name: vali-curator
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-    tag: "v0.66.0"
+    tag: "v0.65.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -657,7 +657,7 @@ images:
       name: telegraf-iptables
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-    tag: "v0.66.0"
+    tag: "v0.65.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -677,7 +677,7 @@ images:
   - name: event-logger
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-    tag: "v0.66.0"
+    tag: "v0.65.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -694,7 +694,7 @@ images:
   - name: tune2fs
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-    tag: "v0.66.0"
+    tag: "v0.65.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
**How to categorize this PR?**
/area logging
/kind regression

**What this PR does / why we need it**:
This PR brings logging plugin back to v0.65.0 due to a regression brought by v0.66.0. 
Under high volume the current `promtail` clients can hit backend limits and thus ingestion can be rejected. v0.65.0 handles the case correctly. 

