### PR TITLE
Downgrade quay.io/kiwigrid/k8s-sidecar Docker tag to `v1.30.9`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -340,7 +340,7 @@ images:
   - name: plutono-data-refresher
     sourceRepository: github.com/kiwigrid/k8s-sidecar
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: "1.30.11"
+    tag: "1.30.9"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
The two most recent releases got yanked because they introduced a bug that causes the `k8s-sidecar` to try to connect to `localhost:80` instead of the kube-apiserver. This is a temporary downgrade PR, because as a consequence, we're seeing clusters where Plutono contains no dashboards. See https://github.com/kiwigrid/k8s-sidecar/issues/431 for more details.

**Special notes for your reviewer**:
/cc @axel7born 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `quay.io/kiwigrid/k8s-sidecar` image is downgraded to `v1.30.9` to prevent a regression that causes Plutono dashboards to not be loaded.
```
