### PR TITLE
Restore `worker-pools-operatingsystemconfig-hashes` secret during restore phase of control plane migration 

### DIFF
--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -42,7 +42,7 @@ func (b *Botanist) InitializeSecretsManagement(ctx context.Context) error {
 	// explicitly only done in case of restoration to prevent split-brain situations as described in
 	// https://github.com/gardener/gardener/issues/5377.
 	if b.IsRestorePhase() {
-		if err := b.restoreSecretsFromShootStateForSecretsManagerAdoption(ctx); err != nil {
+		if err := b.restoreSecretsFromShootState(ctx); err != nil {
 			return err
 		}
 	}
@@ -101,14 +101,13 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 	return rotation
 }
 
-func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx context.Context) error {
+func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 	var fns []flow.TaskFn
 
 	for _, v := range b.Shoot.GetShootState().Spec.Gardener {
 		entry := v
 
-		if entry.Labels[secretsmanager.LabelKeyManagedBy] != secretsmanager.LabelValueSecretsManager ||
-			entry.Type != v1beta1constants.DataTypeSecret {
+		if entry.Type != v1beta1constants.DataTypeSecret {
 			continue
 		}
 

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -456,6 +456,11 @@ var _ = Describe("Secrets", func() {
 								Data:   runtime.RawExtension{Raw: rawData("extension-foo-secret")},
 							},
 							{
+								Name: "secret-without-labels",
+								Type: "secret",
+								Data: runtime.RawExtension{Raw: rawData("secret-without-labels")},
+							},
+							{
 								Name: "some-other-data",
 								Type: "not-a-secret",
 							},
@@ -488,6 +493,11 @@ var _ = Describe("Secrets", func() {
 				By("Verify external secrets got restored")
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "extension-foo-secret"}, secret)).To(Succeed())
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": "extension-foo"}))
+				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
+
+				By("Verify secret without labels got restored")
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "secret-without-labels"}, secret)).To(Succeed())
+				Expect(secret.Labels).To(BeEmpty())
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify unrelated data not to be restored")

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -456,10 +456,6 @@ var _ = Describe("Secrets", func() {
 								Data:   runtime.RawExtension{Raw: rawData("extension-foo-secret")},
 							},
 							{
-								Name: "secret-without-labels",
-								Type: "secret",
-							},
-							{
 								Name: "some-other-data",
 								Type: "not-a-secret",
 							},
@@ -495,7 +491,6 @@ var _ = Describe("Secrets", func() {
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify unrelated data not to be restored")
-				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "secret-without-labels"}, &corev1.Secret{})).To(BeNotFoundError())
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "some-other-data"}, &corev1.Secret{})).To(BeNotFoundError())
 			})
 		})

--- a/test/e2e/gardener/shoot/create_migrate_delete.go
+++ b/test/e2e/gardener/shoot/create_migrate_delete.go
@@ -50,6 +50,15 @@ var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func(
 			seedClientSourceCluster = s.SeedClient
 		})
 
+		if !v1beta1helper.IsWorkerless(s.Shoot) {
+			// The operating system config pool hashes secret is only deployed for shoots with workers.
+			It("Mark the operating system config pool hashes secret to verify that it will be correctly migrated", func(ctx SpecContext) {
+				Eventually(ctx, func() error {
+					return shootmigration.MarkOSCSecret(ctx, s.SeedClientSet.Client(), s.Shoot.Status.TechnicalID)
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+		}
+
 		It("Populate comparison elements before migration", func(ctx SpecContext) {
 			Eventually(ctx, func() error {
 				var err error

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -44,7 +44,7 @@ type ShootMigrationTest struct {
 	MigrationTime                     metav1.Time
 }
 
-// ShootMigrationConfig is the configuration for a shoot migration test that will be filled with user provided data
+// ShootMigrationConfig is the configuration for a shoot migration test that will be filled with user provided data.
 type ShootMigrationConfig struct {
 	TargetSeedName  string
 	SourceSeedName  string
@@ -53,7 +53,7 @@ type ShootMigrationConfig struct {
 	AddTestRunTaint string
 }
 
-// ShootComparisonElements contains details about Machines and Nodes that will be compared during the tests
+// ShootComparisonElements contains details about Machines and Nodes that will be compared during the tests.
 type ShootComparisonElements struct {
 	MachineNames []string
 	MachineNodes []string
@@ -61,7 +61,7 @@ type ShootComparisonElements struct {
 	SecretsMap   map[string]corev1.Secret
 }
 
-// NewShootMigrationTest creates a new simple shoot migration test
+// NewShootMigrationTest creates a new simple shoot migration test.
 func NewShootMigrationTest(ctx context.Context, f *GardenerFramework, cfg *ShootMigrationConfig) (*ShootMigrationTest, error) {
 	t := &ShootMigrationTest{
 		GardenerFramework: f,
@@ -113,7 +113,7 @@ func (t *ShootMigrationTest) initSeedsAndClients(ctx context.Context) error {
 	return nil
 }
 
-// MigrateShoot triggers shoot migration by changing the value of "shoot.Spec.SeedName" to the value of "ShootMigrationConfig.TargetSeedName"
+// MigrateShoot triggers shoot migration by changing the value of "shoot.Spec.SeedName" to the value of "ShootMigrationConfig.TargetSeedName".
 func (t *ShootMigrationTest) MigrateShoot(ctx context.Context) error {
 	// Dump gardener state if delete shoot is in exit handler
 	if os.Getenv("TM_PHASE") == "Exit" {
@@ -152,7 +152,7 @@ func appendToleration(tolerations []gardencorev1beta1.Toleration, key string, va
 	return append(tolerations, toleration)
 }
 
-// VerifyMigration checks that the shoot components are migrated properly
+// VerifyMigration checks that the shoot components are migrated properly.
 func (t ShootMigrationTest) VerifyMigration(ctx context.Context) error {
 	if err := t.populateAfterMigrationComparisonElements(ctx); err != nil {
 		return err
@@ -167,7 +167,7 @@ func (t ShootMigrationTest) VerifyMigration(ctx context.Context) error {
 	return shootmigration.CheckForOrphanedNonNamespacedResources(ctx, t.SeedShootNamespace, t.SourceSeedClient.Client())
 }
 
-// GetNodeNames uses the shootClient to fetch all Node names from the Shoot
+// GetNodeNames uses the shootClient to fetch all Node names from the Shoot.
 func (t *ShootMigrationTest) GetNodeNames(ctx context.Context, shootClient kubernetes.Interface) (nodeNames []string, err error) {
 	if t.Shoot.Status.IsHibernated {
 		return make([]string, 0), nil // Initialize to empty slice in order pass 0 elements DeepEqual check
@@ -188,7 +188,7 @@ func (t *ShootMigrationTest) GetNodeNames(ctx context.Context, shootClient kuber
 	return
 }
 
-// GetMachineDetails uses the seedClient to fetch all Machine names and the names of their corresponding Nodes
+// GetMachineDetails uses the seedClient to fetch all Machine names and the names of their corresponding Nodes.
 func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient kubernetes.Interface) (machineNames, machineNodes []string, err error) {
 	log := t.GardenerFramework.Logger.WithValues("namespace", t.SeedShootNamespace)
 
@@ -216,12 +216,12 @@ func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient k
 }
 
 // GetPersistedSecrets uses the seedClient to fetch the data of all Secrets that have the `persist` label key set to true
-// from the Shoot's control plane namespace
+// from the Shoot's control plane namespace.
 func (t *ShootMigrationTest) GetPersistedSecrets(ctx context.Context, seedClient kubernetes.Interface) (map[string]corev1.Secret, error) {
 	return shootmigration.GetPersistedSecrets(ctx, seedClient.Client(), t.SeedShootNamespace)
 }
 
-// PopulateBeforeMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsBeforeMigration with the necessary Machine details and Node names
+// PopulateBeforeMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsBeforeMigration with the necessary Machine details and Node names.
 func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx context.Context) (err error) {
 	t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsBeforeMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.SourceSeedClient)
 	if err != nil {
@@ -235,7 +235,7 @@ func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx conte
 	return
 }
 
-// PopulateAfterMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsAfterMigration with the necessary Machine details and Node names
+// PopulateAfterMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsAfterMigration with the necessary Machine details and Node names.
 func (t *ShootMigrationTest) populateAfterMigrationComparisonElements(ctx context.Context) (err error) {
 	t.ComparisonElementsAfterMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.TargetSeedClient)
 	if err != nil {
@@ -318,12 +318,12 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 	return nil
 }
 
-// MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated
+// MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated.
 func (t ShootMigrationTest) MarkOSCSecret(ctx context.Context) error {
 	return shootmigration.MarkOSCSecret(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace)
 }
 
-// CreateSecretAndServiceAccount creates test secret and service account
+// CreateSecretAndServiceAccount creates test secret and service account.
 func (t ShootMigrationTest) CreateSecretAndServiceAccount(ctx context.Context) error {
 	testSecret, testServiceAccount := constructTestSecretAndServiceAccount()
 	if err := t.ShootClient.Client().Create(ctx, testSecret); err != nil {
@@ -343,7 +343,7 @@ func (t ShootMigrationTest) CheckSecretAndServiceAccount(ctx context.Context) er
 	return t.ShootClient.Client().Get(ctx, client.ObjectKeyFromObject(testServiceAccount), testServiceAccount)
 }
 
-// CleanUpSecretAndServiceAccount cleans up the test secret and service account
+// CleanUpSecretAndServiceAccount cleans up the test secret and service account.
 func (t ShootMigrationTest) CleanUpSecretAndServiceAccount(ctx context.Context) error {
 	testSecret, testServiceAccount := constructTestSecretAndServiceAccount()
 

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -215,12 +215,6 @@ func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient k
 	return
 }
 
-// GetPersistedSecrets uses the seedClient to fetch the data of all Secrets that have the `persist` label key set to true
-// from the Shoot's control plane namespace.
-func (t *ShootMigrationTest) GetPersistedSecrets(ctx context.Context, seedClient kubernetes.Interface) (map[string]corev1.Secret, error) {
-	return shootmigration.GetPersistedSecrets(ctx, seedClient.Client(), t.SeedShootNamespace)
-}
-
 // PopulateBeforeMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsBeforeMigration with the necessary Machine details and Node names.
 func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx context.Context) (err error) {
 	t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsBeforeMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.SourceSeedClient)
@@ -231,7 +225,7 @@ func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx conte
 	if err != nil {
 		return
 	}
-	t.ComparisonElementsBeforeMigration.SecretsMap, err = t.GetPersistedSecrets(ctx, t.SourceSeedClient)
+	t.ComparisonElementsBeforeMigration.SecretsMap, err = shootmigration.GetPersistedSecrets(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace)
 	return
 }
 
@@ -245,7 +239,7 @@ func (t *ShootMigrationTest) populateAfterMigrationComparisonElements(ctx contex
 	if err != nil {
 		return
 	}
-	t.ComparisonElementsAfterMigration.SecretsMap, err = t.GetPersistedSecrets(ctx, t.TargetSeedClient)
+	t.ComparisonElementsAfterMigration.SecretsMap, err = shootmigration.GetPersistedSecrets(ctx, t.TargetSeedClient.Client(), t.SeedShootNamespace)
 	return
 }
 
@@ -316,11 +310,6 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 		}
 	}
 	return nil
-}
-
-// MarkOSCSecret marks the operating system config pool hashes secret to verify that it is correctly migrated.
-func (t ShootMigrationTest) MarkOSCSecret(ctx context.Context) error {
-	return shootmigration.MarkOSCSecret(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace)
 }
 
 // CreateSecretAndServiceAccount creates test secret and service account.

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -22,6 +22,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	. "github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/applications"
+	shootmigration "github.com/gardener/gardener/test/utils/shoots/migration"
 )
 
 const (
@@ -109,7 +110,7 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 	}
 
 	ginkgo.By("Mark osc hash secret")
-	if err := t.MarkOSCSecret(ctx); err != nil {
+	if err := shootmigration.MarkOSCSecret(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace); err != nil {
 		return err
 	}
 

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -127,7 +127,7 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 	guestBookApp.DeployGuestBookApp(ctx)
 	guestBookApp.Test(ctx)
 
-	return nil
+	return t.PopulateBeforeMigrationComparisonElements(ctx)
 }
 
 func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp applications.GuestBookTest) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that caused node rollouts during control plane migration when the `NewWorkerPoolHash` feature gate was enabled.
The issue occurred because the `worker-pools-operatingsystemconfig-hashes` secret was not getting restored from the `ShootState` during the restore phase of control plane migration.
More information can be found in the respective issue: #12957

As part of this PR, I have also enhanced the cpm e2e tests to check for restoration of the `worker-pools-operatingsystemconfig-hashes` secret.

**Which issue(s) this PR fixes**:
Fixes #12957

**Special notes for your reviewer**:
/invite @kon-angelo @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `worker-pools-operatingsystemconfig-hashes` secret is now restored in the `Shoot`'s control plane during the restore phase of control plane migration. This fixes an issue which caused node rollouts to happen during control plane migration when the `NewWorkerPoolHash` feature gate is enabled.
```
