### PR TITLE
Document the `UseUnifiedHTTPProxyPort` feature gate in the docs

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,6 +31,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` | `1.122` |
 | DoNotCopyBackupCredentials               | `true`  | `Beta`  | `1.123` |         |
 | OpenTelemetryCollector                   | `false` | `Alpha` | `1.124` |         |
+| UseUnifiedHTTPProxyPort                  | `false` | `Alpha` | `1.130` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 
@@ -202,7 +203,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | CredentialsRotationWithoutWorkersRollout     | `false` | `Alpha`      | `1.112` | `1.120` |
 | CredentialsRotationWithoutWorkersRollout     | `true`  | `Beta`       | `1.121` | `1.126` |
 | CredentialsRotationWithoutWorkersRollout     | `true`  | `GA`         | `1.127` | `1.128` |
-| CredentialsRotationWithoutWorkersRollout     | `true`  | `Removed`    | `1.129` |         |
+| CredentialsRotationWithoutWorkersRollout     |         | `Removed`    | `1.129` |         |
 
 ## Using a Feature
 
@@ -252,4 +253,5 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | IstioTLSTermination                      | `gardenlet`, `gardener-operator`   | Enables TLS termination for the Istio Ingress Gateway instead of TLS termination at the kube-apiserver. It allows load-balancing of requests to the kube-apiserver on request level instead of connection level.                                                                                                                                                                                                                                                                                                                                         |
 | CloudProfileCapabilities                 | `gardener-apiserver`               | Enables the usage of capabilities in the `CloudProfile`. Capabilities are used to create a relation between machineTypes and machineImages. It allows to validate worker groups of a shoot ensuring the selected image and machine combination will boot up successfully. Capabilities are also used to determine valid upgrade paths during automated maintenance operation.                                                                                                                                                                            |
 | DoNotCopyBackupCredentials               | `gardenlet`                        | Disables the copying of Shoot infrastructure credentials as backup credentials when the Shoot is used as a ManagedSeed. Operators are responsible for providing the credentials for backup explicitly. Credentials that were already copied will be labeled with `secret.backup.gardener.cloud/status=previously-managed` and would have to be cleaned up by operators.                                                                                                                                                                                  |
-| OpenTelemetryCollector                   | `gardenlet`                        | Routes logs through an instance of an `OpenTelemetry Collector` in the control-plane of `Shoots`.                                                                                                                                                                   |
+| OpenTelemetryCollector                   | `gardenlet`                        | Routes logs through an instance of an `OpenTelemetry Collector` in the control-plane of `Shoots`.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| UseUnifiedHTTPProxyPort                  | `gardenlet`                        | Enables the gardenlet to set up the unified HTTP proxy network infrastructure. Gardenlet will also reconfigure the API server proxy and shoot VPN client to connect to the unified port using the new X-Gardener-Destination header.                                                                                                                                                                                                                                                                                                                     |


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking documentation
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/13003 introduces the `UseUnifiedHTTPProxyPort` feature gate but does not mention the feature gate in the feature gate docs.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/13003

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
