### PR TITLE
Return before validation in case of conversion error

### DIFF
--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -318,6 +318,7 @@ func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster 
 			coreKubeAPIServerConfig := &gardencore.KubeAPIServerConfig{}
 			if err := gardenCoreScheme.Convert(kubeAPIServer.KubeAPIServerConfig, coreKubeAPIServerConfig, nil); err != nil {
 				allErrs = append(allErrs, field.InternalError(path, err))
+				return allErrs
 			}
 
 			allErrs = append(allErrs, gardencorevalidation.ValidateKubeAPIServer(coreKubeAPIServerConfig, virtualCluster.Kubernetes.Version, true, gardenerutils.DefaultGroupResourcesForEncryption(), path)...)
@@ -342,6 +343,7 @@ func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster 
 		coreKubeControllerManagerConfig := &gardencore.KubeControllerManagerConfig{}
 		if err := gardenCoreScheme.Convert(kubeControllerManager.KubeControllerManagerConfig, coreKubeControllerManagerConfig, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(path, err))
+			return allErrs
 		}
 
 		allErrs = append(allErrs, gardencorevalidation.ValidateKubeControllerManager(coreKubeControllerManagerConfig, nil, virtualCluster.Kubernetes.Version, true, path)...)
@@ -391,6 +393,7 @@ func validateETCDAutoscaling(autoscaling *gardencorev1beta1.ControlPlaneAutoscal
 		coreAutoscaling := &gardencore.ControlPlaneAutoscaling{}
 		if err := gardenCoreScheme.Convert(autoscaling, coreAutoscaling, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath, err))
+			return allErrs
 		}
 
 		allErrs = append(allErrs, gardencorevalidation.ValidateControlPlaneAutoscaling(coreAutoscaling, minRequired, fldPath)...)
@@ -475,6 +478,7 @@ func validateGardenerAPIServerConfig(config *operatorv1alpha1.GardenerAPIServerC
 		watchCacheSizes := &gardencore.WatchCacheSizes{}
 		if err := gardenCoreScheme.Convert(config.WatchCacheSizes, watchCacheSizes, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("watchCacheSizes"), err))
+			return allErrs
 		}
 		allErrs = append(allErrs, gardencorevalidation.ValidateWatchCacheSizes(watchCacheSizes, fldPath.Child("watchCacheSizes"))...)
 	}
@@ -483,6 +487,7 @@ func validateGardenerAPIServerConfig(config *operatorv1alpha1.GardenerAPIServerC
 		logging := &gardencore.APIServerLogging{}
 		if err := gardenCoreScheme.Convert(config.Logging, logging, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("logging"), err))
+			return allErrs
 		}
 		allErrs = append(allErrs, gardencorevalidation.ValidateAPIServerLogging(logging, fldPath.Child("logging"))...)
 	}
@@ -491,6 +496,7 @@ func validateGardenerAPIServerConfig(config *operatorv1alpha1.GardenerAPIServerC
 		requests := &gardencore.APIServerRequests{}
 		if err := gardenCoreScheme.Convert(config.Requests, requests, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("requests"), err))
+			return allErrs
 		}
 		allErrs = append(allErrs, gardencorevalidation.ValidateAPIServerRequests(requests, fldPath.Child("requests"))...)
 	}
@@ -780,26 +786,31 @@ func validateEncryptionConfigUpdate(oldGarden, newGarden *operatorv1alpha1.Garde
 	if oldKubeAPIServer := oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer; oldKubeAPIServer != nil && oldKubeAPIServer.KubeAPIServerConfig != nil && oldKubeAPIServer.EncryptionConfig != nil {
 		if err := gardenCoreScheme.Convert(oldKubeAPIServer.EncryptionConfig, oldKubeAPIServerEncryptionConfig, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(kubeAPIServerEncryptionConfigFldPath, err))
+			return allErrs
 		}
 	}
 	if newKubeAPIServer := newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer; newKubeAPIServer != nil && newKubeAPIServer.KubeAPIServerConfig != nil && newKubeAPIServer.EncryptionConfig != nil {
 		if err := gardenCoreScheme.Convert(newKubeAPIServer.EncryptionConfig, newKubeAPIServerEncryptionConfig, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(kubeAPIServerEncryptionConfigFldPath, err))
+			return allErrs
 		}
 	}
 	if oldGardenerAPIServer := oldGarden.Spec.VirtualCluster.Gardener.APIServer; oldGardenerAPIServer != nil && oldGardenerAPIServer.EncryptionConfig != nil {
 		if err := gardenCoreScheme.Convert(oldGardenerAPIServer.EncryptionConfig, oldGAPIServerEncryptionConfig, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(gAPIServerEncryptionConfigFldPath, err))
+			return allErrs
 		}
 	}
 	if newGardenerAPIServer := newGarden.Spec.VirtualCluster.Gardener.APIServer; newGardenerAPIServer != nil && newGardenerAPIServer.EncryptionConfig != nil {
 		if err := gardenCoreScheme.Convert(newGardenerAPIServer.EncryptionConfig, newGAPIServerEncryptionConfig, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(gAPIServerEncryptionConfigFldPath, err))
+			return allErrs
 		}
 	}
 	if credentials := newGarden.Status.Credentials; credentials != nil && credentials.Rotation != nil && credentials.Rotation.ETCDEncryptionKey != nil {
 		if err := gardenCoreScheme.Convert(credentials.Rotation.ETCDEncryptionKey, etcdEncryptionKeyRotation, nil); err != nil {
 			allErrs = append(allErrs, field.InternalError(field.NewPath("status", "credentials", "rotation", "etcdEncryptionKey"), err))
+			return allErrs
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
The Garden resource references types from the core v1beta1 API. On validation, we convert the v1beta1 object to the internal type to be able to invoke the already existing validation function. We need to exit early on conversion error as errors later on might be a direct result of the current conversion error. That's what this PR does.

**Which issue(s) this PR fixes**:
Fixes #11378

**Special notes for your reviewer**:
@ialidzhikov 

**Release note**:

<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
