### PR TITLE
Fix wildcardConfiguration for exposure classes.

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -84,13 +84,10 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 					TLSSecret: *b.ControlPlaneWildcardCert,
 				}
 
-				// Wildcard endpoint must use the default istio ingress gateway if the shoot uses zonal istio ingress gateway.
-				// Otherwise, the wildcard endpoint can share the same istio ingress gateway as the kube-apiserver endpoint.
-				if b.DefaultIstioNamespace() != b.IstioNamespace() {
-					wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-						Namespace: b.DefaultIstioNamespace(),
-						Labels:    b.DefaultIstioLabels(),
-					}
+				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
+				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
+					Namespace: b.IstioNamespaceIgnoreExposureClass(),
+					Labels:    b.IstioLabelsIgnoreExposureClass(),
 				}
 			}
 
@@ -145,13 +142,10 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 					TLSSecret: *b.ControlPlaneWildcardCert,
 				}
 
-				// Wildcard endpoint must use the default istio ingress gateway if the shoot uses zonal istio ingress gateway.
-				// Otherwise, the wildcard endpoint can share the same istio ingress gateway as the kube-apiserver endpoint.
-				if b.DefaultIstioNamespace() != b.IstioNamespace() {
-					wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-						Namespace: b.DefaultIstioNamespace(),
-						Labels:    b.DefaultIstioLabels(),
-					}
+				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
+				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
+					Namespace: b.IstioNamespaceIgnoreExposureClass(),
+					Labels:    b.IstioLabelsIgnoreExposureClass(),
 				}
 			}
 

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -86,8 +86,8 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 
 				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
 				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-					Namespace: b.IstioNamespaceIgnoreExposureClass(),
-					Labels:    b.IstioLabelsIgnoreExposureClass(),
+					Namespace: b.WildcardIstioNamespace(),
+					Labels:    b.WildcardIstioLabels(),
 				}
 			}
 
@@ -144,8 +144,8 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 
 				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
 				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-					Namespace: b.IstioNamespaceIgnoreExposureClass(),
-					Labels:    b.IstioLabelsIgnoreExposureClass(),
+					Namespace: b.WildcardIstioNamespace(),
+					Labels:    b.WildcardIstioLabels(),
 				}
 			}
 

--- a/pkg/gardenlet/operation/istio_config.go
+++ b/pkg/gardenlet/operation/istio_config.go
@@ -30,6 +30,12 @@ func (o *Operation) DefaultIstioNamespace() string {
 	return *o.sniConfig().Ingress.Namespace
 }
 
+// IstioNamespaceIgnoreExposureClass returns the Istio ingress gateway namespace from the SNI configuration,
+// ignoring any exposure class handler logic.
+func (o *Operation) IstioNamespaceIgnoreExposureClass() string {
+	return *o.Config.SNI.Ingress.Namespace
+}
+
 // IstioLabels contain the labels to be used for the istio ingress gateway entities.
 func (o *Operation) IstioLabels() map[string]string {
 	return o.istioLabels(o.singleZoneIfPinned())
@@ -38,6 +44,12 @@ func (o *Operation) IstioLabels() map[string]string {
 // DefaultIstioLabels contain the labels to be used for the default istio ingress gateway entities disregarding zonal affinities.
 func (o *Operation) DefaultIstioLabels() map[string]string {
 	return o.istioLabels(nil)
+}
+
+// IstioLabelsIgnoreExposureClass returns the Istio ingress gateway labels from the SNI configuration,
+// ignoring any exposure class handler logic.
+func (o *Operation) IstioLabelsIgnoreExposureClass() map[string]string {
+	return sharedcomponent.GetIstioZoneLabels(o.Config.SNI.Ingress.Labels, nil)
 }
 
 func (o *Operation) istioLabels(zone *string) map[string]string {

--- a/pkg/gardenlet/operation/istio_config.go
+++ b/pkg/gardenlet/operation/istio_config.go
@@ -30,9 +30,9 @@ func (o *Operation) DefaultIstioNamespace() string {
 	return *o.sniConfig().Ingress.Namespace
 }
 
-// IstioNamespaceIgnoreExposureClass returns the Istio ingress gateway namespace from the SNI configuration,
+// WildcardIstioNamespace returns the Istio ingress gateway namespace from the SNI configuration,
 // ignoring any exposure class handler logic.
-func (o *Operation) IstioNamespaceIgnoreExposureClass() string {
+func (o *Operation) WildcardIstioNamespace() string {
 	return *o.Config.SNI.Ingress.Namespace
 }
 
@@ -46,9 +46,9 @@ func (o *Operation) DefaultIstioLabels() map[string]string {
 	return o.istioLabels(nil)
 }
 
-// IstioLabelsIgnoreExposureClass returns the Istio ingress gateway labels from the SNI configuration,
+// WildcardIstioLabels returns the Istio ingress gateway labels from the SNI configuration,
 // ignoring any exposure class handler logic.
-func (o *Operation) IstioLabelsIgnoreExposureClass() map[string]string {
+func (o *Operation) WildcardIstioLabels() map[string]string {
 	return sharedcomponent.GetIstioZoneLabels(o.Config.SNI.Ingress.Labels, nil)
 }
 

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -100,7 +100,7 @@ var _ = Describe("istioconfig", func() {
 		})
 
 		DescribeTable("#component.IstioConfigInterface implementation",
-			func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, ignoreExposureClassLabels gomegatypes.GomegaMatcher) {
+			func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, matchWildcardLabels gomegatypes.GomegaMatcher) {
 				if zoneAnnotation != nil {
 					operation.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones] = *zoneAnnotation
 				}
@@ -114,7 +114,7 @@ var _ = Describe("istioconfig", func() {
 				Expect(operation.IstioServiceName()).To(matcherService)
 				Expect(operation.IstioNamespace()).To(matcherNamespace)
 				Expect(operation.IstioLabels()).To(matchLabels)
-				Expect(operation.IstioLabelsIgnoreExposureClass()).To(ignoreExposureClassLabels)
+				Expect(operation.WildcardIstioLabels()).To(matchWildcardLabels)
 			},
 
 			Entry("non-pinned control plane without exposure class", nil, false,
@@ -163,7 +163,7 @@ var _ = Describe("istioconfig", func() {
 			})
 
 			DescribeTable("#component.IstioConfigInterface implementation",
-				func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, ignoreExposureClassLabels gomegatypes.GomegaMatcher) {
+				func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, matchWildcardLabels gomegatypes.GomegaMatcher) {
 					if zoneAnnotation != nil {
 						operation.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones] = *zoneAnnotation
 					}
@@ -177,7 +177,7 @@ var _ = Describe("istioconfig", func() {
 					Expect(operation.IstioServiceName()).To(matcherService)
 					Expect(operation.IstioNamespace()).To(matcherNamespace)
 					Expect(operation.IstioLabels()).To(matchLabels)
-					Expect(operation.IstioLabelsIgnoreExposureClass()).To(ignoreExposureClassLabels)
+					Expect(operation.WildcardIstioLabels()).To(matchWildcardLabels)
 				},
 
 				Entry("pinned control plane (single zone) without exposure class", &zoneName, false,

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -100,7 +100,7 @@ var _ = Describe("istioconfig", func() {
 		})
 
 		DescribeTable("#component.IstioConfigInterface implementation",
-			func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels gomegatypes.GomegaMatcher) {
+			func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, ignoreExposureClassLabels gomegatypes.GomegaMatcher) {
 				if zoneAnnotation != nil {
 					operation.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones] = *zoneAnnotation
 				}
@@ -114,37 +114,44 @@ var _ = Describe("istioconfig", func() {
 				Expect(operation.IstioServiceName()).To(matcherService)
 				Expect(operation.IstioNamespace()).To(matcherNamespace)
 				Expect(operation.IstioLabels()).To(matchLabels)
+				Expect(operation.IstioLabelsIgnoreExposureClass()).To(ignoreExposureClassLabels)
 			},
 
 			Entry("non-pinned control plane without exposure class", nil, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName),
 				Equal(defaultLabels),
+				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (single zone) without exposure class", &zoneName, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName+"--"+zoneName),
 				Equal(utils.MergeStringMaps(defaultLabels, map[string]string{"istio": defaultLabels["istio"] + "--zone--" + zoneName})),
+				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (multi zone) without exposure class", &multiZone, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName),
+				Equal(defaultLabels),
 				Equal(defaultLabels),
 			),
 			Entry("non-pinned control plane with exposure class", nil, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
 				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
+				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName+"--"+zoneName),
 				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName})),
+				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (multi zone) with exposure class", &multiZone, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
 				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
+				Equal(defaultLabels),
 			),
 		)
 
@@ -156,7 +163,7 @@ var _ = Describe("istioconfig", func() {
 			})
 
 			DescribeTable("#component.IstioConfigInterface implementation",
-				func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels gomegatypes.GomegaMatcher) {
+				func(zoneAnnotation *string, useExposureClass bool, matcherService, matcherNamespace, matchLabels, ignoreExposureClassLabels gomegatypes.GomegaMatcher) {
 					if zoneAnnotation != nil {
 						operation.SeedNamespaceObject.Annotations[resourcesv1alpha1.HighAvailabilityConfigZones] = *zoneAnnotation
 					}
@@ -170,17 +177,20 @@ var _ = Describe("istioconfig", func() {
 					Expect(operation.IstioServiceName()).To(matcherService)
 					Expect(operation.IstioNamespace()).To(matcherNamespace)
 					Expect(operation.IstioLabels()).To(matchLabels)
+					Expect(operation.IstioLabelsIgnoreExposureClass()).To(ignoreExposureClassLabels)
 				},
 
 				Entry("pinned control plane (single zone) without exposure class", &zoneName, false,
 					Equal(defaultServiceName),
 					Equal(defaultNamespaceName),
 					Equal(utils.MergeStringMaps(defaultLabels, map[string]string{"istio": defaultLabels["istio"]})),
+					Equal(defaultLabels),
 				),
 				Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 					Equal(exposureClassServiceName),
 					Equal(exposureClassNamespaceName),
 					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler"})),
+					Equal(defaultLabels),
 				),
 			)
 		})


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

The selector for the gateway `kube-apiserver-wildcard` was pointing to the non-zonal, exposure class ingress gateway. However, the dns entry is pointing to the istio-ingress namespace.
As a result, it was not possible to open a terminal via the dashboard, when the shoot uses an exposure class.

This PR changes the selector, so that the Istio config is applied to the correct istio-ingressgateway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes an issue where connecting to the kube-apiserver via the seed ingress URL did not work when the shoot used an exposure class.
```
