### PR TITLE
Add missing json tags to extensionsv1alpha1.BastionList

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -81,10 +81,10 @@ type BastionStatus struct {
 
 // BastionList is a collection of Bastions.
 type BastionList struct {
-	metav1.TypeMeta
+	metav1.TypeMeta `json:",inline"`
 	// Standard list object metadata.
-	metav1.ListMeta
+	metav1.ListMeta `json:"metadata"`
 
 	// Items is the list of Bastions.
-	Items []Bastion
+	Items []Bastion `json:"items"`
 }

--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -83,7 +83,8 @@ type BastionStatus struct {
 type BastionList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list object metadata.
-	metav1.ListMeta `json:"metadata"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Bastions.
 	Items []Bastion `json:"items"`

--- a/pkg/apis/extensions/v1alpha1/types_cluster.go
+++ b/pkg/apis/extensions/v1alpha1/types_cluster.go
@@ -32,7 +32,8 @@ type Cluster struct {
 // ClusterList is a list of Cluster resources.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Cluster.
 	Items []Cluster `json:"items"`

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -50,7 +50,8 @@ func (i *ControlPlane) GetExtensionStatus() Status {
 // ControlPlaneList is a list of ControlPlane resources.
 type ControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of ControlPlanes.
 	Items []ControlPlane `json:"items"`

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -51,7 +51,8 @@ func (i *DNSRecord) GetExtensionStatus() Status {
 // DNSRecordList is a list of DNSRecord resources.
 type DNSRecordList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	// +optional
+	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of DNSRecords.
 	Items []DNSRecord `json:"items"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
@Bobi-Wan reported that listing extension Bastions via controller-runtime client does not work. This is due to missing json tags for the `extensionsv1alpha1.BastionList` type.

Reproducer: https://gist.github.com/ialidzhikov/4e33e39af9a233a2fff31b7df9bb917f

The output against a cluster with 1 extension Bastion is:
```
% go run main.go
Bastions count via BastionList = 0
Bastions count via PartialObjectMetadataList = 1
```

After replacing the `github.com/gardener/gardener` dependency for the example reproducer module from above with the content from this PR:
```
% go run main.go
Bastions count via BastionList = 1
Bastions count via PartialObjectMetadataList = 1
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue preventing `extensions.gardener.cloud/v1alpha1.Bastion`s to be listed due to missing json tags is now fixed.
```
