### PR TITLE
Skip Prometheus federation from seeds if ingress pointer is nil

### DIFF
--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1041,11 +1041,13 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 		prometheusAggregateIngressTargets []monitoringv1alpha1.Target
 	)
 	for _, seed := range seedList.Items {
-		ingressHost := v1beta1constants.IngressDomainPrefixPrometheusAggregate + "." + seed.Spec.Ingress.Domain
-		if ingressHost == aggregatePrometheusIngressHost {
-			prometheusAggregateTargets = append(prometheusAggregateTargets, monitoringv1alpha1.Target("prometheus-"+aggregateprometheus.Label))
-		} else {
-			prometheusAggregateIngressTargets = append(prometheusAggregateIngressTargets, monitoringv1alpha1.Target(ingressHost))
+		if seed.Spec.Ingress != nil {
+			ingressHost := v1beta1constants.IngressDomainPrefixPrometheusAggregate + "." + seed.Spec.Ingress.Domain
+			if ingressHost == aggregatePrometheusIngressHost {
+				prometheusAggregateTargets = append(prometheusAggregateTargets, monitoringv1alpha1.Target("prometheus-"+aggregateprometheus.Label))
+			} else {
+				prometheusAggregateIngressTargets = append(prometheusAggregateIngressTargets, monitoringv1alpha1.Target(ingressHost))
+			}
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind bug

**What this PR does / why we need it**:

Commit 787856e optimises the federation path from aggregate to garden Prometheus to use the internal service when the seed is the runtime cluster. Unfortunately, that commit accidentally removed a check to validate the seed has an ingress. See [here](https://github.com/gardener/gardener/commit/787856e714a879542a681cdcc99154900f805a75#diff-b29dc7a483619769f04fd5fbb1abe579cfd29123f508d704f9a6138a10a33a8eL1035).

This PR brings that back.

**Special notes for your reviewer**:

/cc @istvanballok @LucaBernstein 

**Release note**:

```other operator
NONE
```
