### PR TITLE
Add disaster recovery guide for the garden cluster

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -263,6 +263,7 @@
 * [Trusted TLS certificate for shoot control planes](operations/trusted-tls-for-control-planes.md)
 * [Trusted TLS certificate for garden runtime cluster](operations/trusted-tls-for-garden-runtime.md)
 * [Overlapping Network Ranges between Seeds and Shoots](operations/overlapping-network-ranges.md)
+* [Disaster Recovery: Restoring a Garden Cluster to a new Runtime Cluster](operations/disaster_recovery_garden.md)
 
 ## Monitoring
 

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -7,7 +7,8 @@ This documentation outlines the procedure for restoring a **Garden cluster** int
 The restoration process described here assumes that no other actors (like `gardener-operator`, `etcd-druid`, DNS,  etc.) which also existed in the previous runtime cluster are active anymore. It is crucial to ensure that these components are scaled down or disabled, for example by invalidating their credentials to avoid conflicts.
 
 ## Required Backup Components (Building Blocks)
-The restoration process requires specific building blocks — like etcd backup, credentials and configuration components — to be supplied, which necessitates their continuous backup. The following sections provides details for these components.
+
+The restoration process requires specific building blocks — like `etcd` backup, credentials and configuration components — to be supplied, which necessitates their continuous backup. The following sections provides details for these components.
 
 ### ETCD backup
 
@@ -20,7 +21,7 @@ Reference:
 
 ### Garden Resource
 
-The `garden` resource should be backed up in its entirety including the `status` subresource. The `status` contains critical information like the current state of credentials rotation.
+The `Garden` resource should be backed up in its entirety including the `status` subresource. The `status` contains critical information like the current state of credentials rotation.
 
 ### Runtime Data
 
@@ -28,7 +29,7 @@ To ensure a successful and less-disruptive restore, the following data containin
 
 #### 1\. Encryption Keys and Configurations
 
-These exist separately for both the `kube-apiserver` and the `gardener-apiserver`. Without them , data stored in etcd cannot be decrypted, leading to data loss.
+These exist separately for both the `kube-apiserver` and the `gardener-apiserver`. Without them , data stored in etcd cannot be decrypted, leading to complete data loss.
 
 * `kube-apiserver-etcd-encryption-key`
 * `kube-apiserver-etcd-encryption-configuration`
@@ -55,7 +56,7 @@ These CAs must be preserved to prevent invalidating existing credentials:
 
 ### Infrastructure Credentials
 
-Typically, a `garden` resources references infrastructure credentials for a DNS provider and the etcd backup bucket. For a restore to succeed, these credentials must be valid and available in the new runtime cluster.
+Typically, a `Garden` resources references infrastructure credentials for a DNS provider and the `etcd` backup bucket. For a restore to succeed, these credentials must be valid and available in the new runtime cluster.
 
 -----
 
@@ -65,7 +66,7 @@ The following steps detail the restoration process.
 
 ### Step 1: Backup of ETCD Backups
 
-In order to avoid data loss due to mistakes it is strongly recommended to create a backup of the etcd backup. This ensures that the restore procedure can be tried again in case of failure.
+In order to avoid data loss due to mistakes it is strongly recommended to create a backup of the `etcd` backup. This ensures that the restore procedure can be tried again in case of failure.
 
 ### Step 2: Create a new Runtime Cluster
 
@@ -73,7 +74,7 @@ Provision a new runtime cluster where the Garden cluster will be restored into.
 
 ### Step 3: Adjust CIDRs
 
-In case the new runtime cluster has different CIDRs than the previous one, the `garden` resource must be adjusted accordingly before applying it to the new cluster.
+In case the new runtime cluster has different CIDRs than the previous one, the `Garden` resource must be adjusted accordingly before applying it to the new cluster.
 
 ### Step 4: Deploy the `gardener-operator`
 
@@ -81,15 +82,15 @@ Deploy the `gardener-operator` into the new runtime cluster. Ensure that it is t
 
 ### Step 5: Apply Backed-up Resources
 
-1.  **Scale Down `gardener-operator`:** Scale down the `gardener-operator` deployment to prevent it from immediately reconciling a new `garden` resource.
+1.  **Scale Down `gardener-operator`:** Scale down the `gardener-operator` deployment to prevent it from immediately reconciling a new `Garden` resource.
 2.  **Delete Webhooks:** Delete the mutating and validating webhooks registered by the `gardener-operator` to unblock later operations. Once the operator is scaled up, it will recreate them.
 3.  **Deploy State Secrets:** Deploy the correct backed-up secrets for CAs, encryption, and signing keys into the new cluster.
-4.  **Deploy Infrastructure Secrets:** Deploy valid infrastructure credentials (e.g., for DNS and etcd backup) into the new cluster.
-5.  **Apply Garden Resource:** Apply the backed-up **`garden` resource** YAML to the new cluster.
+4.  **Deploy Infrastructure Secrets:** Deploy valid infrastructure credentials (e.g., for DNS and `etcd` backup) into the new cluster.
+5.  **Apply Garden Resource:** Apply the backed-up **`Garden` resource** to the new cluster.
 
 ### Step 6: Configure Credentials Rotation Status
 
-This step is critical for `garden` resources where credentials rotation was in the **`Prepared`** phase. This ensures the operator takes the correct code path and can complete the rotation later.
+This step is critical for `Garden` resources where credentials rotation was in the **`Prepared`** phase. This ensures the `gardener-operator` takes the correct code path and can complete the rotation later.
 
 Patch the **status subresource** of the garden resource with content similar to the snippet below, reflecting the last completed rotation steps.
 
@@ -120,14 +121,14 @@ credentials:
 
 ### Step 7: Configure Encrypted Resources
 
-* If the `garden` specifies **additional resources for encryption** in the spec, the status must be patched **before** the first reconciliation.
+* If the `Garden` specifies **additional resources for encryption** in the spec, the status must be patched **before** the first reconciliation.
 * The resources defined in the following spec fields must be copied and applied to the `garden.status.encryptedResources` list:
     * `garden.spec.virtualCluster.kubernetes.kubeAPIServer.encryptionConfig.resources`
     * `garden.spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources`
 
 ### Step 8: Start Restoration
 
-**Scale Up `gardener-operator`:** Scale the `gardener-operator` deployment back up. It will now reconcile the `garden` resource with the correct initial status.
+**Scale Up `gardener-operator`:** Scale the `gardener-operator` deployment back up. It will now reconcile the `Garden` resource with the correct initial status.
 
 ### Step 9: Restoring multi-member ETCD clusters (HA configuration)
 
@@ -152,7 +153,7 @@ If the cluster is being restored from the `Preparing` phase (meaning rotation wa
 
 When performing a restore, ensure that the encryption keys and configurations deployed match the state that existed in the former runtime cluster.
 Mismatched keys or an incorrect rotation status can cause the `gardener-operator` to issue new encryption keys. This in turn will render existing data inaccessible.
-Depending on the conditions it might also cause data in etcd to be encrypted with new keys, leading to permanent data loss. Having a separate backup of the etcd backups mitigates this risk.
+Depending on the conditions, it might also cause data in etcd to be encrypted with new keys, leading to permanent data loss. Having a separate backup of the etcd backups mitigates this risk.
 
 ## Testing Locally
 
@@ -160,24 +161,23 @@ Disaster Recovery can be tested with the local development setup. This may help 
 
 ### Preparation
 
-For testing purposes create a local kind-cluster and deploy a Garden cluster into it by following the [Local Development Setup Guide](../deployment/getting_started_locally.md). The recommended way is to use the `gardener-operator` and its respective `make` targets. At the time of writing this, the following commands can be used:
+For testing purposes create a local `kind` cluster and deploy a Garden cluster into it by following the [Local Development Setup Guide](../deployment/getting_started_locally.md). The recommended way is to use the `gardener-operator` and its respective `make` targets. At the time of writing this, the following commands can be used:
 
 ```console
-make kind-multi-zone-up operator-up
-make operator-seed-up
+make kind-multi-zone-up operator-up operator-seed-up
 ```
 
-Once everything is up and running, create a couple of resources (`project`, `secret`, `serviceaccount`, ...) used to validate and restore procedure.
+Once everything is up and running, create a couple of resources (`Project`, `Secret`, `ServiceAccount`, ...) used to validate and restore procedure.
 
-Depending on the testcases which should be covered, trigger a credentials rotation, confiugre a HA setup or add additional resources to be encrypted.
+Depending on the testcases which should be covered, trigger a credentials rotation, configure an HA setup or add additional resources to be encrypted.
 
 Finally, create a service account token and store it away. The token can be used later to validate that existing credentials are still valid after the restore.
 
 ### Persisting Backup and State Data
 
-Create backups of the state and infrastructure credentials secrets in the `garden` namespace as described above. Additionally, export the `garden` resource including its status subresource.
+Create backups of the state and infrastructure credentials secrets in the `garden` namespace as described above. Additionally, export the `Garden` resource including its status subresource.
 
-To persist the etcd backups, create a copy of the local directory, where the `backup-restore` sidecar writes to. For local development setups, this is `dev/local-backupbuckets/` and the directory is prefixed with `garden-`. Note, that backups are created periodically, so wait some minutes to ensure that latest changes are included.
+To persist the `etcd` backups, create a copy of the local directory, where the `backup-restore` sidecar writes to. For local development setups, this is `dev/local-backupbuckets/` and the directory is prefixed with `garden-`. Note, that backups are created periodically, so wait some minutes to ensure that latest changes are included.
 
 ### Causing a Disaster
 
@@ -197,11 +197,11 @@ make kind-multi-zone-up operator-up
 
 Subsequently, copy the persisted etcd backups into the new local backup bucket directory at `dev/local-backupbuckets/`.
 
-Before the `garden` can be applied, the name of the backup bucket needs to be added to the `garden` resource at `.spec.virtualCluster.etcd.main.backup.bucketName`. The name matches the directory name of the local backup bucket created earlier (prefixed with `garden-`).
+Before the `Garden` can be applied, the name of the backup bucket needs to be added to the `Garden` resource at `.spec.virtualCluster.etcd.main.backup.bucketName`. The name matches the directory name of the local backup bucket created earlier (prefixed with `garden-`).
 
-Now, follow the restoration procedure as described above, starting with scaling down the `gardener-operator`, deploying the secrets, applying the `garden` resource and patching the status subresource, if necessary.
+Now, follow the restoration procedure as described above, starting with scaling down the `gardener-operator`, deploying the secrets, applying the `Garden` resource and patching the status subresource, if necessary.
 
 ### Validation
 
-The `garden` resource should reconcile successfully and etcd should contain data from before the disaster.
+The `Garden` resource should reconcile successfully and etcd should contain data from before the disaster.
 Finally, use the token created before to validate that existing credentials are still valid after the restore.

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -13,7 +13,7 @@ The primary goal is to minimize the impact on stakeholders and other components,
 
 - [Required Backup Components (Building Blocks)](#required-backup-components-building-blocks)
 - [Restoration Procedure](#restoration-procedure)
-- [Edge Cases and Special Considerations](#edge-cases-and-special-considerations)
+- [Additional Information and Considerations](#additional-information-and-considerations)
 - [Testing Locally](#testing-locally)
 
 ## Required Backup Components (Building Blocks)
@@ -203,7 +203,7 @@ It will now reconcile the `Garden` resource with the correct initial status.
 
 -----
 
-## Edge Cases and Special Considerations
+## Additional Information and Considerations
 
 #### 1. Restoring from Credentials Rotation Phase `Prepared`
 

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -86,7 +86,7 @@ The following steps detail the restoration process.
 
 To avoid any conflicts caused by actors still running in the previous runtime cluster, ensure that all relevant components are scaled down or disabled.
 
-If it is still possible, scale down the following `Deplyoments` in the `garden` namespace:
+If it is still possible, scale down the following `Deployments` in the `garden` namespace:
 * `gardener-operator`
 * `etcd-druid`
 * `gardener-resource-manager`

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -17,7 +17,7 @@ The following sections provides details for these components.
 ### ETCD backup
 
 The Garden cluster's ETCD is managed by `etcd-druid`, which can take care of performing continuous backups.
-This can be configured in the `garden` resource and is strongly recommended for any setup.
+This can be configured in the `Garden` resource and is strongly recommended for any setup.
 
 > [!IMPORTANT]
 > Without ETCD backups, a restore is not possible.
@@ -27,7 +27,7 @@ Reference:
 - [Garden ETCD](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#etcd)
 - [Example Backup Configuration](https://github.com/gardener/gardener/blob/1f9458b6eb73a8d1f489f003403e16d01bd014a9/example/operator/20-garden.yaml#L86-L93)
 
-### Garden Resource
+### `Garden` Resource
 
 The `Garden` resource should be backed up in its entirety including the `status` subresource.
 The `status` contains critical information like the current state of credentials rotation.
@@ -38,7 +38,7 @@ Finding a reasonable backup frequency depends on the frequency of changes applie
 ### Runtime Data
 
 To ensure a successful and less-disruptive restore, the following data containing state information must be backed up from the runtime cluster.
-These are stored as `secrets` in the **`garden` namespace** and their names are typically suffixed by content hashes and, if triggered, a hash indicating recent rotation (e.g., `ca-f6032ea0-5e58a`).
+These are stored as `Secrets` in the **`garden` namespace** and their names are typically suffixed by content hashes and, if triggered, a hash indicating recent rotation (e.g., `ca-f6032ea0-5e58a`).
 
 Preserving the encryption keys is absolutely critical, while the other secrets are necessary to avoid invalidating existing credentials.
 
@@ -106,7 +106,7 @@ Ensure that it is the same version as the one used in the previous cluster to av
 2.  **Delete Webhooks:** Delete the [mutating](../concepts/operator.md#defaulting) and [validating](../concepts/operator.md#validation) webhooks registered for the `Garden` resource to unblock later operations. Both webhooks are named `gardener-operator`. Once the operator is scaled up, it will recreate them.
 3.  **Deploy State Secrets:** Deploy the correct backed-up secrets for CAs, encryption, and signing keys into the new cluster.
 4.  **Deploy Infrastructure Secrets:** Deploy valid infrastructure credentials (e.g., for DNS and `etcd` backup) into the new cluster.
-5.  **Apply Garden Resource:** Apply the backed-up **`Garden` resource** to the new cluster.
+5.  **Apply `Garden` Resource:** Apply the backed-up **`Garden` resource** to the new cluster.
 
 ### Step 6: Configure Credential Rotation Status
 
@@ -193,7 +193,7 @@ See [Encryption At Rest](https://kubernetes.io/docs/tasks/administer-cluster/enc
 When performing a restore, ensure that the encryption keys and configurations deployed match the state that existed in the former runtime cluster.
 Mismatched keys or an incorrect rotation status can cause the `gardener-operator` to issue new encryption keys.
 This in turn will render existing data inaccessible.
-Depending on the conditions, it might also cause data in etcd to be encrypted with new keys, leading to permanent data loss.
+Depending on the conditions, it might also cause data in `etcd` to be encrypted with new keys, leading to permanent data loss.
 
 > [!TIP]
 > Therefore, it is strongly recommended to create a copy of the etcd backups before starting the restore procedure.

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -9,6 +9,13 @@ The primary goal is to minimize the impact on stakeholders and other components,
 > The restoration process described here assumes that no other actors (like `gardener-operator`, `etcd-druid`, DNS controller,  etc.) which also existed in the previous runtime cluster are active anymore.
 > It is crucial to ensure that these components are scaled down or disabled, for example by invalidating their credentials to avoid conflicts.
 
+## Table of Contents
+
+- [Required Backup Components (Building Blocks)](#required-backup-components-building-blocks)
+- [Restoration Procedure](#restoration-procedure)
+- [Edge Cases and Special Considerations](#edge-cases-and-special-considerations)
+- [Testing Locally](#testing-locally)
+
 ## Required Backup Components (Building Blocks)
 
 The restoration process requires specific building blocks — like `etcd` backup, credentials and configuration components — to be supplied, which necessitates their continuous backup.
@@ -224,6 +231,19 @@ Depending on the conditions, it might also cause data in `etcd` to be encrypted 
 > [!TIP]
 > Therefore, it is strongly recommended to create a copy of the etcd backups before starting the restore procedure.
 > Having the ability to retry the restore procedure with a pristine etcd backup is crucial in case of mistakes.
+
+#### 4. Using a Copy of ETCD Backups
+
+In case the restore procedure fails due to misconfiguration or mistakes, having a copy of the etcd backups allows retrying the restore without data loss.
+To use the copy, "simply" replace the contents of the backup bucket with the copied data before starting the restore procedure again.
+
+However, there might be cases where the [backup bucket is configured with immutability](immutable-backup-buckets.md).
+Overwriting data in the existing bucket will not be possible in this case. 
+Instead, a new bucket has to be created and referenced.
+
+Firstly, create a new backup bucket in the storage provider used. 
+Then, copy the contents of the preserved etcd backup copy into the new bucket.
+Finally, update the `Garden` resource to reference the new bucket at `.spec.virtualCluster.etcd.main.backup.bucketName` before applying it.
 
 ## Testing Locally
 

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -1,0 +1,207 @@
+# Disaster Recovery: Restoring a Garden Cluster to a new Runtime Cluster 🛠️
+
+This documentation outlines the procedure for restoring a **Garden cluster** into a new runtime cluster. The primary goal is to minimize the impact on stakeholders and other components, particularly by preventing the invalidation of credentials issued before the restore.
+
+## Disclaimer
+
+The restoration process described here assumes that no other actors (like `gardener-operator`, `etcd-druid`, DNS,  etc.) which also existed in the previous runtime cluster are active anymore. It is crucial to ensure that these components are scaled down or disabled, for example by invalidating their credentials to avoid conflicts.
+
+## Required Backup Components (Building Blocks)
+The restoration process requires specific building blocks — like etcd backup, credentials and configuration components — to be supplied, which necessitates their continuous backup. The following sections provides details for these components.
+
+### ETCD backup
+
+The Garden cluster's ETCD is managed by `etcd-druid`, which can take care performing continuous backups. This can be configured in the `garden` resource and is strongly recommended for any setup.
+
+Reference:
+- [Backup and Restore Concept](https://github.com/gardener/gardener/blob/master/docs/concepts/backup-restore.md)
+- [Garden ETCD](https://github.com/gardener/gardener/blob/master/docs/concepts/operator.md#etcd)
+- [Example Backup Configuration](https://github.com/gardener/gardener/blob/1f9458b6eb73a8d1f489f003403e16d01bd014a9/example/operator/20-garden.yaml#L86-L93)
+
+### Garden Resource
+
+The `garden` resource should be backed up in its entirety including the `status` subresource. The `status` contains critical information like the current state of credentials rotation.
+
+### Runtime Data
+
+To ensure a successful and less-disruptive restore, the following data containing state information must be backed up from the runtime cluster. These are stored as `secrets` in the **`garden` namespace** and their names are typically suffixed by content hashes and, if triggered, a hash indicating recent rotation (e.g., `ca-f6032ea0-5e58a`).
+
+#### 1\. Encryption Keys and Configurations
+
+These exist separately for both the `kube-apiserver` and the `gardener-apiserver`. Without them , data stored in etcd cannot be decrypted, leading to data loss.
+
+* `kube-apiserver-etcd-encryption-key`
+* `kube-apiserver-etcd-encryption-configuration`
+* `gardener-apiserver-etcd-encryption-key`
+* `gardener-apiserver-etcd-encryption-configuration`
+
+#### 2\. Non-Auto-Rotated Certificate Authorities (CAs)
+
+These CAs must be preserved to prevent invalidating existing credentials:
+
+* `ca`
+* `ca-front-proxy`
+* `ca-etcd`
+* `ca-etcd-peer`
+* `ca-gardener`
+* `ca-client`
+
+#### 3\. Signing Keys
+
+* `service-account-key`
+* `gardener-apiserver-workload-identity-signing-key`
+
+**Note:** It is **not** necessary to store or restore secrets that have "bundle" in their name.
+
+### Infrastructure Credentials
+
+Typically, a `garden` resources references infrastructure credentials for a DNS provider and the etcd backup bucket. For a restore to succeed, these credentials must be valid and available in the new runtime cluster.
+
+-----
+
+## Restoration Procedure
+
+The following steps detail the restoration process.
+
+### Step 1: Backup of ETCD Backups
+
+In order to avoid data loss due to mistakes it is strongly recommended to create a backup of the etcd backup. This ensures that the restore procedure can be tried again in case of failure.
+
+### Step 2: Create a new Runtime Cluster
+
+Provision a new runtime cluster where the Garden cluster will be restored into.
+
+### Step 3: Adjust CIDRs
+
+In case the new runtime cluster has different CIDRs than the previous one, the `garden` resource must be adjusted accordingly before applying it to the new cluster.
+
+### Step 4: Deploy the `gardener-operator`
+
+Deploy the `gardener-operator` into the new runtime cluster. Ensure that it is the same version as the one used in the previous cluster to avoid compatibility issues.
+
+### Step 5: Apply Backed-up Resources
+
+1.  **Scale Down `gardener-operator`:** Scale down the `gardener-operator` deployment to prevent it from immediately reconciling a new `garden` resource.
+2.  **Delete Webhooks:** Delete the mutating and validating webhooks registered by the `gardener-operator` to unblock later operations. Once the operator is scaled up, it will recreate them.
+3.  **Deploy State Secrets:** Deploy the correct backed-up secrets for CAs, encryption, and signing keys into the new cluster.
+4.  **Deploy Infrastructure Secrets:** Deploy valid infrastructure credentials (e.g., for DNS and etcd backup) into the new cluster.
+5.  **Apply Garden Resource:** Apply the backed-up **`garden` resource** YAML to the new cluster.
+
+### Step 6: Configure Credentials Rotation Status
+
+This step is critical for `garden` resources where credentials rotation was in the **`Prepared`** phase. This ensures the operator takes the correct code path and can complete the rotation later.
+
+Patch the **status subresource** of the garden resource with content similar to the snippet below, reflecting the last completed rotation steps.
+
+```yaml
+observedGeneration: 1
+credentials:
+  rotation:
+    certificateAuthorities:
+      lastInitiationFinishedTime: "2025-06-27T10:43:01Z"
+      lastInitiationTime: "2025-06-27T10:39:57Z"
+      phase: Prepared # Must be set if rotation was in Prepared phase
+    etcdEncryptionKey:
+      lastInitiationFinishedTime: "2025-06-27T10:43:01Z"
+      lastInitiationTime: "2025-06-27T10:39:57Z"
+      phase: Prepared # Must be set if rotation was in Prepared phase
+    observability:
+      lastCompletionTime: "2025-06-27T10:43:01Z"
+      lastInitiationTime: "2025-06-27T10:39:57Z"
+    serviceAccountKey:
+      lastInitiationFinishedTime: "2025-06-27T10:43:01Z"
+      lastInitiationTime: "2025-06-27T10:39:57Z"
+      phase: Prepared # Must be set if rotation was in Prepared phase
+    workloadIdentityKey:
+      lastInitiationFinishedTime: "2025-06-27T10:43:01Z"
+      lastInitiationTime: "2025-06-27T10:39:57Z"
+      phase: Prepared # Must be set if rotation was in Prepared phase
+```
+
+### Step 7: Configure Encrypted Resources
+
+* If the `garden` specifies **additional resources for encryption** in the spec, the status must be patched **before** the first reconciliation.
+* The resources defined in the following spec fields must be copied and applied to the `garden.status.encryptedResources` list:
+    * `garden.spec.virtualCluster.kubernetes.kubeAPIServer.encryptionConfig.resources`
+    * `garden.spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.resources`
+
+### Step 8: Start Restoration
+
+**Scale Up `gardener-operator`:** Scale the `gardener-operator` deployment back up. It will now reconcile the `garden` resource with the correct initial status.
+
+### Step 9: Restoring multi-member ETCD clusters (HA configuration)
+
+* For a Garden running with an **HA configuration**, restoring **the etcd cluster requires manual steps**.
+* Follow the specific procedure documented in the `etcd-druid` repository:
+    * **Reference:** `https://github.com/gardener/etcd-druid/blob/master/docs/usage/recovering-etcd-clusters.md`
+* Apply the steps to both `etcd-main` and `etcd-events` clusters.
+
+-----
+
+## Edge Cases and Special Considerations
+
+#### 1\. Restoring from Credentials Rotation Phase `Prepared`
+
+When restoring from the `Prepared` phase, the secrets deployed in Step 1 will have two suffixes: the content hash and a second suffix indicating a non-empty `last-rotation-initiation-time` label.
+
+#### 2\. Restoring from Credentials Rotation Phase `Preparing`
+
+If the cluster is being restored from the `Preparing` phase (meaning rotation was actively in progress), you must verify the content of the secrets and the encryption state in **etcd** to ensure consistency.
+
+#### 3\. Encryption Keys
+
+When performing a restore, ensure that the encryption keys and configurations deployed match the state that existed in the former runtime cluster.
+Mismatched keys or an incorrect rotation status can cause the `gardener-operator` to issue new encryption keys. This in turn will render existing data inaccessible.
+Depending on the conditions it might also cause data in etcd to be encrypted with new keys, leading to permanent data loss. Having a separate backup of the etcd backups mitigates this risk.
+
+## Testing Locally
+
+Disaster Recovery can be tested with the local development setup. This may help to gain confidence before performing the procedure on production clusters.
+
+### Preparation
+
+For testing purposes create a local kind-cluster and deploy a Garden cluster into it by following the [Local Development Setup Guide](../deployment/getting_started_locally.md). The recommended way is to use the `gardener-operator` and its respective `make` targets. At the time of writing this, the following commands can be used:
+
+```console
+make kind-multi-zone-up operator-up
+make operator-seed-up
+```
+
+Once everything is up and running, create a couple of resources (`project`, `secret`, `serviceaccount`, ...) used to validate and restore procedure.
+
+Depending on the testcases which should be covered, trigger a credentials rotation, confiugre a HA setup or add additional resources to be encrypted.
+
+Finally, create a service account token and store it away. The token can be used later to validate that existing credentials are still valid after the restore.
+
+### Persisting Backup and State Data
+
+Create backups of the state and infrastructure credentials secrets in the `garden` namespace as described above. Additionally, export the `garden` resource including its status subresource.
+
+To persist the etcd backups, create a copy of the local directory, where the `backup-restore` sidecar writes to. For local development setups, this is `dev/local-backupbuckets/` and the directory is prefixed with `garden-`. Note, that backups are created periodically, so wait some minutes to ensure that latest changes are included.
+
+### Causing a Disaster
+
+To simulate a disaster, simply delete the kind cluster:
+
+```console
+make kind-multi-zone-down
+```
+
+### Restoring the Garden Cluster
+
+To start with the restore part, create a new kind cluster:
+
+```console
+make kind-multi-zone-up operator-up
+```
+
+Subsequently, copy the persisted etcd backups into the new local backup bucket directory at `dev/local-backupbuckets/`.
+
+Before the `garden` can be applied, the name of the backup bucket needs to be added to the `garden` resource at `.spec.virtualCluster.etcd.main.backup.bucketName`. The name matches the directory name of the local backup bucket created earlier (prefixed with `garden-`).
+
+Now, follow the restoration procedure as described above, starting with scaling down the `gardener-operator`, deploying the secrets, applying the `garden` resource and patching the status subresource, if necessary.
+
+### Validation
+
+The `garden` resource should reconcile successfully and etcd should contain data from before the disaster.
+Finally, use the token created before to validate that existing credentials are still valid after the restore.

--- a/docs/operations/disaster_recovery_garden.md
+++ b/docs/operations/disaster_recovery_garden.md
@@ -5,8 +5,9 @@ The primary goal is to minimize the impact on stakeholders and other components,
 
 ## Disclaimer
 
-The restoration process described here assumes that no other actors (like `gardener-operator`, `etcd-druid`, DNS,  etc.) which also existed in the previous runtime cluster are active anymore.
-It is crucial to ensure that these components are scaled down or disabled, for example by invalidating their credentials to avoid conflicts.
+> [!IMPORTANT]
+> The restoration process described here assumes that no other actors (like `gardener-operator`, `etcd-druid`, DNS,  etc.) which also existed in the previous runtime cluster are active anymore.
+> It is crucial to ensure that these components are scaled down or disabled, for example by invalidating their credentials to avoid conflicts.
 
 ## Required Backup Components (Building Blocks)
 
@@ -17,7 +18,9 @@ The following sections provides details for these components.
 
 The Garden cluster's ETCD is managed by `etcd-druid`, which can take care of performing continuous backups.
 This can be configured in the `garden` resource and is strongly recommended for any setup.
-**Without ETCD backups, a restore is not possible.**
+
+> [!IMPORTANT]
+> Without ETCD backups, a restore is not possible.
 
 Reference:
 - [Backup and Restore Concept](https://github.com/gardener/gardener/blob/master/docs/concepts/backup-restore.md)
@@ -39,7 +42,7 @@ These are stored as `secrets` in the **`garden` namespace** and their names are 
 
 Preserving the encryption keys is absolutely critical, while the other secrets are necessary to avoid invalidating existing credentials.
 
-#### 1\. Encryption Keys and Configurations
+#### 1. Encryption Keys and Configurations
 
 These exist separately for both the `kube-apiserver` and the `gardener-apiserver`.
 Without them, data stored in `etcd` cannot be decrypted, leading to complete data loss.
@@ -49,7 +52,7 @@ Without them, data stored in `etcd` cannot be decrypted, leading to complete dat
 * `gardener-apiserver-etcd-encryption-key`
 * `gardener-apiserver-etcd-encryption-configuration`
 
-#### 2\. Non-Auto-Rotated Certificate Authorities (CAs)
+#### 2\. Manually-Rotated Certificate Authorities (CAs)
 
 The following CAs must be preserved:
 
@@ -65,7 +68,8 @@ The following CAs must be preserved:
 * `service-account-key`
 * `gardener-apiserver-workload-identity-signing-key`
 
-**Note:** It is **not** necessary to store or restore secrets that have "bundle" in their name.
+> [!NOTE]
+> It is **not** necessary to store or restore secrets that have "bundle" in their name.
 
 ### Infrastructure Credentials
 
@@ -104,9 +108,9 @@ Ensure that it is the same version as the one used in the previous cluster to av
 4.  **Deploy Infrastructure Secrets:** Deploy valid infrastructure credentials (e.g., for DNS and `etcd` backup) into the new cluster.
 5.  **Apply Garden Resource:** Apply the backed-up **`Garden` resource** to the new cluster.
 
-### Step 6: Configure Credentials Rotation Status
+### Step 6: Configure Credential Rotation Status
 
-This step is critical for `Garden` resources where credentials rotation was in the **`Prepared`** phase.
+This step is critical for `Garden` resources where credential rotation was in the **`Prepared`** phase.
 This ensures the `gardener-operator` takes the correct code path and can complete the rotation later.
 
 Patch the **status subresource** of the garden resource with content similar to the snippet below, reflecting the last completed rotation steps.
@@ -179,7 +183,8 @@ The encryption state of resources in **etcd** might require both the new and the
 
 Whether this is the case or not depends on the time of the last successful backup of etcd data.
 
-Please note, there are always two encryption configurations: one for the `kube-apiserver` and one for the `gardener-apiserver`.
+> [!NOTE]
+> There are always two encryption configurations: one for the `kube-apiserver` and one for the `gardener-apiserver`.
 
 See [Encryption At Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) for more details.
 
@@ -190,8 +195,9 @@ Mismatched keys or an incorrect rotation status can cause the `gardener-operator
 This in turn will render existing data inaccessible.
 Depending on the conditions, it might also cause data in etcd to be encrypted with new keys, leading to permanent data loss.
 
-Therefore, it is strongly recommended to create a copy of the etcd backups before starting the restore procedure.
-Having the ability to retry the restore procedure with a pristine etcd backup is crucial in case of mistakes.
+> [!TIP]
+> Therefore, it is strongly recommended to create a copy of the etcd backups before starting the restore procedure.
+> Having the ability to retry the restore procedure with a pristine etcd backup is crucial in case of mistakes.
 
 ## Testing Locally
 
@@ -214,7 +220,7 @@ Depending on the testcases which should be covered, trigger a credentials rotati
 Finally, create a `ServiceAccount` in the virtual Garden cluster and have the API server issue a token for it.
 
 ```console
-kubectl create token <service-account-name> -n <namespace> --duration=24h>
+kubectl create token <service-account-name> -n <namespace> --duration=24h
 ```
 
 Store the token into a [kubeconfig file](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#AuthInfo) and test, that it can be used to access the virtual Garden cluster.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

In case of a disastrous event affecting the runtime or garden cluster, an operator might decide to restore the garden cluster into a new runtime cluster. This document outlines the necessary steps and gives a few hints on potential pitfalls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @benedikt-haug

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
Add disaster recovery guide for the garden cluster
```
