### PR TITLE
Allow skipping the Kubernetes version check by setting the env variable `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK`

### DIFF
--- a/docs/development/kubernetes-clients.md
+++ b/docs/development/kubernetes-clients.md
@@ -157,7 +157,13 @@ The client collection mainly exist for historical reasons (there used to be a lo
 However, Gardener is in the process of moving more towards controller-runtime and only using their clients, as they provide many benefits and are much easier to use.
 Also, [gardener/gardener#4251](https://github.com/gardener/gardener/issues/4251) aims at refactoring our controller and admission components to native controller-runtime components.
 
-> ⚠️ Please always prefer controller-runtime clients over other clients when writing new code or refactoring existing code.
+> [!WARNING]
+> Please always prefer controller-runtime clients over other clients when writing new code or refactoring existing code.
+
+> [!TIP]
+> The [`DiscoverVersion`](https://github.com/gardener/gardener/blob/v1.134.0/pkg/client/kubernetes/types.go#L190-L193) function, which is used to retrieve the API server version, validates if the discovered version is a supported Kubernetes version by Gardener.
+> See [Supported Kubernetes Versions](../usage/shoot-operations/supported_k8s_versions.md).
+> To disable this check, set the `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK=true` environment variable.
 
 ## Cache Types: Informers, Listers, Controller-Runtime Caches
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -31,7 +31,7 @@ const EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBE
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 func CheckIfSupported(gitVersion string) error {
 	if os.Getenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV) == "true" {
-		logf.Log.Info("%s set to true, not checking for k8s version compatibility", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
+		logf.Log.Info("not checking for k8s version compatibility because flag is set to true", "flag", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
 		return nil
 	}
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // SupportedVersions is the list of supported Kubernetes versions for all runtime and target clusters, i.e. all gardens,
@@ -21,13 +22,15 @@ var SupportedVersions = []string{
 	"1.34",
 }
 
-// DISABLE_VERSION_CHECK_ENV holds the name of the environment variable to prevent a crash
-// if the detected k8s version is not in the list of supported k8s versions
-const DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBERNETES_VERSION"
+// EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV holds the name of the environment variable to prevent a crash
+// if the detected k8s version is not in the list of supported k8s versions.
+// This should only be used if you know exactly what you are doing and on your own risk.
+const EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBERNETES_VERSION"
 
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 func CheckIfSupported(gitVersion string) error {
-	if os.Getenv(DISABLE_VERSION_CHECK_ENV) == "true" {
+	if os.Getenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV) == "true" {
+		logf.Log.Info("%s set to true, not checking for k8s version compatibility", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
 		return nil
 	}
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -6,6 +6,7 @@ package kubernetesversion
 
 import (
 	"fmt"
+	"os"
 
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
@@ -20,8 +21,16 @@ var SupportedVersions = []string{
 	"1.34",
 }
 
+// DISABLE_VERSION_CHECK_ENV holds the name of the environment variable to prevent a crash
+// if the detected k8s version is not in the list of supported k8s versions
+const DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBERNETES_VERSION"
+
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 func CheckIfSupported(gitVersion string) error {
+	if os.Getenv(DISABLE_VERSION_CHECK_ENV) == "true" {
+		return nil
+	}
+
 	for _, supportedVersion := range SupportedVersions {
 		ok, err := versionutils.CompareVersions(gitVersion, "~", supportedVersion)
 		if err != nil {

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -31,7 +31,7 @@ const EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBE
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 func CheckIfSupported(gitVersion string) error {
 	if os.Getenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV) == "true" {
-		logf.Log.Info("not checking for k8s version compatibility because flag is set to true", "flag", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
+		logf.Log.Info("Not checking for k8s version compatibility because flag is set to true", "flag", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
 		return nil
 	}
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -33,6 +33,7 @@ const envExperimentalDisableKubernetesVersionCheck = "EXPERIMENTAL_DISABLE_KUBER
 // the check will be skipped.
 func CheckIfSupported(gitVersion string) error {
 	if os.Getenv(envExperimentalDisableKubernetesVersionCheck) == "true" {
+		logf.Log.Info("Skipping the check if the Kubernetes version is supported because flag is set to true", "flag", envExperimentalDisableKubernetesVersionCheck)
 		return nil
 	}
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -29,6 +29,8 @@ var SupportedVersions = []string{
 const envExperimentalDisableKubernetesVersionCheck = "EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK"
 
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
+// Experimental: If the environment variable `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK` is set to "true",
+// the check will be skipped.
 func CheckIfSupported(gitVersion string) error {
 	if os.Getenv(envExperimentalDisableKubernetesVersionCheck) == "true" {
 		return nil

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -23,15 +23,14 @@ var SupportedVersions = []string{
 	"1.34",
 }
 
-// EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV holds the name of the environment variable to prevent a crash
+// envExperimentalDisableKubernetesVersionCheck holds the name of the environment variable to prevent a crash
 // if the detected k8s version is not in the list of supported k8s versions.
 // This should only be used if you know exactly what you are doing and on your own risk.
-const EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV = "DO_NOT_CRASH_ON_UNSUPPORTED_KUBERNETES_VERSION"
+const envExperimentalDisableKubernetesVersionCheck = "EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK"
 
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 func CheckIfSupported(gitVersion string) error {
-	if os.Getenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV) == "true" {
-		logf.Log.Info("Not checking for k8s version compatibility because flag is set to true", "flag", EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV)
+	if os.Getenv(envExperimentalDisableKubernetesVersionCheck) == "true" {
 		return nil
 	}
 

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // SupportedVersions is the list of supported Kubernetes versions for all runtime and target clusters, i.e. all gardens,

--- a/pkg/utils/validation/kubernetesversion/version_test.go
+++ b/pkg/utils/validation/kubernetesversion/version_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Version", func() {
 	)
 	DescribeTable("#UnsupportedButCheckDisabledByEnvVariable",
 		func(env, gitVersion string, matcher gomegatypes.GomegaMatcher) {
-			os.Setenv(DISABLE_VERSION_CHECK_ENV, env)
+			os.Setenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV, env)
 			Expect(CheckIfSupported(gitVersion)).To(matcher)
 		},
 

--- a/pkg/utils/validation/kubernetesversion/version_test.go
+++ b/pkg/utils/validation/kubernetesversion/version_test.go
@@ -16,32 +16,25 @@ import (
 
 var _ = Describe("Version", func() {
 	DescribeTable("#CheckIfSupported",
-		func(gitVersion string, matcher gomegatypes.GomegaMatcher) {
+		func(gitVersion string, disableVersionCheck bool, matcher gomegatypes.GomegaMatcher) {
+			env := "false"
+			if disableVersionCheck {
+				env = "true"
+			}
+			_ = os.Setenv("EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK", env)
 			Expect(CheckIfSupported(gitVersion)).To(matcher)
 		},
 
-		Entry("1.29", "1.29", MatchError(ContainSubstring("unsupported kubernetes version"))),
-		Entry("1.30", "1.30", Succeed()),
-		Entry("1.31", "1.31", Succeed()),
-		Entry("1.32", "1.32", Succeed()),
-		Entry("1.33", "1.33", Succeed()),
-		Entry("1.34", "1.34", Succeed()),
-		Entry("1.35", "1.35", MatchError(ContainSubstring("unsupported kubernetes version"))),
-	)
-	DescribeTable("#UnsupportedButCheckDisabledByEnvVariable",
-		func(env, gitVersion string, matcher gomegatypes.GomegaMatcher) {
-			os.Setenv(EXPERIMENTAL_DISABLE_VERSION_CHECK_ENV, env)
-			Expect(CheckIfSupported(gitVersion)).To(matcher)
-		},
+		Entry("1.29", "1.29", false, MatchError(ContainSubstring("unsupported kubernetes version"))),
+		Entry("1.30", "1.30", false, Succeed()),
+		Entry("1.31", "1.31", false, Succeed()),
+		Entry("1.32", "1.32", false, Succeed()),
+		Entry("1.33", "1.33", false, Succeed()),
+		Entry("1.34", "1.34", false, Succeed()),
+		Entry("1.35", "1.35", false, MatchError(ContainSubstring("unsupported kubernetes version"))),
 
-		Entry("1.28", "", "1.28", MatchError(ContainSubstring("unsupported kubernetes version"))),
-		Entry("1.29", "", "1.29", MatchError(ContainSubstring("unsupported kubernetes version"))),
-		Entry("1.30", "", "1.30", Succeed()),
-		Entry("1.31", "", "1.31", Succeed()),
-		Entry("1.32", "", "1.32", Succeed()),
-		Entry("1.33", "", "1.33", Succeed()),
-		Entry("1.35", "", "1.35", MatchError(ContainSubstring("unsupported kubernetes version"))),
-		Entry("1.34", "true", "1.34", Succeed()),
-		Entry("1.28", "true", "1.28", Succeed()),
+		// Disabling the version check by setting the env var EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK to true
+		Entry("1.23", "1.23", true, Succeed()), // too low
+		Entry("2.34", "2.34", true, Succeed()), // too high
 	)
 })

--- a/pkg/utils/validation/kubernetesversion/version_test.go
+++ b/pkg/utils/validation/kubernetesversion/version_test.go
@@ -5,6 +5,8 @@
 package kubernetesversion_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
@@ -25,5 +27,21 @@ var _ = Describe("Version", func() {
 		Entry("1.33", "1.33", Succeed()),
 		Entry("1.34", "1.34", Succeed()),
 		Entry("1.35", "1.35", MatchError(ContainSubstring("unsupported kubernetes version"))),
+	)
+	DescribeTable("#UnsupportedButCheckDisabledByEnvVariable",
+		func(env, gitVersion string, matcher gomegatypes.GomegaMatcher) {
+			os.Setenv(DISABLE_VERSION_CHECK_ENV, env)
+			Expect(CheckIfSupported(gitVersion)).To(matcher)
+		},
+
+		Entry("1.28", "", "1.28", MatchError(ContainSubstring("unsupported kubernetes version"))),
+		Entry("1.29", "", "1.29", Succeed()),
+		Entry("1.30", "", "1.30", Succeed()),
+		Entry("1.31", "", "1.31", Succeed()),
+		Entry("1.32", "", "1.32", Succeed()),
+		Entry("1.33", "", "1.33", Succeed()),
+		Entry("1.34", "", "1.34", MatchError(ContainSubstring("unsupported kubernetes version"))),
+		Entry("1.34", "true", "1.34", Succeed()),
+		Entry("1.28", "true", "1.28", Succeed()),
 	)
 })

--- a/pkg/utils/validation/kubernetesversion/version_test.go
+++ b/pkg/utils/validation/kubernetesversion/version_test.go
@@ -35,12 +35,12 @@ var _ = Describe("Version", func() {
 		},
 
 		Entry("1.28", "", "1.28", MatchError(ContainSubstring("unsupported kubernetes version"))),
-		Entry("1.29", "", "1.29", Succeed()),
+		Entry("1.29", "", "1.29", MatchError(ContainSubstring("unsupported kubernetes version"))),
 		Entry("1.30", "", "1.30", Succeed()),
 		Entry("1.31", "", "1.31", Succeed()),
 		Entry("1.32", "", "1.32", Succeed()),
 		Entry("1.33", "", "1.33", Succeed()),
-		Entry("1.34", "", "1.34", MatchError(ContainSubstring("unsupported kubernetes version"))),
+		Entry("1.35", "", "1.35", MatchError(ContainSubstring("unsupported kubernetes version"))),
 		Entry("1.34", "true", "1.34", Succeed()),
 		Entry("1.28", "true", "1.28", Succeed()),
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind ops-productivity

**What this PR does / why we need it**:

It happens from time to time that GKE upgrades the control plane to the next minor k8s version which is not yet supported by the gardener version currently running. In such a case the OPS people can not simply upgrade to a higher gardener version in a hurry because this might break the existing installation.
Instead forks of the gardener version in production must be created which disables the k8s version check temporarily.

It would be much nicer if for such situations, the OPS people can modify the affected deployments to disable this check until a gardener version is ready which supports this k8s version.

With this PR a Environment Variable 

`EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK=true` can be set to achieve this.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Kubernetes version check can now be explicitly disabled by setting the environment variable `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK` to `true`. This is intended for specific experimental or troubleshooting scenarios where temporarily bypassing the version validation is necessary.
```
