### PR TITLE
Update opentelemetry operator image to v0.136.0

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -173,7 +173,7 @@ images:
   - name: opentelemetry-operator
     sourceRepository: github.com/open-telemetry/opentelemetry-operator
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/opentelemetry-operator/opentelemetry-operator
-    tag: "v0.129.1"
+    tag: "v0.136.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -193,6 +193,11 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
 				APIGroups: []string{"opentelemetry.io"},
 				Resources: []string{"instrumentations", "opentelemetrycollectors"},
 				Verbs:     []string{"get", "list", "patch", "update", "watch"},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -138,6 +138,11 @@ var _ = Describe("OpenTelemetry Operator", func() {
 					Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 				},
 				{
+					APIGroups: []string{"networking.k8s.io"},
+					Resources: []string{"networkpolicies"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
 					APIGroups: []string{"opentelemetry.io"},
 					Resources: []string{"instrumentations", "opentelemetrycollectors"},
 					Verbs:     []string{"get", "list", "patch", "update", "watch"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This replaces https://github.com/gardener/gardener/pull/13084.

The operator needs new permissions to network policies. This PR updates the image and includes the necessary permissions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following dependencies have been updated:
- `open-telemetry/opentelemetry-operator` from `v0.129.1` to `v0.136.0`. [Release Notes](https://redirect.github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.136.0)
```
