### PR TITLE
[GEP-26] Handle properly backup WorkloadIdentity credentials in gardenletdeployer actuator

### DIFF
--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -445,7 +445,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	if spec.Backup == nil {
 		return nil
 	}
-	if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+	if spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() || spec.Backup.CredentialsRef.Kind != "Secret" {
 		return nil
 	}
 
@@ -546,7 +546,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 func (a *Actuator) deleteBackupSecret(ctx context.Context, spec *gardencorev1beta1.SeedSpec, obj client.Object) error {
 	// If backup is specified, delete the backup secret if it exists and is owned by the object
 	if spec.Backup != nil {
-		if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+		if spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() || spec.Backup.CredentialsRef.Kind != "Secret" {
 			return nil
 		}
 		backupSecret, err := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
@@ -570,7 +570,7 @@ func (a *Actuator) getBackupSecret(ctx context.Context, spec *gardencorev1beta1.
 	)
 
 	// If backup is specified, get the backup secret if it exists and is owned by the object
-	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == "v1" && spec.Backup.CredentialsRef.Kind == "Secret" {
+	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && spec.Backup.CredentialsRef.Kind == "Secret" {
 		backupSecret, err = kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return nil, err

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -445,10 +445,12 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	if spec.Backup == nil {
 		return nil
 	}
+	if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+		return nil
+	}
 
 	// If backup is specified and DoNotCopyBackupCredentials feature gate is disabled,
 	// create or update the backup secret if it doesn't exist or is owned by the object.
-	// TODO(vpnachev): Add support for WorkloadIdentity
 	var (
 		checksum     string
 		allowCopying = !utilfeature.DefaultFeatureGate.Enabled(features.DoNotCopyBackupCredentials)
@@ -544,6 +546,9 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 func (a *Actuator) deleteBackupSecret(ctx context.Context, spec *gardencorev1beta1.SeedSpec, obj client.Object) error {
 	// If backup is specified, delete the backup secret if it exists and is owned by the object
 	if spec.Backup != nil {
+		if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+			return nil
+		}
 		backupSecret, err := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return err
@@ -565,7 +570,7 @@ func (a *Actuator) getBackupSecret(ctx context.Context, spec *gardencorev1beta1.
 	)
 
 	// If backup is specified, get the backup secret if it exists and is owned by the object
-	if spec.Backup != nil {
+	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == "v1" && spec.Backup.CredentialsRef.Kind == "Secret" {
 		backupSecret, err = kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return nil, err

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -112,7 +112,10 @@ func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) ga
 			if seedTemplate.Spec.Backup == nil {
 				return nil, nil
 			}
-			// TODO(vpnachev): Add support for WorkloadIdentity
+			if seedTemplate.Spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() ||
+				seedTemplate.Spec.Backup.CredentialsRef.Kind != "Secret" {
+				return nil, nil
+			}
 			return kubernetesutils.GetSecretByObjectReference(ctx, r.VirtualClient, seedTemplate.Spec.Backup.CredentialsRef)
 		},
 		GetTargetDomain: func() string {


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind enhancement
/label ipcei/workload-identity

**What this PR does / why we need it**:
Handle properly backup WorkloadIdentity credentials in gardenletdeployer actuator

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `gardenletdeployer` unable to handle backup credentials of type `WorkloadIdentity` has been fixed. 
```
