### PR TITLE
Move defaulting of the Shoot networks from the `ShootValidator` to the `ShootMutator` admission plugin (part 3)

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -235,6 +235,7 @@ This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`
 It mutates the `Shoot` in the following way:
 - It sets the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
 - It maintains annotations used for Shoot lifecycle operations such as `shoot.gardener.cloud/tasks` and `maintenance.shoot.gardener.cloud/needs-retry-operation`.
+- It defaults Shoot `.spec.networking.pods` and `.spec.networking.services` fields in case they are not provided and the Seed specifies the `.spec.networks.shootDefaults` field.
 
 Over time, the `ShootMutator` admission plugin will take over all the mutations that are performed by `ShootValidator`.
 For more details, see https://github.com/gardener/gardener/issues/2158.

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -231,7 +231,7 @@ func addDeploymentTasks(shoot *core.Shoot, tasks ...string) {
 func (c *mutationContext) defaultShootNetworks(workerless bool) {
 	if c.seed != nil {
 		if c.shoot.Spec.Networking.Pods == nil && !workerless {
-			if c.seed.Spec.Networks.ShootDefaults != nil {
+			if c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Pods != nil {
 				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Pods, c.shoot.Spec.Networking.IPFamilies) {
 					c.shoot.Spec.Networking.Pods = c.seed.Spec.Networks.ShootDefaults.Pods
 				}
@@ -239,7 +239,7 @@ func (c *mutationContext) defaultShootNetworks(workerless bool) {
 		}
 
 		if c.shoot.Spec.Networking.Services == nil {
-			if c.seed.Spec.Networks.ShootDefaults != nil {
+			if c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Services != nil {
 				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Services, c.shoot.Spec.Networking.IPFamilies) {
 					c.shoot.Spec.Networking.Services = c.seed.Spec.Networks.ShootDefaults.Services
 				}

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -60,9 +60,9 @@ func New() (*MutateShoot, error) {
 }
 
 // AssignReadyFunc assigns the ready function to the admission handler.
-func (v *MutateShoot) AssignReadyFunc(f admission.ReadyFunc) {
-	v.readyFunc = f
-	v.SetReadyFunc(f)
+func (m *MutateShoot) AssignReadyFunc(f admission.ReadyFunc) {
+	m.readyFunc = f
+	m.SetReadyFunc(f)
 }
 
 // SetCoreInformerFactory gets Lister from SharedInformerFactory.
@@ -230,20 +230,16 @@ func addDeploymentTasks(shoot *core.Shoot, tasks ...string) {
 
 func (c *mutationContext) defaultShootNetworks(workerless bool) {
 	if c.seed != nil {
-		if c.shoot.Spec.Networking.Pods == nil && !workerless {
-			if c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Pods != nil {
-				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Pods, c.shoot.Spec.Networking.IPFamilies) {
-					c.shoot.Spec.Networking.Pods = c.seed.Spec.Networks.ShootDefaults.Pods
-				}
-			}
+		if c.shoot.Spec.Networking.Pods == nil && !workerless &&
+			c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Pods != nil &&
+			cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Pods, c.shoot.Spec.Networking.IPFamilies) {
+			c.shoot.Spec.Networking.Pods = c.seed.Spec.Networks.ShootDefaults.Pods
 		}
 
-		if c.shoot.Spec.Networking.Services == nil {
-			if c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Services != nil {
-				if cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Services, c.shoot.Spec.Networking.IPFamilies) {
-					c.shoot.Spec.Networking.Services = c.seed.Spec.Networks.ShootDefaults.Services
-				}
-			}
+		if c.shoot.Spec.Networking.Services == nil &&
+			c.seed.Spec.Networks.ShootDefaults != nil && c.seed.Spec.Networks.ShootDefaults.Services != nil &&
+			cidrMatchesIPFamily(*c.seed.Spec.Networks.ShootDefaults.Services, c.shoot.Spec.Networking.IPFamilies) {
+			c.shoot.Spec.Networking.Services = c.seed.Spec.Networks.ShootDefaults.Services
 		}
 	}
 }

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -869,16 +869,14 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 	}
 
 	if c.seed != nil {
-		if c.shoot.Spec.Networking.Pods == nil && !workerless {
-			if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
-				allErrs = append(allErrs, field.Required(path.Child("pods"), "pods is required"))
-			}
+		if c.shoot.Spec.Networking.Pods == nil && !workerless &&
+			slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
+			allErrs = append(allErrs, field.Required(path.Child("pods"), "pods is required"))
 		}
 
-		if c.shoot.Spec.Networking.Services == nil {
-			if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
-				allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
-			}
+		if c.shoot.Spec.Networking.Services == nil &&
+			slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
+			allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
 		}
 
 		if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2322,28 +2322,6 @@ var _ = Describe("validator", func() {
 
 			})
 
-			It("should default shoot networks if seed provides ShootDefaults", func() {
-				seed.Spec.Networks.ShootDefaults = &gardencorev1beta1.ShootNetworks{
-					Pods:     &podsCIDR,
-					Services: &servicesCIDR,
-				}
-				shoot.Spec.Networking.Pods = nil
-				shoot.Spec.Networking.Services = nil
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(shoot.Spec.Networking.Pods).To(Equal(&podsCIDR))
-				Expect(shoot.Spec.Networking.Services).To(Equal(&servicesCIDR))
-			})
-
 			It("should reject because the shoot node and the seed node networks intersect (HA control plane)", func() {
 				shoot.Spec.Networking.Nodes = &seedNodesCIDR
 				shoot.Spec.ControlPlane = &core.ControlPlane{HighAvailability: &core.HighAvailability{FailureTolerance: core.FailureTolerance{Type: core.FailureToleranceTypeZone}}}

--- a/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
+++ b/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_suite_test.go
@@ -322,10 +322,6 @@ var _ = BeforeSuite(func() {
 				Pods:     "10.0.0.0/16",
 				Services: "10.1.0.0/16",
 				Nodes:    ptr.To("10.2.0.0/16"),
-				ShootDefaults: &gardencorev1beta1.ShootNetworks{
-					Pods:     ptr.To("100.128.0.0/11"),
-					Services: ptr.To("100.72.0.0/13"),
-				},
 			},
 		},
 	}

--- a/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_test.go
+++ b/test/integration/apiserver/admissionplugins/shootvalidator/shootvalidator_test.go
@@ -49,7 +49,11 @@ var _ = Describe("ShootValidator tests", func() {
 					},
 				},
 				Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.31.1"},
-				Networking: &gardencorev1beta1.Networking{Type: ptr.To("foo-networking")},
+				Networking: &gardencorev1beta1.Networking{
+					Type:     ptr.To("foo-networking"),
+					Pods:     ptr.To("100.128.0.0/11"),
+					Services: ptr.To("100.72.0.0/13"),
+				},
 			},
 		}
 	})

--- a/test/integration/controllermanager/bastion/bastion_suite_test.go
+++ b/test/integration/controllermanager/bastion/bastion_suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=Bastion,DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
+				"--disable-admission-plugins=Bastion,DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator",
 			},
 		},
 	}

--- a/test/integration/controllermanager/shoot/migration/migration_suite_test.go
+++ b/test/integration/controllermanager/shoot/migration/migration_suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 	By("Start test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator"},
 		},
 	}
 

--- a/test/integration/controllermanager/shootstate/shootstate_suite_test.go
+++ b/test/integration/controllermanager/shootstate/shootstate_suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 	By("Start test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator"},
 		},
 	}
 

--- a/test/integration/gardenlet/shoot/state/state_suite_test.go
+++ b/test/integration/gardenlet/shoot/state/state_suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator",
 			},
 		},
 	}

--- a/test/integration/gardenlet/shoot/status/status_suite_test.go
+++ b/test/integration/gardenlet/shoot/status/status_suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR is part 3 of https://github.com/gardener/gardener/issues/2158. The end goal of https://github.com/gardener/gardener/issues/2158 is to move all mutations from the `ShootValidator` admission plugin to the new `ShootMutator` admission plugin.

This PR moves the defaulting of the Shoot networks from the `ShootValidator` to the `ShootMutator` admission plugin.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2158

**Special notes for your reviewer**:
~~This PR is based on https://github.com/gardener/gardener/pull/13171. Hence, it is in draft state until https://github.com/gardener/gardener/pull/13171 is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Defaulting of the Shoot networks is moved from the `ShootValidator` to the `ShootMutator` admission plugin.
```
