### PR TITLE
Remove usages of `controller-runtime`'s deprecated `reconcile.Result{Requeue: true}`

### DIFF
--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -102,7 +102,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if result, err := r.reconcile(ctx, log, ex, operationType); err != nil {
 			return result, err
 		}
-		return reconcile.Result{Requeue: r.resync != 0, RequeueAfter: r.resync}, nil
+		return reconcile.Result{RequeueAfter: r.resync}, nil
 	}
 }
 

--- a/pkg/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/controller/tokenrequestor/reconciler_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -145,7 +145,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -166,7 +166,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -186,7 +186,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -208,7 +208,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -237,7 +237,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -256,7 +256,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err = ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			targetSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -284,7 +284,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -302,7 +302,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -331,7 +331,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: time.Hour}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: time.Hour}))
 			})
 		})
 
@@ -356,7 +356,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should detect if the caBundle is incorrect (token case)", func() {
@@ -371,7 +371,7 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -388,7 +388,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should detect if the caBundle is incorrect (kubeconfig case)", func() {
@@ -400,7 +400,7 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(sourceClient.Create(ctx, secret)).To(Succeed())
 
-			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(ctrl.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("kubeconfig", newKubeconfigRaw(token, []byte("fake-ca-bundle"))))
@@ -417,7 +417,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -432,7 +432,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -461,7 +461,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
@@ -476,7 +476,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 		})
 
 		Context("error", func() {
@@ -514,7 +514,7 @@ var _ = Describe("Reconciler", func() {
 
 				result, err := ctrl.Reconcile(ctx, request)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 				Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 				Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))

--- a/pkg/controllermanager/controller/project/project/add.go
+++ b/pkg/controllermanager/controller/project/project/add.go
@@ -5,19 +5,29 @@
 package project
 
 import (
+	"context"
+
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ControllerName is the name of this controller.
@@ -32,18 +42,59 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
 	}
 
+	partialShootMetadata := &metav1.PartialObjectMetadata{}
+	partialShootMetadata.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
 		For(&gardencorev1beta1.Project{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Namespace{}, builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Delete))).
 		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(r.RoleBindingPredicate())).
+		Watches(
+			partialShootMetadata,
+			handler.EnqueueRequestsFromMapFunc(r.MapShootToProjectInDeletion(mgr.GetLogger().WithValues("controller", ControllerName))),
+			builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Delete)),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 0),
 			RateLimiter:             r.RateLimiter,
 			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,
 		}).
 		Complete(r)
+}
+
+// MapShootToProjectInDeletion returns a mapper that returns requests for the Project to which the Shoot belongs,
+// if the Project is being deleted and does not contain any other Shoots.
+func (r *Reconciler) MapShootToProjectInDeletion(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		shoot, ok := obj.(*metav1.PartialObjectMetadata)
+		if !ok {
+			return nil
+		}
+
+		shootsExist, err := kubernetesutils.ResourcesExist(ctx, r.Client, &gardencorev1beta1.ShootList{}, r.Client.Scheme(), client.InNamespace(shoot.Namespace))
+		if err != nil {
+			log.Error(err, "Failed to check if namespace still contains shoots", "namespace", shoot.Namespace)
+			return nil
+		}
+
+		if shootsExist {
+			return nil
+		}
+
+		project, _, err := gardenerutils.ProjectAndNamespaceFromReader(ctx, r.Client, shoot.Namespace)
+		if err != nil {
+			log.Error(err, "Failed to get project for namespace", "namespace", shoot.Namespace)
+			return nil
+		}
+
+		if project.DeletionTimestamp == nil {
+			return nil
+		}
+
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: project.Name}}}
+	}
 }
 
 // RoleBindingPredicate filters for events for RoleBindings that we might need to reconcile back.

--- a/pkg/controllermanager/controller/project/project/add_test.go
+++ b/pkg/controllermanager/controller/project/project/add_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Add", func() {
 		reconciler = &project.Reconciler{}
 	})
 
-	Describe("RoleBindingPredicate", func() {
+	Describe("#RoleBindingPredicate", func() {
 		var (
 			p           predicate.Predicate
 			roleBinding *rbacv1.RoleBinding
@@ -129,7 +129,7 @@ var _ = Describe("Add", func() {
 			Expect(reconciler.MapShootToProjectInDeletion(log)(ctx, &gardencorev1beta1.Project{})).To(BeEmpty())
 		})
 
-		Context("when other shoots exist in namespace", func() {
+		When("other shoots exist in namespace", func() {
 			var (
 				namespace = "garden-test"
 
@@ -162,7 +162,7 @@ var _ = Describe("Add", func() {
 			})
 		})
 
-		Context("when no other shoots exist", func() {
+		When("no other shoots exist", func() {
 			var (
 				namespace   = "garden-test"
 				projectName = "test-project"

--- a/pkg/controllermanager/controller/project/project/add_test.go
+++ b/pkg/controllermanager/controller/project/project/add_test.go
@@ -5,90 +5,219 @@
 package project_test
 
 import (
+	"context"
+
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/project/project"
 )
 
-var _ = Describe("RoleBindingPredicate", func() {
-	var (
-		p           predicate.Predicate
-		roleBinding *rbacv1.RoleBinding
-	)
+var _ = Describe("Add", func() {
+	var reconciler *project.Reconciler
 
 	BeforeEach(func() {
-		p = (&project.Reconciler{}).RoleBindingPredicate()
-		roleBinding = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				ResourceVersion: "1",
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "project-member",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.UserKind,
-				Name:     "admin",
-			}},
-		}
+		reconciler = &project.Reconciler{}
 	})
 
-	Describe("#Create", func() {
-		It("should return false", func() {
-			Expect(p.Create(event.CreateEvent{})).To(BeFalse())
+	Describe("RoleBindingPredicate", func() {
+		var (
+			p           predicate.Predicate
+			roleBinding *rbacv1.RoleBinding
+		)
+
+		BeforeEach(func() {
+			p = reconciler.RoleBindingPredicate()
+			roleBinding = &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1",
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "project-member",
+				},
+				Subjects: []rbacv1.Subject{{
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.UserKind,
+					Name:     "admin",
+				}},
+			}
 		})
-	})
 
-	Describe("#Update", func() {
-		It("should return true for periodic cache resyncs", func() {
-			Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: roleBinding.DeepCopy()})).To(BeTrue())
+		Describe("#Create", func() {
+			It("should return false", func() {
+				Expect(p.Create(event.CreateEvent{})).To(BeFalse())
+			})
 		})
 
-		It("should return true if roleRef changed", func() {
-			oldRoleBinding := roleBinding.DeepCopy()
-			roleBinding.ResourceVersion = "2"
-			roleBinding.RoleRef.Name = "other"
-
-			Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeTrue())
-		})
-
-		It("should return true if subjects changed", func() {
-			oldRoleBinding := roleBinding.DeepCopy()
-			roleBinding.ResourceVersion = "2"
-			roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.UserKind,
-				Name:     "viewer",
+		Describe("#Update", func() {
+			It("should return true for periodic cache resyncs", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: roleBinding.DeepCopy()})).To(BeTrue())
 			})
 
-			Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeTrue())
+			It("should return true if roleRef changed", func() {
+				oldRoleBinding := roleBinding.DeepCopy()
+				roleBinding.ResourceVersion = "2"
+				roleBinding.RoleRef.Name = "other"
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeTrue())
+			})
+
+			It("should return true if subjects changed", func() {
+				oldRoleBinding := roleBinding.DeepCopy()
+				roleBinding.ResourceVersion = "2"
+				roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+					APIGroup: rbacv1.GroupName,
+					Kind:     rbacv1.UserKind,
+					Name:     "viewer",
+				})
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeTrue())
+			})
+
+			It("should return false if something else changed", func() {
+				oldRoleBinding := roleBinding.DeepCopy()
+				roleBinding.ResourceVersion = "2"
+				metav1.SetMetaDataLabel(&roleBinding.ObjectMeta, "foo", "bar")
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeFalse())
+			})
 		})
 
-		It("should return false if something else changed", func() {
-			oldRoleBinding := roleBinding.DeepCopy()
-			roleBinding.ResourceVersion = "2"
-			metav1.SetMetaDataLabel(&roleBinding.ObjectMeta, "foo", "bar")
+		Describe("#Delete", func() {
+			It("should return true", func() {
+				Expect(p.Delete(event.DeleteEvent{})).To(BeTrue())
+			})
+		})
 
-			Expect(p.Update(event.UpdateEvent{ObjectNew: roleBinding, ObjectOld: oldRoleBinding})).To(BeFalse())
+		Describe("#Generic", func() {
+			It("should return false", func() {
+				Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+			})
 		})
 	})
 
-	Describe("#Delete", func() {
-		It("should return true", func() {
-			Expect(p.Delete(event.DeleteEvent{})).To(BeTrue())
-		})
-	})
+	Describe("#MapShootToProjectInDeletion", func() {
+		var (
+			ctx        = context.Background()
+			log        logr.Logger
+			fakeClient client.Client
+		)
 
-	Describe("#Generic", func() {
-		It("should return false", func() {
-			Expect(p.Generic(event.GenericEvent{})).To(BeFalse())
+		BeforeEach(func() {
+			log = logr.Discard()
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				Build()
+			reconciler.Client = fakeClient
+		})
+
+		It("should do nothing if the object is no shoot", func() {
+			Expect(reconciler.MapShootToProjectInDeletion(log)(ctx, &gardencorev1beta1.Project{})).To(BeEmpty())
+		})
+
+		Context("when other shoots exist in namespace", func() {
+			var (
+				namespace = "garden-test"
+
+				shoot         *metav1.PartialObjectMetadata
+				existingShoot *gardencorev1beta1.Shoot
+			)
+
+			BeforeEach(func() {
+				shoot = &metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+						Kind:       "Shoot",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-shoot",
+						Namespace: namespace,
+					},
+				}
+				existingShoot = &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-shoot",
+						Namespace: namespace,
+					},
+				}
+			})
+
+			It("should return empty list of projects", func() {
+				Expect(fakeClient.Create(ctx, existingShoot)).To(Succeed())
+				Expect(reconciler.MapShootToProjectInDeletion(log)(ctx, shoot)).To(BeEmpty())
+			})
+		})
+
+		Context("when no other shoots exist", func() {
+			var (
+				namespace   = "garden-test"
+				projectName = "test-project"
+
+				shoot            *metav1.PartialObjectMetadata
+				project          *gardencorev1beta1.Project
+				projectNamespace *corev1.Namespace
+			)
+
+			BeforeEach(func() {
+				shoot = &metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+						Kind:       "Shoot",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-shoot",
+						Namespace: namespace,
+					},
+				}
+
+				project = &gardencorev1beta1.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       projectName,
+						Finalizers: []string{"gardener"},
+					},
+					Spec: gardencorev1beta1.ProjectSpec{
+						Namespace: &namespace,
+					},
+				}
+
+				projectNamespace = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+						Labels: map[string]string{
+							"project.gardener.cloud/name": projectName,
+						},
+					},
+				}
+
+				Expect(fakeClient.Create(ctx, project)).To(Succeed())
+				Expect(fakeClient.Create(ctx, projectNamespace)).To(Succeed())
+			})
+
+			It("should map the shoot to project when project is being deleted", func() {
+				Expect(fakeClient.Delete(ctx, project)).To(Succeed())
+
+				Expect(reconciler.MapShootToProjectInDeletion(log)(ctx, shoot)).To(Equal([]reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: projectName}},
+				}))
+			})
+
+			It("should return empty list of projects if project is not being deleted", func() {
+				Expect(reconciler.MapShootToProjectInDeletion(log)(ctx, shoot)).To(BeEmpty())
+			})
 		})
 	})
 })

--- a/pkg/controllermanager/controller/project/project/reconciler.go
+++ b/pkg/controllermanager/controller/project/project/reconciler.go
@@ -322,7 +322,7 @@ func (r *Reconciler) delete(ctx context.Context, log logr.Logger, project *garde
 		if inUse {
 			r.Recorder.Eventf(project, corev1.EventTypeWarning, gardencorev1beta1.ProjectEventNamespaceNotEmpty, "Cannot release namespace %q because it still contains Shoots", *namespace)
 			log.Info("Cannot release Project Namespace because it still contains Shoots")
-			return reconcile.Result{Requeue: true}, patchProjectPhase(ctx, r.Client, project, gardencorev1beta1.ProjectTerminating)
+			return reconcile.Result{}, patchProjectPhase(ctx, r.Client, project, gardencorev1beta1.ProjectTerminating)
 		}
 
 		released, err := r.releaseNamespace(ctx, log, project, *namespace)

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -14,8 +14,12 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
-// DefaultReconciliationTimeout is the default timeout for the context of reconciliation functions.
-const DefaultReconciliationTimeout = 3 * time.Minute
+const (
+	// DefaultReconciliationTimeout is the default timeout for the context of reconciliation functions.
+	DefaultReconciliationTimeout = 3 * time.Minute
+	// DefaultRequeueAfterDuration is the default duration to wait before requeuing a reconciliation request.
+	DefaultRequeueAfterDuration = 5 * time.Millisecond
+)
 
 const separator = ","
 

--- a/pkg/controllerutils/reconciler/reconcile.go
+++ b/pkg/controllerutils/reconciler/reconcile.go
@@ -12,7 +12,7 @@ import (
 // RequeueAfterError or not.
 func ReconcileErr(err error) (reconcile.Result, error) {
 	if requeueAfter, ok := err.(*RequeueAfterError); ok {
-		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter.RequeueAfter}, nil
+		return reconcile.Result{RequeueAfter: requeueAfter.RequeueAfter}, nil
 	}
 	return reconcile.Result{}, err
 }

--- a/pkg/controllerutils/reconciler/reconcile_test.go
+++ b/pkg/controllerutils/reconciler/reconcile_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Reconcile", func() {
 		It("should return the correct result if it's a RequeueAfterError", func() {
 			res, err := ReconcileErr(requeueAfterError)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}))
+			Expect(res).To(Equal(reconcile.Result{RequeueAfter: requeueAfter}))
 		})
 	})
 

--- a/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot/helper/infos_test.go
@@ -253,7 +253,6 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 			It("should requeue with the general sync period", func() {
 				requeueAfter := infos.RequeueAfter
-				Expect(requeueAfter.Requeue).To(BeFalse())
 				Expect(requeueAfter.RequeueAfter).To(Equal(cfg.SyncPeriod.Duration))
 			})
 
@@ -269,7 +268,6 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 				It("should requeue with the shoot's sync period", func() {
 					requeueAfter := infos.RequeueAfter
-					Expect(requeueAfter.Requeue).To(BeFalse())
 					Expect(requeueAfter.RequeueAfter).To(Equal(shootSyncPeriod))
 				})
 			})
@@ -294,7 +292,6 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 					It("should requeue the shoot during its next maintenance time window", func() {
 						requeueAfter := infos.RequeueAfter
-						Expect(requeueAfter.Requeue).To(BeFalse())
 						Expect(requeueAfter.RequeueAfter).To(BeNumerically(">", 0))
 						Expect(requeueAfter.RequeueAfter).To(BeNumerically("<", 23*time.Hour))
 
@@ -350,7 +347,6 @@ var _ = Describe("CalculateControllerInfos", func() {
 
 						It("should requeue the shoot during its next maintenance time window", func() {
 							requeueAfter := infos.RequeueAfter
-							Expect(requeueAfter.Requeue).To(BeFalse())
 							Expect(requeueAfter.RequeueAfter).To(BeNumerically(">", 23*time.Hour))
 							Expect(requeueAfter.RequeueAfter).To(BeNumerically("<", 47*time.Hour))
 

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -161,7 +161,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -178,7 +178,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: delay}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: delay}))
 		})
 
 		It("should issue a new token since the renew timestamp is in the past", func() {
@@ -193,7 +193,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 
 			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).To(HaveKeyWithValue("token", []byte(token)))
@@ -223,7 +223,7 @@ var _ = Describe("Reconciler", func() {
 
 			result, err := ctrl.Reconcile(ctx, request)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: expectedRenewDuration}))
+			Expect(result).To(Equal(reconcile.Result{RequeueAfter: expectedRenewDuration}))
 		})
 
 		Context("error", func() {

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if result, err := r.reconcile(ctx, log, garden, secretsManager, targetVersion); err != nil {
 		return result, r.updateStatusOperationError(ctx, garden, err, operationType)
-	} else if result.Requeue {
+	} else if result.RequeueAfter > 0 {
 		return result, nil
 	}
 

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -131,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// The second reconciliation will remove the old key and set the phase to completed.
 	if etcdEncryptionKeyRotationPhase := helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials); etcdEncryptionKeyRotationPhase == gardencorev1beta1.RotationPrepared &&
 		helper.ShouldETCDEncryptionKeyRotationBeAutoCompleteAfterPrepared(garden.Status.Credentials) {
-		return reconcile.Result{RequeueAfter: 5 * time.Millisecond}, nil
+		return reconcile.Result{RequeueAfter: controllerutils.DefaultRequeueAfterDuration}, nil
 	}
 
 	return reconcile.Result{RequeueAfter: r.Config.Controllers.Garden.SyncPeriod.Duration}, nil

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -638,7 +638,7 @@ func (r *Reconciler) reconcile(
 
 	if !enableAdmissionControllerAuthorizers {
 		log.Info("Triggering a second reconciliation to enable authorizers in gardener-admission-controller")
-		return reconcile.Result{RequeueAfter: 5 * time.Millisecond}, nil
+		return reconcile.Result{RequeueAfter: controllerutils.DefaultRequeueAfterDuration}, nil
 	}
 
 	if err := r.updateHelmChartRefForGardenlets(ctx, log, virtualClusterClient); err != nil {

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -638,7 +638,7 @@ func (r *Reconciler) reconcile(
 
 	if !enableAdmissionControllerAuthorizers {
 		log.Info("Triggering a second reconciliation to enable authorizers in gardener-admission-controller")
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: 5 * time.Millisecond}, nil
 	}
 
 	if err := r.updateHelmChartRefForGardenlets(ctx, log, virtualClusterClient); err != nil {

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 	}
 
-	return reconcile.Result{Requeue: true, RequeueAfter: r.Config.SyncPeriod.Duration}, errorList.ErrorOrNil()
+	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, errorList.ErrorOrNil()
 }
 
 type objectId struct {

--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -67,6 +67,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 				resourcemanagerpredicate.NoLongerIgnored(),
 				// we need to reconcile once if the ManagedResource got marked as ignored in order to update the conditions
 				resourcemanagerpredicate.GotMarkedAsIgnored(),
+				r.ClassFilter.CleanupCompleted(),
 			),
 			// TODO: refactor this predicate chain into a single predicate.Funcs that can be properly tested as a whole
 			predicate.Or(

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// must be delayed, until the deletion is finished.
 	if r.ClassFilter.IsWaitForCleanupRequired(mr) {
 		log.Info("Waiting for previous handler to clean resources created by ManagedResource")
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	}
 	return r.reconcile(ctx, log, mr)
 }

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	. "github.com/gardener/gardener/pkg/resourcemanager/predicate"
@@ -191,6 +192,49 @@ var _ = Describe("ClassFilter", func() {
 				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("")}})).To(BeTrue())
 				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("foo")}})).To(BeTrue())
 				Expect(filter.Responsible(&resourcesv1alpha1.ManagedResource{Spec: resourcesv1alpha1.ManagedResourceSpec{Class: ptr.To("bar")}})).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("#CleanupCompletedPredicate", func() {
+		var predicate predicate.Predicate
+
+		BeforeEach(func() {
+			predicate = NewClassFilter("").CleanupCompleted()
+		})
+
+		Context("#Create", func() {
+			It("should always return false", func() {
+				Expect(predicate.Create(event.CreateEvent{Object: &resourcesv1alpha1.ManagedResource{}})).To(BeFalse())
+			})
+		})
+
+		Context("#Update", func() {
+			DescribeTable("should return correct result based on cleanup requirements",
+				func(oldMR, newMR *resourcesv1alpha1.ManagedResource, expected bool) {
+					got := predicate.Update(event.UpdateEvent{
+						ObjectOld: oldMR,
+						ObjectNew: newMR,
+					})
+					Expect(got).To(Equal(expected))
+				},
+				Entry("when cleanup was required and is now completed", mrDifferentFinalizerSameClass, mrWithoutFinalizerSameClass, true),
+				Entry("when cleanup was not required in old object", mrWithoutFinalizerSameClass, mrWithoutFinalizerSameClass, false),
+				Entry("when cleanup is still required", mrDifferentFinalizerSameClass, mrDifferentFinalizerSameClass, false),
+				Entry("when neither old nor new require cleanup", mrSameFinalizerSameClass, mrSameFinalizerSameClass, false),
+				Entry("when old object was responsible but new is not", mrSameFinalizerSameClass, mrWithoutFinalizerDifferentClass, false),
+			)
+		})
+
+		Describe("#Delete", func() {
+			It("should always return false", func() {
+				Expect(predicate.Delete(event.DeleteEvent{Object: &resourcesv1alpha1.ManagedResource{}})).To(BeFalse())
+			})
+		})
+
+		Describe("#Generic", func() {
+			It("should always return false", func() {
+				Expect(predicate.Generic(event.GenericEvent{Object: &resourcesv1alpha1.ManagedResource{}})).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/resourcemanager/predicate/class_filter_test.go
+++ b/pkg/resourcemanager/predicate/class_filter_test.go
@@ -203,13 +203,13 @@ var _ = Describe("ClassFilter", func() {
 			predicate = NewClassFilter("").CleanupCompleted()
 		})
 
-		Context("#Create", func() {
+		Describe("#Create", func() {
 			It("should always return false", func() {
 				Expect(predicate.Create(event.CreateEvent{Object: &resourcesv1alpha1.ManagedResource{}})).To(BeFalse())
 			})
 		})
 
-		Context("#Update", func() {
+		Describe("#Update", func() {
 			DescribeTable("should return correct result based on cleanup requirements",
 				func(oldMR, newMR *resourcesv1alpha1.ManagedResource, expected bool) {
 					got := predicate.Update(event.UpdateEvent{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity open-source
/kind cleanup

**What this PR does / why we need it**:
This PR removes usages of the deprecated `controller-runtime`'s `reconcile.Result{Requeue: true}`. The PR generally follows these rules:
1. If a reconciliation function  returns a `reconcile.Result{Requeue: true, RequeueAfter: <value greater than 0>}` simply remove the `Requeue: true` field as `Requeue: true` does not serve any purpose here.
2. If a reconciliation is expected to be requeued only once, replace `Requeue: true` with `RequeueAfter: 5 * time.Millisecond` - this is the smallest duration that is returned by the default `controller-runtime` rate limiter when `Requeue: true` is used
3. For reconciliations that could benefit from a rate limited requeue, it adds a `RequeueReconciler` interface and  `RateLimitedRequeueReconcilerAdapter` function that can be used to transform the `RequeueReconciler` to a `Reconciler` interface. With this, the [functionality of `controller-runtime`'s `Requeue: true`](https://github.com/kubernetes-sigs/controller-runtime/blob/7c50567748ae97d4ef904e93a1b918033c0b5d0b/pkg/internal/controller/controller.go#L462-L494) is still supported. 

**Which issue(s) this PR fixes**:
Fixes #12210 

**Special notes for your reviewer**:
Still a draft as I am not 100% confident whether we need the new `RequeueReconciler` interface added in commit https://github.com/gardener/gardener/pull/13052/commits/fe9c4d2f07e97ce60d2cfaa9a7c6d1d0269ae3b2 and used in commits https://github.com/gardener/gardener/pull/13052/commits/a7a58b7950e7687713e9ed181ec6a05e5f01256a and https://github.com/gardener/gardener/pull/13052/commits/6817d09efa0a1fb6d8d1d19e41cca42d73a2c3cb
Initially, I had also used this in the certificates reloader controller, however it seems that it is no longer necessary after https://github.com/gardener/gardener/pull/12852

I am open to other suggestions and these could also potentially be replaced by a `RequeueAfter` with some short duration. I also wonder if I should make the interface more generic, instead of directly specifying the type for the rate limiter and reconciler to be `reconcile.Request`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Usages of `controller-runtime`'s deprecated `reconcile.Result{Requeue: true}` have been removed. 
```
```other operator
`Project`s are no-longer requeued with back-off when they have a `deletionTimestamp` and still existing `Shoots` in the corresponding namespaces. Instead they are now automatically requeued on `Shoot` deletion events if they no-longer contain any `Shoot`s so that the deletion of the `Project` can finish.
```
```other operator
`ManagedResources` are no-longer requeued with back-off, if their responsibility was transferred from one `gardener-resource-manager` to another, while waiting for the original `gardener-resource-manager` to finish cleaning up the deployed resources. Instead, `ManagedResources` are automatically requeued when the cleanup of resources by the original `gardener-resource-manager` has finished.
```