### PR TITLE
[release-v1.128] [GEP-26] Handle properly backup WorkloadIdentity credentials in gardenletdeployer actuator

### DIFF
--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -443,7 +443,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	if spec.Backup == nil {
 		return nil
 	}
-	if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+	if spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() || spec.Backup.CredentialsRef.Kind != "Secret" {
 		return nil
 	}
 
@@ -544,7 +544,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 func (a *Actuator) deleteBackupSecret(ctx context.Context, spec *gardencorev1beta1.SeedSpec, obj client.Object) error {
 	// If backup is specified, delete the backup secret if it exists and is owned by the object
 	if spec.Backup != nil {
-		if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+		if spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() || spec.Backup.CredentialsRef.Kind != "Secret" {
 			return nil
 		}
 		backupSecret, err := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
@@ -568,7 +568,7 @@ func (a *Actuator) getBackupSecret(ctx context.Context, spec *gardencorev1beta1.
 	)
 
 	// If backup is specified, get the backup secret if it exists and is owned by the object
-	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == "v1" && spec.Backup.CredentialsRef.Kind == "Secret" {
+	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && spec.Backup.CredentialsRef.Kind == "Secret" {
 		backupSecret, err = kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return nil, err

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -443,10 +443,12 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	if spec.Backup == nil {
 		return nil
 	}
+	if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+		return nil
+	}
 
 	// If backup is specified and DoNotCopyBackupCredentials feature gate is disabled,
 	// create or update the backup secret if it doesn't exist or is owned by the object.
-	// TODO(vpnachev): Add support for WorkloadIdentity
 	var (
 		checksum     string
 		allowCopying = !utilfeature.DefaultFeatureGate.Enabled(features.DoNotCopyBackupCredentials)
@@ -542,6 +544,9 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 func (a *Actuator) deleteBackupSecret(ctx context.Context, spec *gardencorev1beta1.SeedSpec, obj client.Object) error {
 	// If backup is specified, delete the backup secret if it exists and is owned by the object
 	if spec.Backup != nil {
+		if spec.Backup.CredentialsRef.APIVersion != "v1" || spec.Backup.CredentialsRef.Kind != "Secret" {
+			return nil
+		}
 		backupSecret, err := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return err
@@ -563,7 +568,7 @@ func (a *Actuator) getBackupSecret(ctx context.Context, spec *gardencorev1beta1.
 	)
 
 	// If backup is specified, get the backup secret if it exists and is owned by the object
-	if spec.Backup != nil {
+	if spec.Backup != nil && spec.Backup.CredentialsRef.APIVersion == "v1" && spec.Backup.CredentialsRef.Kind == "Secret" {
 		backupSecret, err = kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 		if client.IgnoreNotFound(err) != nil {
 			return nil, err

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Interface", func() {
 				shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), gomock.Any()).Return(nil)
 				expectGetSeed(false)
 				expectCheckSeedSpec()
-				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring gardenlet namespace in target cluster")
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring garden namespace in target cluster")
 				expectCreateGardenNamespace()
 				recorder.EXPECT().Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
 				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Deploying gardenlet into target cluster")

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -112,7 +112,10 @@ func (r *Reconciler) newActuator(gardenlet *seedmanagementv1alpha1.Gardenlet) ga
 			if seedTemplate.Spec.Backup == nil {
 				return nil, nil
 			}
-			// TODO(vpnachev): Add support for WorkloadIdentity
+			if seedTemplate.Spec.Backup.CredentialsRef.APIVersion != corev1.SchemeGroupVersion.String() ||
+				seedTemplate.Spec.Backup.CredentialsRef.Kind != "Secret" {
+				return nil, nil
+			}
 			return kubernetesutils.GetSecretByObjectReference(ctx, r.VirtualClient, seedTemplate.Spec.Backup.CredentialsRef)
 		},
 		GetTargetDomain: func() string {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/gardener/gardener/pull/13060

```bugfix operator
A bug in the `gardenletdeployer` unable to handle backup credentials of type `WorkloadIdentity` has been fixed. 
```
