### PR TITLE
Route the `KubeApiServerTooManyAuditlogFailures` alert also to the shoot owners

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -692,7 +692,7 @@ var _ = Describe("KubeAPIServer", func() {
 										"service":    "auditlog",
 										"severity":   "warning",
 										"type":       "seed",
-										"visibility": "operator",
+										"visibility": "all",
 									},
 									Annotations: map[string]string{
 										"summary":     "The kubernetes API server has too many failed attempts to log audit events",

--- a/pkg/component/kubernetes/apiserver/prometheusrule.go
+++ b/pkg/component/kubernetes/apiserver/prometheusrule.go
@@ -144,7 +144,7 @@ func (k *kubeAPIServer) reconcilePrometheusRule(ctx context.Context, prometheusR
 							"service":    "auditlog",
 							"severity":   "warning",
 							"type":       "seed",
-							"visibility": "operator",
+							"visibility": "all",
 						},
 						Annotations: map[string]string{
 							"summary":     "The kubernetes API server has too many failed attempts to log audit events",

--- a/pkg/component/kubernetes/apiserver/testdata/shoot-kube-apiserver.prometheusrule.test.yaml
+++ b/pkg/component/kubernetes/apiserver/testdata/shoot-kube-apiserver.prometheusrule.test.yaml
@@ -102,7 +102,7 @@ tests:
         service: auditlog
         severity: warning
         type: seed
-        visibility: operator
+        visibility: all
       exp_annotations:
         description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
         summary: 'The kubernetes API server has too many failed attempts to log audit events'


### PR DESCRIPTION
**How to categorize this PR?**
/area audit-logging monitoring
/kind enhancement

**What this PR does / why we need it**:
Route the `KubeApiServerTooManyAuditlogFailures` alert also to the shoot owners

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vicwicker @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `KubeApiServerTooManyAuditlogFailures` alert is now sent also to the shoot owners. 
```
