### PR TITLE
Fix flakiness of local multi-zone development setup

### DIFF
--- a/charts/gardener/provider-local/templates/coredns/networkpolicy.yaml
+++ b/charts/gardener/provider-local/templates/coredns/networkpolicy.yaml
@@ -9,9 +9,14 @@ spec:
   - from:
     # Allow traffic from the docker kind network's gateway IP. This is the source IP seen by NetworkPolicies
     # when using the nodePort port-mapping on the kind control-node node (5353:30053) used by e2e tests and if the
-    # coredns pod runs on the control-plane node.
+    # coredns pod runs on the control-plane node. This is relevant for docker desktop on mac.
     - ipBlock:
         cidr: 172.18.0.1/32
+    # Allow traffic from the docker kind network's gateway IP. This is the source IP seen by NetworkPolicies
+    # when using the nodePort port-mapping on the kind control-node node (5353:30053) used by e2e tests and if the
+    # coredns pod runs on the control-plane node. This is relevant for running on linux.
+    - ipBlock:
+        cidr: 172.18.255.1/32
     # If the coredns pod runs on another node than the control-plane node, incoming traffic on the nodePort gets SNATed
     # by kube-proxy and is then sent over the tunl0 interface to the node where the coredns pod runs. In this case, the
     # source IP seen by NetworkPolicies on the destination node is the node IP of the control-plane node (on the tunl0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind flake

**What this PR does / why we need it**:

The tests of the local multi-zone development setup use a `coredns` pod inside the `kind` cluster to perform name resolution. This is used to determine where the entry point of a non-HA cluster resides as there are three availability zones.

The `coredns` pod can be scheduled on any of the three cluster nodes. It has `NetworkPolicies` associated to it to allow only relevant pods access.

Unfortunately, depending on where the pod runs it sees different source IPs, especially when the request comes from outside of the cluster, i.e. from the tests:
1. If `coredns` runs on the control plane node, which actually exposes the port to the tests, and it runs on linux, e.g. in `prow`, it sees `172.18.255.1` as the source IP:

<details>

```
15:19:11.138595 veth751a8cc Out IP 172.18.255.1.60938 > 172.18.0.2.30053: Flags [S], seq 2849031514, win 65535, options [mss 1460,sackOK,TS val 3857728900 ecr 0,nop,wscale 9], length 0
```

</details>

2. If `coredns` runs on the control plane node, which actually exposes the port to the tests, and it runs on docker desktop for mac, it sees `172.18.0.1` as the source IP:

<details>

```
15:32:41.345261 eth0  In  IP 172.18.0.1.60076 > 172.18.0.2.30053: Flags [S], seq 2729926437, win 65495, options [mss 65495,sackOK,TS val 3007026681 ecr 0,nop,wscale 7], length 0
```

</details>

3. If `coredns` runs on one of the other nodes the traffic comes in via the pod overlay network. It sees the first IP of the pod range of a node, e.g. `10.1.212.0`, which is bound to `tunl0` device on the source node, as the source IP:

<details>

```
14:38:14.969364 eth0  In  IP 10.1.212.0.23121 > 10.1.254.107.9053: Flags [S], seq 3207935289, win 65535, options [mss 1220,sackOK,TS val 2616865342 ecr 0,nop,wscale 9], length 0
```

</details>

Unfortunately, the first case was missing. Hence, DNS requests from the tests were blocked by network policy if `coredns` was running on the control plane node.

**Which issue(s) this PR fixes**:
Fixes #12919

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
