### PR TITLE
[GEP-33] Ensure `NamespacedCloudProfile` status format

### DIFF
--- a/docs/api-reference/provider-local.md
+++ b/docs/api-reference/provider-local.md
@@ -251,6 +251,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Image is the image for the machine image.</p>
 </td>
 </tr>

--- a/docs/proposals/33-machine-image-capabilities.md
+++ b/docs/proposals/33-machine-image-capabilities.md
@@ -188,14 +188,14 @@ In this case it does not result in an error but in performance loss.
 
 ## Proposal
 
-Introduce a top level capabilities array in the CloudProfile `spec.capabilities`.
+Introduce a top level array in the CloudProfile `spec.machineCapabilities`.
 
 ```go
 type Spec struct {
-    Capabilities []Capability
+  MachineCapabilities []CapabilityDefinition
 }
 
-type Capability struct {
+type CapabilityDefinition struct {
   Name string
   Values []string
 }
@@ -205,7 +205,7 @@ Capabilities are very specific to the provider and the selected catalog offered 
 To minimize complexity and data size in the cloud profile, the capabilities are defined as a map with string keys and string arrays as values.
 The key is the capability name and the value is an array of possible values.
 
-For each cloud profile the capabilities are defined in the `spec.capabilities` array. 
+For each cloud profile the capabilities are defined in the `spec.machineCapabilities` array. 
 The full set of possibilities for each capability is defined here.
 As some capabilities can have multiple values at the same time an array of possible values is used instead of a single value.
 
@@ -215,7 +215,7 @@ If no further information is provided each machine type and machine image will b
 ```yaml
 # CloudProfile Example
 spec:
-  capabilities:
+  machineCapabilities:
     - name: architecture
       values: [amd64, arm64]
     - name: hypervisorType
@@ -255,7 +255,7 @@ The architecture is also added to the image version capability flavors. This is 
 ```yaml
 # CloudProfile
 spec:
-  capabilities: # <-- Full list of possible capabilities used as default
+  machineCapabilities: # <-- Full list of possible capabilities used as default
     - name: architecture
       values: [amd64]
     - name: hypervisorType
@@ -361,7 +361,7 @@ If multiple machine image versions are valid for a machine type, the selection i
 
 The following implications are to be considered in regards to `NamespacedCloudProfile`s:
  
-* `NamespacedCloudProfile`s won't have a global `capabilities` definition.
+* `NamespacedCloudProfile`s won't have a global `machineCapabilities` definition.
 * For overridden machine image versions, no `capabilities` must be defined, as they are inherited from the machine image versions of the parent `CloudProfile`.
 * For custom machine image versions, the `capabilities` need to be defined in the `NamespacedCloudProfile`, as they would be in the `CloudProfile` (as well as for the `providerConfig`).
    

--- a/extensions/pkg/controller/worker/cloudprofile.go
+++ b/extensions/pkg/controller/worker/cloudprofile.go
@@ -78,7 +78,7 @@ func selectBestImageFlavor[T CapabilitiesAccessor](
 		capabilitiesWithProviderTypes = append(capabilitiesWithProviderTypes, capabilitiesWithProviderType{
 			providerEntry: set,
 			// Normalize capabilities copy by applying defaults
-			capabilities: v1beta1helper.GetCapabilitiesWithAppliedDefaults(set.GetCapabilities(), capabilityDefinitions),
+			capabilities: v1beta1.GetCapabilitiesWithAppliedDefaults(set.GetCapabilities(), capabilityDefinitions),
 		})
 	}
 

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -295,8 +295,8 @@ func GetCapabilitiesWithAppliedDefaults(capabilities core.Capabilities, capabili
 	return result
 }
 
-// GetImageFlavorWithAppliedDefaults returns MachineImageFlavors sets with applied defaults from the capability definitions.
-func GetImageFlavorWithAppliedDefaults(imageFlavors []core.MachineImageFlavor, capabilityDefinitions []core.CapabilityDefinition) []core.MachineImageFlavor {
+// GetImageFlavorsWithAppliedDefaults returns MachineImageFlavors sets with applied defaults from the capability definitions.
+func GetImageFlavorsWithAppliedDefaults(imageFlavors []core.MachineImageFlavor, capabilityDefinitions []core.CapabilityDefinition) []core.MachineImageFlavor {
 	if len(imageFlavors) == 0 {
 		// If no capabilityFlavors are defined, assume all capabilities are supported.
 		return []core.MachineImageFlavor{{Capabilities: GetCapabilitiesWithAppliedDefaults(core.Capabilities{}, capabilityDefinitions)}}

--- a/pkg/apis/core/helper/cloudprofile.go
+++ b/pkg/apis/core/helper/cloudprofile.go
@@ -282,30 +282,17 @@ func CapabilityDefinitionsToCapabilities(capabilityDefinitions []core.Capability
 	return capabilities
 }
 
-// GetCapabilitiesWithAppliedDefaults returns new capabilities with applied defaults from the capability definitions.
-func GetCapabilitiesWithAppliedDefaults(capabilities core.Capabilities, capabilityDefinitions []core.CapabilityDefinition) core.Capabilities {
-	result := make(core.Capabilities, len(capabilityDefinitions))
-	for _, capabilityDefinition := range capabilityDefinitions {
-		if values, ok := capabilities[capabilityDefinition.Name]; ok {
-			result[capabilityDefinition.Name] = values
-		} else {
-			result[capabilityDefinition.Name] = capabilityDefinition.Values
-		}
-	}
-	return result
-}
-
 // GetImageFlavorsWithAppliedDefaults returns MachineImageFlavors sets with applied defaults from the capability definitions.
 func GetImageFlavorsWithAppliedDefaults(imageFlavors []core.MachineImageFlavor, capabilityDefinitions []core.CapabilityDefinition) []core.MachineImageFlavor {
 	if len(imageFlavors) == 0 {
 		// If no capabilityFlavors are defined, assume all capabilities are supported.
-		return []core.MachineImageFlavor{{Capabilities: GetCapabilitiesWithAppliedDefaults(core.Capabilities{}, capabilityDefinitions)}}
+		return []core.MachineImageFlavor{{Capabilities: core.GetCapabilitiesWithAppliedDefaults(core.Capabilities{}, capabilityDefinitions)}}
 	}
 
 	result := make([]core.MachineImageFlavor, len(imageFlavors))
 	for i, imageFlavor := range imageFlavors {
 		result[i] = core.MachineImageFlavor{
-			Capabilities: GetCapabilitiesWithAppliedDefaults(imageFlavor.Capabilities, capabilityDefinitions),
+			Capabilities: core.GetCapabilitiesWithAppliedDefaults(imageFlavor.Capabilities, capabilityDefinitions),
 		}
 	}
 	return result

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -552,7 +552,7 @@ var _ = Describe("CloudProfile Helper", func() {
 		})
 	})
 
-	Describe("#GetImageFlavorWithAppliedDefaults", func() {
+	Describe("#GetImageFlavorsWithAppliedDefaults", func() {
 		It("should apply defaults when capabilityFlavors are empty", func() {
 			var imageFlavors []core.MachineImageFlavor
 			capabilityDefinitions := []core.CapabilityDefinition{
@@ -560,7 +560,7 @@ var _ = Describe("CloudProfile Helper", func() {
 				{Name: "architecture", Values: []string{"amd64"}},
 			}
 
-			result := GetImageFlavorWithAppliedDefaults(imageFlavors, capabilityDefinitions)
+			result := GetImageFlavorsWithAppliedDefaults(imageFlavors, capabilityDefinitions)
 
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Capabilities).To(Equal(core.Capabilities{
@@ -579,7 +579,7 @@ var _ = Describe("CloudProfile Helper", func() {
 				{Name: "architecture", Values: []string{"amd64", "arm64"}},
 			}
 
-			result := GetImageFlavorWithAppliedDefaults(imageFlavors, capabilityDefinitions)
+			result := GetImageFlavorsWithAppliedDefaults(imageFlavors, capabilityDefinitions)
 
 			Expect(result).To(HaveLen(2))
 			Expect(result[0].Capabilities).To(Equal(core.Capabilities{

--- a/pkg/apis/core/helper/cloudprofile_test.go
+++ b/pkg/apis/core/helper/cloudprofile_test.go
@@ -518,40 +518,6 @@ var _ = Describe("CloudProfile Helper", func() {
 		Entry("with capabilities", "architecture", "network"),
 	)
 
-	Describe("#GetCapabilitiesWithAppliedDefaults", func() {
-		It("should apply default values when capabilities are nil", func() {
-			var capabilities core.Capabilities
-			capabilityDefinitions := []core.CapabilityDefinition{
-				{Name: "capability1", Values: []string{"value1", "value2"}},
-				{Name: "architecture", Values: []string{"amd64"}},
-			}
-
-			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
-
-			Expect(result).To(Equal(core.Capabilities{
-				"capability1":  []string{"value1", "value2"},
-				"architecture": []string{"amd64"},
-			}))
-		})
-
-		It("should retain existing values and apply defaults for missing capabilities", func() {
-			capabilities := core.Capabilities{
-				"capability1": []string{"value1"},
-			}
-			capabilityDefinitions := []core.CapabilityDefinition{
-				{Name: "capability1", Values: []string{"value1", "value2"}},
-				{Name: "architecture", Values: []string{"amd64"}},
-			}
-
-			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
-
-			Expect(result).To(Equal(core.Capabilities{
-				"capability1":  []string{"value1"},
-				"architecture": []string{"amd64"},
-			}))
-		})
-	})
-
 	Describe("#GetImageFlavorsWithAppliedDefaults", func() {
 		It("should apply defaults when capabilityFlavors are empty", func() {
 			var imageFlavors []core.MachineImageFlavor

--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -173,31 +173,6 @@ type MachineType struct {
 	Capabilities Capabilities
 }
 
-// GetArchitecture returns the architecture of the machine type.
-func (m *MachineType) GetArchitecture(capabilityDefinitions []CapabilityDefinition) string {
-	if len(capabilityDefinitions) == 0 {
-		return ptr.Deref(m.Architecture, "")
-	}
-
-	if len(m.Capabilities[constants.ArchitectureName]) == 1 {
-		return m.Capabilities[constants.ArchitectureName][0]
-	}
-
-	if len(m.Capabilities[constants.ArchitectureName]) == 0 {
-		for _, capabilityDefinition := range capabilityDefinitions {
-			if capabilityDefinition.Name == constants.ArchitectureName && len(capabilityDefinition.Values) == 1 {
-				return capabilityDefinition.Values[0]
-			}
-		}
-	}
-
-	// constants.ArchitectureName is a required capability and
-	// machineType.Capabilities[constants.ArchitectureName] can only
-	// be empty for cloudprofiles supporting exactly one architecture.
-	// we should never reach this point.
-	return ""
-}
-
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.
 type MachineTypeStorage struct {
 	// Class is the class of the storage type.
@@ -348,4 +323,26 @@ type Capabilities map[string]CapabilityValues
 // This is a workaround as the Protobuf generator can't handle a slice of maps.
 type MachineImageFlavor struct {
 	Capabilities
+}
+
+// GetArchitecture returns the architecture of the machine type.
+func (m *MachineType) GetArchitecture(capabilityDefinitions []CapabilityDefinition) string {
+	capabilityArchitecture := GetCapabilitiesWithAppliedDefaults(m.Capabilities, capabilityDefinitions)[constants.ArchitectureName]
+	if len(capabilityArchitecture) == 1 {
+		return capabilityArchitecture[0]
+	}
+	return ptr.Deref(m.Architecture, "")
+}
+
+// GetCapabilitiesWithAppliedDefaults returns new capabilities with applied defaults from the capability definitions.
+func GetCapabilitiesWithAppliedDefaults(capabilities Capabilities, capabilityDefinitions []CapabilityDefinition) Capabilities {
+	result := make(Capabilities, len(capabilityDefinitions))
+	for _, capabilityDefinition := range capabilityDefinitions {
+		if values, ok := capabilities[capabilityDefinition.Name]; ok {
+			result[capabilityDefinition.Name] = values
+		} else {
+			result[capabilityDefinition.Name] = capabilityDefinition.Values
+		}
+	}
+	return result
 }

--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -174,11 +174,28 @@ type MachineType struct {
 }
 
 // GetArchitecture returns the architecture of the machine type.
-func (m *MachineType) GetArchitecture() string {
+func (m *MachineType) GetArchitecture(capabilityDefinitions []CapabilityDefinition) string {
+	if len(capabilityDefinitions) == 0 {
+		return ptr.Deref(m.Architecture, "")
+	}
+
 	if len(m.Capabilities[constants.ArchitectureName]) == 1 {
 		return m.Capabilities[constants.ArchitectureName][0]
 	}
-	return ptr.Deref(m.Architecture, "")
+
+	if len(m.Capabilities[constants.ArchitectureName]) == 0 {
+		for _, capabilityDefinition := range capabilityDefinitions {
+			if capabilityDefinition.Name == constants.ArchitectureName && len(capabilityDefinition.Values) == 1 {
+				return capabilityDefinition.Values[0]
+			}
+		}
+	}
+
+	// constants.ArchitectureName is a required capability and
+	// machineType.Capabilities[constants.ArchitectureName] can only
+	// be empty for cloudprofiles supporting exactly one architecture.
+	// we should never reach this point.
+	return ""
 }
 
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.

--- a/pkg/apis/core/types_test.go
+++ b/pkg/apis/core/types_test.go
@@ -53,4 +53,37 @@ var _ = Describe("API Types", func() {
 		Entry("#ClassificationDeprecated is active", ClassificationDeprecated, true),
 		Entry("#ClassificationExpired is not active", ClassificationExpired, false),
 	)
+	Describe("#GetCapabilitiesWithAppliedDefaults", func() {
+		It("should apply default values when capabilities are nil", func() {
+			var capabilities Capabilities
+			capabilityDefinitions := []CapabilityDefinition{
+				{Name: "capability1", Values: []string{"value1", "value2"}},
+				{Name: "architecture", Values: []string{"amd64"}},
+			}
+
+			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
+
+			Expect(result).To(Equal(Capabilities{
+				"capability1":  []string{"value1", "value2"},
+				"architecture": []string{"amd64"},
+			}))
+		})
+
+		It("should retain existing values and apply defaults for missing capabilities", func() {
+			capabilities := Capabilities{
+				"capability1": []string{"value1"},
+			}
+			capabilityDefinitions := []CapabilityDefinition{
+				{Name: "capability1", Values: []string{"value1", "value2"}},
+				{Name: "architecture", Values: []string{"amd64"}},
+			}
+
+			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
+
+			Expect(result).To(Equal(Capabilities{
+				"capability1":  []string{"value1"},
+				"architecture": []string{"amd64"},
+			}))
+		})
+	})
 })

--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -533,7 +533,7 @@ func FilterDeprecatedVersion() func(expirableVersion gardencorev1beta1.Expirable
 	}
 }
 
-func extractArchitecturesFromImageFlavor(imageFlavors []gardencorev1beta1.MachineImageFlavor, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) []string {
+func extractArchitecturesFromImageFlavors(imageFlavors []gardencorev1beta1.MachineImageFlavor, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) []string {
 	if len(imageFlavors) == 0 {
 		for _, capabilityDefinition := range capabilityDefinitions {
 			if capabilityDefinition.Name == constants.ArchitectureName {
@@ -554,7 +554,7 @@ func extractArchitecturesFromImageFlavor(imageFlavors []gardencorev1beta1.Machin
 // GetArchitecturesFromImageVersion returns the list of supported architectures for the machine image version.
 // It first tries to retrieve the architectures from the capability flavors and falls back to the architectures field if none are found.
 func GetArchitecturesFromImageVersion(imageVersion gardencorev1beta1.MachineImageVersion, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) []string {
-	if architectures := extractArchitecturesFromImageFlavor(imageVersion.CapabilityFlavors, capabilityDefinitions); len(architectures) > 0 {
+	if architectures := extractArchitecturesFromImageFlavors(imageVersion.CapabilityFlavors, capabilityDefinitions); len(architectures) > 0 {
 		return architectures
 	}
 	return imageVersion.Architectures

--- a/pkg/apis/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile.go
@@ -567,30 +567,17 @@ func ArchitectureSupportedByImageVersion(version gardencorev1beta1.MachineImageV
 	return slices.Contains(supportedArchitectures, architecture)
 }
 
-// GetCapabilitiesWithAppliedDefaults returns new capabilities with applied defaults from the capability definitions.
-func GetCapabilitiesWithAppliedDefaults(capabilities gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) gardencorev1beta1.Capabilities {
-	result := make(gardencorev1beta1.Capabilities, len(capabilityDefinitions))
-	for _, capabilityDefinition := range capabilityDefinitions {
-		if values, ok := capabilities[capabilityDefinition.Name]; ok {
-			result[capabilityDefinition.Name] = values
-		} else {
-			result[capabilityDefinition.Name] = capabilityDefinition.Values
-		}
-	}
-	return result
-}
-
 // GetImageFlavorsWithAppliedDefaults returns new MachineImageFlavors with applied defaults from the capability definitions.
 func GetImageFlavorsWithAppliedDefaults(imageFlavors []gardencorev1beta1.MachineImageFlavor, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) []gardencorev1beta1.MachineImageFlavor {
 	if len(imageFlavors) == 0 {
 		// If no capabilityFlavors are defined, assume all capabilities are supported.
-		return []gardencorev1beta1.MachineImageFlavor{{Capabilities: GetCapabilitiesWithAppliedDefaults(gardencorev1beta1.Capabilities{}, capabilityDefinitions)}}
+		return []gardencorev1beta1.MachineImageFlavor{{Capabilities: gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(gardencorev1beta1.Capabilities{}, capabilityDefinitions)}}
 	}
 
 	result := make([]gardencorev1beta1.MachineImageFlavor, len(imageFlavors))
 	for i, imageFlavor := range imageFlavors {
 		result[i] = gardencorev1beta1.MachineImageFlavor{
-			Capabilities: GetCapabilitiesWithAppliedDefaults(imageFlavor.Capabilities, capabilityDefinitions),
+			Capabilities: gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(imageFlavor.Capabilities, capabilityDefinitions),
 		}
 	}
 	return result
@@ -649,8 +636,8 @@ func AreCapabilitiesSupportedByImageFlavors(
 // AreCapabilitiesCompatible checks if two sets of capabilities are compatible.
 // It applies defaults from the capability definitions to both sets before checking compatibility.
 func AreCapabilitiesCompatible(capabilities1, capabilities2 gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) bool {
-	defaultedCapabilities1 := GetCapabilitiesWithAppliedDefaults(capabilities1, capabilityDefinitions)
-	defaultedCapabilities2 := GetCapabilitiesWithAppliedDefaults(capabilities2, capabilityDefinitions)
+	defaultedCapabilities1 := gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(capabilities1, capabilityDefinitions)
+	defaultedCapabilities2 := gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(capabilities2, capabilityDefinitions)
 
 	isSupported := true
 	commonCapabilities := GetCapabilitiesIntersection(defaultedCapabilities1, defaultedCapabilities2)

--- a/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/apis/core/v1beta1/helper/cloudprofile_test.go
@@ -1506,40 +1506,6 @@ var _ = Describe("CloudProfile Helper", func() {
 			Entry("Should be true for supported architecture", []string{"amd64", "arm64"}, "arm64", true),
 		)
 
-		Describe("#GetCapabilitiesWithAppliedDefaults", func() {
-			It("should apply default values when capabilities are nil", func() {
-				var capabilities gardencorev1beta1.Capabilities
-				capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
-					{Name: "capability1", Values: []string{"value1", "value2"}},
-					{Name: "architecture", Values: []string{"amd64"}},
-				}
-
-				result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
-
-				Expect(result).To(Equal(gardencorev1beta1.Capabilities{
-					"capability1":  []string{"value1", "value2"},
-					"architecture": []string{"amd64"},
-				}))
-			})
-
-			It("should retain existing values and apply defaults for missing capabilities", func() {
-				capabilities := gardencorev1beta1.Capabilities{
-					"capability1": []string{"value1"},
-				}
-				capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
-					{Name: "capability1", Values: []string{"value1", "value2"}},
-					{Name: "architecture", Values: []string{"amd64"}},
-				}
-
-				result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
-
-				Expect(result).To(Equal(gardencorev1beta1.Capabilities{
-					"capability1":  []string{"value1"},
-					"architecture": []string{"amd64"},
-				}))
-			})
-		})
-
 		Describe("#GetImageFlavorsWithAppliedDefaults", func() {
 			It("should apply defaults when capabilityFlavors are empty", func() {
 				var imageFlavors []gardencorev1beta1.MachineImageFlavor

--- a/pkg/apis/core/v1beta1/types_test.go
+++ b/pkg/apis/core/v1beta1/types_test.go
@@ -53,4 +53,38 @@ var _ = Describe("Types", func() {
 		Entry("#ClassificationDeprecated is active", ClassificationDeprecated, true),
 		Entry("#ClassificationExpired is not active", ClassificationExpired, false),
 	)
+
+	Describe("#GetCapabilitiesWithAppliedDefaults", func() {
+		It("should apply default values when capabilities are nil", func() {
+			var capabilities Capabilities
+			capabilityDefinitions := []CapabilityDefinition{
+				{Name: "capability1", Values: []string{"value1", "value2"}},
+				{Name: "architecture", Values: []string{"amd64"}},
+			}
+
+			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
+
+			Expect(result).To(Equal(Capabilities{
+				"capability1":  []string{"value1", "value2"},
+				"architecture": []string{"amd64"},
+			}))
+		})
+
+		It("should retain existing values and apply defaults for missing capabilities", func() {
+			capabilities := Capabilities{
+				"capability1": []string{"value1"},
+			}
+			capabilityDefinitions := []CapabilityDefinition{
+				{Name: "capability1", Values: []string{"value1", "value2"}},
+				{Name: "architecture", Values: []string{"amd64"}},
+			}
+
+			result := GetCapabilitiesWithAppliedDefaults(capabilities, capabilityDefinitions)
+
+			Expect(result).To(Equal(Capabilities{
+				"capability1":  []string{"value1"},
+				"architecture": []string{"amd64"},
+			}))
+		})
+	})
 })

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -56,18 +56,18 @@ func ValidateCloudProfileUpdate(newProfile, oldProfile *core.CloudProfile) field
 // ValidateCloudProfileSpec validates the specification of a CloudProfile object.
 func ValidateCloudProfileSpec(spec *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
 	var (
-		allErrs      = field.ErrorList{}
-		capabilities = helper.CapabilityDefinitionsToCapabilities(spec.MachineCapabilities)
+		allErrs             = field.ErrorList{}
+		machineCapabilities = helper.CapabilityDefinitionsToCapabilities(spec.MachineCapabilities)
 	)
 
 	if len(spec.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must provide a provider type"))
 	}
 
-	allErrs = append(allErrs, validateCloudProfileKubernetesSettings(spec.Kubernetes, fldPath.Child("kubernetes"))...)
-	allErrs = append(allErrs, ValidateCloudProfileMachineImages(spec.MachineImages, capabilities, fldPath.Child("machineImages"))...)
-	allErrs = append(allErrs, validateCloudProfileMachineTypes(spec.MachineTypes, capabilities, fldPath.Child("machineTypes"))...)
 	allErrs = append(allErrs, validateCapabilityDefinitions(spec.MachineCapabilities, fldPath.Child("machineCapabilities"))...)
+	allErrs = append(allErrs, validateCloudProfileKubernetesSettings(spec.Kubernetes, fldPath.Child("kubernetes"))...)
+	allErrs = append(allErrs, ValidateCloudProfileMachineImages(spec.MachineImages, machineCapabilities, fldPath.Child("machineImages"))...)
+	allErrs = append(allErrs, validateCloudProfileMachineTypes(spec.MachineTypes, machineCapabilities, fldPath.Child("machineTypes"))...)
 	allErrs = append(allErrs, validateVolumeTypes(spec.VolumeTypes, fldPath.Child("volumeTypes"))...)
 	allErrs = append(allErrs, validateCloudProfileRegions(spec.Regions, fldPath.Child("regions"))...)
 	allErrs = append(allErrs, validateCloudProfileBastion(spec, fldPath.Child("bastion"))...)

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -301,7 +301,7 @@ func validateCloudProfileBastion(spec *core.CloudProfileSpec, fldPath *field.Pat
 
 	if spec.Bastion.MachineType != nil {
 		var validationErrors field.ErrorList
-		machineArch, validationErrors = validateBastionMachineType(spec.Bastion.MachineType, spec.MachineTypes, fldPath.Child("machineType"))
+		machineArch, validationErrors = validateBastionMachineType(spec.Bastion.MachineType, spec.MachineTypes, spec.MachineCapabilities, fldPath.Child("machineType"))
 		allErrs = append(allErrs, validationErrors...)
 	}
 
@@ -312,7 +312,7 @@ func validateCloudProfileBastion(spec *core.CloudProfileSpec, fldPath *field.Pat
 	return allErrs
 }
 
-func validateBastionMachineType(bastionMachineType *core.BastionMachineType, machineTypes []core.MachineType, fldPath *field.Path) (*string, field.ErrorList) {
+func validateBastionMachineType(bastionMachineType *core.BastionMachineType, machineTypes []core.MachineType, capabilityDefinitions []core.CapabilityDefinition, fldPath *field.Path) (*string, field.ErrorList) {
 	machineIndex := slices.IndexFunc(machineTypes, func(machineType core.MachineType) bool {
 		return machineType.Name == bastionMachineType.Name
 	})
@@ -321,7 +321,7 @@ func validateBastionMachineType(bastionMachineType *core.BastionMachineType, mac
 		return nil, field.ErrorList{field.Invalid(fldPath.Child("name"), bastionMachineType.Name, "machine type not found in spec.machineTypes")}
 	}
 
-	return ptr.To(machineTypes[machineIndex].GetArchitecture()), nil
+	return ptr.To(machineTypes[machineIndex].GetArchitecture(capabilityDefinitions)), nil
 }
 
 func validateBastionImage(bastionImage *core.BastionMachineImage, machineImages []core.MachineImage, capabilities core.Capabilities, machineArch *string, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -184,20 +184,28 @@ func ValidateCloudProfileMachineImages(machineImages []core.MachineImage, capabi
 
 		for index, machineVersion := range image.Versions {
 			versionsPath := idxPath.Child("versions").Index(index)
-			allErrs = append(allErrs, validateContainerRuntimesInterfaces(machineVersion.CRI, versionsPath.Child("cri"))...)
-			allErrs = append(allErrs, validateSupportedVersionsConfiguration(machineVersion.ExpirableVersion, helper.ToExpirableVersions(image.Versions), versionsPath)...)
-
-			if len(capabilities) == 0 {
-				if len(machineVersion.Architectures) == 0 {
-					allErrs = append(allErrs, field.Required(versionsPath.Child("architectures"), "must provide at least one architecture"))
-				}
-				if len(machineVersion.CapabilityFlavors) > 0 {
-					allErrs = append(allErrs, field.Forbidden(versionsPath.Child("capabilityFlavors"), "must not provide capabilities without global definition"))
-				}
-			}
+			allErrs = append(allErrs, ValidateMachineImageAdditionalConfig(machineVersion, versionsPath, image, capabilities)...)
 		}
 	}
 
+	return allErrs
+}
+
+// ValidateMachineImageAdditionalConfig validates RuntimeInterfaces and supported versions configuration of a MachineImageVersion.
+func ValidateMachineImageAdditionalConfig(machineVersion core.MachineImageVersion, versionsPath *field.Path, image core.MachineImage, capabilities core.Capabilities) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateContainerRuntimesInterfaces(machineVersion.CRI, versionsPath.Child("cri"))...)
+	allErrs = append(allErrs, validateSupportedVersionsConfiguration(machineVersion.ExpirableVersion, helper.ToExpirableVersions(image.Versions), versionsPath)...)
+
+	if len(capabilities) == 0 {
+		if len(machineVersion.Architectures) == 0 {
+			allErrs = append(allErrs, field.Required(versionsPath.Child("architectures"), "must provide at least one architecture"))
+		}
+		if len(machineVersion.CapabilityFlavors) > 0 {
+			allErrs = append(allErrs, field.Forbidden(versionsPath.Child("capabilityFlavors"), "must not provide capabilities without global definition"))
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1397,7 +1397,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeRequired),
 							"Field":  Equal("spec.machineImages[0].versions[0].capabilityFlavors[0].architecture"),
-							"Detail": Equal("must provide one architecture"),
+							"Detail": Equal("must specify one architecture explicitly as multiple architectures are defined in spec.machineCapabilities"),
 						})),
 					))
 				})

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -389,7 +389,7 @@ func validateMachineImageVersionArchitecture(machineImageVersion core.MachineIma
 			architectureCapabilityValues := flavor.Capabilities[v1beta1constants.ArchitectureName]
 			architectureFieldPath := fldPath.Child("capabilityFlavors").Index(flavorIdx).Child("architecture")
 			if len(architectureCapabilityValues) == 0 && len(supportedArchitectures) > 1 {
-				allErrs = append(allErrs, field.Required(architectureFieldPath, "must provide one architecture"))
+				allErrs = append(allErrs, field.Required(architectureFieldPath, "must specify one architecture explicitly as multiple architectures are defined in spec.machineCapabilities"))
 			} else if len(architectureCapabilityValues) > 1 {
 				allErrs = append(allErrs, field.Invalid(architectureFieldPath, architectureCapabilityValues, "must not define more than one architecture within an image flavor"))
 			}
@@ -400,13 +400,14 @@ func validateMachineImageVersionArchitecture(machineImageVersion core.MachineIma
 			allCapabilityArchitectures = sets.New(supportedArchitectures...)
 		}
 		if len(machineImageVersion.Architectures) > 0 && !allCapabilityArchitectures.HasAll(machineImageVersion.Architectures...) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("architectures"), machineImageVersion.Architectures, fmt.Sprintf("architecture field values set (%s) conflict with the capability architectures (%s)", strings.Join(machineImageVersion.Architectures, ","), strings.Join(allCapabilityArchitectures.UnsortedList(), ","))))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("architectures"), machineImageVersion.Architectures,
+				fmt.Sprintf("architecture field values set (%s) conflict with the capability architectures (%s)", strings.Join(machineImageVersion.Architectures, ","), strings.Join(allCapabilityArchitectures.UnsortedList(), ","))))
 		}
 	}
 
 	for archIdx, arch := range machineImageVersion.Architectures {
 		if !slices.Contains(supportedArchitectures, arch) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("architectures").Index(archIdx), arch, v1beta1constants.ValidArchitectures))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("architectures").Index(archIdx), arch, supportedArchitectures))
 		}
 	}
 

--- a/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Strategy", func() {
 			}
 			newCloudProfile := oldCloudProfile.DeepCopy()
 			newCloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
-				{Name: "architecture", Values: []string{"amd64"}},
+				{Name: "architecture", Values: []string{"amd64", "arm64"}},
 			}
 
 			cloudprofileregistry.Strategy.PrepareForUpdate(context.Background(), newCloudProfile, oldCloudProfile)

--- a/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
@@ -200,28 +200,4 @@ var _ = Describe("Strategy", func() {
 			}))
 		})
 	})
-
-	Describe("#Canonicalize", func() {
-		It("should sync architecture capabilities to empty architecture fields", func() {
-			cloudProfile := &core.CloudProfile{
-				Spec: core.CloudProfileSpec{
-					MachineCapabilities: []core.CapabilityDefinition{
-						{Name: "architecture", Values: []string{"amd64"}},
-					},
-					MachineImages: []core.MachineImage{{Versions: []core.MachineImageVersion{
-						{CapabilityFlavors: []core.MachineImageFlavor{{Capabilities: core.Capabilities{
-							"architecture": []string{"amd64"}}}}},
-					}}},
-					MachineTypes: []core.MachineType{{Capabilities: core.Capabilities{
-						"architecture": []string{"amd64"},
-					}}},
-				},
-			}
-
-			cloudprofileregistry.Strategy.Canonicalize(cloudProfile)
-
-			Expect(cloudProfile.Spec.MachineTypes[0].Architecture).To(PointTo(Equal("amd64")))
-			Expect(cloudProfile.Spec.MachineImages[0].Versions[0].Architectures).To(ConsistOf("amd64"))
-		})
-	})
 })

--- a/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
@@ -200,4 +200,27 @@ var _ = Describe("Strategy", func() {
 			}))
 		})
 	})
+	Describe("#Canonicalize", func() {
+		It("should sync architecture capabilities to empty architecture fields", func() {
+			cloudProfile := &core.CloudProfile{
+				Spec: core.CloudProfileSpec{
+					MachineCapabilities: []core.CapabilityDefinition{
+						{Name: "architecture", Values: []string{"amd64"}},
+					},
+					MachineImages: []core.MachineImage{{Versions: []core.MachineImageVersion{
+						{CapabilityFlavors: []core.MachineImageFlavor{{Capabilities: core.Capabilities{
+							"architecture": []string{"amd64"}}}}},
+					}}},
+					MachineTypes: []core.MachineType{{Capabilities: core.Capabilities{
+						"architecture": []string{"amd64"},
+					}}},
+				},
+			}
+
+			cloudprofileregistry.Strategy.Canonicalize(cloudProfile)
+
+			Expect(cloudProfile.Spec.MachineTypes[0].Architecture).To(PointTo(Equal("amd64")))
+			Expect(cloudProfile.Spec.MachineImages[0].Versions[0].Architectures).To(ConsistOf("amd64"))
+		})
+	})
 })

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -156,14 +156,11 @@ func syncArchitectureCapabilities(namespacedCloudProfile *gardencorev1beta1.Name
 // The sync can only happen after having had a look at the parent CloudProfile and whether it uses capabilities.
 func defaultMachineTypeArchitectures(cloudProfile gardencore.CloudProfileSpec, capabilitiesDefinitions []gardencore.CapabilityDefinition) {
 	for i, machineType := range cloudProfile.MachineTypes {
-		if ptr.Deref(machineType.Architecture, "") != "" {
-			continue
-		}
-		capabilityArchitecture := gardencorehelper.GetCapabilitiesWithAppliedDefaults(machineType.Capabilities, capabilitiesDefinitions)[v1beta1constants.ArchitectureName]
-		if len(capabilityArchitecture) > 0 {
-			cloudProfile.MachineTypes[i].Architecture = &capabilityArchitecture[0]
-		} else {
+		effectiveArchitecture := machineType.GetArchitecture(capabilitiesDefinitions)
+		if effectiveArchitecture == "" {
 			cloudProfile.MachineTypes[i].Architecture = ptr.To(v1beta1constants.ArchitectureAMD64)
+		} else if cloudProfile.MachineTypes[i].Architecture == nil {
+			cloudProfile.MachineTypes[i].Architecture = ptr.To(effectiveArchitecture)
 		}
 	}
 }

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -122,8 +122,8 @@ func MergeCloudProfiles(namespacedCloudProfile *gardencorev1beta1.NamespacedClou
 		namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, namespacedCloudProfile.Spec.Kubernetes.Versions, expirableVersionKeyFunc, mergeExpirationDates, false)
 	}
 
-	// @Roncossek: Remove ensureUniformFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are deprecated.
-	uniformNamespacedCloudProfileSpec := ensureUniformFormat(namespacedCloudProfile.Spec, cloudProfile.Spec.MachineCapabilities)
+	// TODO(Roncossek): Remove mutateArchitectureCapabilityFields once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
+	uniformNamespacedCloudProfileSpec := mutateArchitectureCapabilityFields(namespacedCloudProfile.Spec, cloudProfile.Spec.MachineCapabilities)
 	namespacedCloudProfile.Status.CloudProfileSpec.MachineImages = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.MachineImages, uniformNamespacedCloudProfileSpec.MachineImages, machineImageKeyFunc, mergeMachineImages, true)
 	namespacedCloudProfile.Status.CloudProfileSpec.MachineTypes = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.MachineTypes, uniformNamespacedCloudProfileSpec.MachineTypes, machineTypeKeyFunc, nil, true)
 	namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.VolumeTypes, namespacedCloudProfile.Spec.VolumeTypes, volumeTypeKeyFunc, nil, true)
@@ -143,10 +143,10 @@ func MergeCloudProfiles(namespacedCloudProfile *gardencorev1beta1.NamespacedClou
 	syncArchitectureCapabilities(namespacedCloudProfile)
 }
 
-// ensureUniformFormat ensures that the given NamespacedCloudProfileSpec is in a uniform format with its parent CloudProfileSpec.
+// mutateArchitectureCapabilityFields ensures that the given NamespacedCloudProfileSpec is in a uniform format with its parent CloudProfileSpec.
 // If the parent CloudProfileSpec uses capability definitions, then the NamespacedCloudProfileSpec is transformed to also use capabilities
 // and vice versa.
-func ensureUniformFormat(
+func mutateArchitectureCapabilityFields(
 	spec gardencorev1beta1.NamespacedCloudProfileSpec,
 	capabilityDefinitions []gardencorev1beta1.CapabilityDefinition,
 ) gardencorev1beta1.NamespacedCloudProfileSpec {

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -196,10 +196,7 @@ func mutateArchitectureCapabilityFields(
 			}
 			architecture := machineType.GetArchitecture(capabilityDefinitions)
 			if architecture == "" {
-				architecture = ptr.Deref(machineType.Architecture, "")
-			}
-			if architecture == "" {
-				architecture = v1beta1constants.ArchitectureAMD64
+				architecture = ptr.Deref(machineType.Architecture, v1beta1constants.ArchitectureAMD64)
 			}
 			machineType.Capabilities = gardencorev1beta1.Capabilities{
 				v1beta1constants.ArchitectureName: []string{architecture},

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -1022,7 +1022,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						Expect(machineTypes).To(HaveLen(2))
 
 						// First machine type should default to amd64
-						Expect(machineTypes[0].Architecture).To(Equal(ptr.To("amd64")))
+						Expect(machineTypes[0].Architecture).To(BeNil())
 						Expect(machineTypes[0].Capabilities).To(HaveKeyWithValue("architecture", gardencorev1beta1.CapabilityValues{"amd64"}))
 
 						// Second machine type should keep arm64
@@ -1176,7 +1176,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						version := namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[0].Versions[0]
 						// no architectures specified so should default to amd64 as per parent capability definition
 						Expect(version.CapabilityFlavors).To(BeEmpty())
-						Expect(version.Architectures).To(ConsistOf("amd64"))
+						Expect(version.Architectures).To(BeEmpty())
 					})
 				})
 			})

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -922,7 +922,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				})
 			})
 
-			Describe("Transform to parent CloudProfile capability/legacy format  functionality", func() {
+			Describe("Transform to parent CloudProfile capability/legacy format functionality", func() {
 				var (
 					cloudProfile           *gardencorev1beta1.CloudProfile
 					namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -1052,37 +1052,6 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						cloudProfile.Spec.MachineCapabilities = nil
 					})
 
-					It("should extract architectures from capability flavors", func() {
-						namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
-							{
-								Name: "ubuntu",
-								Versions: []gardencorev1beta1.MachineImageVersion{
-									{
-										ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "20.04"},
-										CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
-											{
-												Capabilities: gardencorev1beta1.Capabilities{
-													"architecture": []string{"amd64"},
-												},
-											},
-											{
-												Capabilities: gardencorev1beta1.Capabilities{
-													"architecture": []string{"arm64"},
-												},
-											},
-										},
-									},
-								},
-							},
-						}
-
-						namespacedcloudprofilecontroller.MergeCloudProfiles(namespacedCloudProfile, cloudProfile)
-
-						version := namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[0].Versions[0]
-						Expect(version.Architectures).To(ConsistOf("amd64", "arm64"))
-						Expect(version.CapabilityFlavors).To(BeNil())
-					})
-
 					It("should preserve existing architectures", func() {
 						namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 							{

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -909,7 +909,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				})
 			})
 
-			Describe("ensureUniformFormat functionality", func() {
+			Describe("mutateArchitectureCapabilityFields functionality", func() {
 				var (
 					cloudProfile           *gardencorev1beta1.CloudProfile
 					namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
@@ -57,6 +57,7 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
 	}
 
+	// @Roncossek: Remove ensureUniformFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are deprecated.
 	uniformSpecConfig := EnsureUniformFormat(specConfig, profile.Status.CloudProfileSpec.MachineCapabilities)
 
 	statusConfig.MachineImages = mergeMachineImages(uniformSpecConfig.MachineImages, statusConfig.MachineImages)

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
@@ -57,8 +57,8 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
 	}
 
-	// @Roncossek: Remove ensureUniformFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are deprecated.
-	uniformSpecConfig := EnsureUniformFormat(specConfig, profile.Status.CloudProfileSpec.MachineCapabilities)
+	// TODO(Roncossek): Remove MutateArchitectureCapabilityFields once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
+	uniformSpecConfig := MutateArchitectureCapabilityFields(specConfig, profile.Status.CloudProfileSpec.MachineCapabilities)
 
 	statusConfig.MachineImages = mergeMachineImages(uniformSpecConfig.MachineImages, statusConfig.MachineImages)
 
@@ -71,11 +71,11 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 	return nil
 }
 
-// EnsureUniformFormat ensures that the given CloudProfileConfig is in a uniform format.
+// MutateArchitectureCapabilityFields supports the migration from the deprecated architecture fields to architecture capabilities during a transition period.
 // Depending on whether the parent CloudProfile is in capability format or not, it transforms the given config to
-// capability format or old format respectively.
-// It assumes that the given config is either completely in capability format or in old format.
-func EnsureUniformFormat(config *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
+// the capability format or the deprecated architecture fields format respectively.
+// It assumes that the given config is either completely in the capability format or in the deprecated architecture fields format.
+func MutateArchitectureCapabilityFields(config *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
 	transformedConfig := v1alpha1.CloudProfileConfig{}
 	isParentInCapabilityFormat := len(capabilityDefinitions) != 0
 

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
@@ -57,8 +57,8 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
 	}
 
-	// TODO(Roncossek): Remove MutateArchitectureCapabilityFields once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
-	uniformSpecConfig := MutateArchitectureCapabilityFields(specConfig, profile.Status.CloudProfileSpec.MachineCapabilities)
+	// TODO(Roncossek): Remove TransformProviderConfigToParentFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
+	uniformSpecConfig := TransformProviderConfigToParentFormat(specConfig, profile.Status.CloudProfileSpec.MachineCapabilities)
 
 	statusConfig.MachineImages = mergeMachineImages(uniformSpecConfig.MachineImages, statusConfig.MachineImages)
 
@@ -71,11 +71,11 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 	return nil
 }
 
-// MutateArchitectureCapabilityFields supports the migration from the deprecated architecture fields to architecture capabilities during a transition period.
+// TransformProviderConfigToParentFormat supports the migration from the deprecated architecture fields to architecture capabilities during a transition period.
 // Depending on whether the parent CloudProfile is in capability format or not, it transforms the given config to
 // the capability format or the deprecated architecture fields format respectively.
 // It assumes that the given config is either completely in the capability format or in the deprecated architecture fields format.
-func MutateArchitectureCapabilityFields(cloudProfileConfig *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
+func TransformProviderConfigToParentFormat(cloudProfileConfig *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
 	isParentInCapabilityFormat := len(capabilityDefinitions) != 0
 	for idx, machineImage := range cloudProfileConfig.MachineImages {
 		cloudProfileConfig.MachineImages[idx].Versions = make([]v1alpha1.MachineImageVersion, 0, len(machineImage.Versions))

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile.go
@@ -75,15 +75,10 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 // Depending on whether the parent CloudProfile is in capability format or not, it transforms the given config to
 // the capability format or the deprecated architecture fields format respectively.
 // It assumes that the given config is either completely in the capability format or in the deprecated architecture fields format.
-func MutateArchitectureCapabilityFields(config *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
-	transformedConfig := v1alpha1.CloudProfileConfig{}
+func MutateArchitectureCapabilityFields(cloudProfileConfig *v1alpha1.CloudProfileConfig, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) *v1alpha1.CloudProfileConfig {
 	isParentInCapabilityFormat := len(capabilityDefinitions) != 0
-
-	for idx, machineImage := range config.MachineImages {
-		transformedConfig.MachineImages = append(transformedConfig.MachineImages, v1alpha1.MachineImages{
-			Name:     machineImage.Name,
-			Versions: make([]v1alpha1.MachineImageVersion, 0, len(machineImage.Versions)),
-		})
+	for idx, machineImage := range cloudProfileConfig.MachineImages {
+		cloudProfileConfig.MachineImages[idx].Versions = make([]v1alpha1.MachineImageVersion, 0, len(machineImage.Versions))
 		for _, version := range machineImage.Versions {
 			isVersionInCapabilityFormat := len(version.CapabilityFlavors) != 0
 			transformedVersion := v1alpha1.MachineImageVersion{Version: version.Version}
@@ -96,11 +91,10 @@ func MutateArchitectureCapabilityFields(config *v1alpha1.CloudProfileConfig, cap
 			} else {
 				transformedVersion = version
 			}
-
-			transformedConfig.MachineImages[idx].Versions = append(transformedConfig.MachineImages[idx].Versions, transformedVersion)
+			cloudProfileConfig.MachineImages[idx].Versions = append(cloudProfileConfig.MachineImages[idx].Versions, transformedVersion)
 		}
 	}
-	return &transformedConfig
+	return cloudProfileConfig
 }
 
 func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.MachineImages) []v1alpha1.MachineImages {

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
@@ -63,7 +63,7 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 		}
 	})
 
-	Describe("MutateArchitectureCapabilityFields", func() {
+	Describe("TransformProviderConfigToParentFormat", func() {
 		var parentCloudProfile *gardencorev1beta1.CloudProfile
 		var cpConfig *v1alpha1.CloudProfileConfig
 		var capabilityMachineImage v1alpha1.MachineImages
@@ -108,14 +108,14 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 				machineImages := []v1alpha1.MachineImages{capabilityMachineImage}
 				cpConfig.MachineImages = machineImages
 
-				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.TransformProviderConfigToParentFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
 				Expect(uniformSpecConfig).To(BeEquivalentTo(cpConfig))
 			})
 
 			It("should transform the status to capability format if the NamespacedCloudProfile spec is in old format", func() {
 				cpConfig.MachineImages = []v1alpha1.MachineImages{legacyMachineImage}
-				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.TransformProviderConfigToParentFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages[0]).To(Equal(capabilityMachineImage))
 			})
 		})
@@ -125,14 +125,14 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 				machineImages := []v1alpha1.MachineImages{legacyMachineImage}
 				cpConfig.MachineImages = machineImages
 
-				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.TransformProviderConfigToParentFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
 				Expect(uniformSpecConfig).To(BeEquivalentTo(cpConfig))
 			})
 
 			It("should transform the status to legacy format if the NamespacedCloudProfile spec is in capability format", func() {
 				cpConfig.MachineImages = []v1alpha1.MachineImages{capabilityMachineImage}
-				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.TransformProviderConfigToParentFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages[0]).To(Equal(legacyMachineImage))
 			})
 		})

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
@@ -63,7 +63,7 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 		}
 	})
 
-	Describe("EnsureUniformFormat", func() {
+	Describe("MutateArchitectureCapabilityFields", func() {
 		var parentCloudProfile *gardencorev1beta1.CloudProfile
 		var cpConfig *v1alpha1.CloudProfileConfig
 		var capabilityMachineImage v1alpha1.MachineImages
@@ -108,14 +108,14 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 				machineImages := []v1alpha1.MachineImages{capabilityMachineImage}
 				cpConfig.MachineImages = machineImages
 
-				uniformSpecConfig := mutator.EnsureUniformFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
 				Expect(uniformSpecConfig).NotTo(BeIdenticalTo(cpConfig))
 			})
 
 			It("should transform the status to capability format if the NamespacedCloudProfile spec is in old format", func() {
 				cpConfig.MachineImages = []v1alpha1.MachineImages{legacyMachineImage}
-				uniformSpecConfig := mutator.EnsureUniformFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages[0]).To(Equal(capabilityMachineImage))
 			})
 		})
@@ -125,14 +125,14 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 				machineImages := []v1alpha1.MachineImages{legacyMachineImage}
 				cpConfig.MachineImages = machineImages
 
-				uniformSpecConfig := mutator.EnsureUniformFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
 				Expect(uniformSpecConfig).NotTo(BeIdenticalTo(cpConfig))
 			})
 
 			It("should transform the status to legacy format if the NamespacedCloudProfile spec is in capability format", func() {
 				cpConfig.MachineImages = []v1alpha1.MachineImages{capabilityMachineImage}
-				uniformSpecConfig := mutator.EnsureUniformFormat(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
+				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages[0]).To(Equal(legacyMachineImage))
 			})
 		})

--- a/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/provider-local/admission/mutator/namespacedcloudprofile_test.go
@@ -110,7 +110,7 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 
 				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
-				Expect(uniformSpecConfig).NotTo(BeIdenticalTo(cpConfig))
+				Expect(uniformSpecConfig).To(BeEquivalentTo(cpConfig))
 			})
 
 			It("should transform the status to capability format if the NamespacedCloudProfile spec is in old format", func() {
@@ -127,7 +127,7 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 
 				uniformSpecConfig := mutator.MutateArchitectureCapabilityFields(cpConfig, parentCloudProfile.Spec.MachineCapabilities)
 				Expect(uniformSpecConfig.MachineImages).To(ContainElements(machineImages))
-				Expect(uniformSpecConfig).NotTo(BeIdenticalTo(cpConfig))
+				Expect(uniformSpecConfig).To(BeEquivalentTo(cpConfig))
 			})
 
 			It("should transform the status to legacy format if the NamespacedCloudProfile spec is in capability format", func() {

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -48,9 +48,9 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 	if err != nil {
 		return fmt.Errorf("could not decode providerConfig of CloudProfile %q: %w", cloudProfile.Name, err)
 	}
-	CapabilityDefinition, err := helper.ConvertV1beta1CapabilityDefinitions(cloudProfile.Spec.MachineCapabilities)
+	capabilityDefinitions, err := helper.ConvertV1beta1CapabilityDefinitions(cloudProfile.Spec.MachineCapabilities)
 	if err != nil {
 		return field.InternalError(field.NewPath("spec").Child("machineCapabilities"), err)
 	}
-	return validation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, CapabilityDefinition, providerConfigPath).ToAggregate()
+	return validation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, capabilityDefinitions, providerConfigPath).ToAggregate()
 }

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -48,9 +48,15 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 	if err != nil {
 		return fmt.Errorf("could not decode providerConfig of CloudProfile %q: %w", cloudProfile.Name, err)
 	}
+
 	capabilityDefinitions, err := helper.ConvertV1beta1CapabilityDefinitions(cloudProfile.Spec.MachineCapabilities)
 	if err != nil {
 		return field.InternalError(field.NewPath("spec").Child("machineCapabilities"), err)
 	}
+
+	if err := validation.ValidateSupportedCapabilities(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
+		return err
+	}
+
 	return validation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, capabilityDefinitions, providerConfigPath).ToAggregate()
 }

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -54,6 +54,7 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 		return field.InternalError(field.NewPath("spec").Child("machineCapabilities"), err)
 	}
 
+	// @Roncossek: Remove ValidateSupportedCapabilities once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are deprecated.
 	if err := validation.ValidateSupportedCapabilities(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
 		return err
 	}

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -16,8 +16,6 @@ import (
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/provider-local/admission"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/validation"
@@ -56,23 +54,5 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 		return field.InternalError(field.NewPath("spec").Child("machineCapabilities"), err)
 	}
 
-	// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
-	if err := restrictToArchitectureCapability(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
-		return err
-	}
-
 	return validation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, capabilityDefinitions, providerConfigPath).ToAggregate()
-}
-
-// restrictToArchitectureCapability ensures that for the transition period from the deprecated architecture fields to the capabilities format only the `architecture` capability is used to support automatic transformation and migration.
-// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
-func restrictToArchitectureCapability(capabilityDefinitions []gardencorev1beta1.CapabilityDefinition, child *field.Path) error {
-	allErrs := field.ErrorList{}
-	for i, def := range capabilityDefinitions {
-		idxPath := child.Index(i)
-		if def.Name != v1beta1constants.ArchitectureName {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("name"), def.Name, []string{v1beta1constants.ArchitectureName}))
-		}
-	}
-	return allErrs.ToAggregate()
 }

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -54,8 +54,8 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 		return field.InternalError(field.NewPath("spec").Child("machineCapabilities"), err)
 	}
 
-	// @Roncossek: Remove ValidateSupportedCapabilities once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are deprecated.
-	if err := validation.ValidateSupportedCapabilities(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
+	// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
+	if err := validation.RestrictToArchitectureCapability(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
 		return err
 	}
 

--- a/pkg/provider-local/admission/validator/cloudprofile.go
+++ b/pkg/provider-local/admission/validator/cloudprofile.go
@@ -16,6 +16,8 @@ import (
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/provider-local/admission"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/validation"
@@ -55,9 +57,22 @@ func (cp *cloudProfileValidator) Validate(_ context.Context, newObj, _ client.Ob
 	}
 
 	// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
-	if err := validation.RestrictToArchitectureCapability(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
+	if err := restrictToArchitectureCapability(capabilityDefinitions, field.NewPath("spec").Child("machineCapabilities")); err != nil {
 		return err
 	}
 
 	return validation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, capabilityDefinitions, providerConfigPath).ToAggregate()
+}
+
+// restrictToArchitectureCapability ensures that for the transition period from the deprecated architecture fields to the capabilities format only the `architecture` capability is used to support automatic transformation and migration.
+// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
+func restrictToArchitectureCapability(capabilityDefinitions []gardencorev1beta1.CapabilityDefinition, child *field.Path) error {
+	allErrs := field.ErrorList{}
+	for i, def := range capabilityDefinitions {
+		idxPath := child.Index(i)
+		if def.Name != v1beta1constants.ArchitectureName {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("name"), def.Name, []string{v1beta1constants.ArchitectureName}))
+		}
+	}
+	return allErrs.ToAggregate()
 }

--- a/pkg/provider-local/apis/local/v1alpha1/types_cloudprofile.go
+++ b/pkg/provider-local/apis/local/v1alpha1/types_cloudprofile.go
@@ -36,7 +36,7 @@ type MachineImageVersion struct {
 	// Version is the version of the image.
 	Version string `json:"version"`
 	// Image is the image for the machine image.
-	Image string `json:"image"`
+	Image string `json:"image,omitempty"`
 	// CapabilityFlavors contains provider-specific image identifiers of this version with their capabilities.
 	CapabilityFlavors []MachineImageFlavor `json:"capabilityFlavors"`
 }

--- a/pkg/provider-local/apis/local/v1alpha1/types_cloudprofile.go
+++ b/pkg/provider-local/apis/local/v1alpha1/types_cloudprofile.go
@@ -36,6 +36,7 @@ type MachineImageVersion struct {
 	// Version is the version of the image.
 	Version string `json:"version"`
 	// Image is the image for the machine image.
+	// +optional
 	Image string `json:"image,omitempty"`
 	// CapabilityFlavors contains provider-specific image identifiers of this version with their capabilities.
 	CapabilityFlavors []MachineImageFlavor `json:"capabilityFlavors"`

--- a/pkg/provider-local/apis/local/validation/cloudprofile.go
+++ b/pkg/provider-local/apis/local/validation/cloudprofile.go
@@ -149,8 +149,7 @@ func validateMachineImageMapping(coreMachineImages []core.MachineImage, machineI
 
 		// validate that for each machine image there is a corresponding cpConfig image
 		if _, existsInConfig := providerImages.GetImage(machineImage.Name); !existsInConfig {
-			allErrs = append(allErrs, field.Required(machineImagePath,
-				fmt.Sprintf("must provide an image mapping for image %q in providerConfig", machineImage.Name)))
+			allErrs = append(allErrs, field.Required(machineImagePath, fmt.Sprintf("must provide an image mapping for image %q in providerConfig", machineImage.Name)))
 			continue
 		}
 
@@ -177,8 +176,7 @@ func validateMachineImageVersionMapping(machineImage core.MachineImage, provider
 		imageVersion, exists := providerImages.GetImageVersion(machineImage.Name, version.Version)
 		if !exists {
 			allErrs = append(allErrs, field.Required(machineImageVersionPath,
-				fmt.Sprintf("machine image version %s@%s is not defined in the providerConfig",
-					machineImage.Name, version.Version),
+				fmt.Sprintf("machine image version %s@%s is not defined in the providerConfig", machineImage.Name, version.Version),
 			))
 			continue // Skip further validation if version doesn't exist
 		}

--- a/pkg/provider-local/apis/local/validation/cloudprofile.go
+++ b/pkg/provider-local/apis/local/validation/cloudprofile.go
@@ -202,7 +202,7 @@ func validateImageFlavorMapping(imageName string, version core.MachineImageVersi
 		isFound := false
 		// search for the corresponding imageVersion.MachineImageFlavor
 		for _, providerFlavor := range imageVersion.CapabilityFlavors {
-			providerDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(providerFlavor.Capabilities, capabilityDefinitions)
+			providerDefaultedCapabilities := gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(providerFlavor.Capabilities, capabilityDefinitions)
 			if v1beta1helper.AreCapabilitiesEqual(coreDefaultedFlavor.Capabilities, providerDefaultedCapabilities) {
 				isFound = true
 				break

--- a/pkg/provider-local/apis/local/validation/cloudprofile.go
+++ b/pkg/provider-local/apis/local/validation/cloudprofile.go
@@ -12,7 +12,6 @@ import (
 	coreapi "github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	api "github.com/gardener/gardener/pkg/provider-local/apis/local"
 	"github.com/gardener/gardener/pkg/utils"
@@ -227,17 +226,4 @@ func NewProviderImagesContext(providerImages []api.MachineImages) *gardenerutils
 			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return v.Version })
 		},
 	)
-}
-
-// RestrictToArchitectureCapability ensures that for the transition period from the deprecated architecture fields to the capabilities format only the `architecture` capability is used to support automatic transformation and migration.
-// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
-func RestrictToArchitectureCapability(capabilityDefinitions []gardencorev1beta1.CapabilityDefinition, child *field.Path) error {
-	allErrs := field.ErrorList{}
-	for i, def := range capabilityDefinitions {
-		idxPath := child.Index(i)
-		if def.Name != v1beta1constants.ArchitectureName {
-			allErrs = append(allErrs, field.NotSupported(idxPath.Child("name"), def.Name, []string{v1beta1constants.ArchitectureName}))
-		}
-	}
-	return allErrs.ToAggregate()
 }

--- a/pkg/provider-local/apis/local/validation/cloudprofile.go
+++ b/pkg/provider-local/apis/local/validation/cloudprofile.go
@@ -229,22 +229,14 @@ func NewProviderImagesContext(providerImages []api.MachineImages) *gardenerutils
 	)
 }
 
-// ValidateSupportedCapabilities validates that only supported capabilities and values are used.
-// This function can be deleted once the dedicated architecture field on MachineType and MachineImageVersion is retired.
-// This strict behavior is required to ensure automatic format conversion of namespaced CloudProfiles during the transition to machine capabilities.
-func ValidateSupportedCapabilities(capabilityDefinitions []gardencorev1beta1.CapabilityDefinition, child *field.Path) error {
-	// During transition to machineCapability based cloud profiles only the following capability is allowed to be set: architecture
+// RestrictToArchitectureCapability ensures that for the transition period from the deprecated architecture fields to the capabilities format only the `architecture` capability is used to support automatic transformation and migration.
+// TODO(Roncossek): Delete this function once the dedicated architecture fields on MachineType and MachineImageVersion have been removed.
+func RestrictToArchitectureCapability(capabilityDefinitions []gardencorev1beta1.CapabilityDefinition, child *field.Path) error {
 	allErrs := field.ErrorList{}
 	for i, def := range capabilityDefinitions {
 		idxPath := child.Index(i)
 		if def.Name != v1beta1constants.ArchitectureName {
 			allErrs = append(allErrs, field.NotSupported(idxPath.Child("name"), def.Name, []string{v1beta1constants.ArchitectureName}))
-		}
-		for j, value := range def.Values {
-			jdxPath := idxPath.Child("values").Index(j)
-			if value != v1beta1constants.ArchitectureAMD64 && value != v1beta1constants.ArchitectureARM64 {
-				allErrs = append(allErrs, field.NotSupported(jdxPath, value, []string{v1beta1constants.ArchitectureAMD64, v1beta1constants.ArchitectureARM64}))
-			}
 		}
 	}
 	return allErrs.ToAggregate()

--- a/pkg/provider-local/controller/worker/machine_images.go
+++ b/pkg/provider-local/controller/worker/machine_images.go
@@ -93,10 +93,10 @@ func appendMachineImage(machineImages []api.MachineImage, machineImage api.Machi
 		})
 	}
 
-	defaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilityDefinitions)
+	defaultedCapabilities := gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(machineImage.Capabilities, capabilityDefinitions)
 
 	for _, existingMachineImage := range machineImages {
-		existingDefaultedCapabilities := v1beta1helper.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilityDefinitions)
+		existingDefaultedCapabilities := gardencorev1beta1.GetCapabilitiesWithAppliedDefaults(existingMachineImage.Capabilities, capabilityDefinitions)
 		if existingMachineImage.Name == machineImage.Name &&
 			existingMachineImage.Version == machineImage.Version &&
 			v1beta1helper.AreCapabilitiesEqual(defaultedCapabilities, existingDefaultedCapabilities) {

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -294,7 +294,7 @@ func SyncArchitectureCapabilityFields(newCloudProfileSpec core.CloudProfileSpec,
 		return
 	}
 
-	isInitialMigration := hasCapabilities && len(oldCloudProfileSpec.MachineCapabilities) == 0
+	isInitialMigration := len(oldCloudProfileSpec.MachineCapabilities) == 0
 
 	// During the initial migration to capabilities, synchronize the architecture fields with the capability definitions.
 	// After the migration, only sync architectures from the capability definitions back to the architecture fields.

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -351,7 +351,7 @@ func syncMachineTypeLegacyArchitecture(newMachineTypes []core.MachineType, capab
 		}
 
 		// Sync capability architecture to architecture field.
-		defaultedCapabilities := gardencorehelper.GetCapabilitiesWithAppliedDefaults(newMachineTypes[i].Capabilities, capabilityDefinitions)
+		defaultedCapabilities := core.GetCapabilitiesWithAppliedDefaults(newMachineTypes[i].Capabilities, capabilityDefinitions)
 		if len(defaultedCapabilities[v1beta1constants.ArchitectureName]) == 1 {
 			newMachineTypes[i].Architecture = ptr.To(defaultedCapabilities[v1beta1constants.ArchitectureName][0])
 		}

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -319,7 +319,7 @@ func syncMachineImageLegacyArchitecture(newMachineImages []core.MachineImage, ca
 		for versionIdx, imageVersion := range newMachineImages[imageIdx].Versions {
 			// If there are no capability definitions, clear capability flavors.
 			if len(capabilityDefinitions) == 0 {
-				imageVersion.CapabilityFlavors = nil
+				newMachineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = nil
 				continue
 			}
 

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -301,7 +301,7 @@ func SyncArchitectureCapabilityFields(newCloudProfileSpec core.CloudProfileSpec,
 	numberOfCloudProfileArchitectures := len(machineCapabilities[v1beta1constants.ArchitectureName])
 	if numberOfCloudProfileArchitectures <= 1 {
 		// syncing is only required if there is more than 1 architectures Spec.MachineCapabilities
-		// 0: means the MachineCapabilities are invalid and will be catched by validation
+		// 0: means the MachineCapabilities are invalid and will be caught by validation
 		// 1: means we have only one architecture and no syncing is required
 		return
 	}
@@ -313,10 +313,8 @@ func SyncArchitectureCapabilityFields(newCloudProfileSpec core.CloudProfileSpec,
 }
 
 func syncMachineImageArchitectureCapabilities(newMachineImages []core.MachineImage) {
-
 	for imageIdx := range newMachineImages {
 		for versionIdx, version := range newMachineImages[imageIdx].Versions {
-
 			// don't sync if capabilities are set by users
 			if len(version.CapabilityFlavors) > 0 {
 				continue
@@ -339,7 +337,6 @@ func syncMachineImageArchitectureCapabilities(newMachineImages []core.MachineIma
 }
 
 func syncMachineTypeArchitectureCapabilities(newMachineTypes []core.MachineType) {
-
 	for i, machineType := range newMachineTypes {
 		// don't sync if capabilities are set by users
 		if len(machineType.Capabilities) > 0 {
@@ -352,7 +349,6 @@ func syncMachineTypeArchitectureCapabilities(newMachineTypes []core.MachineType)
 		newMachineTypes[i].Capabilities = core.Capabilities{
 			v1beta1constants.ArchitectureName: []string{legacyArchitecture},
 		}
-
 	}
 }
 

--- a/pkg/utils/gardener/cloudprofile.go
+++ b/pkg/utils/gardener/cloudprofile.go
@@ -329,9 +329,9 @@ func syncMachineImageLegacyArchitecture(newMachineImages []core.MachineImage, ca
 			}
 			// Sync capability architectures to architectures field.
 			defaultedImageFlavors := gardencorehelper.GetImageFlavorsWithAppliedDefaults(imageVersion.CapabilityFlavors, capabilityDefinitions)
-			defaultedCapabilityArchitectures := gardencorehelper.ExtractArchitecturesFromImageFlavors(defaultedImageFlavors)
-			if len(defaultedCapabilityArchitectures) > 0 {
-				newMachineImages[imageIdx].Versions[versionIdx].Architectures = defaultedCapabilityArchitectures
+			defaultArchitectures := gardencorehelper.ExtractArchitecturesFromImageFlavors(defaultedImageFlavors)
+			if len(defaultArchitectures) > 0 {
+				newMachineImages[imageIdx].Versions[versionIdx].Architectures = defaultArchitectures
 			}
 		}
 	}

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -743,7 +743,7 @@ var _ = Describe("CloudProfile", func() {
 		Describe("#SyncArchitectureCapabilityFields", func() {
 			var (
 				cloudProfileSpecNew core.CloudProfileSpec
-				cloudProfileSpecOld *core.CloudProfileSpec
+				cloudProfileSpecOld core.CloudProfileSpec
 			)
 
 			BeforeEach(func() {
@@ -755,7 +755,7 @@ var _ = Describe("CloudProfile", func() {
 						{},
 					},
 				}
-				cloudProfileSpecOld = cloudProfileSpecNew.DeepCopy()
+				cloudProfileSpecOld = *cloudProfileSpecNew.DeepCopy()
 			})
 
 			Describe("Initial migration", func() {
@@ -769,7 +769,7 @@ var _ = Describe("CloudProfile", func() {
 					cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures = []string{"amd64"}
 					cloudProfileSpecNew.MachineTypes[0].Architecture = ptr.To("amd64")
 
-					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, *cloudProfileSpecOld)
+					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(Equal([]string{"amd64"}))
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors).To(BeEmpty())
 					Expect(cloudProfileSpecNew.MachineTypes[0].Architecture).To(Equal(ptr.To("amd64")))
@@ -783,7 +783,7 @@ var _ = Describe("CloudProfile", func() {
 						{Capabilities: core.Capabilities{"architecture": []string{"arm64"}}},
 					}
 
-					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, *cloudProfileSpecOld)
+					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
 
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(ConsistOf("amd64", "arm64", "custom"))
 				})
@@ -794,7 +794,7 @@ var _ = Describe("CloudProfile", func() {
 					cloudProfileSpecOld.MachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
 					cloudProfileSpecOld.MachineTypes[0].Architecture = ptr.To("amd64")
 
-					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, *cloudProfileSpecOld)
+					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
 
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(Equal([]string{"amd64", "arm64"}))
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"amd64"}))
@@ -812,7 +812,7 @@ var _ = Describe("CloudProfile", func() {
 					cloudProfileSpecOld.MachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
 					cloudProfileSpecOld.MachineTypes[0].Architecture = ptr.To("amd64")
 
-					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, *cloudProfileSpecOld)
+					gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
 
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(Equal([]string{"arm64"}))
 					Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors).To(BeEmpty())

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -828,9 +828,9 @@ var _ = Describe("CloudProfile", func() {
 
 			It("should use the default architecture amd64 if architecture field is empty and capabilities are empty", func() {
 				gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
-				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(BeEmpty())
+				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(Equal([]string{"amd64"}))
 				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"amd64"}))
-				Expect(cloudProfileSpecNew.MachineTypes[0].Architecture).To(BeNil())
+				Expect(cloudProfileSpecNew.MachineTypes[0].Architecture).To(Equal(ptr.To("amd64")))
 				Expect(cloudProfileSpecNew.MachineTypes[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"amd64"}))
 			})
 		})

--- a/pkg/utils/gardener/cloudprofile_test.go
+++ b/pkg/utils/gardener/cloudprofile_test.go
@@ -791,15 +791,15 @@ var _ = Describe("CloudProfile", func() {
 
 			It("should create capabilities and capabilityFlavors from architecture fields if they are empty", func() {
 				cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures = []string{"amd64", "arm64"}
-				cloudProfileSpecNew.MachineTypes[0].Architecture = ptr.To("amd64")
+				cloudProfileSpecNew.MachineTypes[0].Architecture = ptr.To("arm64")
 
 				gardenerutils.SyncArchitectureCapabilityFields(cloudProfileSpecNew, cloudProfileSpecOld)
 
 				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].Architectures).To(Equal([]string{"amd64", "arm64"}))
 				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"amd64"}))
 				Expect(cloudProfileSpecNew.MachineImages[0].Versions[0].CapabilityFlavors[1].Capabilities["architecture"]).To(BeEquivalentTo([]string{"arm64"}))
-				Expect(cloudProfileSpecNew.MachineTypes[0].Architecture).To(Equal(ptr.To("amd64")))
-				Expect(cloudProfileSpecNew.MachineTypes[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"amd64"}))
+				Expect(cloudProfileSpecNew.MachineTypes[0].Architecture).To(Equal(ptr.To("arm64")))
+				Expect(cloudProfileSpecNew.MachineTypes[0].Capabilities["architecture"]).To(BeEquivalentTo([]string{"arm64"}))
 			})
 
 			It("should not write to capabilities if they are already set", func() {

--- a/pkg/utils/gardener/namespacedcloudprofile.go
+++ b/pkg/utils/gardener/namespacedcloudprofile.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// TransformSpecToParentFormat ensures that the given NamespacedCloudProfileSpec is in a uniform format with its parent CloudProfileSpec.
+// If the parent CloudProfileSpec uses capability definitions, then the NamespacedCloudProfileSpec is transformed to also use capabilities
+// and vice versa.
+// TODO(Roncossek): Remove TransformSpecToParentFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
+func TransformSpecToParentFormat(
+	spec gardencorev1beta1.NamespacedCloudProfileSpec,
+	capabilityDefinitions []gardencorev1beta1.CapabilityDefinition,
+) gardencorev1beta1.NamespacedCloudProfileSpec {
+	isParentInCapabilityFormat := len(capabilityDefinitions) > 0
+	transformedSpec := spec.DeepCopy()
+
+	// Normalize MachineImages
+	for idx, machineImage := range transformedSpec.MachineImages {
+		for idy, version := range machineImage.Versions {
+			legacyArchitectures := version.Architectures
+
+			if isParentInCapabilityFormat && len(version.CapabilityFlavors) == 0 {
+				// Convert legacy architectures to capability flavors
+				version.CapabilityFlavors = []gardencorev1beta1.MachineImageFlavor{}
+				for _, arch := range legacyArchitectures {
+					version.CapabilityFlavors = append(version.CapabilityFlavors, gardencorev1beta1.MachineImageFlavor{
+						Capabilities: gardencorev1beta1.Capabilities{
+							v1beta1constants.ArchitectureName: []string{arch},
+						},
+					})
+				}
+				version.Architectures = legacyArchitectures
+			} else if !isParentInCapabilityFormat {
+				// Convert capability flavors to legacy architectures
+				if len(legacyArchitectures) == 0 {
+					architectureSet := sets.New[string]()
+					if len(version.CapabilityFlavors) > 0 {
+						for _, flavor := range version.CapabilityFlavors {
+							architectureSet.Insert(flavor.Capabilities[v1beta1constants.ArchitectureName]...)
+						}
+					}
+					version.Architectures = architectureSet.UnsortedList()
+				}
+				version.CapabilityFlavors = nil
+			}
+
+			transformedSpec.MachineImages[idx].Versions[idy] = version
+		}
+	}
+
+	// Normalize MachineTypes
+	for idx, machineType := range transformedSpec.MachineTypes {
+		if isParentInCapabilityFormat {
+			if len(machineType.Capabilities) > 0 {
+				continue
+			}
+			architecture := machineType.GetArchitecture(capabilityDefinitions)
+			if architecture == "" {
+				architecture = ptr.Deref(machineType.Architecture, v1beta1constants.ArchitectureAMD64)
+			}
+			machineType.Capabilities = gardencorev1beta1.Capabilities{
+				v1beta1constants.ArchitectureName: []string{architecture},
+			}
+		} else {
+			if machineType.Architecture == nil {
+				if len(machineType.Capabilities) > 0 {
+					architecture := machineType.Capabilities[v1beta1constants.ArchitectureName]
+					if len(architecture) > 0 {
+						machineType.Architecture = &architecture[0]
+					}
+				}
+			}
+			machineType.Capabilities = nil
+		}
+		transformedSpec.MachineTypes[idx] = machineType
+	}
+	return *transformedSpec
+}

--- a/pkg/utils/gardener/namespacedcloudprofile_test.go
+++ b/pkg/utils/gardener/namespacedcloudprofile_test.go
@@ -7,7 +7,6 @@ package gardener_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
@@ -255,64 +254,77 @@ var _ = Describe("TransformSpecToParentFormat", func() {
 		result := TransformSpecToParentFormat(spec, capabilityDefinitions)
 
 		// Verify all machine images have capability flavors
-		Expect(result.MachineImages).To(ConsistOf(
-			MatchFields(IgnoreExtras, Fields{
-				"Name": Equal("ubuntu"),
-				"Versions": ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{"Version": Equal("20.04")}),
-						"Architectures":    Equal([]string{"amd64"}),
-						"CapabilityFlavors": ConsistOf(MatchFields(IgnoreExtras, Fields{
-							"Capabilities": MatchAllKeys(Keys{
-								"architecture": BeEquivalentTo([]string{"amd64"}),
-							}),
-						})),
-					}),
-					MatchFields(IgnoreExtras, Fields{
-						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{"Version": Equal("22.04")}),
-						"Architectures":    Equal([]string{"arm64"}),
-						"CapabilityFlavors": ConsistOf(MatchFields(IgnoreExtras, Fields{
-							"Capabilities": MatchAllKeys(Keys{
-								"architecture": BeEquivalentTo([]string{"arm64"}),
-							}),
-						})),
-					}),
-				),
-			}),
-			MatchFields(IgnoreExtras, Fields{
-				"Name": Equal("debian"),
-				"Versions": ConsistOf(
-					MatchFields(IgnoreExtras, Fields{
-						"ExpirableVersion": MatchFields(IgnoreExtras, Fields{"Version": Equal("11")}),
-						"Architectures":    Equal([]string{"amd64", "arm64"}),
-						"CapabilityFlavors": ConsistOf(MatchFields(IgnoreExtras, Fields{
-							"Capabilities": MatchAllKeys(Keys{
-								"architecture": BeEquivalentTo([]string{"amd64"}),
-							}),
-						}), MatchFields(IgnoreExtras, Fields{
-							"Capabilities": MatchAllKeys(Keys{
-								"architecture": BeEquivalentTo([]string{"arm64"}),
-							}),
-						})),
-					}),
-				),
-			}),
-		))
+		Expect(result.MachineImages).To(Equal([]gardencorev1beta1.MachineImage{
+			{
+				Name: "ubuntu",
+				Versions: []gardencorev1beta1.MachineImageVersion{
+					{
+						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "20.04"},
+						Architectures:    []string{"amd64"},
+						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+							{
+								Capabilities: gardencorev1beta1.Capabilities{
+									"architecture": {"amd64"},
+								},
+							},
+						},
+					},
+					{
+						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "22.04"},
+						Architectures:    []string{"arm64"},
+						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+							{
+								Capabilities: gardencorev1beta1.Capabilities{
+									"architecture": {"arm64"},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "debian",
+				Versions: []gardencorev1beta1.MachineImageVersion{
+					{
+						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "11"},
+						Architectures:    []string{"amd64", "arm64"},
+						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+							{
+								Capabilities: gardencorev1beta1.Capabilities{
+									"architecture": {"amd64"},
+								},
+							},
+							{
+								Capabilities: gardencorev1beta1.Capabilities{
+									"architecture": {"arm64"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}))
 		// Verify all machine types have capabilities
-		Expect(result.MachineTypes).To(ConsistOf(
-			MatchFields(IgnoreExtras, Fields{
-				"Name": Equal("m5.large"),
-				"Capabilities": MatchAllKeys(Keys{
-					"architecture": BeEquivalentTo([]string{"amd64"}),
-				}),
-			}),
-			MatchFields(IgnoreExtras, Fields{
-				"Name": Equal("m6g.large"),
-				"Capabilities": MatchAllKeys(Keys{
-					"architecture": BeEquivalentTo([]string{"arm64"}),
-				}),
-			}),
-		))
+		Expect(result.MachineTypes).To(Equal([]gardencorev1beta1.MachineType{
+			{
+				Name:         "m5.large",
+				CPU:          resource.MustParse("2"),
+				Memory:       resource.MustParse("8Gi"),
+				Architecture: ptr.To("amd64"),
+				Capabilities: gardencorev1beta1.Capabilities{
+					"architecture": {"amd64"},
+				},
+			},
+			{
+				Name:         "m6g.large",
+				CPU:          resource.MustParse("2"),
+				Memory:       resource.MustParse("8Gi"),
+				Architecture: ptr.To("arm64"),
+				Capabilities: gardencorev1beta1.Capabilities{
+					"architecture": {"arm64"},
+				},
+			},
+		}))
 	})
 
 	It("should return empty spec for empty input", func() {

--- a/pkg/utils/gardener/namespacedcloudprofile_test.go
+++ b/pkg/utils/gardener/namespacedcloudprofile_test.go
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var _ = Describe("TransformSpecToParentFormat", func() {
+	When("parent uses capabilities", func() {
+		var capabilityDefinitions []gardencorev1beta1.CapabilityDefinition
+
+		BeforeEach(func() {
+			capabilityDefinitions = []gardencorev1beta1.CapabilityDefinition{
+				{
+					Name:   v1beta1constants.ArchitectureName,
+					Values: []string{"amd64", "arm64"},
+				},
+			}
+		})
+
+		It("should transform legacy architectures to capability flavors", func() {
+			spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: "ubuntu",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "20.04",
+								},
+								Architectures: []string{"amd64", "arm64"},
+							},
+						},
+					},
+				},
+				MachineTypes: []gardencorev1beta1.MachineType{
+					{
+						Name:         "m5.large",
+						CPU:          resource.MustParse("2"),
+						Memory:       resource.MustParse("8Gi"),
+						Architecture: ptr.To("amd64"),
+					},
+				},
+			}
+
+			result := TransformSpecToParentFormat(spec, capabilityDefinitions)
+
+			Expect(result.MachineImages).To(HaveLen(1))
+			Expect(result.MachineImages[0].Versions).To(HaveLen(1))
+			version := result.MachineImages[0].Versions[0]
+			Expect(version.Architectures).To(Equal([]string{"amd64", "arm64"}))
+			Expect(version.CapabilityFlavors).To(HaveLen(2))
+			Expect(version.CapabilityFlavors[0].Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"amd64"}))
+			Expect(version.CapabilityFlavors[1].Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"arm64"}))
+
+			Expect(result.MachineTypes).To(HaveLen(1))
+			machineType := result.MachineTypes[0]
+			Expect(machineType.Architecture).To(Equal(ptr.To("amd64")))
+			Expect(machineType.Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"amd64"}))
+		})
+
+		It("should preserve existing capability flavors when already present", func() {
+			spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: "ubuntu",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "20.04",
+								},
+								CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+									{
+										Capabilities: gardencorev1beta1.Capabilities{
+											v1beta1constants.ArchitectureName: []string{"amd64"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				MachineTypes: []gardencorev1beta1.MachineType{
+					{
+						Name:   "m5.large",
+						CPU:    resource.MustParse("2"),
+						Memory: resource.MustParse("8Gi"),
+						Capabilities: gardencorev1beta1.Capabilities{
+							v1beta1constants.ArchitectureName: []string{"amd64"},
+						},
+					},
+				},
+			}
+
+			result := TransformSpecToParentFormat(spec, capabilityDefinitions)
+
+			Expect(result.MachineImages[0].Versions[0].CapabilityFlavors).To(HaveLen(1))
+			Expect(result.MachineImages[0].Versions[0].CapabilityFlavors[0].Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"amd64"}))
+			Expect(result.MachineTypes[0].Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"amd64"}))
+		})
+
+		It("should default to AMD64 for machine types without architecture", func() {
+			spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+				MachineTypes: []gardencorev1beta1.MachineType{
+					{
+						Name:   "m5.large",
+						CPU:    resource.MustParse("2"),
+						Memory: resource.MustParse("8Gi"),
+					},
+				},
+			}
+
+			result := TransformSpecToParentFormat(spec, capabilityDefinitions)
+
+			Expect(result.MachineTypes[0].Capabilities[v1beta1constants.ArchitectureName]).To(BeEquivalentTo([]string{"amd64"}))
+		})
+	})
+
+	When("parent doesn't use capabilities", func() {
+		It("should transform capability flavors to legacy architectures", func() {
+			spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: "ubuntu",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "20.04",
+								},
+								CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+									{
+										Capabilities: gardencorev1beta1.Capabilities{
+											v1beta1constants.ArchitectureName: []string{"amd64"},
+										},
+									},
+									{
+										Capabilities: gardencorev1beta1.Capabilities{
+											v1beta1constants.ArchitectureName: []string{"arm64"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				MachineTypes: []gardencorev1beta1.MachineType{
+					{
+						Name:   "m5.large",
+						CPU:    resource.MustParse("2"),
+						Memory: resource.MustParse("8Gi"),
+						Capabilities: gardencorev1beta1.Capabilities{
+							v1beta1constants.ArchitectureName: []string{"amd64"},
+						},
+					},
+				},
+			}
+
+			result := TransformSpecToParentFormat(spec, nil)
+
+			Expect(result.MachineImages[0].Versions[0].Architectures).To(ConsistOf("amd64", "arm64"))
+			Expect(result.MachineImages[0].Versions[0].CapabilityFlavors).To(BeNil())
+			Expect(result.MachineTypes[0].Capabilities).To(BeNil())
+			Expect(result.MachineTypes[0].Architecture).To(Equal(ptr.To("amd64")))
+		})
+
+		It("should leave architectures empty for machine image versions with empty capability flavors, to not overwrite images during deepMerge", func() {
+			spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: "ubuntu",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "20.04",
+								},
+								CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{},
+							},
+						},
+					},
+				},
+			}
+
+			result := TransformSpecToParentFormat(spec, nil)
+
+			Expect(result.MachineImages[0].Versions[0].Architectures).To(BeEmpty())
+		})
+	})
+
+	It("should handle multiple machine images and types correctly", func() {
+		spec := gardencorev1beta1.NamespacedCloudProfileSpec{
+			MachineImages: []gardencorev1beta1.MachineImage{
+				{
+					Name: "ubuntu",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "20.04",
+							},
+							Architectures: []string{"amd64"},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "22.04",
+							},
+							Architectures: []string{"arm64"},
+						},
+					},
+				},
+				{
+					Name: "debian",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "11",
+							},
+							Architectures: []string{"amd64", "arm64"},
+						},
+					},
+				},
+			},
+			MachineTypes: []gardencorev1beta1.MachineType{
+				{
+					Name:         "m5.large",
+					CPU:          resource.MustParse("2"),
+					Memory:       resource.MustParse("8Gi"),
+					Architecture: ptr.To("amd64"),
+				},
+				{
+					Name:         "m6g.large",
+					CPU:          resource.MustParse("2"),
+					Memory:       resource.MustParse("8Gi"),
+					Architecture: ptr.To("arm64"),
+				},
+			},
+		}
+
+		capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
+			{
+				Name:   v1beta1constants.ArchitectureName,
+				Values: []string{"amd64", "arm64"},
+			},
+		}
+
+		result := TransformSpecToParentFormat(spec, capabilityDefinitions)
+
+		// Verify all machine images have capability flavors
+		Expect(result.MachineImages).To(HaveLen(2))
+		for _, image := range result.MachineImages {
+			for _, version := range image.Versions {
+				Expect(version.CapabilityFlavors).ToNot(BeEmpty())
+			}
+		}
+
+		// Verify all machine types have capabilities
+		Expect(result.MachineTypes).To(HaveLen(2))
+		for _, machineType := range result.MachineTypes {
+			Expect(machineType.Capabilities[v1beta1constants.ArchitectureName]).ToNot(BeEmpty())
+		}
+	})
+
+	It("should return empty spec for empty input", func() {
+		spec := gardencorev1beta1.NamespacedCloudProfileSpec{}
+		capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
+			{
+				Name:   v1beta1constants.ArchitectureName,
+				Values: []string{"amd64", "arm64"},
+			},
+		}
+
+		result := TransformSpecToParentFormat(spec, capabilityDefinitions)
+
+		Expect(result).To(Equal(gardencorev1beta1.NamespacedCloudProfileSpec{}))
+	})
+
+	It("should not modify the original spec (deep copy behavior)", func() {
+		originalSpec := gardencorev1beta1.NamespacedCloudProfileSpec{
+			MachineImages: []gardencorev1beta1.MachineImage{
+				{
+					Name: "ubuntu",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version: "20.04",
+							},
+							Architectures: []string{"amd64"},
+						},
+					},
+				},
+			},
+		}
+
+		capabilityDefinitions := []gardencorev1beta1.CapabilityDefinition{
+			{
+				Name:   v1beta1constants.ArchitectureName,
+				Values: []string{"amd64", "arm64"},
+			},
+		}
+
+		// Keep references to verify original is unchanged
+		originalArchitectures := originalSpec.MachineImages[0].Versions[0].Architectures
+		originalCapabilityFlavors := originalSpec.MachineImages[0].Versions[0].CapabilityFlavors
+
+		result := TransformSpecToParentFormat(originalSpec, capabilityDefinitions)
+
+		// Original should remain unchanged
+		Expect(originalSpec.MachineImages[0].Versions[0].Architectures).To(Equal(originalArchitectures))
+		Expect(originalSpec.MachineImages[0].Versions[0].CapabilityFlavors).To(Equal(originalCapabilityFlavors))
+
+		// Result should have capability flavors added
+		Expect(result.MachineImages[0].Versions[0].CapabilityFlavors).ToNot(BeNil())
+		Expect(result.MachineImages[0].Versions[0].CapabilityFlavors).To(HaveLen(1))
+	})
+})

--- a/pkg/utils/gardener/namespacedcloudprofile_test.go
+++ b/pkg/utils/gardener/namespacedcloudprofile_test.go
@@ -254,35 +254,34 @@ var _ = Describe("TransformSpecToParentFormat", func() {
 		result := TransformSpecToParentFormat(spec, capabilityDefinitions)
 
 		// Verify all machine images have capability flavors
-		Expect(result.MachineImages).To(Equal([]gardencorev1beta1.MachineImage{
-			{
-				Name: "ubuntu",
-				Versions: []gardencorev1beta1.MachineImageVersion{
-					{
-						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "20.04"},
-						Architectures:    []string{"amd64"},
-						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
-							{
-								Capabilities: gardencorev1beta1.Capabilities{
-									"architecture": {"amd64"},
-								},
+		Expect(result.MachineImages).To(ConsistOf(gardencorev1beta1.MachineImage{
+			Name: "ubuntu",
+			Versions: []gardencorev1beta1.MachineImageVersion{
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "20.04"},
+					Architectures:    []string{"amd64"},
+					CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+						{
+							Capabilities: gardencorev1beta1.Capabilities{
+								"architecture": {"amd64"},
 							},
 						},
 					},
-					{
-						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "22.04"},
-						Architectures:    []string{"arm64"},
-						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
-							{
-								Capabilities: gardencorev1beta1.Capabilities{
-									"architecture": {"arm64"},
-								},
+				},
+				{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "22.04"},
+					Architectures:    []string{"arm64"},
+					CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+						{
+							Capabilities: gardencorev1beta1.Capabilities{
+								"architecture": {"arm64"},
 							},
 						},
 					},
 				},
 			},
-			{
+		},
+			gardencorev1beta1.MachineImage{
 				Name: "debian",
 				Versions: []gardencorev1beta1.MachineImageVersion{
 					{
@@ -302,8 +301,7 @@ var _ = Describe("TransformSpecToParentFormat", func() {
 						},
 					},
 				},
-			},
-		}))
+			}))
 		// Verify all machine types have capabilities
 		Expect(result.MachineTypes).To(Equal([]gardencorev1beta1.MachineType{
 			{

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -218,8 +218,10 @@ var _ = Describe("Admission", func() {
 
 						It("should reject unsupported Capabilities or CapabilityValues in machineTypes", func() {
 							Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+							namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{}
 							namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{{Name: "my-other-machine",
-								Capabilities: gardencore.Capabilities{constants.ArchitectureName: []string{"arm64"},
+								Capabilities: gardencore.Capabilities{
+									constants.ArchitectureName: []string{"arm64"},
 									// Unsupported CapabilityValue
 									"capability2": []string{"value3"},
 									// Unsupported Capability

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -159,12 +159,18 @@ var _ = Describe("Admission", func() {
 
 					When("Architecture capability has multiple supported values", func() {
 						BeforeEach(func() {
+							parentCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors = []gardencorev1beta1.MachineImageFlavor{
+								{Capabilities: gardencorev1beta1.Capabilities{constants.ArchitectureName: []string{"amd64"}}},
+							}
 							namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
 								{
 									Name: "test-image",
 									Versions: []gardencore.MachineImageVersion{{
 										ExpirableVersion: gardencore.ExpirableVersion{Version: "1.0.1"},
 										CRI:              []gardencore.CRI{{Name: "containerd"}},
+										CapabilityFlavors: []gardencore.MachineImageFlavor{{
+											Capabilities: gardencore.Capabilities{constants.ArchitectureName: []string{"amd64"}},
+										}},
 									}}}}
 						})
 
@@ -234,12 +240,15 @@ var _ = Describe("Admission", func() {
 
 				Describe("Adding machineImages defined in the parent CloudProfile", func() {
 					BeforeEach(func() {
-						namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
-							{
-								Name: "test-image",
-								Versions: []gardencore.MachineImageVersion{{
-									ExpirableVersion: gardencore.ExpirableVersion{Version: "1.0.0", ExpirationDate: validExpirationDate},
-								}}}}
+						parentCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors = []gardencorev1beta1.MachineImageFlavor{{
+							Capabilities: gardencorev1beta1.Capabilities{constants.ArchitectureName: []string{"amd64"}},
+						}}
+						namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{{
+							Name: "test-image",
+							Versions: []gardencore.MachineImageVersion{{
+								ExpirableVersion: gardencore.ExpirableVersion{Version: "1.0.0", ExpirationDate: validExpirationDate},
+							}},
+						}}
 					})
 
 					It("should allow to add a machineImage without Capabilities", func() {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -213,7 +213,6 @@ var _ = Describe("Admission", func() {
 
 						It("should reject unsupported Capabilities or CapabilityValues in machineTypes", func() {
 							Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
-							namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{}
 							namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{{Name: "my-other-machine",
 								Capabilities: gardencore.Capabilities{
 									constants.ArchitectureName: []string{"arm64"},

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -563,7 +564,20 @@ var _ = Describe("Admission", func() {
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("expiration date for version \"1.0.0\" must be set")))
 			})
 
-			It("should fail for creating a NamespacedCloudProfile that overrides an existing MachineImage version and specifies classification/cri/arch/flavors/kubeletVersionConstraint/inPlaceUpdates", func() {
+			DescribeTable("should fail for creating a NamespacedCloudProfile that overrides an existing MachineImage version and specifies classification/cri/arch/flavors/kubeletVersionConstraint/inPlaceUpdates", func(parentUsesCapabilities bool) {
+				var additionalMatcher types.GomegaMatcher
+				if parentUsesCapabilities {
+					parentCloudProfile.Spec.MachineCapabilities = []gardencorev1beta1.CapabilityDefinition{{
+						Name:   "architecture",
+						Values: []string{"amd64", "arm64"},
+					}}
+					// capabilityFlavors will be deleted on transform in transformation to parent format
+					additionalMatcher = PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.machineImages[0].versions[0].capabilityFlavors"),
+						"Detail": ContainSubstring("must not provide capabilities to an extended machine image in NamespacedCloudProfile"),
+					}))
+				}
 				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 					{Name: "test-image", Versions: []gardencorev1beta1.MachineImageVersion{
 						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.0"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}},
@@ -588,7 +602,7 @@ var _ = Describe("Admission", func() {
 
 				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				matchers := []types.GomegaMatcher{PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.machineImages[0].versions[0].cri"),
 					"Detail": ContainSubstring("must not provide a cri to an extended machine image in NamespacedCloudProfile"),
@@ -598,22 +612,26 @@ var _ = Describe("Admission", func() {
 					"Detail": ContainSubstring("must not provide a classification to an extended machine image in NamespacedCloudProfile"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.machineImages[0].versions[0].architectures"),
-					"Detail": ContainSubstring("must not provide an architecture to an extended machine image in NamespacedCloudProfile"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.machineImages[0].versions[0].capabilityFlavors"),
-					"Detail": ContainSubstring("must not provide capabilities to an extended machine image in NamespacedCloudProfile"),
-				})), PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.machineImages[0].versions[0].kubeletVersionConstraint"),
 					"Detail": ContainSubstring("must not provide a kubelet version constraint to an extended machine image in NamespacedCloudProfile"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeForbidden),
 					"Field":  Equal("spec.machineImages[0].versions[0].inPlaceUpdates"),
 					"Detail": ContainSubstring("must not provide inPlaceUpdates to an extended machine image in NamespacedCloudProfile"),
-				}))))
-			})
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.machineImages[0].versions[0].architectures"),
+					"Detail": ContainSubstring("must not provide an architecture to an extended machine image in NamespacedCloudProfile"),
+				}))}
+
+				if parentUsesCapabilities {
+					matchers = append(matchers, additionalMatcher)
+				}
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(ConsistOf(matchers))
+			},
+				Entry("parent without capabilities", false),
+				Entry("parent with capabilities", true),
+			)
 
 			It("should fail for updating a NamespacedCloudProfile that specifies an already expired MachineImage version", func() {
 				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1094,7 +1094,7 @@ func (c *validationContext) validateMachineImage(idxPath *field.Path, worker cor
 	isUpdateStrategyInPlace := helper.IsUpdateStrategyInPlace(worker.UpdateStrategy)
 	isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, inPlaceUpdateSupported, validMachineImageVersions := validateMachineImagesConstraints(a, c.cloudProfileSpec.MachineImages, isNewWorkerPool, isUpdateStrategyInPlace, worker.Machine, oldWorker.Machine, c.cloudProfileSpec.MachineCapabilities)
 	if !isMachineImagePresentInCloudprofile {
-		return field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, fmt.Sprintf("machine image version is not supported, supported machine image versions are: %+v", validMachineImageVersions))
+		return field.Invalid(idxPath.Child("machine", "image", "version"), worker.Machine.Image.Version, fmt.Sprintf("machine image version is not supported, supported machine image versions are: %+v", validMachineImageVersions))
 	}
 
 	if !architectureSupported || !activeMachineImageVersion || (isUpdateStrategyInPlace && !inPlaceUpdateSupported) {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1094,7 +1094,7 @@ func (c *validationContext) validateMachineImage(idxPath *field.Path, worker cor
 	isUpdateStrategyInPlace := helper.IsUpdateStrategyInPlace(worker.UpdateStrategy)
 	isMachineImagePresentInCloudprofile, architectureSupported, activeMachineImageVersion, inPlaceUpdateSupported, validMachineImageVersions := validateMachineImagesConstraints(a, c.cloudProfileSpec.MachineImages, isNewWorkerPool, isUpdateStrategyInPlace, worker.Machine, oldWorker.Machine, c.cloudProfileSpec.MachineCapabilities)
 	if !isMachineImagePresentInCloudprofile {
-		return field.Invalid(idxPath.Child("machine", "image", "version"), worker.Machine.Image.Version, fmt.Sprintf("machine image version is not supported, supported machine image versions are: %+v", validMachineImageVersions))
+		return field.NotSupported(idxPath.Child("machine", "image", "version"), worker.Machine.Image.Version, validMachineImageVersions)
 	}
 
 	if !architectureSupported || !activeMachineImageVersion || (isUpdateStrategyInPlace && !inPlaceUpdateSupported) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -4157,7 +4157,7 @@ var _ = Describe("validator", func() {
 						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 						err := admissionHandler.Admit(ctx, attrs, nil)
 
-						Expect(err).To(MatchError(ContainSubstring("machine image version is not supported")))
+						Expect(err).To(MatchError(ContainSubstring("Unsupported value: \"1.2.baz\": supported values:")))
 					})
 
 					It("should default a machine image version to latest major.minor.patch version", func() {

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1248,6 +1248,8 @@ build:
             - extensions/pkg/apis/config/v1alpha1
             - extensions/pkg/controller
             - extensions/pkg/controller/cmd
+            - extensions/pkg/controller/worker
+            - extensions/pkg/predicate
             - extensions/pkg/util
             - extensions/pkg/webhook
             - extensions/pkg/webhook/certificates
@@ -1291,7 +1293,9 @@ build:
             - pkg/client/kubernetes
             - pkg/client/kubernetes/cache
             - pkg/controllerutils
+            - pkg/controllerutils/mapper
             - pkg/controllerutils/predicate
+            - pkg/controllerutils/reconciler
             - pkg/extensions
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
@@ -1301,6 +1305,7 @@ build:
             - pkg/provider-local/admission/mutator
             - pkg/provider-local/admission/validator
             - pkg/provider-local/apis/local
+            - pkg/provider-local/apis/local/helper
             - pkg/provider-local/apis/local/install
             - pkg/provider-local/apis/local/v1alpha1
             - pkg/provider-local/apis/local/validation
@@ -1313,6 +1318,7 @@ build:
             - pkg/utils/flow
             - pkg/utils/gardener
             - pkg/utils/gardener/operator
+            - pkg/utils/gardener/shootstate
             - pkg/utils/imagevector
             - pkg/utils/kubernetes
             - pkg/utils/kubernetes/health

--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -33,6 +33,7 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 
 		expirationDateFuture metav1.Time
 		imageFlavors         []gardencorev1beta1.MachineImageFlavor
+		capabilities         gardencorev1beta1.Capabilities
 	)
 
 	BeforeEach(func() {
@@ -48,6 +49,7 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 			imageFlavors = []gardencorev1beta1.MachineImageFlavor{
 				{Capabilities: gardencorev1beta1.Capabilities{"architecture": []string{v1beta1constants.ArchitectureAMD64}}},
 			}
+			capabilities = gardencorev1beta1.Capabilities{"architecture": []string{v1beta1constants.ArchitectureAMD64}}
 		}
 
 		dateNow, _ := time.Parse(time.DateOnly, time.Now().Format(time.DateOnly))
@@ -77,10 +79,11 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					},
 				},
 				MachineTypes: []gardencorev1beta1.MachineType{{
-					Name:   "some-type",
-					CPU:    resource.MustParse("1"),
-					GPU:    resource.MustParse("0"),
-					Memory: resource.MustParse("1Gi"),
+					Name:         "some-type",
+					CPU:          resource.MustParse("1"),
+					GPU:          resource.MustParse("0"),
+					Memory:       resource.MustParse("1Gi"),
+					Capabilities: capabilities,
 				}},
 				Regions: []gardencorev1beta1.Region{
 					{Name: "some-region"},
@@ -175,6 +178,7 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					Memory:       resource.MustParse("1Gi"),
 					Usable:       &usable,
 					Architecture: &architecture,
+					Capabilities: capabilities,
 				},
 				{
 					Name:         "some-other-type",
@@ -183,6 +187,7 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					Memory:       resource.MustParse("2Gi"),
 					Usable:       &usable,
 					Architecture: &architecture,
+					Capabilities: capabilities,
 				}},
 			Regions: []gardencorev1beta1.Region{
 				{Name: "some-region"},

--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -41,15 +40,12 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 		var capabilityDefinitions []gardencorev1beta1.CapabilityDefinition
 		if isCapabilitiesCloudProfile {
 			capabilityDefinitions = []gardencorev1beta1.CapabilityDefinition{
-				{
-					Name:   "architecture",
-					Values: []string{v1beta1constants.ArchitectureAMD64},
-				},
+				{Name: "architecture", Values: []string{"amd64"}},
 			}
 			imageFlavors = []gardencorev1beta1.MachineImageFlavor{
-				{Capabilities: gardencorev1beta1.Capabilities{"architecture": []string{v1beta1constants.ArchitectureAMD64}}},
+				{Capabilities: gardencorev1beta1.Capabilities{"architecture": []string{"amd64"}}},
 			}
-			capabilities = gardencorev1beta1.Capabilities{"architecture": []string{v1beta1constants.ArchitectureAMD64}}
+			capabilities = gardencorev1beta1.Capabilities{"architecture": []string{"amd64"}}
 		}
 
 		dateNow, _ := time.Parse(time.DateOnly, time.Now().Format(time.DateOnly))
@@ -71,19 +67,15 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					{
 						Name: "some-image",
 						Versions: []gardencorev1beta1.MachineImageVersion{
-							{
-								ExpirableVersion:  gardencorev1beta1.ExpirableVersion{Version: "4.5.6"},
-								CapabilityFlavors: imageFlavors,
-							},
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6"}},
 						},
 					},
 				},
 				MachineTypes: []gardencorev1beta1.MachineType{{
-					Name:         "some-type",
-					CPU:          resource.MustParse("1"),
-					GPU:          resource.MustParse("0"),
-					Memory:       resource.MustParse("1Gi"),
-					Capabilities: capabilities,
+					Name:   "some-type",
+					CPU:    resource.MustParse("1"),
+					GPU:    resource.MustParse("0"),
+					Memory: resource.MustParse("1Gi"),
 				}},
 				Regions: []gardencorev1beta1.Region{
 					{Name: "some-region"},
@@ -106,13 +98,19 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 						Name: "some-image",
 						Versions: []gardencorev1beta1.MachineImageVersion{
 							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6", ExpirationDate: &expirationDateFuture}},
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "7.8.9"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}, Architectures: []string{"amd64"}, CapabilityFlavors: imageFlavors},
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "7.8.9"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}}, // no capabilities defined, as spec.MachineCapabilities will be used
 						},
 					},
 					{
 						Name: "custom-image",
 						Versions: []gardencorev1beta1.MachineImageVersion{
-							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.2"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}, Architectures: []string{"amd64"}, CapabilityFlavors: imageFlavors},
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.2"},
+								CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
+								Architectures:    []string{"amd64"},
+								// explicitly define capabilities 1.1.2 is not in parent cloudprofile
+								CapabilityFlavors: imageFlavors,
+							},
 						},
 						UpdateStrategy: &updateStrategy,
 					},
@@ -145,15 +143,14 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					Name: "some-image",
 					Versions: []gardencorev1beta1.MachineImageVersion{
 						{
-							ExpirableVersion:  gardencorev1beta1.ExpirableVersion{Version: "7.8.9"},
-							CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
-							Architectures:     []string{"amd64"},
-							CapabilityFlavors: imageFlavors,
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "7.8.9"},
+							CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
+							Architectures:    []string{"amd64"},
 						},
 						{
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6", ExpirationDate: &expirationDateFuture},
-							CRI:              []gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}, Architectures: []string{"amd64"},
-							CapabilityFlavors: imageFlavors,
+							CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
+							Architectures:    []string{"amd64"},
 						},
 					},
 					UpdateStrategy: &updateStrategy,
@@ -178,7 +175,6 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					Memory:       resource.MustParse("1Gi"),
 					Usable:       &usable,
 					Architecture: &architecture,
-					Capabilities: capabilities,
 				},
 				{
 					Name:         "some-other-type",
@@ -546,7 +542,11 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 				{
 					Name: "some-image",
 					Versions: []gardencorev1beta1.MachineImageVersion{
-						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6", ExpirationDate: &expirationDatePast}},
+						{
+							ExpirableVersion:  gardencorev1beta1.ExpirableVersion{Version: "4.5.6", ExpirationDate: &expirationDatePast},
+							Architectures:     []string{"amd64"},
+							CapabilityFlavors: imageFlavors,
+						},
 					},
 				},
 			}
@@ -561,10 +561,9 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					Name: "some-image",
 					Versions: []gardencorev1beta1.MachineImageVersion{
 						{
-							ExpirableVersion:  gardencorev1beta1.ExpirableVersion{Version: "4.5.6"},
-							CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
-							Architectures:     []string{"amd64"},
-							CapabilityFlavors: imageFlavors,
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6"},
+							CRI:              []gardencorev1beta1.CRI{{Name: "containerd"}},
+							Architectures:    []string{"amd64"},
 						},
 					},
 					UpdateStrategy: ptr.To(gardencorev1beta1.UpdateStrategyMajor),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

This PR contributes to the ongoing migration towards utilizing `machineCapabilities` within CloudProfiles.

Currently, NamespacedCloudProfiles are reconciled whenever their parent CloudProfile is updated. This behavior results in inconsistencies when the parent CloudProfile transitions to using machine capabilities, while the NamespacedCloudProfile remains in the legacy format.

This PR ensures the status of NamespacedCloudProfiles adheres to the expected format by implementing two conversion functions:
- For `spec.machineTypes` and `spec.machineImages`, conversion occurs during reconciliation within the controller.
- For `spec.providerConfig`, conversion is handled in the mutating webhook of each provider (e.g. provider-local).

In addition ressource reference validation is added to ensure no `MachineCapabilities` are removed that are still used by existing `MachineImages` or `MachineTypes` in namespaced cloud profiles.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11301

**Special notes for your reviewer**:
cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`NamespacedCloudprofiles` are now compatible with parent `CloudProfiles` that use `MachineCapabilities`. Read more about capabilities in [GEP-33](https://github.com/gardener/gardener/blob/master/docs/proposals/33-machine-image-capabilities.md).
```
