### PR TITLE
Improve `RewriteEncryptedDataRemoveLabel` error messages

### DIFF
--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -127,6 +127,7 @@ func RewriteEncryptedDataRemoveLabel(
 	}); err != nil {
 		return fmt.Errorf("failed patching metadata of an API Server deployment: %w", err)
 	}
+	return nil
 }
 
 func rewriteEncryptedData(

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -104,7 +104,7 @@ func RewriteEncryptedDataRemoveLabel(
 ) error {
 	encryptedGVKs, message, err := GetResourcesForRewrite(targetClientSet.Kubernetes().Discovery(), resourcesToEncrypt, encryptedResources, defaultGVKs)
 	if err != nil {
-		return fmt.Errorf("failed getting a list of schema.GroupVersionKind for all the resources that needs to be rewritten: %w", err)
+		return fmt.Errorf("failed getting a list of schema.GroupVersionKind for all the resources that need to be rewritten: %w", err)
 	}
 
 	if err := rewriteEncryptedData(
@@ -121,14 +121,12 @@ func RewriteEncryptedDataRemoveLabel(
 		return fmt.Errorf("failed rewriting encrypted data: %w", err)
 	}
 
-	err = PatchAPIServerDeploymentMeta(ctx, runtimeClient, namespace, name, func(meta *metav1.PartialObjectMetadata) {
+	if err := PatchAPIServerDeploymentMeta(ctx, runtimeClient, namespace, name, func(meta *metav1.PartialObjectMetadata) {
 		delete(meta.Annotations, AnnotationKeyEtcdSnapshotted)
 		delete(meta.Annotations, AnnotationKeyResourcesLabeled)
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("failed patching metadata of an API Server deployment: %w", err)
 	}
-	return nil
 }
 
 func rewriteEncryptedData(

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -76,7 +76,7 @@ func RewriteEncryptedDataAddLabel(
 		message+" (Add label)",
 		encryptedGVKs...,
 	); err != nil {
-		return err
+		return fmt.Errorf("failed to rewrite encrypted data: %w", err)
 	}
 
 	// If we have hit this point then we have labeled all the resources successfully. Now we can mark this step as "completed"
@@ -172,7 +172,7 @@ func rewriteEncryptedData(
 				}
 
 				if err := c.Patch(ctx, &obj, patch); err != nil {
-					return fmt.Errorf("failed to patch object when rewriting encrypted data: %w", err)
+					return fmt.Errorf("failed to patch object: %w", err)
 				}
 
 				return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind flake

**What this PR does / why we need it**:
This PR improves error messages for `RewriteEncryptedDataRemoveLabel` as currently it is hard to know what function failed given the error message `client rate limiter Wait returned an error: context deadline exceeded`

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/13068

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
