### PR TITLE
Fix CPM testmachinery test for hibernated shoots

### DIFF
--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -101,17 +101,21 @@ func validateConfig() {
 }
 
 func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *applications.GuestBookTest) error {
+	ginkgo.By("Mark osc hash secret")
+	if err := shootmigration.MarkOSCSecret(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace); err != nil {
+		return err
+	}
+
+	if err := t.PopulateBeforeMigrationComparisonElements(ctx); err != nil {
+		return err
+	}
+
 	if t.Shoot.Status.IsHibernated {
 		return nil
 	}
 
 	if !v1beta1helper.NginxIngressEnabled(t.Shoot.Spec.Addons) {
 		return errors.New("the shoot must have the nginx-ingress addon enabled")
-	}
-
-	ginkgo.By("Mark osc hash secret")
-	if err := shootmigration.MarkOSCSecret(ctx, t.SourceSeedClient.Client(), t.SeedShootNamespace); err != nil {
-		return err
 	}
 
 	ginkgo.By("Create test Secret and Service Account")
@@ -128,7 +132,7 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 	guestBookApp.DeployGuestBookApp(ctx)
 	guestBookApp.Test(ctx)
 
-	return t.PopulateBeforeMigrationComparisonElements(ctx)
+	return nil
 }
 
 func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp applications.GuestBookTest) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration testing
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that occurred when running cpm testmachinery tests for hibernated shoots that was introduced with https://github.com/gardener/gardener/pull/13056. 

The error message is as follows:
```
2025-10-13 19:17:38	
2025-10-13T19:17:38.466690065Z stdout F   In [AfterEach] at: /src/test/testmachinery/system/shoot_cp_migration/migrate_test.go:80 @ 10/13/25 19:17:38.466
2025-10-13 19:17:38	
2025-10-13T19:17:38.466683949Z stdout F   [FAILED] The Shoot CP Migration health checks failed with: initial Machines [], do not match after-migrate Machines []
```

This happens because machines were no-longer fetched before control plane migration started for hibernated shoots resulting in nil slices being compared to slices of length 0 here: https://github.com/plkokanov/gardener/blob/61933874db24bb76013fd3c6424f0146a4c2d378/test/framework/shootmigrationtest.go#L247-L250

The PR moves the code which marks the OSC secret and fetches the machines, nodes and secrets so that it is executed even for hibernated shoots so that we keep the old behaviour.

Note that the service account and secret deployed in the shoot via `CreateSecretAndServiceAccount` are not fetched with `PopulateBeforeMigrationComparisonElements`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vitanovs 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
