### PR TITLE
Fix topology aware routing is deactivated when l7 load-balancing for `kube-apiservers` is not active

### DIFF
--- a/docs/operations/topology_aware_routing.md
+++ b/docs/operations/topology_aware_routing.md
@@ -133,8 +133,6 @@ The `virtual-garden-etcd-main-client` and `virtual-garden-etcd-events-client` Se
 The `virtual-garden-kube-apiserver` Service is topology-aware if it uses layer 4 load-balancing. If it is using layer 7 load-balancing it is not. It is consumed by `virtual-garden-kube-controller-manager`, `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, extension admission components, `gardener-dashboard` and other components.
 Layer 7 load-balancing is active when `IstioTLSTermination` feature gate is active in `gardener-operator`. Please see this [documentation](./kube_apiserver_loadbalancing.md) for more details.
 
-> Note: Unlike the other Services, the `virtual-garden-kube-apiserver` Service is of type LoadBalancer. In-cluster components consuming the `virtual-garden-kube-apiserver` Service by its Service name will have benefit from the topology-aware routing. However, the TopologyAwareHints feature cannot help with external traffic routed to load balancer's address - such traffic won't be routed in a topology-aware manner and will be routed according to the cloud-provider specific implementation.
-
 ##### gardener-apiserver
 
 The `gardener-apiserver` Service is topology-aware. It is consumed by `virtual-garden-kube-apiserver`. The aggregation layer in `virtual-garden-kube-apiserver` proxies requests sent for the Gardener API types to the `gardener-apiserver`.

--- a/docs/operations/topology_aware_routing.md
+++ b/docs/operations/topology_aware_routing.md
@@ -109,7 +109,8 @@ The `etcd-main-client` and `etcd-events-client` Services are topology-aware. The
 
 ##### kube-apiserver
 
-The `kube-apiserver` Service is topology-aware. It is consumed by the controllers running in the Shoot control plane.
+The `kube-apiserver` Service is topology-aware if the shoot uses layer 4 load-balancing. If it is using layer 7 load-balancing it is not. It is consumed by the controllers running in the Shoot control plane.  
+Layer 7 load-balancing is active when `IstioTLSTermination` feature gate is active on the Seed and the Shoot did not opt out. Please see this [documentation](./kube_apiserver_loadbalancing.md) for more details.
 
 > Note: The `istio-ingressgateway` component routes traffic in topology-aware manner - if possible, it routes traffic to the target `kube-apiserver` Pods in the same zone. If there is no healthy `kube-apiserver` Pod available in the same zone, the traffic is routed to any of the healthy Pods in the other zones. This behaviour is unconditionally enabled.
 
@@ -129,7 +130,8 @@ The `virtual-garden-etcd-main-client` and `virtual-garden-etcd-events-client` Se
 
 ##### virtual-garden-kube-apiserver
 
-The `virtual-garden-kube-apiserver` Service is topology-aware. It is consumed by `virtual-garden-kube-controller-manager`, `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, extension admission components, `gardener-dashboard` and other components.
+The `virtual-garden-kube-apiserver` Service is topology-aware if it uses layer 4 load-balancing. If it is using layer 7 load-balancing it is not. It is consumed by `virtual-garden-kube-controller-manager`, `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, extension admission components, `gardener-dashboard` and other components.
+Layer 7 load-balancing is active when `IstioTLSTermination` feature gate is active in `gardener-operator`. Please see this [documentation](./kube_apiserver_loadbalancing.md) for more details.
 
 > Note: Unlike the other Services, the `virtual-garden-kube-apiserver` Service is of type LoadBalancer. In-cluster components consuming the `virtual-garden-kube-apiserver` Service by its Service name will have benefit from the topology-aware routing. However, the TopologyAwareHints feature cannot help with external traffic routed to load balancer's address - such traffic won't be routed in a topology-aware manner and will be routed according to the cloud-provider specific implementation.
 

--- a/pkg/gardenlet/operation/botanist/apiserverproxy.go
+++ b/pkg/gardenlet/operation/botanist/apiserverproxy.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/component/networking/apiserverproxy"
-	"github.com/gardener/gardener/pkg/features"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
@@ -42,7 +40,7 @@ func (b *Botanist) DefaultAPIServerProxy() (apiserverproxy.Interface, error) {
 		SidecarImage:        sidecarImage.String(),
 		ProxySeedServerHost: b.outOfClusterAPIServerFQDN(),
 		DNSLookupFamily:     dnsLookupFamily,
-		IstioTLSTermination: features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
+		IstioTLSTermination: b.ShootUsesIstioTLSTermination(),
 	}
 
 	return apiserverproxy.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.SecretsManager, values), nil

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -50,7 +50,7 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !(features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo())),
+			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) || !v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,
 		},

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -50,7 +50,7 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) || !v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
+			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && (!features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) || !v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo())),
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,
 		},

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -50,7 +50,7 @@ func (b *Botanist) defaultKubeAPIServerServiceWithSuffix(suffix string, register
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		&kubeapiserverexposure.ServiceValues{
-			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()),
+			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled && !(features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo())),
 			RuntimeKubernetesVersion:    b.Seed.KubernetesVersion,
 			NameSuffix:                  suffix,
 		},

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -23,7 +23,6 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
@@ -272,7 +271,7 @@ func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 func (b *Botanist) generateGenericTokenKubeconfig(ctx context.Context) error {
 	contextName := b.Shoot.ControlPlaneNamespace
 	kubeAPIServerAddress := b.Shoot.ComputeInClusterAPIServerAddress(true)
-	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) && v1beta1helper.IsShootIstioTLSTerminationEnabled(b.Shoot.GetInfo()) {
+	if b.ShootUsesIstioTLSTermination() {
 		// Add the failure tolerance type to the context name if high availability is enabled. This ensures that the
 		// generic token kubeconfig changes when a shoot is upgraded from non-HA to HA. The generic token kubeconfig is
 		// updated that the control plane pods are restarted and get the updated hosts alias for the kube-apiserver domain.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
#13081 introduced a regression which deactivated topology aware routing for kube-apiservers where l7 load-balancing is not activated (see [here](https://github.com/gardener/gardener/pull/13081#discussion_r2426083439)).
This PR fixes this and also enhances the topology aware routing documentation in these matters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which deactivates topology aware routing for kube-apiservers when l7 load-balancing is not active has been fixed.
```
