### PR TITLE
Update etcd-doc regarding backup

### DIFF
--- a/docs/concepts/etcd.md
+++ b/docs/concepts/etcd.md
@@ -44,7 +44,7 @@ Furthermore, Gardener creates a [BackupEntry](../extensions/resources/backupentr
 How long backups are stored in the bucket after a shoot has been deleted depends on the configured _retention period_ in the `Seed` resource.
 Please see this [example configuration](https://github.com/gardener/gardener/blob/849cd857d0d20e5dde26b9740ca2814603a56dfd/example/20-componentconfig-gardenlet.yaml#L20) for more information.
 
-For `Garden`s specifying backups for etcd ([example](../../example/operator/20-garden.yaml)), the bucket must be pre-created externally and provided via the `Garden` specification.
+For `Garden`s specifying backups for etcd ([example](../../example/operator/20-garden.yaml)), an existing bucket can be provided via the `Garden` specification. If the bucket does not exist yet, it will be created by Gardener and the respective provider extension.
 
 Both etcd instances are configured to run with a special backup-restore _sidecar_.
 It takes care about regularly backing up etcd data and restoring it in case of data loss (in the main etcd only).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Bucket for backup of virtual garden does not necessarily be created manually

**Which issue(s) this PR fixes**:
No issue created

