### PR TITLE
Update dependency-watchdog to v1.6.0 with support for Endpointslices for weeder

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -82,7 +82,7 @@ images:
   - name: dependency-watchdog
     sourceRepository: github.com/gardener/dependency-watchdog
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog
-    tag: "v1.5.0"
+    tag: "v1.6.0"
   - name: nginx-ingress-controller
     sourceRepository: github.com/kubernetes/ingress-nginx
     repository: registry.k8s.io/ingress-nginx/controller-chroot

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
@@ -287,13 +287,13 @@ func (b *bootstrapper) getClusterRolePolicyRules() []rbacv1.PolicyRule {
 		return []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"endpoints"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			{
-				APIGroups: []string{""},
 				Resources: []string{"pods"},
 				Verbs:     []string{"get", "list", "watch", "delete"},
+			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 		}
 

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
@@ -76,20 +76,20 @@ rules:`
 - apiGroups:
   - ""
   resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - pods
   verbs:
   - get
   - list
   - watch
   - delete
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
 `
 					}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Updates dependency-watchdog to `v1.6.0` along with it the PR also updates the cluster role for the weeder component to work with `EndpointSlices`. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I've completely removed endpoint access for DWD as EndpointSlices became Generally Available (GA) in Kubernetes v1.19 and g/g is much ahead in support of k8s clusters. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other dependency
The following dependencies have been updated:
- `gardener/dependency-watchdog` from `v1.5.0` to `v1.6.0`. [Release Notes](https://redirect.github.com/gardener/dependency-watchdog/releases/tag/v1.6.0)
- `github.com/gardener/dependency-watchdog` from `v1.5.0` to `v1.6.0`. 
```
