### PR TITLE
Deflake gardenadm e2e test

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -2067,6 +2067,17 @@ func (r *resourceManager) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForDeployment)
 	defer cancel()
 
+	if r.values.ResponsibilityMode != ForTarget {
+		desiredCRD, err := r.emptyCustomResourceDefinition()
+		if err != nil {
+			return err
+		}
+
+		if err := kubernetesutils.WaitUntilCRDManifestsReady(ctx, r.client, desiredCRD.Name); err != nil {
+			return fmt.Errorf("failed waiting for CRD %q to be ready: %w", desiredCRD.Name, err)
+		}
+	}
+
 	return Until(timeoutCtx, IntervalWaitForDeployment, health.IsDeploymentUpdated(r.client, r.emptyDeployment()))
 }
 

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -3115,7 +3115,7 @@ subjects:
 
 				cfg.ResponsibilityMode = ForSource
 				configMap = configMapFor(nil, ForSource, false, false)
-				deployment = deploymentFor(configMap.Name, true, nil, false)
+				deployment = deploymentFor(configMap.Name, false, nil, false)
 				resourceManager = New(fakeClient, deployNamespace, nil, cfg)
 
 				deployment.Spec.Replicas = ptr.To[int32](0)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -161,28 +161,28 @@ func run(ctx context.Context, opts *Options) error {
 		deployNetworkPolicies = g.Add(flow.Task{
 			Name:         "Deploying network policies",
 			Fn:           b.ApplyNetworkPolicies,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployExtensionControllers),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployExtensionControllers),
 		})
 		deployShootNamespaces = g.Add(flow.Task{
 			Name:         "Deploying shoot namespaces system component",
 			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Deploy,
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
 		})
 		waitUntilShootNamespacesReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespaces have been reconciled",
 			Fn:           b.Shoot.Components.SystemComponents.Namespaces.Wait,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
+			Dependencies: flow.NewTaskIDs(deployShootNamespaces),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying kube-proxy system component",
 			Fn:           b.DeployKubeProxy,
 			SkipIf:       !kubeProxyEnabled,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady, waitUntilExtensionControllersReady),
+			Dependencies: flow.NewTaskIDs(waitUntilShootNamespacesReady, waitUntilExtensionControllersReady),
 		})
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
 			Fn:           b.DeployNetwork,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady, waitUntilExtensionControllersReady),
+			Dependencies: flow.NewTaskIDs(waitUntilShootNamespacesReady, waitUntilExtensionControllersReady),
 		})
 		waitUntilNetworkReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot network plugin has been reconciled",

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -217,9 +217,9 @@ func run(ctx context.Context, opts *Options) error {
 		})
 		deployExtensionControllersIntoPodNetwork = g.Add(flow.Task{
 			Name: "Redeploying extension controllers into pod network",
-			Fn: func(ctx context.Context) error {
+			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.ReconcileExtensionControllerInstallations(ctx, false)
-			},
+			}).RetryUntilTimeout(5*time.Second, 30*time.Second),
 			SkipIf:       podNetworkAvailable,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerInPodNetworkReady),
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind flake

**What this PR does / why we need it**:
This PR attempts to deflake two of the known flakes in gardenadm e2e test.

1. Wait for GRM to be ready before deploying ManagedResources. Although the CR is deployed in the `deployGardenerResourceManager` step, it's complaining it's not found. Not sure why, but I think it makes sense to wait for GRM to be ready anyway before deploying MRs.
Example flakes: 
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12622/pull-gardener-e2e-kind-gardenadm-release-v1-123/1950115668481282048
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12888/pull-gardener-e2e-kind-gardenadm/1963344919934275584
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12618/pull-gardener-e2e-kind-gardenadm/1950096754443554816
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13071/pull-gardener-e2e-kind-gardenadm/1973725682970136576

2. Retry extension controller deployment when it fails due to an outdated object.
Example flakes:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13048/pull-gardener-e2e-kind-gardenadm/1973117004957093888
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/12844/pull-gardener-e2e-kind-gardenadm/1973117371090472960


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12624

**Special notes for your reviewer**:
There are more flakes that need to be checked. Opening this just to make the situation a little bit better. Will keep looking into the other flakes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
