### PR TITLE
[release-v1.127] Automated cherry pick of #13168: Downgrade quay.io/kiwigrid/k8s-sidecar Docker tag to `v1.30.9`

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -340,7 +340,7 @@ images:
   - name: plutono-data-refresher
     sourceRepository: github.com/kiwigrid/k8s-sidecar
     repository: quay.io/kiwigrid/k8s-sidecar
-    tag: "1.30.10"
+    tag: "1.30.9"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
/area monitoring
/kind regression

Cherry pick of #13168 on release-v1.127.

#13168: Downgrade quay.io/kiwigrid/k8s-sidecar Docker tag to `v1.30.9`

**Release Notes:**
```bugfix operator
The `quay.io/kiwigrid/k8s-sidecar` image is downgraded to `v1.30.9` to prevent a regression that causes Plutono dashboards to not be loaded.
```