### PR TITLE
Use internal service for garden to aggregate Prometheus federation when the seed is the runtime cluster

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -251,3 +251,11 @@ rules:
   - watch
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -34,7 +34,7 @@ func AdditionalScrapeConfigs() []string {
 }
 
 // CentralScrapeConfigs returns the central ScrapeConfig resources for the garden prometheus.
-func CentralScrapeConfigs(prometheusAggregateIngressTargets []monitoringv1alpha1.Target, globalMonitoringSecret *corev1.Secret) []*monitoringv1alpha1.ScrapeConfig {
+func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target, prometheusAggregateIngressTargets []monitoringv1alpha1.Target, globalMonitoringSecret *corev1.Secret) []*monitoringv1alpha1.ScrapeConfig {
 	out := []*monitoringv1alpha1.ScrapeConfig{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus",
@@ -51,6 +51,11 @@ func CentralScrapeConfigs(prometheusAggregateIngressTargets []monitoringv1alpha1
 			MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig("prometheus_(.+)"),
 		},
 	}}
+
+	if len(prometheusAggregateTargets) > 0 {
+		name := "prometheus-" + aggregate.Label
+		out = append(out, newScrapeConfigForFederation(federationConfig{name: name, targets: prometheusAggregateTargets, isIngress: false}))
+	}
 
 	if len(prometheusAggregateIngressTargets) > 0 && globalMonitoringSecret != nil {
 		name := "prometheus-" + aggregate.Label + "-ingress"

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -34,7 +34,7 @@ func AdditionalScrapeConfigs() []string {
 }
 
 // CentralScrapeConfigs returns the central ScrapeConfig resources for the garden prometheus.
-func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target, globalMonitoringSecret *corev1.Secret) []*monitoringv1alpha1.ScrapeConfig {
+func CentralScrapeConfigs(prometheusAggregateIngressTargets []monitoringv1alpha1.Target, globalMonitoringSecret *corev1.Secret) []*monitoringv1alpha1.ScrapeConfig {
 	out := []*monitoringv1alpha1.ScrapeConfig{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prometheus",
@@ -52,9 +52,9 @@ func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target
 		},
 	}}
 
-	if len(prometheusAggregateTargets) > 0 && globalMonitoringSecret != nil {
-		name := "prometheus-" + aggregate.Label
-		out = append(out, newScrapeConfigForFederation(federationConfig{name: name, targets: prometheusAggregateTargets, isIngress: true, secret: globalMonitoringSecret}))
+	if len(prometheusAggregateIngressTargets) > 0 && globalMonitoringSecret != nil {
+		name := "prometheus-" + aggregate.Label + "-ingress"
+		out = append(out, newScrapeConfigForFederation(federationConfig{name: name, targets: prometheusAggregateIngressTargets, isIngress: true, secret: globalMonitoringSecret}))
 	}
 
 	return out

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -18,6 +18,12 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
+type federationConfig struct {
+	name    string
+	targets []monitoringv1alpha1.Target
+	secret  *corev1.Secret
+}
+
 //go:embed assets/scrapeconfigs/cadvisor.yaml
 var cAdvisor string
 
@@ -46,48 +52,55 @@ func CentralScrapeConfigs(prometheusAggregateTargets []monitoringv1alpha1.Target
 	}}
 
 	if len(prometheusAggregateTargets) > 0 && globalMonitoringSecret != nil {
-		out = append(out, &monitoringv1alpha1.ScrapeConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "prometheus-" + aggregate.Label},
-			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorLabels:     ptr.To(true),
-				HonorTimestamps: ptr.To(false),
-				MetricsPath:     ptr.To("/federate"),
-				Scheme:          ptr.To("HTTPS"),
-				Params: map[string][]string{
-					"match[]": {
-						`{__name__=~"seed:(.+):count"}`,
-						`{__name__=~"seed:(.+):sum"}`,
-						`{__name__=~"seed:(.+):sum_cp"}`,
-						`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
-						`{__name__=~"seed:(.+):sum_by_container",__name__!="seed:kube_pod_container_status_restarts_total:sum_by_container",container="kube-apiserver"}`,
-						`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
-						`{__name__="ALERTS"}`,
-						`{__name__="shoot:availability"}`,
-						`{__name__="prometheus_tsdb_lowest_timestamp"}`,
-						`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
-						`{__name__="seed:persistentvolume:inconsistent_size"}`,
-						`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
-						`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
-					},
-				},
-				TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
-				BasicAuth: &monitoringv1.BasicAuth{
-					Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: secretsutils.DataKeyUserName},
-					Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: secretsutils.DataKeyPassword},
-				},
-				StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateTargets}},
-				RelabelConfigs: []monitoringv1.RelabelConfig{{
-					Action:      "replace",
-					Replacement: ptr.To("prometheus-" + aggregate.Label),
-					TargetLabel: "job",
-				}},
-				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-					SourceLabels: []monitoringv1.LabelName{"alertname"},
-					TargetLabel:  "shoot_alertname",
-				}},
-			},
-		})
+		name := "prometheus-" + aggregate.Label
+		out = append(out, newScrapeConfigForFederation(federationConfig{name: name, targets: prometheusAggregateTargets, secret: globalMonitoringSecret}))
 	}
 
 	return out
+}
+
+func newScrapeConfigForFederation(federation federationConfig) *monitoringv1alpha1.ScrapeConfig {
+	config := &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: federation.name},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			HonorLabels:     ptr.To(true),
+			HonorTimestamps: ptr.To(false),
+			MetricsPath:     ptr.To("/federate"),
+			Scheme:          ptr.To("HTTPS"),
+			Params: map[string][]string{
+				"match[]": {
+					`{__name__=~"seed:(.+):count"}`,
+					`{__name__=~"seed:(.+):sum"}`,
+					`{__name__=~"seed:(.+):sum_cp"}`,
+					`{__name__=~"seed:(.+):sum_by_pod",namespace=~"extension-(.+)"}`,
+					`{__name__=~"seed:(.+):sum_by_container",__name__!="seed:kube_pod_container_status_restarts_total:sum_by_container",container="kube-apiserver"}`,
+					`{__name__=~"shoot:(.+):(.+)",__name__!="shoot:apiserver_storage_objects:sum_by_resource",__name__!="shoot:apiserver_watch_duration:quantile"}`,
+					`{__name__="ALERTS"}`,
+					`{__name__="shoot:availability"}`,
+					`{__name__="prometheus_tsdb_lowest_timestamp"}`,
+					`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
+					`{__name__="seed:persistentvolume:inconsistent_size"}`,
+					`{__name__="seed:kube_pod_container_status_restarts_total:max_by_namespace"}`,
+					`{__name__=~"metering:.+:(sum_by_namespace|sum_by_instance_type)"}`,
+				},
+			},
+			TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
+			BasicAuth: &monitoringv1.BasicAuth{
+				Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: federation.secret.Name}, Key: secretsutils.DataKeyUserName},
+				Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: federation.secret.Name}, Key: secretsutils.DataKeyPassword},
+			},
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: federation.targets}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{{
+				Action:      "replace",
+				Replacement: ptr.To("prometheus-" + aggregate.Label),
+				TargetLabel: "job",
+			}},
+			MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+				SourceLabels: []monitoringv1.LabelName{"alertname"},
+				TargetLabel:  "shoot_alertname",
+			}},
+		},
+	}
+
+	return config
 }

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -85,8 +85,8 @@ metric_relabel_configs:
 
 		When("global monitoring secret provided", func() {
 			var (
-				prometheusAggregateTargets = []monitoringv1alpha1.Target{"foo", "bar"}
-				globalMonitoringSecret     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "global-monitoring-secret"}}
+				prometheusAggregateIngressTargets = []monitoringv1alpha1.Target{"ingress-foo", "ingress-bar"}
+				globalMonitoringSecret            = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "global-monitoring-secret"}}
 			)
 
 			When("there are no aggregate targets", func() {
@@ -96,10 +96,10 @@ metric_relabel_configs:
 			})
 
 			It("should also contain the aggregate prometheus scrape config", func() {
-				Expect(garden.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecret)).To(HaveExactElements(
+				Expect(garden.CentralScrapeConfigs(prometheusAggregateIngressTargets, globalMonitoringSecret)).To(HaveExactElements(
 					scrapeConfigPrometheus,
 					&monitoringv1alpha1.ScrapeConfig{
-						ObjectMeta: metav1.ObjectMeta{Name: "prometheus-aggregate"},
+						ObjectMeta: metav1.ObjectMeta{Name: "prometheus-aggregate-ingress"},
 						Spec: monitoringv1alpha1.ScrapeConfigSpec{
 							HonorLabels:     ptr.To(true),
 							HonorTimestamps: ptr.To(false),
@@ -127,7 +127,7 @@ metric_relabel_configs:
 								Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "username"},
 								Password: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: globalMonitoringSecret.Name}, Key: "password"},
 							},
-							StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateTargets}},
+							StaticConfigs: []monitoringv1alpha1.StaticConfig{{Targets: prometheusAggregateIngressTargets}},
 							RelabelConfigs: []monitoringv1.RelabelConfig{{
 								Action:      "replace",
 								Replacement: ptr.To("prometheus-aggregate"),

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -176,8 +176,9 @@ honor_labels: true`
 					"name": name,
 				},
 				Annotations: map[string]string{
-					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9090}]`,
-					"networking.resources.gardener.cloud/namespace-selectors":                        `[{"matchLabels":{"gardener.cloud/role":"shoot"}}]`,
+					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9090}]`,
+					"networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports":   `[{"protocol":"TCP","port":9090}]`,
+					"networking.resources.gardener.cloud/namespace-selectors":                          `[{"matchLabels":{"gardener.cloud/role":"shoot"}}]`,
 				},
 			},
 			Spec: corev1.ServiceSpec{

--- a/pkg/component/observability/monitoring/prometheus/service.go
+++ b/pkg/component/observability/monitoring/prometheus/service.go
@@ -50,6 +50,10 @@ func (p *prometheus) service() *corev1.Service {
 		}}))
 
 	default:
+		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForGardenScrapeTargets(service, networkingv1.NetworkPolicyPort{
+			Port:     ptr.To(intstr.FromInt32(port)),
+			Protocol: ptr.To(corev1.ProtocolTCP),
+		}))
 		utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, networkingv1.NetworkPolicyPort{
 			Port:     ptr.To(intstr.FromInt32(port)),
 			Protocol: ptr.To(corev1.ProtocolTCP),

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1030,14 +1030,14 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 		return fmt.Errorf("failed listing secrets in virtual garden: %w", err)
 	}
 
-	var prometheusAggregateTargets []monitoringv1alpha1.Target
+	var prometheusAggregateIngressTargets []monitoringv1alpha1.Target
 	for _, seed := range seedList.Items {
 		if seed.Spec.Ingress != nil {
-			prometheusAggregateTargets = append(prometheusAggregateTargets, monitoringv1alpha1.Target(v1beta1constants.IngressDomainPrefixPrometheusAggregate+"."+seed.Spec.Ingress.Domain))
+			prometheusAggregateIngressTargets = append(prometheusAggregateIngressTargets, monitoringv1alpha1.Target(v1beta1constants.IngressDomainPrefixPrometheusAggregate+"."+seed.Spec.Ingress.Domain))
 		}
 	}
 
-	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(prometheusAggregateTargets, globalMonitoringSecretRuntime))
+	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(prometheusAggregateIngressTargets, globalMonitoringSecretRuntime))
 	return prometheus.Deploy(ctx)
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1037,7 +1037,7 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 		}
 	}
 
-	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(prometheusAggregateIngressTargets, globalMonitoringSecretRuntime))
+	prometheus.SetCentralScrapeConfigs(gardenprometheus.CentralScrapeConfigs(nil, prometheusAggregateIngressTargets, globalMonitoringSecretRuntime))
 	return prometheus.Deploy(ctx)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR enhances Prometheus federation from garden to aggregate Prometheus when the runtime cluster is also a seed cluster by using internal services instead of ingress endpoints.

In the local setup, ingress-based federation doesn't work because the garden Prometheus doesn't have access to the Istio ingress gateway pods. To enable ingress-based federation, we would need to label the garden Prometheus with:

```
networking.resources.gardener.cloud/to-all-istio-ingresses-istio-ingressgateway-tcp-9443: allowed
```

Furthermore, in productive scenarios,  ingress-based federation is routed via Internet because the ingress of the aggregate Prometheus is resolved to a public endpoint, which incurs network costs for Internet ingress and egress. This can be optimised by leveraging the internal service network path.

This PR solves the issue by implementing alternative routing logic that detects when both Prometheus instances are in the same cluster and uses the aggregate Prometheus internal service instead. This avoids the ingress access problem entirely in the local setup and optimises the productive scenario. Cross-cluster federation is still routed via the external ingress.

**Special notes for your reviewer**:

/cc @istvanballok @chrkl @rickardsjp 

**Release note**:

```other operator
Use aggregate Prometheus internal service for federation from the garden Prometheus when the runtime cluster is a seed
```
