### PR TITLE
Fix release plan version numbering

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -29,17 +29,17 @@ v1.132  | Week 45-46 | November 3, 2025       | November 16, 2025  | [@LucaBerns
 v1.133  | Week 47-48 | November 17, 2025      | November 30, 2025  | [@ialidzhikov](https://github.com/ialidzhikov)               |
 v1.134  | Week 49-50 | December 1, 2025       | December 14, 2025  | [@marc1404](https://github.com/marc1404)           |
 v1.135  | Week 01-04 | December 29, 2025      | January 25, 2026   | [@timuthy](https://github.com/timuthy)                       |
-v1.137  | Week 05-06 | January 26, 2026       | February 8, 2026   | [@ary1992](https://github.com/ary1992)                       |
-v1.138  | Week 07-08 | February 9, 2026       | February 22, 2026  | [@acumino](https://github.com/acumino)                       |
-v1.139  | Week 09-10 | February 23, 2026      | March 8, 2026      | [@ScheererJ](https://github.com/ScheererJ)                   |
-v1.140  | Week 11-12 | March 9, 2026          | March 22, 2026     | [@oliver-goetz](https://github.com/oliver-goetz)             |
-v1.141  | Week 13-14 | March 23, 2026         | April 5, 2026      | [@tobschli](https://github.com/tobschli)                     |
-v1.142  | Week 15-16 | April 6, 2026          | April 19, 2026     | [@plkokanov](https://github.com/plkokanov)                   |
-v1.143  | Week 17-18 | April 20, 2026         | May 3, 2026        | [@rfranzke](https://github.com/rfranzke)                     |
-v1.144  | Week 19-20 | May 4, 2026            | May 17, 2026       | [@shafeeqes](https://github.com/shafeeqes)                   |
-v1.145  | Week 21-22 | May 18, 2026           | May 31, 2026       | [@Kostov6](https://github.com/Kostov6)                       |
-v1.146  | Week 23-24 | June 1, 2026           | June 14, 2026      | [@vitanovs](https://github.com/vitanovs)                     |
-v1.147  | Week 25-26 | June 15, 2026          | June 28, 2026      | [@dimitar-kostadinov](https://github.com/dimitar-kostadinov) |
+v1.136  | Week 05-06 | January 26, 2026       | February 8, 2026   | [@ary1992](https://github.com/ary1992)                       |
+v1.137  | Week 07-08 | February 9, 2026       | February 22, 2026  | [@acumino](https://github.com/acumino)                       |
+v1.138  | Week 09-10 | February 23, 2026      | March 8, 2026      | [@ScheererJ](https://github.com/ScheererJ)                   |
+v1.139  | Week 11-12 | March 9, 2026          | March 22, 2026     | [@oliver-goetz](https://github.com/oliver-goetz)             |
+v1.140  | Week 13-14 | March 23, 2026         | April 5, 2026      | [@tobschli](https://github.com/tobschli)                     |
+v1.141  | Week 15-16 | April 6, 2026          | April 19, 2026     | [@plkokanov](https://github.com/plkokanov)                   |
+v1.142  | Week 17-18 | April 20, 2026         | May 3, 2026        | [@rfranzke](https://github.com/rfranzke)                     |
+v1.143  | Week 19-20 | May 4, 2026            | May 17, 2026       | [@shafeeqes](https://github.com/shafeeqes)                   |
+v1.144  | Week 21-22 | May 18, 2026           | May 31, 2026       | [@Kostov6](https://github.com/Kostov6)                       |
+v1.145  | Week 23-24 | June 1, 2026           | June 14, 2026      | [@vitanovs](https://github.com/vitanovs)                     |
+v1.146  | Week 25-26 | June 15, 2026          | June 28, 2026      | [@dimitar-kostadinov](https://github.com/dimitar-kostadinov) |
 
 Apart from the release of the next version, the release responsible is also taking care of potential hotfix releases of the last three minor versions.
 The release responsible is the main contact person for coordinating new feature PRs for the next minor versions or cherry-pick PRs for the last three minor versions.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
v1.136 was missing

**Special notes for your reviewer**:
/cc @ary1992 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
