### PR TITLE
Generate an ULA as services range for worker-less IPv6 shoots

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -874,9 +874,10 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 			allErrs = append(allErrs, field.Required(path.Child("pods"), "pods is required"))
 		}
 
-		if c.shoot.Spec.Networking.Services == nil &&
-			slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
-			allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
+		if c.shoot.Spec.Networking.Services == nil {
+			if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) || (workerless && slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv6)) {
+				allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
+			}
 		}
 
 		if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Generate a ULA as services CIDR for worker-less IPv6 shoots, when no service range is specified.
In general, the IPv6 ranges are provided by the infrastructure provider. As we don't create infrastructure resources for worker-less shoots, but need a valid CIDR to configure kube-apiservers we generate an ULA range.  

**Which issue(s) this PR fixes**:
Fixes #13198

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is possible now to create IPv6 workerless shoots without specifying a service range.
```
