### PR TITLE
Replace custom client certificate parsing function with `parsedSubjectPeerCertificate()` in istio TLS termination lua script

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -73,40 +73,37 @@ spec:
                         for key, value in pairs(remove) do
                           request_handle:headers():remove(value)
                         end
-        
+
                         local streamInfo = request_handle:streamInfo()
                         local ssl = streamInfo:downstreamSslConnection()
-        
-                        -- TODO(oliver-goetz) switch to ssl:parsedSubjectPeerCertificate() once it is available.
-                        local cn = ssl:subjectPeerCertificate()
-                        if cn ~= "" then
+
+                        -- Parse client certificate subject.
+                        local parsedSubject = ssl:parsedSubjectPeerCertificate()
+                        if parsedSubject then
                           -- Set the authenticated shoot as dynamic metadata.
                           streamInfo:dynamicMetadata():set("envoy.filters.http.lua", "{{ .APIServerAuthenticationDynamicMetadataKey }}", "{{ .ControlPlaneNamespace }}")
-        
-                          -- Add request headers for kube-apiserver authentication.
-                          local remoteUserHeaderAdded = false
-                          -- Iterate over all substrings in cn that are separated by commas.
-                          for pair in string.gmatch(cn, "([^,]+)") do
-                              -- For each substring extract key and value that are separated by '='.
-                              local key, value = pair:match("([^=]+)=([^=]+)")
-                              -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
-                              -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
-                              -- CN of the client certificate defines the username, O defines groups.
-                              -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
-                              if key == "CN" then
-                                request_handle:headers():add("{{ .APIServerRequestHeaderUserName }}", value)
-                                remoteUserHeaderAdded = true
-                              elseif key == "O" then
-                                request_handle:headers():add("{{ .APIServerRequestHeaderGroup }}", value)
-                              end
-                          end
-        
-                          -- Kill request if remote user header was not added.
-                          if not remoteUserHeaderAdded then
+
+                          local cn = parsedSubject:commonName()
+                          -- Kill request if CN is empty.
+                          if cn == "" then
                             request_handle:respond({[":status"] = "400"}, "Invalid certificate subject")
                           end
+
+                          -- Add request headers for kube-apiserver authentication.
+                          -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
+                          -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
+                          -- CN of the client certificate defines the username, O defines groups.
+                          -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
+                          request_handle:headers():add("{{ .APIServerRequestHeaderUserName }}", cn)
+
+                          local os = parsedSubject:organizationName()
+                          for _, o in ipairs(os) do
+                            if o ~= "" then
+                              request_handle:headers():add("{{ .APIServerRequestHeaderGroup }}", o)
+                            end
+                          end
                         end
-        
+
                         -- Route timeouts to upstream have to be disabled. Otherwise, watches would be terminated after 15 seconds.
                         -- See https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts
                         request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "0")

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/apiserver-tls-termination-envoyfilter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/apiserver-tls-termination-envoyfilter.yaml
@@ -39,34 +39,31 @@ spec:
                 local streamInfo = request_handle:streamInfo()
                 local ssl = streamInfo:downstreamSslConnection()
 
-                -- TODO(oliver-goetz) switch to ssl:parsedSubjectPeerCertificate() once it is available.
-                local cn = ssl:subjectPeerCertificate()
-                if cn ~= "" then
+                -- Parse client certificate subject.
+                local parsedSubject = ssl:parsedSubjectPeerCertificate()
+                if parsedSubject then
                   -- Get the host from the request and set it as dynamic metadata.
                   local host = streamInfo:requestedServerName()
                   streamInfo:dynamicMetadata():set("envoy.filters.http.lua", "{{ .Values.apiServerAuthenticationDynamicMetadataKey }}", host)
 
-                  -- Add request headers for kube-apiserver authentication.
-                  local remoteUserHeaderAdded = false
-                  -- Iterate over all substrings in cn that are separated by commas.
-                  for pair in string.gmatch(cn, "([^,]+)") do
-                      -- For each substring extract key and value that are separated by '='.
-                      local key, value = pair:match("([^=]+)=([^=]+)")
-                      -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
-                      -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
-                      -- CN of the client certificate defines the username, O defines groups.
-                      -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
-                      if key == "CN" then
-                        request_handle:headers():add("{{ .Values.apiServerRequestHeaderUserName }}", value)
-                        remoteUserHeaderAdded = true
-                      elseif key == "O" then
-                        request_handle:headers():add("{{ .Values.apiServerRequestHeaderGroup }}", value)
-                      end
+                  local cn = parsedSubject:commonName()
+                  -- Kill request if CN is empty.
+                  if cn == "" then
+                    request_handle:respond({[":status"] = "400"}, "Invalid certificate subject")
                   end
 
-                  -- Kill request if remote user header was not added.
-                  if not remoteUserHeaderAdded then
-                    request_handle:respond({[":status"] = "400"}, "Invalid certificate subject")
+                  -- Add request headers for kube-apiserver authentication.
+                  -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
+                  -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
+                  -- CN of the client certificate defines the username, O defines groups.
+                  -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
+                  request_handle:headers():add("{{ .Values.apiServerRequestHeaderUserName }}", cn)
+
+                  local os = parsedSubject:organizationName()
+                  for _, o in ipairs(os) do
+                    if o ~= "" then
+                      request_handle:headers():add("{{ .Values.apiServerRequestHeaderGroup }}", o)
+                    end
                   end
                 end
 

--- a/pkg/component/networking/istio/test_charts/apiserver_tls_termination.yaml
+++ b/pkg/component/networking/istio/test_charts/apiserver_tls_termination.yaml
@@ -40,34 +40,31 @@ spec:
                 local streamInfo = request_handle:streamInfo()
                 local ssl = streamInfo:downstreamSslConnection()
 
-                -- TODO(oliver-goetz) switch to ssl:parsedSubjectPeerCertificate() once it is available.
-                local cn = ssl:subjectPeerCertificate()
-                if cn ~= "" then
+                -- Parse client certificate subject.
+                local parsedSubject = ssl:parsedSubjectPeerCertificate()
+                if parsedSubject then
                   -- Get the host from the request and set it as dynamic metadata.
                   local host = streamInfo:requestedServerName()
                   streamInfo:dynamicMetadata():set("envoy.filters.http.lua", "authenticated-kube-apiserver-host", host)
 
-                  -- Add request headers for kube-apiserver authentication.
-                  local remoteUserHeaderAdded = false
-                  -- Iterate over all substrings in cn that are separated by commas.
-                  for pair in string.gmatch(cn, "([^,]+)") do
-                      -- For each substring extract key and value that are separated by '='.
-                      local key, value = pair:match("([^=]+)=([^=]+)")
-                      -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
-                      -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
-                      -- CN of the client certificate defines the username, O defines groups.
-                      -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
-                      if key == "CN" then
-                        request_handle:headers():add("X-Remote-User", value)
-                        remoteUserHeaderAdded = true
-                      elseif key == "O" then
-                        request_handle:headers():add("X-Remote-Group", value)
-                      end
+                  local cn = parsedSubject:commonName()
+                  -- Kill request if CN is empty.
+                  if cn == "" then
+                    request_handle:respond({[":status"] = "400"}, "Invalid certificate subject")
                   end
 
-                  -- Kill request if remote user header was not added.
-                  if not remoteUserHeaderAdded then
-                    request_handle:respond({[":status"] = "400"}, "Invalid certificate subject")
+                  -- Add request headers for kube-apiserver authentication.
+                  -- Istio is an authenticating proxy in this case, so we must set the defined headers accordingly.
+                  -- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#authenticating-proxy
+                  -- CN of the client certificate defines the username, O defines groups.
+                  -- see https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-for-user-accounts
+                  request_handle:headers():add("X-Remote-User", cn)
+
+                  local os = parsedSubject:organizationName()
+                  for _, o in ipairs(os) do
+                    if o ~= "" then
+                      request_handle:headers():add("X-Remote-Group", o)
+                    end
                   end
                 end
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane scalability 
/kind enhancement

**What this PR does / why we need it**:
Since [envoy v1.33.0](https://www.envoyproxy.io/docs/envoy/v1.33.0/version_history/v1.33/v1.33.0) / [Istio v1.25.0](https://istio.io/latest/docs/releases/supported-releases/#supported-envoy-versions) envoy offers [`parsedSubjectPeerCertificate()`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/lua_filter.html#parsedsubjectpeercertificate) function to parse client certificate.
This PR replaces our current custom parsing logic with this function.

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:
/cc @ScheererJ @DockToFuture 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The custom client certificate parsing in `IstioTLSTermination` lua scripts was replaced with `parsedSubjectPeerCertificate()` envoy function. 
```
