### PR TITLE
`*Binding`: Only check read permissions for cross-namespace references

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -588,7 +588,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced secret", func() {
+			It("should reject because the user is not allowed to read the referenced secret (cross namespace)", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				coreSecretBindingCopy := coreSecretBinding.DeepCopy()
+				coreSecretBindingCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(coreSecretBindingCopy, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBindingCopy.Namespace, coreSecretBindingCopy.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow even though the user is not allowed to read the referenced secret (same namespace)", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -597,7 +612,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should reject because one of the referenced quotas does not exist", func() {
@@ -611,7 +626,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced quota", func() {
+			It("should reject because the user is not allowed to read the referenced quota (cross namespace)", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				coreSecretBindingCopy := coreSecretBinding.DeepCopy()
+				coreSecretBindingCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(coreSecretBindingCopy, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBindingCopy.Namespace, coreSecretBindingCopy.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow even though the user is not allowed to read the referenced quota (same namespace)", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -620,7 +650,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -778,7 +808,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced secret", func() {
+			It("should reject because the user is not allowed to read the referenced secret (cross-namespace)", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefSecretCopy := securityCredentialsBindingRefSecret.DeepCopy()
+				securityCredentialsBindingRefSecretCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefSecretCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecretCopy.Namespace, securityCredentialsBindingRefSecretCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow because the user is not allowed to read the referenced secret (same namespace)", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -787,7 +832,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should reject because one of the referenced quotas does not exist", func() {
@@ -801,7 +846,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced quota", func() {
+			It("should reject because the user is not allowed to read the referenced quota (cross-namespace)", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefSecretCopy := securityCredentialsBindingRefSecret.DeepCopy()
+				securityCredentialsBindingRefSecretCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefSecretCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecretCopy.Namespace, securityCredentialsBindingRefSecretCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow because the user is not allowed to read the referenced quota (same namespace)", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -810,7 +870,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -951,7 +1011,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced WorkloadIdentity", func() {
+			It("should reject because the user is not allowed to read the referenced WorkloadIdentity (cross-namespace)", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefWorkloadIdentityCopy := securityCredentialsBindingRefWorkloadIdentity.DeepCopy()
+				securityCredentialsBindingRefWorkloadIdentityCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefWorkloadIdentityCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentityCopy.Namespace, securityCredentialsBindingRefWorkloadIdentityCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow because the user is not allowed to read the referenced WorkloadIdentity (same namespace)", func() {
 				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -960,7 +1035,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should reject because one of the referenced quotas does not exist", func() {
@@ -974,7 +1049,22 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should reject because the user is not allowed to read the referenced quota", func() {
+			It("should reject because the user is not allowed to read the referenced quota (cross-namespace)", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefWorkloadIdentityCopy := securityCredentialsBindingRefWorkloadIdentity.DeepCopy()
+				securityCredentialsBindingRefWorkloadIdentityCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "disallowed-user"}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefWorkloadIdentityCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentityCopy.Namespace, securityCredentialsBindingRefWorkloadIdentityCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should reject because the user is not allowed to read the referenced quota (same namespace)", func() {
 				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
 				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
 
@@ -983,7 +1073,7 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This change adjusts the resource reference admission logic to only perform read permission checks for cross-namespace references (e.g., `Secret`, `WorkloadIdentity`, `Quota`).  
When a resource references another object in the **same** namespace, no explicit `get` permission check is done anymore - now consistent with Kubernetes behavior, where `Pod`s can mount `Secret`s without requiring the creator to have read permissions on them.  

This change simplifies workflows like those described in GEP-28, where `gardenadm connect` creates short-lived client certificates via the `CertificateSigningRequest` API to establish autonomous shoots. Without this adjustment, this client would need additional read permissions on `Secret`s, which is undesirable.

**Which issue(s) this PR fixes**:
Related of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
- Aligns permission model with native Kubernetes semantics.
- Avoids unnecessary RBAC requirements for short-lived or bootstrapping clients.
- Unit tests extended to cover same-namespace vs. cross-namespace scenarios.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
