### PR TITLE
Fix L7 load-balancing in multi-zone kube-apiserver deployments

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -50,7 +50,7 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
+			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,
 		},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -392,11 +392,13 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 		defaultUnreachableTolerationSeconds = nodeToleration.DefaultUnreachableTolerationSeconds
 	}
 
+	endpointSliceHintsEnabled := helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings) && versionutils.ConstraintK8sLess132.Check(r.RuntimeVersion)
+
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
 		DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 		DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
-		EndpointSliceHintsEnabled:                 helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
+		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,
 		LogLevel:                                  r.Config.LogLevel,
 		LogFormat:                                 r.Config.LogFormat,
 		ManagedResourceLabels:                     map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -613,7 +613,7 @@ func (r *Reconciler) newKubeAPIServerServiceWithSuffix(log logr.Logger, garden *
 		&kubeapiserverexposure.ServiceValues{
 			NamePrefix:                  namePrefix,
 			NameSuffix:                  suffix,
-			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings),
+			TopologyAwareRoutingEnabled: helper.TopologyAwareRoutingEnabled(garden.Spec.RuntimeCluster.Settings) && !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
 			RuntimeKubernetesVersion:    r.RuntimeVersion,
 		},
 		func() client.ObjectKey {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Currently, kube-apiserver L7 load-balancing is not working correctly for multi-zonal setups when topology aware routing is activated in the seed or garden.
Gardener usually runs only one kube-apiserver instance per zone, so respecting topology-aware-routing would deactivate L7 load-balancing in most multi-zone cases.

This PR deactivates topology-aware-routing for kube-apiservers if L7 load-balancing is activated as described [in the docs](https://github.com/gardener/gardener/blob/master/docs/operations/kube_apiserver_loadbalancing.md#kube-api-server-load-balancing).

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:
This bug did not occur in the local setup since endpointslice controller does not apply topology aware hints here.
The first node is labeled as `node-role.kubernetes.io/control-plane` which is not considered by the controller (see  [constraints](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#constraints)).
When the first node excluded, not every zone has a node, so endpointslice controller does not add hints.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented L7 load-balancing for kube-apiservers to work correctly on Seeds/Gardens where topology-aware-routing is activated.
```
