### PR TITLE
[GEP-28] Make `gardenadm connect` prepare Gardener resources and `gardenlet` wait for `Shoot` existence in Gardener API

### DIFF
--- a/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/medium-touch/kustomization.yaml
@@ -7,6 +7,9 @@ sortOptions:
 resources:
 - ../../base
 
+components:
+- ../../../../gardenconfig/components/credentials/secret-project-garden
+
 patches:
 - path: patch-shoot-medium-touch.yaml
 - target:

--- a/dev-setup/gardenconfig/overlays/gardenadm/kustomization.yaml
+++ b/dev-setup/gardenconfig/overlays/gardenadm/kustomization.yaml
@@ -8,4 +8,3 @@ components:
 - ../../components/cloudprofile
 - ../../components/projects/garden
 - ../../components/credentials/etcd-backup
-- ../../components/credentials/secret-project-garden

--- a/docs/cli-reference/gardenadm/gardenadm_connect.md
+++ b/docs/cli-reference/gardenadm/gardenadm_connect.md
@@ -23,6 +23,7 @@ gardenadm connect
       --bootstrap-token string       Bootstrap token for connecting the autonomous shoot cluster to a garden cluster (create it with 'gardenadm token' in the garden cluster)
       --ca-certificate bytesBase64   Base64-encoded certificate authority bundle of the Gardener control plane
   -d, --config-dir string            Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+      --force                        Forces the deployment of gardenlet, even if it already exists
   -h, --help                         help for connect
 ```
 

--- a/pkg/admissioncontroller/gardenletidentity/shoot/identity_test.go
+++ b/pkg/admissioncontroller/gardenletidentity/shoot/identity_test.go
@@ -33,6 +33,7 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", &user.DefaultInfo{Name: "gardener.cloud:system:shoot:foo:bar"}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix but shoot group not present", &user.DefaultInfo{Name: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"bar"}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix and shoot group", &user.DefaultInfo{Name: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenlet),
+		Entry("gardenadm usertype", &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenadm),
 		Entry("Extension ServiceAccount", &user.DefaultInfo{Name: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}}, "", "", false, gardenletidentity.UserTypeExtension),
 	)
 
@@ -50,6 +51,7 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", authenticationv1.UserInfo{Username: "gardener.cloud:system:shoot:foo:bar"}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix but shoot group not present", authenticationv1.UserInfo{Username: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"bar"}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix and shoot group", authenticationv1.UserInfo{Username: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenlet),
+		Entry("gardenadm usertype", authenticationv1.UserInfo{Username: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenadm),
 		Entry("Extension ServiceAccount", authenticationv1.UserInfo{Username: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}, Extra: map[string]authenticationv1.ExtraValue{}}, "", "", false, gardenletidentity.UserTypeExtension),
 	)
 
@@ -67,5 +69,6 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:shoot:foo:bar"}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix but shoot group not present", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:shoot:foo:bar", Organization: []string{"bar"}}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix and shoot group", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:shoot:foo:bar", Organization: []string{"gardener.cloud:system:shoots"}}}, "foo", "bar", true, gardenletidentity.UserTypeGardenlet),
+		Entry("gardenadm usertype", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:gardenadm:shoot:foo:bar", Organization: []string{"gardener.cloud:system:shoots"}}}, "foo", "bar", true, gardenletidentity.UserTypeGardenadm),
 	)
 })

--- a/pkg/admissioncontroller/gardenletidentity/usertypes.go
+++ b/pkg/admissioncontroller/gardenletidentity/usertypes.go
@@ -13,4 +13,6 @@ const (
 	UserTypeGardenlet UserType = "gardenlet"
 	// UserTypeExtension is the UserType of an extension client.
 	UserTypeExtension UserType = "extension"
+	// UserTypeGardenadm is the UserType of a gardenadm client.
+	UserTypeGardenadm UserType = "gardenadm"
 )

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -110,7 +110,7 @@ func (h *Handler) Handle(ctx context.Context, request admission.Request) admissi
 		)
 	}
 
-	return admissionwebhook.Allowed("")
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected resource: %q", requestResource))
 }
 
 func (h *Handler) admitBackupBucket(ctx context.Context, seedName string, request admission.Request) admission.Response {

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -113,14 +113,30 @@ var _ = Describe("handler", func() {
 			It("should have no opinion because no resource request", func() {
 				request.UserInfo = gardenletUser
 
-				Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+				Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:    int32(http.StatusBadRequest),
+							Message: `unexpected resource: ""`,
+						},
+					},
+				}))
 			})
 
 			It("should have no opinion because resource is irrelevant", func() {
 				request.UserInfo = gardenletUser
 				request.Resource = metav1.GroupVersionResource{}
 
-				Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+				Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:    int32(http.StatusBadRequest),
+							Message: `unexpected resource: ""`,
+						},
+					},
+				}))
 			})
 		})
 

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/gardenadm.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/gardenadm.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootrestriction
+
+import (
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+func (h *Handler) admitGardenadmRequests(gardenletShootInfo types.NamespacedName, request admission.Request) admission.Response {
+	requestResource := schema.GroupResource{Group: request.Resource.Group, Resource: request.Resource.Resource}
+	switch requestResource {
+	case projectResource:
+		if request.Operation != admissionv1.Create {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
+		}
+
+		project := &gardencorev1beta1.Project{}
+		if err := h.Decoder.Decode(request, project); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if gardenletShootInfo.Namespace == ptr.Deref(project.Spec.Namespace, "") {
+			return admission.Allowed("")
+		}
+
+		return admission.Errored(http.StatusForbidden, fmt.Errorf("object does not belong to shoot %s", gardenletShootInfo))
+
+	case shootResource:
+		if request.Operation != admissionv1.Create {
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
+		}
+
+		shoot := &gardencorev1beta1.Shoot{}
+		if err := h.Decoder.Decode(request, shoot); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if gardenletShootInfo.Namespace == shoot.Namespace && gardenletShootInfo.Name == shoot.Name {
+			return admission.Allowed("")
+		}
+
+		return admission.Errored(http.StatusForbidden, fmt.Errorf("object does not belong to shoot %s", gardenletShootInfo))
+	}
+
+	return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected resource: %q", requestResource))
+}

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -679,7 +679,7 @@ var _ = Describe("Shoot", func() {
 			})
 		})
 
-		Context("gardenlet client", func() {
+		Context("gardenadm client", func() {
 			Context("when requested for CloudProfiles", func() {
 				var attrs *auth.AttributesRecord
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth/shoot"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
@@ -49,6 +50,7 @@ var _ = Describe("Shoot", func() {
 		shootNamespace string
 		shootName      string
 		gardenletUser  user.Info
+		gardenadmUser  user.Info
 	)
 
 	BeforeEach(func() {
@@ -65,6 +67,10 @@ var _ = Describe("Shoot", func() {
 		shootName = "shoot-name"
 		gardenletUser = &user.DefaultInfo{
 			Name:   "gardener.cloud:system:shoot:" + shootNamespace + ":" + shootName,
+			Groups: []string{"gardener.cloud:system:shoots"},
+		}
+		gardenadmUser = &user.DefaultInfo{
+			Name:   "gardener.cloud:gardenadm:shoot:" + shootNamespace + ":" + shootName,
 			Groups: []string{"gardener.cloud:system:shoots"},
 		}
 	})
@@ -670,6 +676,294 @@ var _ = Describe("Shoot", func() {
 					Entry("delete", "delete"),
 					Entry("deletecollection", "deletecollection"),
 				)
+			})
+		})
+
+		Context("gardenlet client", func() {
+			Context("when requested for CloudProfiles", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "cloudprofiles",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'get'", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "list"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for ConfigMaps", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        corev1.SchemeGroupVersion.Group,
+						Resource:        "configmaps",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'create'", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because shoot info does match user info", func() {
+					attrs.Verb = "create"
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for CredentialsBindings", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        securityv1alpha1.SchemeGroupVersion.Group,
+						Resource:        "credentialsbindings",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'create'", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because shoot info does match user info", func() {
+					attrs.Verb = "create"
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for Projects", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "projects",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'create'", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "list"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for Secrets", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        corev1.SchemeGroupVersion.Group,
+						Resource:        "secrets",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'create'", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because shoot info does match user info", func() {
+					attrs.Verb = "create"
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for SecretBindings", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "secretbindings",
+						ResourceRequest: true,
+					}
+				})
+
+				It("should allow because verb is 'create'", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because shoot info does match user info", func() {
+					attrs.Verb = "create"
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+			})
+
+			Context("when requested for Shoots", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            shootName,
+						Namespace:       shootNamespace,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "shoots",
+						ResourceRequest: true,
+					}
+				})
+
+				DescribeTable("should allow because verb is allowed",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("create", "create"),
+					Entry("mark-autonomous", "mark-autonomous"),
+				)
+
+				It("should have no opinion because verb is not allowed", func() {
+					attrs.Verb = "get"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because shoot info does match user info", func() {
+					attrs.Verb = "create"
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(BeEmpty())
+				})
 			})
 		})
 	})

--- a/pkg/admissioncontroller/webhook/auth/shoot/gardenadm.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/gardenadm.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"slices"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	auth "k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func (a *authorizer) authorizeGardenadmRequests(requestLog logr.Logger, shootNamespace, _ string, attrs auth.Attributes) (auth.Decision, string, error) {
+	if attrs.IsResourceRequest() {
+		requestResource := schema.GroupResource{Group: attrs.GetAPIGroup(), Resource: attrs.GetResource()}
+		switch requestResource {
+		case cloudProfileResource, controllerDeploymentResource, controllerRegistrationResource:
+			if isGardenadmRequestAllowed(attrs, nil, "get") {
+				return auth.DecisionAllow, "", nil
+			}
+
+		case projectResource:
+			if isGardenadmRequestAllowed(attrs, nil, "create") {
+				return auth.DecisionAllow, "", nil
+			}
+
+		case configMapResource, secretResource, secretBindingResource, credentialsBindingResource:
+			if isGardenadmRequestAllowed(attrs, &shootNamespace, "create") {
+				return auth.DecisionAllow, "", nil
+			}
+
+		case shootResource:
+			if isGardenadmRequestAllowed(attrs, &shootNamespace, "create", "mark-autonomous") {
+				return auth.DecisionAllow, "", nil
+			}
+
+		default:
+			requestLog.Info(
+				"Unhandled resource request",
+				"group", attrs.GetAPIGroup(),
+				"version", attrs.GetAPIVersion(),
+				"resource", attrs.GetResource(),
+				"verb", attrs.GetVerb(),
+			)
+		}
+	}
+
+	return auth.DecisionNoOpinion, "", nil
+}
+
+func isGardenadmRequestAllowed(attrs auth.Attributes, shootNamespace *string, allowedVerbs ...string) bool {
+	if shootNamespace != nil && attrs.GetNamespace() != *shootNamespace {
+		return false
+	}
+	return slices.Contains(allowedVerbs, attrs.GetVerb())
+}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -819,6 +819,9 @@ const (
 	// ShootUserNamePrefix is the identity username prefix for gardenlets running in autonomous shoot clusters when
 	// authenticating to the API server.
 	ShootUserNamePrefix = "gardener.cloud:system:shoot:"
+	// GardenadmUserNamePrefix is the identity username prefix for `gardenadm connect` when it bootstraps the
+	// gardenlet.
+	GardenadmUserNamePrefix = "gardener.cloud:gardenadm:shoot:"
 
 	// ClusterRoleNameGardenerAdministrators is the name of a cluster role in the garden cluster defining privileges
 	// for administrators.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -260,6 +260,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	if len(spec.Region) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "must specify a region"))
 	}
+
 	if workerless {
 		if spec.SecretBindingName != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretBindingName"), workerlessErrorMsg))
@@ -267,7 +268,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 		if spec.CredentialsBindingName != nil {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsBindingName"), workerlessErrorMsg))
 		}
-	} else {
+	} else if !helper.IsShootAutonomous(spec.Provider.Workers) {
 		if len(ptr.Deref(spec.SecretBindingName, "")) == 0 && len(ptr.Deref(spec.CredentialsBindingName, "")) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("secretBindingName"), "must be set when credentialsBindingName is not"))
 		} else if len(ptr.Deref(spec.SecretBindingName, "")) != 0 && len(ptr.Deref(spec.CredentialsBindingName, "")) != 0 {
@@ -281,6 +282,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretBindingName"), "is no longer supported for Kubernetes >= 1.34, use spec.credentialsBindingName instead"))
 		}
 	}
+
 	if spec.SeedName != nil && len(*spec.SeedName) == 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), spec.SeedName, "seed name must not be empty when providing the key"))
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1833,6 +1833,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 						}))
 					})
 				})
+
+				It("should allow not referencing a SecretBinding and CredentialsBinding", func() {
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+					shoot.Spec.SecretBindingName = nil
+					shoot.Spec.CredentialsBindingName = nil
+
+					Expect(ValidateShoot(shoot)).To(BeEmpty())
+				})
 			})
 
 			Describe("ClusterAutoscaler options validation", func() {

--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -1305,9 +1305,18 @@ func validatingWebhookConfiguration(namespace string, caBundle []byte, testValue
 				Name:                    "shoot-restriction.gardener.cloud",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				TimeoutSeconds:          ptr.To[int32](10),
-				Rules:                   []admissionregistrationv1.RuleWithOperations{},
-				FailurePolicy:           &failurePolicyFail,
-				MatchPolicy:             &matchPolicyEquivalent,
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{"core.gardener.cloud"},
+							APIVersions: []string{"v1beta1"},
+							Resources:   []string{"projects", "shoots"},
+						},
+					},
+				},
+				FailurePolicy: &failurePolicyFail,
+				MatchPolicy:   &matchPolicyEquivalent,
 				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					URL:      ptr.To("https://gardener-admission-controller." + namespace + "/webhooks/admission/shootrestriction"),
 					CABundle: caBundle,

--- a/pkg/component/gardener/admissioncontroller/webhooks.go
+++ b/pkg/component/gardener/admissioncontroller/webhooks.go
@@ -375,8 +375,15 @@ func (a *gardenerAdmissionController) validatingWebhookConfiguration(caSecret *c
 				Name:                    "shoot-restriction.gardener.cloud",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				TimeoutSeconds:          ptr.To[int32](10),
-				Rules:                   []admissionregistrationv1.RuleWithOperations{
-					// TODO(rfranzke): We'll add some rules here as development of autonomous shoots progresses.
+				Rules: []admissionregistrationv1.RuleWithOperations{
+					{
+						Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{gardencorev1beta1.GroupName},
+							APIVersions: []string{gardencorev1beta1.SchemeGroupVersion.Version},
+							Resources:   []string{"projects", "shoots"},
+						},
+					},
 				},
 				FailurePolicy: &failurePolicyFail,
 				MatchPolicy:   &matchPolicyEquivalent,

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -893,7 +893,7 @@ func createBootstrapKubeconfig(
 
 	case seedmanagementv1alpha1.BootstrapToken:
 		if len(bootstrapToken) != 0 {
-			bootstrapKubeconfig, err = gardenletbootstraputil.CreateGardenletKubeconfigWithToken(gardenClientRestConfig, bootstrapToken)
+			bootstrapKubeconfig, err = gardenletbootstraputil.CreateKubeconfigWithToken(gardenClientRestConfig, bootstrapToken)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -56,6 +56,7 @@ type AutonomousBotanist struct {
 	DBus       dbus.DBus
 	FS         afero.Afero
 	Extensions []Extension
+	Resources  gardenadm.Resources
 
 	// Bastion is only set for `gardenadm bootstrap`.
 	Bastion *bastion.Bastion
@@ -161,6 +162,7 @@ func NewAutonomousBotanist(
 		}
 	}
 
+	autonomousBotanist.Resources = resources
 	autonomousBotanist.Extensions = extensions
 
 	return autonomousBotanist, nil

--- a/pkg/gardenadm/cmd/connect/options.go
+++ b/pkg/gardenadm/cmd/connect/options.go
@@ -25,6 +25,8 @@ type Options struct {
 	BootstrapToken string
 	// CertificateAuthority is the CA bundle of the control plane.
 	CertificateAuthority []byte
+	// Force forces the deployment of gardenlet, even if it already exists.
+	Force bool
 }
 
 // ParseArgs parses the arguments to the options.
@@ -63,4 +65,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.BytesBase64Var(&o.CertificateAuthority, "ca-certificate", nil, "Base64-encoded certificate authority bundle of the Gardener control plane")
 	fs.StringVar(&o.BootstrapToken, "bootstrap-token", "", "Bootstrap token for connecting the autonomous shoot cluster to a garden cluster (create it with 'gardenadm token' in the garden cluster)")
+	fs.BoolVar(&o.Force, "force", false, "Forces the deployment of gardenlet, even if it already exists")
 }

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -54,7 +54,7 @@ func GetKubeconfigFromSecret(ctx context.Context, seedClient client.Client, key 
 
 // UpdateGardenKubeconfigSecret updates the secret in the seed cluster that holds the kubeconfig of the Garden cluster.
 func UpdateGardenKubeconfigSecret(ctx context.Context, certClientConfig *rest.Config, certData, privateKeyData []byte, seedClient client.Client, kubeconfigKey client.ObjectKey) ([]byte, error) {
-	kubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, privateKeyData, certData)
+	kubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, privateKeyData, certData)
 	if err != nil {
 		return nil, err
 	}
@@ -138,16 +138,16 @@ func UpdateGardenKubeconfigCAIfChanged(ctx context.Context, log logr.Logger, gar
 	}, curAuth.ClientCertificateData, curAuth.ClientKeyData, seedClient, kubeconfigKey)
 }
 
-// CreateGardenletKubeconfigWithClientCertificate creates a kubeconfig for the Gardenlet with the given client certificate.
-func CreateGardenletKubeconfigWithClientCertificate(config *rest.Config, privateKeyData, certDat []byte) ([]byte, error) {
+// CreateKubeconfigWithClientCertificate creates a kubeconfig for the Gardenlet with the given client certificate.
+func CreateKubeconfigWithClientCertificate(config *rest.Config, privateKeyData, certDat []byte) ([]byte, error) {
 	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
 		ClientCertificateData: certDat,
 		ClientKeyData:         privateKeyData,
 	})
 }
 
-// CreateGardenletKubeconfigWithToken creates a kubeconfig for the Gardenlet with the given bootstrap token.
-func CreateGardenletKubeconfigWithToken(config *rest.Config, token string) ([]byte, error) {
+// CreateKubeconfigWithToken creates a kubeconfig for the Gardenlet with the given bootstrap token.
+func CreateKubeconfigWithToken(config *rest.Config, token string) ([]byte, error) {
 	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
 		Token: token,
 	})
@@ -210,7 +210,7 @@ func ComputeGardenletKubeconfigWithBootstrapToken(ctx context.Context, gardenCli
 		}
 	}
 
-	return CreateGardenletKubeconfigWithToken(gardenClientRestConfig, bootstraptoken.FromSecretData(bootstrapTokenSecret.Data))
+	return CreateKubeconfigWithToken(gardenClientRestConfig, bootstraptoken.FromSecretData(bootstrapTokenSecret.Data))
 }
 
 // ComputeGardenletKubeconfigWithServiceAccountToken creates a kubeconfig containing the token of a service account
@@ -263,7 +263,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 	}
 
 	// Get bootstrap kubeconfig from service account secret
-	return CreateGardenletKubeconfigWithToken(gardenClientRestConfig, tokenRequest.Status.Token)
+	return CreateKubeconfigWithToken(gardenClientRestConfig, tokenRequest.Status.Token)
 }
 
 // ClusterRoleBindingName concatenates the gardener seed bootstrapper group with the given name, separated by a colon.

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Util", func() {
 					Get(ctx, secretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).
 					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "Secret"}, secretKey.Name))
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedSecret.Data = map[string][]byte{kubernetes.KubeConfig: expectedKubeconfig}
@@ -145,7 +145,7 @@ var _ = Describe("Util", func() {
 						return nil
 					})
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				expectedCopy := expectedSecret.DeepCopy()
@@ -193,14 +193,14 @@ var _ = Describe("Util", func() {
 			It("should update the secret if the CA has changed", func() {
 				gardenClientConnection.GardenClusterCACert = []byte("bar")
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedCertClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
 					Insecure: false,
 					CAData:   gardenClientConnection.GardenClusterCACert,
 				}}
-				expectedUpdatedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
+				expectedUpdatedKubeconfig, err := CreateKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedSecret := expectedSecret.DeepCopy()
@@ -224,7 +224,7 @@ var _ = Describe("Util", func() {
 			It("should not update the secret if the CA didn't change", func() {
 				gardenClientConnection.GardenClusterCACert = certClientConfig.CAData
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedKubeconfig, err := UpdateGardenKubeconfigCAIfChanged(ctx, log, nil, c, expectedKubeconfig, gardenClientConnection)
@@ -235,14 +235,14 @@ var _ = Describe("Util", func() {
 			It("should update the secret if the CA has been removed (via 'none')", func() {
 				gardenClientConnection.GardenClusterCACert = []byte("none")
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedCertClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
 					Insecure: true,
 					CAData:   []byte{},
 				}}
-				expectedUpdatedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
+				expectedUpdatedKubeconfig, err := CreateKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedSecret := expectedSecret.DeepCopy()
@@ -266,14 +266,14 @@ var _ = Describe("Util", func() {
 			It("should update the secret if the CA has been removed (via 'null')", func() {
 				gardenClientConnection.GardenClusterCACert = []byte("null")
 
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedCertClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
 					Insecure: true,
 					CAData:   []byte{},
 				}}
-				expectedUpdatedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
+				expectedUpdatedKubeconfig, err := CreateKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedSecret := expectedSecret.DeepCopy()
@@ -295,7 +295,7 @@ var _ = Describe("Util", func() {
 			})
 
 			It("should update the secret from garden cluster", func() {
-				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				expectedKubeconfig, err := CreateKubeconfigWithClientCertificate(certClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				caConfigMap := &corev1.ConfigMap{
@@ -312,7 +312,7 @@ var _ = Describe("Util", func() {
 					Insecure: false,
 					CAData:   []byte(caConfigMap.Data["ca.crt"]),
 				}}
-				expectedUpdatedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
+				expectedUpdatedKubeconfig, err := CreateKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
 				updatedSecret := expectedSecret.DeepCopy()

--- a/pkg/gardenlet/bootstrappers/garden_kubeconfig_test.go
+++ b/pkg/gardenlet/bootstrappers/garden_kubeconfig_test.go
@@ -116,7 +116,7 @@ var _ = Describe("GardenKubeconfig", func() {
 					runner.Config.GardenClientConnection.GardenClusterCACert = restConfig.CAData
 
 					var err error
-					existingKubeconfig, err = gardenletbootstraputil.CreateGardenletKubeconfigWithClientCertificate(restConfig, nil, nil)
+					existingKubeconfig, err = gardenletbootstraputil.CreateKubeconfigWithClientCertificate(restConfig, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
 					secret := &corev1.Secret{
@@ -139,7 +139,7 @@ var _ = Describe("GardenKubeconfig", func() {
 					runner.Config.GardenClientConnection.GardenClusterCACert = newCABundle
 
 					restConfig.CAData = newCABundle
-					updatedKubeconfig, err := gardenletbootstraputil.CreateGardenletKubeconfigWithClientCertificate(restConfig, nil, nil)
+					updatedKubeconfig, err := gardenletbootstraputil.CreateKubeconfigWithClientCertificate(restConfig, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(runner.Start(ctx)).To(Succeed())
@@ -203,7 +203,7 @@ var _ = Describe("GardenKubeconfig", func() {
 					It("should request a kubeconfig with the bootstrap kubeconfig", func() {
 						var csrName = "created-csr"
 
-						requestedKubeconfig, err := gardenletbootstraputil.CreateGardenletKubeconfigWithClientCertificate(restConfig, nil, nil)
+						requestedKubeconfig, err := gardenletbootstraputil.CreateKubeconfigWithClientCertificate(restConfig, nil, nil)
 						Expect(err).ToNot(HaveOccurred())
 
 						secret := &corev1.Secret{

--- a/pkg/utils/graph/eventhandler_shoot.go
+++ b/pkg/utils/graph/eventhandler_shoot.go
@@ -106,7 +106,9 @@ func (g *graph) HandleShootCreateOrUpdate(ctx context.Context, shoot *gardencore
 	g.deleteAllIncomingEdges(VertexTypeSecretBinding, VertexTypeShoot, shoot.Namespace, shoot.Name)
 	g.deleteAllIncomingEdges(VertexTypeCredentialsBinding, VertexTypeShoot, shoot.Namespace, shoot.Name)
 	g.deleteAllIncomingEdges(VertexTypeShootState, VertexTypeShoot, shoot.Namespace, shoot.Name)
-	g.deleteAllOutgoingEdges(VertexTypeShoot, shoot.Namespace, shoot.Name, VertexTypeSeed)
+	if !g.forAutonomousShoots {
+		g.deleteAllOutgoingEdges(VertexTypeShoot, shoot.Namespace, shoot.Name, VertexTypeSeed)
+	}
 
 	var (
 		shootVertex     = g.getOrCreateVertex(VertexTypeShoot, shoot.Namespace, shoot.Name)

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -73,6 +73,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 		setups = append(setups,
 			resourceSetup{&certificatesv1.CertificateSigningRequest{}, g.setupCertificateSigningRequestWatch},
 			resourceSetup{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
+			resourceSetup{&gardencorev1beta1.Shoot{}, g.setupShootWatch},
 		)
 	} else {
 		setups = append(setups,

--- a/test/integration/controllermanager/certificatesigningrequest/certificatesigningrequest_test.go
+++ b/test/integration/controllermanager/certificatesigningrequest/certificatesigningrequest_test.go
@@ -151,4 +151,53 @@ var _ = Describe("CSR autoapprove controller tests", func() {
 			}).Should(Succeed())
 		})
 	})
+
+	Context("gardenadm client certificate", func() {
+		var (
+			shootNamespace = "shoot-namespace"
+			shootName      = "shoot-name"
+		)
+
+		BeforeEach(func() {
+			certificateSubject = &pkix.Name{
+				Organization: []string{v1beta1constants.ShootsGroup},
+				CommonName:   v1beta1constants.GardenadmUserNamePrefix + shootNamespace + ":" + shootName,
+			}
+			csrData, err = certutil.MakeCSR(privateKey, certificateSubject, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			csr.Spec.Request = csrData
+			csr.Spec.Username = "system:bootstrap:123abc"
+
+			bootstrapTokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bootstrap-token-" + bootstrapTokenID,
+					Namespace: "kube-system",
+					Labels:    map[string]string{testID: testRunID},
+				},
+				Data: map[string][]byte{
+					"description": []byte(fmt.Sprintf("Used for connecting the autonomous Shoot %s/%s", shootNamespace, shootName)),
+				},
+			}
+
+			By("Create bootstrap token Secret")
+			Expect(testClient.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+			log.Info("Created bootstrap token Secret for test", "secret", client.ObjectKeyFromObject(bootstrapTokenSecret))
+
+			DeferCleanup(func() {
+				By("Delete BootstrapToken Secret")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, bootstrapTokenSecret))).To(Succeed())
+			})
+		})
+
+		It("should approve the csr", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(csr), csr)).To(Succeed())
+				g.Expect(csr.Status.Conditions).To(ContainElement(And(
+					HaveField("Type", certificatesv1.CertificateApproved),
+					HaveField("Reason", "AutoApproved"),
+					HaveField("Message", "Auto approving gardenlet client certificate after SubjectAccessReview."),
+				)))
+			}).Should(Succeed())
+		})
+	})
 })

--- a/test/integration/gardenlet/managedseed/managedseed_suite_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_suite_test.go
@@ -183,7 +183,7 @@ var _ = BeforeSuite(func() {
 	})
 
 	By("Ensure gardenlet-kubeconfig secret is created")
-	gardenletKubeconfig, err := gardenletbootstraputil.CreateGardenletKubeconfigWithToken(restConfig, "foobar")
+	gardenletKubeconfig, err := gardenletbootstraputil.CreateKubeconfigWithToken(restConfig, "foobar")
 	Expect(err).NotTo(HaveOccurred())
 
 	gardenletKubeconfigSecret := &corev1.Secret{


### PR DESCRIPTION
/area control-plane
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR continues the work on the `gardenlet` bootstrap process as part of issue #2906. It extends the `gardenadm connect` workflow and `gardenlet` startup sequence to ensure that the `Shoot` resource exists in the garden cluster before the `gardenlet` starts its controllers.

With this change:
- `gardenadm connect` creates all `Shoot`-related namespaced resources (e.g., `Shoot`, `Secret`, `SecretBinding`, etc.) in the garden cluster before deploying the `gardenlet`.
- `gardenlet` now waits until the corresponding `Shoot` resource appears before starting its controllers.
- Global resources such as `CloudProfile`, `ControllerRegistration`, and others are verified to exist but are not created by `gardenadm connect`.
- Improvements to bootstrap handling include caching the bootstrap kubeconfig and requesting short-lived credentials.
- Various authorization and restriction webhooks are adapted to work with the new flow.

This improves the reliability of connecting a `gardenlet` to an existing garden cluster and ensures a consistent and predictable startup order.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
```other operator
NONE
```