### PR TITLE
Introduce the `ShootMutator` admission plugin (part 1)

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -226,6 +226,15 @@ This admission controller reacts on `UPDATE` and `DELETE` operations for `Shoot`
 It validates certain configuration values in the specification that are specific to `ManagedSeed`s (e.g. the nginx-addon of the Shoot has to be disabled, the Shoot VPA has to be enabled).
 It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
 
+## `ShootMutator`
+
+**Type**: Mutating. **Enabled by default**: Yes.
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
+It sets the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
+Over time, it will take over all the mutations that are performed by the `ShootValidator` admission plugin.
+For more details, see https://github.com/gardener/gardener/issues/2158.
+
 ## `ShootNodeLocalDNSEnabledByDefault`
 
 **Type**: Mutating. **Enabled by default**: No.
@@ -284,7 +293,7 @@ will not be affected by this admission plugin.
 This admission controller reacts on `CREATE`, `UPDATE` and `DELETE` operations for `Shoot`s.
 It validates certain configurations in the specification against the referred `CloudProfile` (e.g., machine images, machine types, used Kubernetes version, ...).
 Generally, it performs validations that cannot be handled by the static API validation due to their dynamic nature (e.g., when something needs to be checked against referred resources).
-Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools, default Kubernetes version) and setting the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
+Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools, default Kubernetes version).
 
 ## `ValidatingAdmissionPolicy`
 

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -27,6 +27,7 @@ import (
 	shootdnsrewriting "github.com/gardener/gardener/plugin/pkg/shoot/dnsrewriting"
 	shootexposureclass "github.com/gardener/gardener/plugin/pkg/shoot/exposureclass"
 	shootmanagedseed "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
+	shootmutator "github.com/gardener/gardener/plugin/pkg/shoot/mutator"
 	shootnodelocaldns "github.com/gardener/gardener/plugin/pkg/shoot/nodelocaldns"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
@@ -52,6 +53,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	shootnodelocaldns.Register(plugins)
 	shootdnsrewriting.Register(plugins)
 	shootvalidator.Register(plugins)
+	shootmutator.Register(plugins)
 	seedvalidator.Register(plugins)
 	seedmutator.Register(plugins)
 	controllerregistrationresources.Register(plugins)

--- a/plugin/pkg/plugins.go
+++ b/plugin/pkg/plugins.go
@@ -63,6 +63,8 @@ const (
 	PluginNameShootTolerationRestriction = "ShootTolerationRestriction"
 	// PluginNameShootValidator is the name of the ShootValidator admission plugin.
 	PluginNameShootValidator = "ShootValidator"
+	// PluginNameShootMutator is the name of the ShootMutator admission plugin.
+	PluginNameShootMutator = "ShootMutator"
 	// PluginNameShootVPAEnabledByDefault is the name of the ShootVPAEnabledByDefault admission plugin.
 	PluginNameShootVPAEnabledByDefault = "ShootVPAEnabledByDefault"
 	// PluginNameShootResourceReservation is the name of the ShootResourceReservation admission plugin.
@@ -86,6 +88,7 @@ func AllPluginNames() []string {
 		PluginNameShootDNSRewriting,                 // ShootDNSRewriting
 		PluginNameShootQuotaValidator,               // ShootQuotaValidator
 		PluginNameShootValidator,                    // ShootValidator
+		PluginNameShootMutator,                      // ShootMutator
 		PluginNameSeedValidator,                     // SeedValidator
 		PluginNameSeedMutator,                       // SeedMutator
 		PluginNameControllerRegistrationResources,   // ControllerRegistrationResources
@@ -131,6 +134,7 @@ func DefaultOnPlugins() sets.Set[string] {
 		PluginNameShootResourceReservation,        // ShootResourceReservation
 		PluginNameShootQuotaValidator,             // ShootQuotaValidator
 		PluginNameShootValidator,                  // ShootValidator
+		PluginNameShootMutator,                    // ShootMutator
 		PluginNameShootVPAEnabledByDefault,        // ShootVPAEnabledByDefault
 		PluginNameSeedValidator,                   // SeedValidator
 		PluginNameSeedMutator,                     // SeedMutator

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -57,10 +58,5 @@ func (m *MutateShoot) Admit(_ context.Context, a admission.Attributes, _ admissi
 }
 
 func addCreatedByAnnotation(shoot *core.Shoot, userName string) {
-	annotations := shoot.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[v1beta1constants.GardenCreatedBy] = userName
-	shoot.Annotations = annotations
+	metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenCreatedBy, userName)
 }

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator
+
+import (
+	"context"
+	"io"
+
+	"k8s.io/apiserver/pkg/admission"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	plugin "github.com/gardener/gardener/plugin/pkg"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(plugin.PluginNameShootMutator, func(_ io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// MutateShoot is an implementation of admission.Interface.
+type MutateShoot struct {
+	*admission.Handler
+}
+
+// New creates a new MutateShoot admission plugin.
+func New() (*MutateShoot, error) {
+	return &MutateShoot{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}, nil
+}
+
+var _ admission.MutationInterface = (*MutateShoot)(nil)
+
+// Admit mutates the Shoot.
+func (m *MutateShoot) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Ignore all kinds other than Shoot
+	if a.GetKind().GroupKind() != core.Kind("Shoot") {
+		return nil
+	}
+
+	return nil
+}

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -5,10 +5,16 @@
 package mutator_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 
+	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/mutator"
 )
 
@@ -32,6 +38,44 @@ var _ = Describe("mutator", func() {
 			Expect(admissionHandler.Handles(admission.Update)).To(BeTrue())
 			Expect(admissionHandler.Handles(admission.Connect)).To(BeFalse())
 			Expect(admissionHandler.Handles(admission.Delete)).To(BeFalse())
+		})
+	})
+
+	Describe("#Admit", func() {
+		var (
+			ctx context.Context
+
+			userInfo = &user.DefaultInfo{Name: "foo"}
+
+			shoot core.Shoot
+
+			admissionHandler *MutateShoot
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			shoot = core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot",
+					Namespace: "garden-my-project",
+				},
+			}
+
+			var err error
+			admissionHandler, err = New()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("created-by annotation", func() {
+			It("should add the created-by annotation", func() {
+				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, userInfo.Name))
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
+
+				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, userInfo.Name))
+			})
 		})
 	})
 })

--- a/plugin/pkg/shoot/mutator/admission_test.go
+++ b/plugin/pkg/shoot/mutator/admission_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiserver/pkg/admission"
+
+	. "github.com/gardener/gardener/plugin/pkg/shoot/mutator"
+)
+
+var _ = Describe("mutator", func() {
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement("ShootMutator"))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should handle CREATE and UPDATE operations", func() {
+			admissionHandler, err := New()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(admissionHandler.Handles(admission.Create)).To(BeTrue())
+			Expect(admissionHandler.Handles(admission.Update)).To(BeTrue())
+			Expect(admissionHandler.Handles(admission.Connect)).To(BeFalse())
+			Expect(admissionHandler.Handles(admission.Delete)).To(BeFalse())
+		})
+	})
+})

--- a/plugin/pkg/shoot/mutator/mutator_suite_test.go
+++ b/plugin/pkg/shoot/mutator/mutator_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mutator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMutator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionPlugin Shoot Mutator Suite")
+}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -255,8 +255,6 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, _ adm
 	}
 
 	if a.GetOperation() == admission.Create {
-		addCreatedByAnnotation(shoot, a.GetUserInfo().GetName())
-
 		if len(ptr.Deref(shoot.Spec.CloudProfileName, "")) > 0 && shoot.Spec.CloudProfile != nil {
 			return fmt.Errorf("new shoot can only specify either cloudProfileName or cloudProfile reference")
 		}
@@ -2242,13 +2240,4 @@ func getDefaultDomainsForSeed(seed *gardencorev1beta1.Seed) []string {
 	}
 
 	return defaultDomains
-}
-
-func addCreatedByAnnotation(shoot *core.Shoot, userName string) {
-	annotations := shoot.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations[v1beta1constants.GardenCreatedBy] = userName
-	shoot.Annotations = annotations
 }

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -491,15 +491,6 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("name must not exceed"))
 				})
 			})
-
-			It("should add the created-by annotation", func() {
-				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, userInfo.Name))
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				Expect(admissionHandler.Admit(ctx, attrs, nil)).NotTo(HaveOccurred())
-
-				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, userInfo.Name))
-			})
 		})
 
 		Context("hibernation checks", func() {

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -642,6 +642,7 @@ build:
             - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation
             - plugin/pkg/shoot/exposureclass
             - plugin/pkg/shoot/managedseed
+            - plugin/pkg/shoot/mutator
             - plugin/pkg/shoot/nodelocaldns
             - plugin/pkg/shoot/oidc
             - plugin/pkg/shoot/oidc/clusteropenidconnectpreset

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -218,6 +218,7 @@ build:
             - plugin/pkg/shoot/dnsrewriting/apis/shootdnsrewriting/validation
             - plugin/pkg/shoot/exposureclass
             - plugin/pkg/shoot/managedseed
+            - plugin/pkg/shoot/mutator
             - plugin/pkg/shoot/nodelocaldns
             - plugin/pkg/shoot/oidc
             - plugin/pkg/shoot/oidc/clusteropenidconnectpreset


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR is part 1 of https://github.com/gardener/gardener/issues/2158. The end goal of https://github.com/gardener/gardener/issues/2158 is to move all mutations from the `ShootValidator` admission plugin to the new `ShootMutator` admission plugin.

This PR introduces the `ShootMutator` admission plugin and moves only 1 mutation from `ShootValidator` to it - the addition of the `gardener.cloud/created-by` annotation on Shoot creation.

With other PRs, the mutations in the `ShootValidator` admission plugin will be moved to the `ShootMutator` gradually.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2158

**Special notes for your reviewer**:
I decided to split the work for https://github.com/gardener/gardener/issues/2158 to several smaller PRs with multiple commits to make possible tracking and reviewing the changes.
A single PR would be error-prone.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new mutating admission plugin is introduced - `ShootMutator`. It is enabled by default. For more details, see the [`ShootMutator` admission plugin docs](https://github.com/gardener/gardener/blob/v1.131.0/docs/concepts/apiserver-admission-plugins.md#shootmutator).
```
