### PR TITLE
`gardener-operator`: Prevent deletion of `garden` namespace in runtime cluster while `Garden` resource still exists

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -678,6 +678,11 @@ In an `UPDATE` request, the configured `.spec.resources` are validated to ensure
 `DELETE` requests for `Extension` resources are denied if they are reported as required (also see [required-runtime](#required-runtime-reconciler) and [required-virtual](#required-virtual-reconciler)).
 These deletions often happen accidentally, and this handler safeguards the system from such actions.
 
+#### `Namespace`
+
+This webhook handler validates `DELETE` operations on the `core/v1.Namespace` resource with name `garden` (which is Gardener's system namespace).
+It prevents deleting it as long as a `operator.gardener.cloud/v1alpha1.Garden` resource (still) exists, i.e., it has to be deleted first before any attempt of deleting the namespace.
+
 ### Defaulting
 
 This webhook handler mutates `Garden` resources on `CREATE`/`UPDATE`/`DELETE` operations.

--- a/pkg/operator/webhook/validation/add.go
+++ b/pkg/operator/webhook/validation/add.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/operator/webhook/validation/extension"
 	"github.com/gardener/gardener/pkg/operator/webhook/validation/garden"
+	"github.com/gardener/gardener/pkg/operator/webhook/validation/namespace"
 )
 
 // AddToManager adds all webhook handlers to the given manager.
@@ -22,6 +23,10 @@ func AddToManager(mgr manager.Manager) error {
 	}
 
 	if err := (&extension.Handler{}).AddToManager(mgr); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %w", extension.HandlerName, err)
+	}
+
+	if err := (&namespace.Handler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", extension.HandlerName, err)
 	}
 

--- a/pkg/operator/webhook/validation/namespace/add.go
+++ b/pkg/operator/webhook/validation/namespace/add.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// HandlerName is the name of this admission webhook handler.
+	HandlerName = "namespace-deletion-validator"
+	// WebhookPath is the HTTP handler path for this admission webhook handler.
+	WebhookPath = "/webhooks/validate-core-v1-namespace"
+)
+
+// AddToManager adds Handler to the given manager.
+func (h *Handler) AddToManager(mgr manager.Manager) error {
+	if h.RuntimeClient == nil {
+		h.RuntimeClient = mgr.GetClient()
+	}
+
+	webhook := admission.
+		WithCustomValidator(mgr.GetScheme(), &corev1.Namespace{}, h).
+		WithRecoverPanic(true)
+
+	mgr.GetWebhookServer().Register(WebhookPath, webhook)
+	return nil
+}

--- a/pkg/operator/webhook/validation/namespace/handler.go
+++ b/pkg/operator/webhook/validation/namespace/handler.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// Handler performs validation.
+type Handler struct {
+	Logger        logr.Logger
+	RuntimeClient client.Client
+}
+
+// ValidateCreate performs the validation.
+func (h *Handler) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateUpdate performs the validation.
+func (h *Handler) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateDelete performs the validation.
+func (h *Handler) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	namespace, ok := obj.(*corev1.Namespace)
+	if !ok {
+		return nil, fmt.Errorf("expected *corev1.Namespace but got %T", obj)
+	}
+
+	gardenExists, err := kubernetesutils.ResourcesExist(ctx, h.RuntimeClient, &operatorv1alpha1.GardenList{}, h.RuntimeClient.Scheme())
+	if err != nil {
+		return nil, apierrors.NewInternalError(err)
+	}
+	if gardenExists {
+		h.Logger.Info("Preventing deletion attempt of namespace because a Garden resource exists", "namespace", namespace.Name)
+		return nil, apierrors.NewForbidden(corev1.Resource("namespaces"), namespace.Name, fmt.Errorf("deletion of namespace %q is forbidden while a Garden resource exists - delete it first before deleting the namespace", namespace.Name))
+	}
+
+	return nil, nil
+}

--- a/pkg/operator/webhook/validation/namespace/handler_test.go
+++ b/pkg/operator/webhook/validation/namespace/handler_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	. "github.com/gardener/gardener/pkg/operator/webhook/validation/namespace"
+)
+
+var _ = Describe("Handler", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+		handler    *Handler
+		namespace  *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
+		handler = &Handler{RuntimeClient: fakeClient}
+		namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		}
+	})
+
+	Describe("#ValidateCreate", func() {
+		It("should do nothing", func() {
+			warning, err := handler.ValidateCreate(ctx, namespace)
+			Expect(warning).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#ValidateUpdate", func() {
+		It("should do nothing", func() {
+			warning, err := handler.ValidateUpdate(ctx, namespace, namespace)
+			Expect(warning).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#ValidateDelete", func() {
+		It("should allow deletion because no Garden exists", func() {
+			warning, err := handler.ValidateDelete(ctx, namespace)
+			Expect(warning).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should prevent deletion because a Garden exists", func() {
+			Expect(fakeClient.Create(ctx, &operatorv1alpha1.Garden{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})).To(Succeed())
+
+			warning, err := handler.ValidateDelete(ctx, namespace)
+			Expect(warning).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("is forbidden while a Garden resource exists - delete it first before deleting the namespace")))
+		})
+	})
+})

--- a/pkg/operator/webhook/validation/namespace/namespace_suite_test.go
+++ b/pkg/operator/webhook/validation/namespace/namespace_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Webhook Validation Namespace Suite")
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -273,6 +273,7 @@ build:
             - pkg/operator/webhook/validation
             - pkg/operator/webhook/validation/extension
             - pkg/operator/webhook/validation/garden
+            - pkg/operator/webhook/validation/namespace
             - pkg/resourcemanager/apis/config/v1alpha1
             - pkg/resourcemanager/controller/garbagecollector/references
             - pkg/resourcemanager/webhook/crddeletionprotection


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
`gardener-operator` now prevents deletion of the `garden` namespace in the runtime cluster while `operator.gardener.cloud/v1alpha1.Garden` resources still exist. This way, accidental deletion is no longer possible (which might lead to dramatic effects due to recursive deletion of all resources in the namespace (e.g., `Secret`s)).

**Special notes for your reviewer**:
FYI @AndreasBurger @matthias-horne @RaphaelVogel @dkistner 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardener-operator` now prevents deletion of the `garden` namespace in the runtime cluster while `operator.gardener.cloud/v1alpha1.Garden` resources still exist.
```
