### PR TITLE
Fix istio wildcard configuration.

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -85,9 +85,11 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 				}
 
 				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
-				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-					Namespace: b.WildcardIstioNamespace(),
-					Labels:    b.WildcardIstioLabels(),
+				if b.WildcardIstioNamespace() != b.IstioNamespace() {
+					wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
+						Namespace: b.WildcardIstioNamespace(),
+						Labels:    b.WildcardIstioLabels(),
+					}
 				}
 			}
 
@@ -143,9 +145,11 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				}
 
 				// Wildcard endpoint must always use the non-zonal and not the exposureclass istio ingress gateway.
-				wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
-					Namespace: b.WildcardIstioNamespace(),
-					Labels:    b.WildcardIstioLabels(),
+				if b.WildcardIstioNamespace() != b.IstioNamespace() {
+					wildcardConfiguration.IstioIngressGateway = &kubeapiserverexposure.IstioIngressGateway{
+						Namespace: b.WildcardIstioNamespace(),
+						Labels:    b.WildcardIstioLabels(),
+					}
 				}
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue introduced by https://github.com/gardener/gardener/pull/13055. If `IstioNameSpace` is the same as `WildcardNameSpace` no `istioGatewayConfiguration` can be generated.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Fixes an issue introduced by https://github.com/gardener/gardener/pull/13055
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
