### PR TITLE
support server block imports for node-local-dns

### DIFF
--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -102,9 +102,9 @@ This should bring the cluster DNS back to functioning state.
 
 ## Node Local DNS
 
-Starting with Gardener v1.129, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. The server configuration is read by a sidecar container and a new configuration file with the correct bind statement and port mappings is generated and imported into NodeLocalDNS pods. Prior to Gardener v1.129, custom DNS configurations might not function as expected with NodeLocalDNS.
-With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.129.
-If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.128 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
+Starting with Gardener v1.131, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. The server configuration is read by a sidecar container and a new configuration file with the correct bind statement and port mappings is generated and imported into NodeLocalDNS pods. Prior to Gardener v1.131, custom DNS configurations might not function as expected with NodeLocalDNS.
+With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.131.
+If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.130 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
 ```yaml
 ...
 spec:

--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -102,9 +102,9 @@ This should bring the cluster DNS back to functioning state.
 
 ## Node Local DNS
 
-Starting with Gardener v1.128, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. Prior to Gardener v1.128, custom DNS configurations might not function as expected with NodeLocalDNS.
-With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.128.
-If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.127 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
+Starting with Gardener v1.129, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. The server configuration is read by a sidecar container and a new configuration file with the correct bind statement and port mappings is generated and imported into NodeLocalDNS pods. Prior to Gardener v1.129, custom DNS configurations might not function as expected with NodeLocalDNS.
+With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.129.
+If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.128 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
 ```yaml
 ...
 spec:

--- a/docs/usage/networking/node-local-dns.md
+++ b/docs/usage/networking/node-local-dns.md
@@ -48,5 +48,5 @@ For more information about `node-local-dns`, please refer to the [KEP](https://g
 
 ## Known Issues
 
-Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.128.
+Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.129.
 Please refer to [Custom DNS Configuration](custom-dns-config.md#node-local-dns).

--- a/docs/usage/networking/node-local-dns.md
+++ b/docs/usage/networking/node-local-dns.md
@@ -48,5 +48,5 @@ For more information about `node-local-dns`, please refer to the [KEP](https://g
 
 ## Known Issues
 
-Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.129.
+Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.131.
 Please refer to [Custom DNS Configuration](custom-dns-config.md#node-local-dns).

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -25,6 +25,8 @@ const (
 	ContainerImageNameConfigmapReloader = "configmap-reloader"
 	// ContainerImageNameCoredns is a constant for an image in the image vector with name 'coredns'.
 	ContainerImageNameCoredns = "coredns"
+	// ContainerImageNameCoreDNSConfigAdapter is a constant for an image in the image vector with name 'coredns-config-adapter'.
+	ContainerImageNameCoreDNSConfigAdapter = "coredns-config-adapter"
 	// ContainerImageNameCortex is a constant for an image in the image vector with name 'cortex'.
 	ContainerImageNameCortex = "cortex"
 	// ContainerImageNameDependencyWatchdog is a constant for an image in the image vector with name 'dependency-watchdog'.

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -25,8 +25,8 @@ const (
 	ContainerImageNameConfigmapReloader = "configmap-reloader"
 	// ContainerImageNameCoredns is a constant for an image in the image vector with name 'coredns'.
 	ContainerImageNameCoredns = "coredns"
-	// ContainerImageNameCoreDNSConfigAdapter is a constant for an image in the image vector with name 'coredns-config-adapter'.
-	ContainerImageNameCoreDNSConfigAdapter = "coredns-config-adapter"
+	// ContainerImageNameCorednsConfigAdapter is a constant for an image in the image vector with name 'coredns-config-adapter'.
+	ContainerImageNameCorednsConfigAdapter = "coredns-config-adapter"
 	// ContainerImageNameCortex is a constant for an image in the image vector with name 'cortex'.
 	ContainerImageNameCortex = "cortex"
 	// ContainerImageNameDependencyWatchdog is a constant for an image in the image vector with name 'dependency-watchdog'.

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -483,6 +483,23 @@ images:
         value:
           - type: 'githubTeam'
             teamname: 'gardener/gardener-core-networking-maintainers'
+  - name: coredns-config-adapter
+    sourceRepository: github.com/gardener/coredns-config-adapter
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/coredns-config-adapter
+    tag: "v0.2.0"
+    labels:
+      - name: 'gardener.cloud/cve-categorisation'
+        value:
+          network_exposure: 'private'
+          authentication_enforced: false
+          user_interaction: 'end-user'
+          confidentiality_requirement: 'low'
+          integrity_requirement: 'high'
+          availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-core-networking-maintainers'
   - name: node-problem-detector
     sourceRepository: github.com/kubernetes/node-problem-detector
     repository: registry.k8s.io/node-problem-detector/node-problem-detector

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -55,6 +55,8 @@ const (
 	containerName = "coredns"
 	serviceName   = "kube-dns" // this is due to legacy reasons
 
+	CustomConfigMapName = "coredns-custom"
+
 	portNameMetrics = "metrics"
 	portMetrics     = 9153
 
@@ -319,7 +321,7 @@ import custom/*.server
 
 		configMapCustom = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        "coredns-custom",
+				Name:        CustomConfigMapName,
 				Namespace:   metav1.NamespaceSystem,
 				Annotations: map[string]string{resourcesv1alpha1.Ignore: "true"},
 			},

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -55,6 +55,7 @@ const (
 	containerName = "coredns"
 	serviceName   = "kube-dns" // this is due to legacy reasons
 
+	// CustomConfigMapName is the name of the custom CoreDNS ConfigMap.
 	CustomConfigMapName = "coredns-custom"
 
 	portNameMetrics = "metrics"

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -64,6 +64,8 @@ const (
 	metricsPortName      = "metrics"
 	errorMetricsPortName = "errormetrics"
 
+	sideCarName = "coredns-config-adapter"
+
 	domain            = gardencorev1beta1.DefaultDomain
 	serviceName       = "kube-dns-upstream"
 	livenessProbePort = 8099
@@ -74,13 +76,14 @@ const (
 
 	daemonSetPollInterval = 5 * time.Second
 
-	volumeMountNameCleanUp      = "cleanup-script"
-	volumeMountPathCleanUp      = "/scripts"
-	volumeMountNameXtablesLock  = "xtables-lock"
-	volumeMountPathXtablesLock  = "/run/xtables.lock"
-	volumeMountPathCustomConfig = "/etc/custom"
-	volumeMountNameCustomConfig = "custom-config-volume"
-	customConfigMapName         = "coredns-custom"
+	volumeMountNameCleanUp         = "cleanup-script"
+	volumeMountPathCleanUp         = "/scripts"
+	volumeMountNameXtablesLock     = "xtables-lock"
+	volumeMountPathXtablesLock     = "/run/xtables.lock"
+	volumeMountPathCustomConfig    = "/etc/custom"
+	volumeMountNameCustomConfig    = "custom-config-volume"
+	volumeMountNameGeneratedConfig = "generated-config"
+	volumeMountPathGeneratedConfig = "/etc/generated-config"
 )
 
 var (
@@ -103,6 +106,8 @@ type Values struct {
 	Image string
 	// AlpineImage is the container image used for the cleanup DaemonSet.
 	AlpineImage string
+	// CoreDNSConfigAdapaterImage is the container image used for the coredns config adapter sidecar.
+	CoreDNSConfigAdapaterImage string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
 	// Config is the node local configuration for the shoot spec

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -106,8 +106,8 @@ type Values struct {
 	Image string
 	// AlpineImage is the container image used for the cleanup DaemonSet.
 	AlpineImage string
-	// CoreDNSConfigAdapaterImage is the container image used for the coredns config adapter sidecar.
-	CoreDNSConfigAdapaterImage string
+	// CorednsConfigAdapterImage is the container image used for the coredns config adapter sidecar.
+	CorednsConfigAdapterImage string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
 	// Config is the node local configuration for the shoot spec

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -465,7 +465,7 @@ status:
 								InitContainers: []corev1.Container{
 									{
 										Name:  "coredns-config-adapter",
-										Image: values.CoreDNSConfigAdapaterImage,
+										Image: values.CorednsConfigAdapterImage,
 										Resources: corev1.ResourceRequirements{
 											Requests: corev1.ResourceList{
 												corev1.ResourceCPU:    resource.MustParse("5m"),

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -213,7 +213,7 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 						InitContainers: []corev1.Container{
 							{
 								Name:  sideCarName,
-								Image: n.values.CoreDNSConfigAdapaterImage,
+								Image: n.values.CorednsConfigAdapterImage,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("5m"),

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -35,7 +35,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		return nil, err
 	}
 
-	imageCoreDNSConfigAdapater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCorednsConfigAdapter)
+	imageCorednsConfigAdapter, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCorednsConfigAdapter)
 	if err != nil {
 		return nil, err
 	}
@@ -44,14 +44,14 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		nodelocaldns.Values{
-			Image:                      image.String(),
-			AlpineImage:                imageAlpine.String(),
-			CoreDNSConfigAdapaterImage: imageCoreDNSConfigAdapater.String(),
-			VPAEnabled:                 b.Shoot.WantsVerticalPodAutoscaler,
-			Config:                     v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
-			Workers:                    b.Shoot.GetInfo().Spec.Provider.Workers,
-			KubeProxyConfig:            b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
-			Log:                        b.Logger,
+			Image:                     image.String(),
+			AlpineImage:               imageAlpine.String(),
+			CorednsConfigAdapterImage: imageCorednsConfigAdapter.String(),
+			VPAEnabled:                b.Shoot.WantsVerticalPodAutoscaler,
+			Config:                    v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Workers:                   b.Shoot.GetInfo().Spec.Provider.Workers,
+			KubeProxyConfig:           b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
+			Log:                       b.Logger,
 		},
 	), nil
 }

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -35,7 +35,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		return nil, err
 	}
 
-	imageCoreDNSConfigAdapater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCoreDNSConfigAdapter)
+	imageCoreDNSConfigAdapater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCorednsConfigAdapter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -35,17 +35,23 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		return nil, err
 	}
 
+	imageCoreDNSConfigAdapater, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCoreDNSConfigAdapter)
+	if err != nil {
+		return nil, err
+	}
+
 	return nodelocaldns.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		nodelocaldns.Values{
-			Image:           image.String(),
-			AlpineImage:     imageAlpine.String(),
-			VPAEnabled:      b.Shoot.WantsVerticalPodAutoscaler,
-			Config:          v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
-			Workers:         b.Shoot.GetInfo().Spec.Provider.Workers,
-			KubeProxyConfig: b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
-			Log:             b.Logger,
+			Image:                      image.String(),
+			AlpineImage:                imageAlpine.String(),
+			CoreDNSConfigAdapaterImage: imageCoreDNSConfigAdapater.String(),
+			VPAEnabled:                 b.Shoot.WantsVerticalPodAutoscaler,
+			Config:                     v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Workers:                    b.Shoot.GetInfo().Spec.Provider.Workers,
+			KubeProxyConfig:            b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
+			Log:                        b.Logger,
 		},
 	), nil
 }

--- a/pkg/provider-local/controller/dnsrecord/actuator.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator.go
@@ -21,6 +21,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/coredns"
 )
 
 // Actuator implements the DNSRecord actuator for the local DNS provider.
@@ -85,7 +86,7 @@ func (a *Actuator) Restore(ctx context.Context, log logr.Logger, dnsRecord *exte
 }
 
 func (a *Actuator) patchCoreDNSConfigMap(ctx context.Context, mutate func(configMap *corev1.ConfigMap)) error {
-	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns-custom", Namespace: "gardener-extension-provider-local-coredns"}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: coredns.CustomConfigMapName, Namespace: "gardener-extension-provider-local-coredns"}}
 	_, err := controllerutil.CreateOrPatch(ctx, a.Client, configMap, func() error {
 		mutate(configMap)
 		return nil

--- a/pkg/provider-local/controller/dnsrecord/actuator_test.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
 )
@@ -103,14 +104,14 @@ var _ = Describe("Actuator", func() {
 			}
 			emptyConfigMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "coredns-custom",
+					Name:      coredns.CustomConfigMapName,
 					Namespace: extensionNamespace.Name,
 				},
 				Data: map[string]string{"test": "data"},
 			}
 			configMapWithRule = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "coredns-custom",
+					Name:      coredns.CustomConfigMapName,
 					Namespace: extensionNamespace.Name,
 				},
 				Data: map[string]string{

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1124,6 +1124,8 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
+            - pkg/component/networking/coredns
+            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1142,6 +1142,8 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
+            - pkg/component/networking/coredns
+            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -737,6 +737,8 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
+            - pkg/component/networking/coredns
+            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Support for custom server blocks in node-local-dns.

This pull request introduces a sidecar container to the Node-Local-DNS pods. The container reads the `coredns-custom` ConfigMap and generates a new configuration file for Node-Local-DNS. This file maps the server block ports from port 8053 to port 53 and includes the appropriate bind statement. The generated file is then imported into node-local-dns.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener-extension-networking-cilium/pull/642

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support custom server blocks in node-local-dns.
```
