### PR TITLE
feat: scrape OpenTelemetry Collector metrics from nodes

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -30,6 +30,9 @@ const (
 	PathConfig = "/var/lib/opentelemetry-collector/config/config"
 	// PathCACert is the path for the otelCollector-tls certificate authority.
 	PathCACert = PathDirectory + "/ca.crt"
+	// MetricsPort is the port on which the OpenTelemetry collector exposes
+	// its internal metrics.
+	MetricsPort = 8888
 
 	openTelemetryCollectorBinaryPath     = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/opentelemetry-collector"
 	openTelemetryCollectorKubeconfigPath = PathDirectory + "/kubeconfig"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -43,6 +43,7 @@ func getOpentelemetryCollectorConfigurationFile(ctx components.Context) (extensi
 		"clientURL":     ctx.OpenTelemetryCollectorIngressHostName + ":443",
 		"pathCACert":    PathCACert,
 		"pathAuthToken": PathAuthToken,
+		"metricsPort":   MetricsPort,
 	}); err != nil {
 		return extensionsv1alpha1.File{}, err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -82,7 +82,12 @@ ExecStart=/opt/bin/opentelemetry-collector --config=` + PathConfig
 				Content: extensionsv1alpha1.FileContent{
 					Inline: &extensionsv1alpha1.FileContentInline{
 						Encoding: "b64",
-						Data: utils.EncodeBase64([]byte(`extensions:
+						Data: utils.EncodeBase64([]byte(`# OpenTelemetry Collector configuration.
+#
+# https://opentelemetry.io/docs/collector/
+# https://opentelemetry.io/docs/collector/configuration/
+# https://opentelemetry.io/docs/collector/internal-telemetry/
+extensions:
   file_storage:
     directory: /var/log/otelcol
     create_directory: true
@@ -144,7 +149,7 @@ processors:
   # If the log came from a pod that is managed by Gardener, the 'k8sattributes' processor
   # will successfully associate the datapoint (log) with the a pod. Since we only
   # watch the kube-system namespace for pods that are managed by Gardener, we can
-  # simply drop all logs that do not have a specific label that we know should have been 
+  # simply drop all logs that do not have a specific label that we know should have been
   # added by the 'k8sattributes' processor. In this case, we check for the
   # existence of the 'k8s.node.name' attribute.
   filter/drop_non_gardener:
@@ -177,6 +182,19 @@ exporters:
       ca_file: /var/lib/opentelemetry-collector/ca.crt
 
 service:
+  telemetry:
+    metrics:
+      level: normal
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+    logs:
+      level: INFO
+      encoding: json
+
   extensions: [file_storage, bearertokenauth]
   pipelines:
     logs/journal:

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -1,3 +1,8 @@
+# OpenTelemetry Collector configuration.
+#
+# https://opentelemetry.io/docs/collector/
+# https://opentelemetry.io/docs/collector/configuration/
+# https://opentelemetry.io/docs/collector/internal-telemetry/
 extensions:
   file_storage:
     directory: /var/log/otelcol
@@ -60,7 +65,7 @@ processors:
   # If the log came from a pod that is managed by Gardener, the 'k8sattributes' processor
   # will successfully associate the datapoint (log) with the a pod. Since we only
   # watch the kube-system namespace for pods that are managed by Gardener, we can
-  # simply drop all logs that do not have a specific label that we know should have been 
+  # simply drop all logs that do not have a specific label that we know should have been
   # added by the 'k8sattributes' processor. In this case, we check for the
   # existence of the 'k8s.node.name' attribute.
   filter/drop_non_gardener:
@@ -93,6 +98,19 @@ exporters:
       ca_file: {{ .pathCACert }}
 
 service:
+  telemetry:
+    metrics:
+      level: normal
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: {{ .metricsPort }}
+    logs:
+      level: INFO
+      encoding: json
+
   extensions: [file_storage, bearertokenauth]
   pipelines:
     logs/journal:

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -459,6 +459,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 						"otelcol_process_.*",
 						"otelcol_receiver_.*",
 						"otelcol_scraper_.*",
+						"otelcol_processor_*",
 					), monitoringv1.RelabelConfig{
 						Action: "keep",
 					}),

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -5,6 +5,7 @@
 package shoot
 
 import (
+	"fmt"
 	"strconv"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -15,8 +16,10 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	otelcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/features"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
@@ -387,6 +390,80 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 				},
 			},
 		)
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
+		nodeMetricsURL := fmt.Sprintf("/api/v1/nodes/${1}:%d/proxy/metrics", otelcomponent.MetricsPort)
+		out = append(
+			out,
+			&monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "opentelemetry-collector-nodes",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels: ptr.To(false),
+					Scheme:      ptr.To("HTTPS"),
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+						Key:                  resourcesv1alpha1.DataKeyToken,
+					}},
+					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+						Key:                  secretsutils.DataKeyCertificateBundle,
+					}}},
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:            monitoringv1alpha1.KubernetesRoleNode,
+						APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
+						FollowRedirects: ptr.To(true),
+						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+							Key:                  resourcesv1alpha1.DataKeyToken,
+						}},
+						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+							Key:                  secretsutils.DataKeyCertificateBundle,
+						}}},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("opentelemetry-collector-nodes"),
+							TargetLabel: "job",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							TargetLabel:  "instance",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_node_label_(.+)`,
+						},
+						{
+							TargetLabel: "__address__",
+							Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							Regex:        `(.+)`,
+							Replacement:  ptr.To(nodeMetricsURL),
+							TargetLabel:  "__metrics_path__",
+						},
+						{
+							TargetLabel: "type",
+							Replacement: ptr.To("shoot"),
+						},
+					},
+					MetricRelabelConfigs: append(monitoringutils.StandardMetricRelabelConfig(
+						"otelcol_exporter_.*",
+						"otelcol_process_.*",
+						"otelcol_receiver_.*",
+						"otelcol_scraper_.*",
+					), monitoringv1.RelabelConfig{
+						Action: "keep",
+					}),
+				},
+			})
 	}
 
 	return out

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -436,7 +436,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								{
 									SourceLabels: []monitoringv1.LabelName{"__name__"},
 									Action:       "keep",
-									Regex:        `^(otelcol_exporter_.*|otelcol_process_.*|otelcol_receiver_.*|otelcol_scraper_.*)$`,
+									Regex:        `^(otelcol_exporter_.*|otelcol_process_.*|otelcol_receiver_.*|otelcol_scraper_.*|otelcol_processor_*)$`,
 								},
 								{
 									Action: "keep",

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -19,6 +19,8 @@ import (
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
+	"github.com/gardener/gardener/pkg/features"
+	testutils "github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("ScrapeConfigs", func() {
@@ -168,25 +170,30 @@ var _ = Describe("ScrapeConfigs", func() {
 					},
 				},
 			}
-		)
 
-		When("cluster is workerless", func() {
-			It("should return the expected objects", func() {
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true)).To(HaveExactElements(workerlessScrapeConfigs))
-			})
-		})
-
-		When("cluster is not workerless", func() {
-			It("should return the expected objects", func() {
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(append(workerlessScrapeConfigs,
-					&monitoringv1alpha1.ScrapeConfig{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "cadvisor",
-						},
-						Spec: monitoringv1alpha1.ScrapeConfigSpec{
-							HonorLabels:     ptr.To(false),
-							HonorTimestamps: ptr.To(false),
-							Scheme:          ptr.To("HTTPS"),
+			nonWorkerlessScrapeConfigs = append(
+				workerlessScrapeConfigs,
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cadvisor",
+					},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						HonorLabels:     ptr.To(false),
+						HonorTimestamps: ptr.To(false),
+						Scheme:          ptr.To("HTTPS"),
+						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+							Key:                  "token",
+						}},
+						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+							Key:                  "bundle.crt",
+						}}},
+						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+							Role:            "Node",
+							APIServer:       ptr.To("https://kube-apiserver:443"),
+							Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
+							FollowRedirects: ptr.To(false),
 							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 								Key:                  "token",
@@ -195,100 +202,181 @@ var _ = Describe("ScrapeConfigs", func() {
 								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
 								Key:                  "bundle.crt",
 							}}},
-							KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-								Role:            "Node",
-								APIServer:       ptr.To("https://kube-apiserver:443"),
-								Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
-								FollowRedirects: ptr.To(false),
-								Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
-									Key:                  "token",
-								}},
-								TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-									Key:                  "bundle.crt",
-								}}},
-							}},
-							RelabelConfigs: []monitoringv1.RelabelConfig{
-								{
-									Action:      "replace",
-									Replacement: ptr.To("cadvisor"),
-									TargetLabel: "job",
-								},
-								{
-									Action: "labelmap",
-									Regex:  `__meta_kubernetes_node_label_(.+)`,
-								},
-								{
-									TargetLabel: "__address__",
-									Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-									Regex:        `(.+)`,
-									Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
-									TargetLabel:  "__metrics_path__",
-								},
-								{
-									TargetLabel: "type",
-									Replacement: ptr.To("shoot"),
-								},
+						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								Action:      "replace",
+								Replacement: ptr.To("cadvisor"),
+								TargetLabel: "job",
 							},
-							MetricRelabelConfigs: []monitoringv1.RelabelConfig{
-								{
-									SourceLabels: []monitoringv1.LabelName{"id"},
-									Action:       "replace",
-									Regex:        `^/system\.slice/(.+)\.service$`,
-									TargetLabel:  "systemd_service_name",
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"id"},
-									Action:       "replace",
-									Regex:        `^/system\.slice/(.+)\.service$`,
-									Replacement:  ptr.To(`$1`),
-									TargetLabel:  "container",
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__"},
-									Action:       "keep",
-									Regex:        `^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$`,
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"namespace"},
-									Action:       "keep",
-									Regex:        `(^$|^kube-system$)`,
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
-									Action:       "drop",
-									Regex:        `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
-									Action:       "keep",
-									Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
-									Action:       "drop",
-									Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
-									Regex:        `container_network.+;/`,
-									Replacement:  ptr.To("true"),
-									TargetLabel:  "host_network",
-								},
-								{
-									Regex:  `^id$`,
-									Action: "labeldrop",
-								},
+							{
+								Action: "labelmap",
+								Regex:  `__meta_kubernetes_node_label_(.+)`,
+							},
+							{
+								TargetLabel: "__address__",
+								Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+								Regex:        `(.+)`,
+								Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
+								TargetLabel:  "__metrics_path__",
+							},
+							{
+								TargetLabel: "type",
+								Replacement: ptr.To("shoot"),
+							},
+						},
+						MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"id"},
+								Action:       "replace",
+								Regex:        `^/system\.slice/(.+)\.service$`,
+								TargetLabel:  "systemd_service_name",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"id"},
+								Action:       "replace",
+								Regex:        `^/system\.slice/(.+)\.service$`,
+								Replacement:  ptr.To(`$1`),
+								TargetLabel:  "container",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Action:       "keep",
+								Regex:        `^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"namespace"},
+								Action:       "keep",
+								Regex:        `(^$|^kube-system$)`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
+								Action:       "drop",
+								Regex:        `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
+								Action:       "keep",
+								Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
+								Action:       "drop",
+								Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
+								Regex:        `container_network.+;/`,
+								Replacement:  ptr.To("true"),
+								TargetLabel:  "host_network",
+							},
+							{
+								Regex:  `^id$`,
+								Action: "labeldrop",
 							},
 						},
 					},
+				},
+				&monitoringv1alpha1.ScrapeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kube-kubelet",
+					},
+					Spec: monitoringv1alpha1.ScrapeConfigSpec{
+						HonorLabels: ptr.To(false),
+						Scheme:      ptr.To("HTTPS"),
+						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+							Key:                  "token",
+						}},
+						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+							Key:                  "bundle.crt",
+						}}},
+						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+							Role:            "Node",
+							APIServer:       ptr.To("https://kube-apiserver"),
+							FollowRedirects: ptr.To(true),
+							Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
+							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+								Key:                  "token",
+							}},
+							TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+								Key:                  "bundle.crt",
+							}}},
+						}},
+						RelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								Action:      "replace",
+								Replacement: ptr.To("kube-kubelet"),
+								TargetLabel: "job",
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
+								TargetLabel:  "instance",
+							},
+							{
+								Action: "labelmap",
+								Regex:  `__meta_kubernetes_node_label_(.+)`,
+							},
+							{
+								TargetLabel: "__address__",
+								Replacement: ptr.To("kube-apiserver:443"),
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+								Regex:        `(.+)`,
+								Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
+								TargetLabel:  "__metrics_path__",
+							},
+							{
+								TargetLabel: "type",
+								Replacement: ptr.To("shoot"),
+							},
+						},
+						MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Action:       "keep",
+								Regex:        `^(kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$`,
+							},
+							{
+								SourceLabels: []monitoringv1.LabelName{"namespace"},
+								Action:       "keep",
+								Regex:        `(^$|^kube-system$)`,
+							},
+						},
+					},
+				},
+			)
+		)
+
+		BeforeEach(func() {
+			DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, false))
+		})
+
+		When("cluster is workerless", func() {
+			It("should return the expected objects", func() {
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, true)).To(HaveExactElements(workerlessScrapeConfigs))
+			})
+		})
+
+		When("cluster is not workerless", func() {
+			It("should return expected scrape configs with OTel feature disabled", func() {
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(nonWorkerlessScrapeConfigs))
+			})
+
+			It("should return expected scrape configs with OTel feature enabled", func() {
+				DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
+				items := append(
+					nonWorkerlessScrapeConfigs,
 					&monitoringv1alpha1.ScrapeConfig{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "kube-kubelet",
+							Name: "opentelemetry-collector-nodes",
 						},
 						Spec: monitoringv1alpha1.ScrapeConfigSpec{
 							HonorLabels: ptr.To(false),
@@ -318,11 +406,11 @@ var _ = Describe("ScrapeConfigs", func() {
 							RelabelConfigs: []monitoringv1.RelabelConfig{
 								{
 									Action:      "replace",
-									Replacement: ptr.To("kube-kubelet"),
+									Replacement: ptr.To("opentelemetry-collector-nodes"),
 									TargetLabel: "job",
 								},
 								{
-									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
+									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
 									TargetLabel:  "instance",
 								},
 								{
@@ -336,7 +424,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								{
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
 									Regex:        `(.+)`,
-									Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
+									Replacement:  ptr.To(`/api/v1/nodes/${1}:8888/proxy/metrics`),
 									TargetLabel:  "__metrics_path__",
 								},
 								{
@@ -348,17 +436,16 @@ var _ = Describe("ScrapeConfigs", func() {
 								{
 									SourceLabels: []monitoringv1.LabelName{"__name__"},
 									Action:       "keep",
-									Regex:        `^(kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$`,
+									Regex:        `^(otelcol_exporter_.*|otelcol_process_.*|otelcol_receiver_.*|otelcol_scraper_.*)$`,
 								},
 								{
-									SourceLabels: []monitoringv1.LabelName{"namespace"},
-									Action:       "keep",
-									Regex:        `(^$|^kube-system$)`,
+									Action: "keep",
 								},
 							},
 						},
 					},
-				)))
+				)
+				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(items))
 			})
 		})
 	})

--- a/pkg/component/observability/monitoring/prometheus/shoot/shoot_suite_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/shoot_suite_test.go
@@ -9,9 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestShoot(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Observability Monitoring Prometheus Shoot Suite")
 }

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1123,6 +1123,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -1154,6 +1156,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
+            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -98,6 +98,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -1135,6 +1137,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -1166,6 +1170,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
+            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -731,6 +731,8 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector
+            - pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
             - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -762,6 +764,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/reconciler
             - pkg/extensions
+            - pkg/features
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR adds support for configuring the port on which internal metrics for the OpenTelemetry collector on the nodes are exposed. The default port for the OTel collector metrics on nodes is `8888`.

Also, a new scrape config is being added to Prometheus in the shoot control-plane, which will scrape the metrics from the OpenTelemetry collector running on the nodes via the [kube-apiserver builtin proxy](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster-services/), similar to the way other targets are already being scraped.

This PR is part of [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemtry-operator-and-collectors.md)

**Which issue(s) this PR fixes**:
Fixes #12164

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for scraping metrics for OpenTelemetry collector on nodes
```
