### PR TITLE
[provider-local] Replace `node` webhook with `MutatingAdmissionPolicy`

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -401,10 +401,6 @@ func (w *webhookTriggerer) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := w.trigger(ctx, w.client, nil, w.client.Status(), &corev1.NodeList{}); err != nil {
-		return err
-	}
-
 	return w.trigger(ctx, w.client, w.client, nil, &appsv1.DeploymentList{}, client.MatchingLabels{"app": "dependency-watchdog-prober"})
 }
 

--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -74,7 +74,6 @@ func WebhookSwitchOptions() *extensionscmdwebhook.SwitchOptions {
 		extensionscmdwebhook.Switch(istiowebhook.WebhookName, istiowebhook.AddToManager),
 		extensionscmdwebhook.Switch(networkpolicywebhook.WebhookName, networkpolicywebhook.AddToManager),
 		extensionscmdwebhook.Switch(nodewebhook.WebhookName, nodewebhook.AddToManager),
-		extensionscmdwebhook.Switch(nodewebhook.WebhookNameShoot, nodewebhook.AddShootWebhookToManager),
 		extensionscmdwebhook.Switch(prometheuswebhook.WebhookName, prometheuswebhook.AddToManager),
 	)
 }

--- a/dev-setup/kind/node-status-capacity/kustomization.yaml
+++ b/dev-setup/kind/node-status-capacity/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- mutatingadmissionpolicy.yaml

--- a/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
+++ b/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
@@ -39,4 +39,4 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["nodes/status"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["UPDATE"]

--- a/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
+++ b/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: node-status-capacity
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["UPDATE"]
+        resources: ["nodes/status"]
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: >
+        Object{
+          status: Object.status{
+            capacity: Object.status.capacity{
+              cpu: "100",
+              memory: "100Gi"
+            },
+            allocatable: Object.status.allocatable{
+              cpu: "100",
+              memory: "100Gi"
+            }
+          }
+        }
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: node-status-capacity
+spec:
+  policyName: node-status-capacity
+  matchResources:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["nodes/status"]
+        operations: ["CREATE", "UPDATE"]

--- a/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
+++ b/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
@@ -17,6 +17,8 @@
 {{- end }}
     extraArgs:
       authorization-config: /etc/gardener-local/kube-apiserver/authz-config.yaml
+      feature-gates: "MutatingAdmissionPolicy=true"
+      runtime-config: "admissionregistration.k8s.io/v1alpha1=true"
     extraVolumes:
     - name: authz-config
       mountPath: /etc/gardener-local/kube-apiserver/authz-config.yaml

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -525,6 +525,7 @@ if [[ "$DEPLOY_REGISTRY" == "true" ]]; then
 fi
 kubectl apply -k "$(dirname "$0")/../dev-setup/kind/calico/overlays/$IPFAMILY" --server-side
 kubectl apply -k "$(dirname "$0")/../dev-setup/kind/metrics-server"            --server-side
+kubectl apply -k "$(dirname "$0")/../dev-setup/kind/node-status-capacity"      --server-side
 
 setup_containerd_registry_mirrors $nodes
 setup_kind_with_lpp_resize_support

--- a/pkg/provider-local/webhook/node/add.go
+++ b/pkg/provider-local/webhook/node/add.go
@@ -19,8 +19,6 @@ import (
 const (
 	// WebhookName is the name of the node webhook.
 	WebhookName = "node"
-	// WebhookNameShoot is the name of the node webhook for shoot clusters.
-	WebhookNameShoot = "node-shoot"
 )
 
 var (
@@ -34,16 +32,7 @@ var (
 type AddOptions struct{}
 
 // AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
-func AddToManagerWithOptions(
-	mgr manager.Manager,
-	_ AddOptions,
-	name string,
-	target string,
-	failurePolicy admissionregistrationv1.FailurePolicyType,
-) (
-	*extensionswebhook.Webhook,
-	error,
-) {
+func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebhook.Webhook, error) {
 	logger.Info("Adding webhook to manager")
 
 	var (
@@ -58,38 +47,21 @@ func AddToManagerWithOptions(
 		return nil, err
 	}
 
-	logger.Info("Creating webhook", "name", name)
+	logger.Info("Creating webhook", "name", WebhookName)
 
 	return &extensionswebhook.Webhook{
-		Name:           name,
+		Name:           WebhookName,
 		Provider:       provider,
 		Types:          types,
-		Target:         target,
-		Path:           name,
+		Target:         extensionswebhook.TargetShoot,
+		Path:           WebhookName,
 		Webhook:        &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
-		FailurePolicy:  &failurePolicy,
+		FailurePolicy:  ptr.To(admissionregistrationv1.Ignore),
 		TimeoutSeconds: ptr.To[int32](5),
 	}, nil
 }
 
 // AddToManager creates a webhook with the default options and adds it to the manager.
 func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return AddToManagerWithOptions(
-		mgr,
-		DefaultAddOptions,
-		WebhookName,
-		extensionswebhook.TargetSeed,
-		admissionregistrationv1.Fail,
-	)
-}
-
-// AddShootWebhookToManager creates a shoot webhook with the default options and adds it to the manager.
-func AddShootWebhookToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return AddToManagerWithOptions(
-		mgr,
-		DefaultAddOptions,
-		WebhookNameShoot,
-		extensionswebhook.TargetShoot,
-		admissionregistrationv1.Ignore,
-	)
+	return AddToManagerWithOptions(mgr, DefaultAddOptions)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR, we are replacing the `node` webhook in the runtime/seed cluster with a `MutatingAdmissionPolicy`. We have seen issues (@LucaBernstein) where `calico-node` fails to come up after a Docker/machine reboot because the `node` webhook of `provider-local` is not reachable. However, `provider-local` itself cannot become ready because `calico-node` is not ready. This situation cannot resolve automatically.

For shoots, the `node` webhook is still active, but this deadlock situation cannot occur there since `provider-local` runs outside of the shoot cluster.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
