### PR TITLE
[GEP-35] `VictoriaLogs` as `Vali` Replacement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -159,8 +159,8 @@
 * [GEP-31: In-Place Node Updates of Shoot Clusters](proposals/31-inplace-node-update.md)
 * [GEP-32: Cloud Profile Version Classification Lifecycles](proposals/32-version-classification-lifecycles.md)
 * [GEP-33: Machine Image Capabilities](proposals/33-machine-image-capabilities.md)
-* [GEP-34: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes](proposals/34-observability2.0-opentelemetry-operator-and-collectors.md)
-* [GEP-35: VictoriaLogs as Log Backend](proposals/35-observability2.0-victoria-logs.md)
+* [GEP-34: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes](proposals/34-observability2.0-opentelemtry-operator-and-collectors.md)
+* [GEP-35: Migrating from Vali to VictoriaLogs](proposals/35-observability2.0-victoria-logs.md)
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,7 @@
 * [GEP-32: Cloud Profile Version Classification Lifecycles](proposals/32-version-classification-lifecycles.md)
 * [GEP-33: Machine Image Capabilities](proposals/33-machine-image-capabilities.md)
 * [GEP-34: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes](proposals/34-observability2.0-opentelemetry-operator-and-collectors.md)
+* [GEP-35: VictoriaLogs as Log Backend](proposals/35-observability2.0-victoria-logs.md)
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,7 +159,7 @@
 * [GEP-31: In-Place Node Updates of Shoot Clusters](proposals/31-inplace-node-update.md)
 * [GEP-32: Cloud Profile Version Classification Lifecycles](proposals/32-version-classification-lifecycles.md)
 * [GEP-33: Machine Image Capabilities](proposals/33-machine-image-capabilities.md)
-* [GEP-34: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes](proposals/34-observability2.0-opentelemtry-operator-and-collectors.md)
+* [GEP-34: Introducing OpenTelemetry Operator and Collectors in Shoot Control Planes](proposals/34-observability2.0-opentelemetry-operator-and-collectors.md)
 * [GEP-35: Migrating from Vali to VictoriaLogs](proposals/35-observability2.0-victoria-logs.md)
 
 ## Development

--- a/docs/proposals/35-observability2.0-victoria-logs.md
+++ b/docs/proposals/35-observability2.0-victoria-logs.md
@@ -58,7 +58,7 @@ This includes 2 steps:
 - Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Garden` reconciliation flow in the `Garden` namespace.
 - Deployment of a new `VictoriaLogs` statefulset during the Garden reconciliation flow but *after* the `VictoriaOperator` deployment has finished. This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
 
-Both new components will strongly resemble the already existing pattern that already existing components implement (e.g. OpenTelemetry Operator, Prometheus Operator). That being an implementation of the `Deployer` interface as well as an additional step the the `Seed` reconciliation flow.
+Both new components will implement the already existing pattern that components implement (e.g. OpenTelemetry Operator, Prometheus Operator). That being an implementation of the `Deployer` interface as well as an additional step the the `Seed` reconciliation flow.
 
 #### Access to VictoriaLogs in the `Garden` cluster
 

--- a/docs/proposals/35-observability2.0-victoria-logs.md
+++ b/docs/proposals/35-observability2.0-victoria-logs.md
@@ -86,18 +86,17 @@ metadata:
   name: example
   namespace: shoot--local--local
 spec:
-  retentionPeriod: "12"
   storage:
     resources:
       requests:
-        storage: 50Gi
+        storage: 30Gi
   resources:
     requests:
-      memory: 500Mi
-      cpu: 500m
+      memory: 100Mi
+      cpu: 10m
     limits:
-      memory: 10Gi
-      cpu: 5
+      memory: 300Mi
+      cpu: 50m
 ```
 
 #### Access to VictoriaLogs in the `Shoot` Control-Plane

--- a/docs/proposals/35-observability2.0-victoria-logs.md
+++ b/docs/proposals/35-observability2.0-victoria-logs.md
@@ -1,0 +1,141 @@
+---
+title: Migrating from Vali to VictoriaLogs
+gep-number: 35
+creation-date: 2025-10-13
+status: implementable
+authors:
+- "@nickytd"
+- "@rrhubenov"
+reviewers:
+- "todo"
+---
+
+# GEP-35: Migrating from Vali to VictoriaLogs
+
+## Table of Contents
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+- [Alternatives](#alternatives)
+
+## Summary
+
+This proposal introduces the deployment of [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) which will act as the replacement for [Vali](https://github.com/credativ/vali) in the Control Plane of all Shoot clusters that have the observability stack enabled, as well as in Seed clusters and Garden clusters. After the work that has been done on [GEP-34](https://github.com/gardener/gardener/pull/11861), we are in a favourable position to easily switch our storage layer for the clusters' log signals.
+
+A new operator is introduced that will be deployed to the `garden` namespace of seed & garden clusters. This operator will manage the deployment of the new `VictoriaLogs` instances to the `garden` namespace of seed & garden clusters, as well as to the Control Plane namespace of Shoot clusters via the `VLSingle` CustomResource.
+
+Since we'd like to make the transition from `Vali` to `VictoriaLogs` as painless as possible, this proposal also introduces multiple ways to migrate in already running landscapes without losing data that has accumulated with the existing `Vali` instances.
+
+## Motivation
+
+Since version v2.3.0, [Loki](https://github.com/grafana/loki) has switched from the Apache-2.0 license to a significantly more restrictive AGPLv3 licene. Since then, the Observability stack of Gardener has been using [Vali](https://github.com/credativ/vali) -- a fork of Loki 2.2.1, which is the last official version that maintains the Apache-2.0 license.
+
+However, the fork maintains only security updates, thus leading to no new features or improvements getting integrated. As such, an upgrade is due so that we can benefit from new technologies and optimizations in the world of  log databases.
+
+One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/), discussed in more detail in [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemtry-operator-and-collectors.md).  After careful consideration, we've converged to using [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) as the default backend for storing logs.
+
+### Goals
+
+- Deploy the VictoriaOperator & VictoriaLogs statefulset in seed clusters.
+- Deploy the VictoriaOperator & VictoriaLogs statefulset in the garden cluster.
+- Deploy a VictoriaLogs statefulset to the Control-Plane of new & existing `Shoot` clusters.
+- Give an appropriate migration strategy from Vali to VictoriaLogs for existing clusters.
+
+### Non-Goals
+
+- Provide tooling around the migration from `Vali` to `VictoriaLogs`
+
+---
+
+## Proposal
+
+### 1. Deployment of VictoriaLogs on the Garden Cluster
+
+This includes 2 steps:
+- Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Garden` reconciliation flow in the `Garden` namespace.
+- Deployment of a new `VictoriaLogs` statefulset during the Garden reconciliation flow but *after* the `VictoriaOperator` deployment has finished. This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
+
+Both new components will strongly resemble the already existing pattern that already existing components implement (e.g. OpenTelemetry Operator, Prometheus Operator). That being an implementation of the `Deployer` interface as well as an additional step the the `Seed` reconciliation flow.
+
+#### Access to VictoriaLogs in the `Garden` cluster
+
+Currently, Vali access is behind a service in the `garden` namespace. This pattern will remain and log shippers will only be expected to use the `OTLP` protocol, instead of the `Loki` protocol, via HTTP when inserting logs to VictoriaLogs.
+
+### 2. Deployment of VictoriaLogs on Seed Clusters
+
+Analogously to the deployment in the `Garden` cluster, this includes 2 steps:
+- Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Seed` reconciliation flow in the `Garden` namespace.
+- Deployment of a new `VictoriaLogs` statefulset during the Seed reconciliation flow but *after* the `VictoriaOperator` deployment has finished. This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
+
+#### Access to VictoriaLogs in the `Seed` cluster
+
+Since the setup is the same as in the `Garden` cluster, see details in 'Access to VictoriaLogs in the `Garden` cluster'.
+
+### 3. Deploy VictoriaLogs in Shoot Control-Planes
+
+During the `Shoot` reconciliation flow, the new `VictoriaLogs` component will be deployed to the Control-Plane namespace of `Shoot` clusters. The operator will manage the resulting `VLSingle` CustomResource and create a `VictoriaLogs` statefulset.
+
+Example VLSingle CR:
+```
+apiVersion: operator.victoriametrics.com/v1
+kind: VLSingle
+metadata:
+  name: example
+  namespace: shoot--local--local
+spec:
+  retentionPeriod: "12"
+  storage:
+    resources:
+      requests:
+        storage: 50Gi
+  resources:
+    requests:
+      memory: 500Mi
+      cpu: 500m
+    limits:
+      memory: 10Gi
+      cpu: 5
+```
+
+#### Access to VictoriaLogs in the `Shoot` Control-Plane
+
+Access to Vali is exposed via an ingress in the shoot control-plane. This will continue with VictoriaLogs as well. Log shippers will need to be configured via OTLP.
+
+### 4. Migration from Vali to VictoriaLogs
+
+During all the replacements of `Vali` we want to ensure that existing clusters do not get disrupted. For this reason, 3 strategies for migration have been considered:
+- "One-shot" migration. Basically reformat all the Vali data into the VictoriaLogs format. Could be done via the Collector since there is no tool that exists to do this OOTB. This would include:
+	- Creating a tool that can query all logs from Vali, reformat them into the standard Loki format, and then send them the Collector instance that will transform them to the OTEL format that the VictoriaLogs component can understand.
+	- Creating scripts for the necessary migration on all the landscapes.
+	- Think of a strategy to make the process as safe as possible -- what happens on failure, how should we query & feed the logs in batches, how would we go back to Vali in case of failure.
+- "Rolling" migration. Get the VictoriaLogs instances up and reroute the logs to the them without removing Vali. This would require both of them to be accessible for the whole rotation period of the logs. This would introduce friction for the time being since there would be 2 sources of logs.
+- "Dual" migration. Same thing as the "rolling" one but send logs to both backends. This would remove the friction but would incur a higher storage cost due to the replication of the logs on both backends.
+
+Which of the approaches is best depends on the specific characteristics of the targeted landscapes. For instance, if the log rotation period is much longer than the time that would be spent developing the tools needed for the "one-shot" migration, then investing in this approach might be best. Bear in mind that this enhancement proposal does not discuss how such tools should be created nor is there a plan for such a proposal to be developed.
+
+---
+
+## Alternatives
+
+### Developing our own operator for the VictoriaLogs deployments
+
+Taking into account the work that would require maintaining such an operator and the negligible benefits that would provide, it has been decided that using the already existing community driven operator would be more beneficial in the long run.
+
+### ClickHouse instead of VictoriaLogs
+
+When choosing a new log database, ClickHouse was one alternative that maintains its Apache-2.0 license, is performant and widely used.
+However after researching it as an option, it was found that ClickHouse:
+- Is more complicated for operating
+- Has an SQL-like query language for querying logs.
+
+In contrast, VictoriaLogs:
+- Is simple for deployment and operating
+- Has a query language that is more similar to the LogQL that `Vali` uses making the transition easier.
+
+As well as these 2 points, VictoriaLogs stood out with other great qualities, such as:
+- Vibrant community support
+- Responsiveness of the code owners
+- Performance 

--- a/docs/proposals/35-observability2.0-victoria-logs.md
+++ b/docs/proposals/35-observability2.0-victoria-logs.md
@@ -53,7 +53,7 @@ Since then, the Observability stack of Gardener has been using [Vali](https://gi
 However, the fork maintains only security updates, thus leading to no new features or improvements getting integrated.
 As such, an upgrade is due so that we can benefit from new technologies and optimizations in the world of log databases.
 
-One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/), discussed in more detail in [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemtry-operator-and-collectors.md).
+One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/), discussed in more detail in [GEP-34](./34-observability2.0-opentelemtry-operator-and-collectors.md).
 After careful consideration, we've converged to using [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) as the backend for storing logs. See the [Alternatives](#alternatives) section for more details on why this choice was made.
 
 ### Goals
@@ -74,17 +74,17 @@ After careful consideration, we've converged to using [VictoriaLogs](https://git
 
 This includes 2 steps:
 - Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Garden` reconciliation flow in the `garden` namespace.
-- Deployment of a `VLSingle` CustomResource during the Garden reconciliation flow *after* the `VictoriaOperator` k8s deployment has finished.
+- Deployment of a `VLSingle` CustomResource during the `Garden` reconciliation flow *after* the `VictoriaOperator` k8s deployment has finished.
 
 The `VLSingle` CustomResource will be managed by the operator and will create a `VictoriaLogs` k8s deployment in the `garden` namespace.
 
 Both new components will implement the already existing pattern that components implement (e.g. OpenTelemetry Operator, Prometheus Operator).
-That being an implementation of the `Deployer` interface as well as an additional step the the `Garden` reconciliation flow.
+That being an implementation of the `Deployer` interface as well as an additional step in the `Garden` reconciliation flow.
 
 #### Sending Logs to `VictoriaLogs` in the `Garden` Cluster
 
 Currently, `Vali` access is behind a service in the `garden` namespace.
-This pattern will remain and log shippers will only be expected to use the `OTLP` protocol, instead of the `Loki` protocol, via HTTP when inserting logs to VictoriaLogs.
+This pattern will remain and log shippers will only be expected to use the `OTLP` protocol, instead of the `Loki` protocol, via HTTP when inserting logs to `VictoriaLogs`.
 In the `Garden` cluster, the only log shippers are the `FluentBit` instances. They will be configured to send logs via `OTLP`.
 
 In other words, the `VictoriaLogs` instance will be exposed via a service in the `garden` namespace.
@@ -127,7 +127,7 @@ spec:
       cpu: 50m
 ```
 
-#### Sending Logs to VictoriaLogs in the `Shoot` Control Plane
+#### Sending Logs to `VictoriaLogs` in the `Shoot` Control Plane
 
 Currently, `Vali` access is behind a service in the namespace of the `Shoot` control plane.
 For external access, there exists an ingress in front of the `OpenTelemetry Collector` in the control plane of `Shoot` clusters that is used to post logs to `Vali`.
@@ -135,14 +135,14 @@ See [GEP-34](./34-observability2.0-opentelemtry-operator-and-collectors.md) for 
 
 The same setup will continue with `VictoriaLogs`, with the only difference being that the `OpenTelemetry Collector` will be configured to ship logs to `VictoriaLogs` via `OTLP` instead of to `Vali` via the `Loki` protocol.
 
-### 4. Migration from Vali to VictoriaLogs
+### 4. Migration from `Vali` to `VictoriaLogs`
 
 #### Data Migration
 During all the replacements of `Vali` we want to ensure that existing clusters do not get disrupted.
 For this reason, 2 strategies for migration have been considered:
 - "One-shot" migration.
 
-Reformat all the Vali data into the VictoriaLogs format (or OTLP).
+Reformat all the `Vali` data into the `VictoriaLogs` format (or OTLP).
 There is no tool that exists to do this out of the box.
 
   | Pros | Cons |
@@ -171,9 +171,9 @@ When this feature gate is enabled:
 - The OpenTelemetry Collector will be reconfigured to ship logs to *both* `Vali` and `VictoriaLogs`.
 - `FluentBit` instances will be reconfigured to ship logs to *both* `Vali` and `VictoriaLogs`.
 
-##### Removing Vali after the migration period
+##### Removing `Vali` after the migration period
 
-Removal of Vali will further rely on another feature gate called `RemoveVali` that will rely on the `VictoriaLogs` already being enabled for the specific component.
+Removal of `Vali` will further rely on another feature gate called `RemoveVali` that will rely on the `VictoriaLogs` already being enabled for the specific component.
 This feature gate will be introduced for the `gardenlet` and the `gardener-operator` components.
 
 When this feature gate is enabled, based on whether the retention period has passed since `VictoriaLogs` has been deployed, `Vali` will be removed from the cluster. 
@@ -198,10 +198,10 @@ Thus, it is advised that the `DeployVictoriaLogs` feature gate is enabled intell
 
 There are 2 main issues that we have with our current observability platform - Plutono:
 - Plutono is a fork of Grafana and as such it lags behind the new features in Grafana.
-  Same as Vali, it only receives security updates.
-- Plutono does not support VictoriaLogs as a data source
+  Same as `Vali`, it only receives security updates.
+- Plutono does not support `VictoriaLogs` as a data source
 
-For this reason, our UI for logs will temporarily be replaced with the built-in web UI that VictoriaLogs ships with.
+For this reason, our UI for logs will temporarily be replaced with the built-in web UI that `VictoriaLogs` ships with.
 Plutono will remain as the dashboard for visualising metrics and dashboards.
 [There is a plan](https://github.com/gardener/monitoring/issues/52) to migrate to [Perses](https://github.com/perses/perses) in the near future, which will unify the interfaces again, but this is out of scope of this GEP.
 
@@ -209,22 +209,22 @@ Plutono will remain as the dashboard for visualising metrics and dashboards.
 
 ## Alternatives
 
-### Developing our own operator for the VictoriaLogs deployments
+### Developing our own operator for the `VictoriaLogs` deployments
 
 Taking into account the work that would require maintaining such an operator and the negligible benefits that would provide, it has been decided that using the already existing community driven operator would be more beneficial in the long run.
 
-### ClickHouse instead of VictoriaLogs
+### ClickHouse instead of `VictoriaLogs`
 
 When choosing a new log database, [ClickHouse](https://github.com/ClickHouse/ClickHouse) was the only mainstream alternative that maintains its Apache-2.0 license, is performant and widely used.
 However after researching it as an option, it was found that ClickHouse:
 - Is more complicated for operating
 - Has an SQL-like query language for querying logs.
 
-In contrast, VictoriaLogs:
+In contrast, `VictoriaLogs`:
 - Is simple for deployment and operating
 - Has a query language that is more similar to the LogQL that `Vali` uses making the transition easier.
 
-Furthermore, VictoriaLogs stood out with other great qualities, such as:
+Furthermore, `VictoriaLogs` stood out with other great qualities, such as:
 - Vibrant community support
 - Responsiveness of the code owners
 - Performance 

--- a/docs/proposals/35-observability2.0-victoria-logs.md
+++ b/docs/proposals/35-observability2.0-victoria-logs.md
@@ -7,7 +7,7 @@ authors:
 - "@nickytd"
 - "@rrhubenov"
 reviewers:
-- "todo"
+- "@plkokanov"
 ---
 
 # GEP-35: Migrating from Vali to VictoriaLogs
@@ -23,25 +23,30 @@ reviewers:
 
 ## Summary
 
-This proposal introduces the deployment of [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) which will act as the replacement for [Vali](https://github.com/credativ/vali) in the Control Plane of all Shoot clusters that have the observability stack enabled, as well as in Seed clusters and Garden clusters. After the work that has been done on [GEP-34](https://github.com/gardener/gardener/pull/11861), we are in a favourable position to easily switch our storage layer for the clusters' log signals.
+This proposal introduces the deployment of [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) which will act as the replacement for [Vali](https://github.com/credativ/vali) in the Control Plane of all Shoot clusters that have the observability stack enabled, as well as in Seed clusters and Garden clusters.
+After the work that has been done on [GEP-34](https://github.com/gardener/gardener/pull/11861), we are in a favourable position to easily switch our storage layer for the clusters' log signals.
 
-A new operator is introduced that will be deployed to the `garden` namespace of seed & garden clusters. This operator will manage the deployment of the new `VictoriaLogs` instances to the `garden` namespace of seed & garden clusters, as well as to the Control Plane namespace of Shoot clusters via the `VLSingle` CustomResource.
+A new operator is introduced that will be deployed to the `garden` namespace of seed & garden clusters.
+This operator will manage the deployment of the new `VictoriaLogs` instances to the `garden` namespace of seed & garden clusters, as well as to the Control Plane namespace of Shoot clusters via the `VLSingle` CustomResource.
 
 Since we'd like to make the transition from `Vali` to `VictoriaLogs` as painless as possible, this proposal also introduces multiple ways to migrate in already running landscapes without losing data that has accumulated with the existing `Vali` instances.
 
 ## Motivation
 
-Since version v2.3.0, [Loki](https://github.com/grafana/loki) has switched from the Apache-2.0 license to a significantly more restrictive AGPLv3 licene. Since then, the Observability stack of Gardener has been using [Vali](https://github.com/credativ/vali) -- a fork of Loki 2.2.1, which is the last official version that maintains the Apache-2.0 license.
+Since version v2.3.0, [Loki](https://github.com/grafana/loki) has switched from the Apache-2.0 license to a significantly more restrictive AGPLv3 licene.
+Since then, the Observability stack of Gardener has been using [Vali](https://github.com/credativ/vali) -- a fork of Loki 2.2.1, which is the last official version that maintains the Apache-2.0 license.
 
-However, the fork maintains only security updates, thus leading to no new features or improvements getting integrated. As such, an upgrade is due so that we can benefit from new technologies and optimizations in the world of  log databases.
+However, the fork maintains only security updates, thus leading to no new features or improvements getting integrated.
+As such, an upgrade is due so that we can benefit from new technologies and optimizations in the world of log databases.
 
-One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/), discussed in more detail in [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemtry-operator-and-collectors.md).  After careful consideration, we've converged to using [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) as the default backend for storing logs.
+One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol/), discussed in more detail in [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemtry-operator-and-collectors.md).
+ After careful consideration, we've converged to using [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) as the default backend for storing logs.
 
 ### Goals
 
-- Deploy the VictoriaOperator & VictoriaLogs statefulset in seed clusters.
-- Deploy the VictoriaOperator & VictoriaLogs statefulset in the garden cluster.
-- Deploy a VictoriaLogs statefulset to the Control-Plane of new & existing `Shoot` clusters.
+- Deploy the VictoriaOperator & VictoriaLogs deployment in seed clusters.
+- Deploy the VictoriaOperator & VictoriaLogs deployment in the garden cluster.
+- Deploy a VictoriaLogs deployment to the control plane of new & existing `Shoot` clusters.
 - Give an appropriate migration strategy from Vali to VictoriaLogs for existing clusters.
 
 ### Non-Goals
@@ -56,29 +61,34 @@ One such advancement is [OTLP](https://opentelemetry.io/docs/specs/otel/protocol
 
 This includes 2 steps:
 - Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Garden` reconciliation flow in the `Garden` namespace.
-- Deployment of a new `VictoriaLogs` statefulset during the Garden reconciliation flow but *after* the `VictoriaOperator` deployment has finished. This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
+- Deployment of a new `VictoriaLogs` deployment during the Garden reconciliation flow but *after* the `VictoriaOperator` deployment has finished.
+This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
 
-Both new components will implement the already existing pattern that components implement (e.g. OpenTelemetry Operator, Prometheus Operator). That being an implementation of the `Deployer` interface as well as an additional step the the `Seed` reconciliation flow.
+Both new components will implement the already existing pattern that components implement (e.g. OpenTelemetry Operator, Prometheus Operator).
+That being an implementation of the `Deployer` interface as well as an additional step the the `Seed` reconciliation flow.
 
 #### Access to VictoriaLogs in the `Garden` cluster
 
-Currently, Vali access is behind a service in the `garden` namespace. This pattern will remain and log shippers will only be expected to use the `OTLP` protocol, instead of the `Loki` protocol, via HTTP when inserting logs to VictoriaLogs.
+Currently, Vali access is behind a service in the `garden` namespace.
+This pattern will remain and log shippers will only be expected to use the `OTLP` protocol, instead of the `Loki` protocol, via HTTP when inserting logs to VictoriaLogs.
 
 ### 2. Deployment of VictoriaLogs on Seed Clusters
 
 Analogously to the deployment in the `Garden` cluster, this includes 2 steps:
 - Deployment of a new [VictoriaOperator](https://github.com/VictoriaMetrics/operator) component during the `Seed` reconciliation flow in the `Garden` namespace.
-- Deployment of a new `VictoriaLogs` statefulset during the Seed reconciliation flow but *after* the `VictoriaOperator` deployment has finished. This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
+- Deployment of a new `VictoriaLogs` k8s deployment during the Seed reconciliation flow but *after* the `VictoriaOperator` deployment has finished.
+This component will include a `VLSingle` CustomResource that the operator will reconcile in the `garden` namespace.
 
 #### Access to VictoriaLogs in the `Seed` cluster
 
 Since the setup is the same as in the `Garden` cluster, see details in 'Access to VictoriaLogs in the `Garden` cluster'.
 
-### 3. Deploy VictoriaLogs in Shoot Control-Planes
+### 3. Deploy VictoriaLogs in Shoot control plane
 
-During the `Shoot` reconciliation flow, the new `VictoriaLogs` component will be deployed to the Control-Plane namespace of `Shoot` clusters. The operator will manage the resulting `VLSingle` CustomResource and create a `VictoriaLogs` statefulset.
+During the `Shoot` reconciliation flow, the new `VictoriaLogs` component will be deployed to the control plane namespace of `Shoot` clusters.
+The operator will manage the resulting `VLSingle` CustomResource and create a `VictoriaLogs` k8s deployment.
 
-Example VLSingle CR:
+Example `VLSingle` CR:
 ```
 apiVersion: operator.victoriametrics.com/v1
 kind: VLSingle
@@ -99,43 +109,58 @@ spec:
       cpu: 50m
 ```
 
-#### Access to VictoriaLogs in the `Shoot` Control-Plane
+#### Access to VictoriaLogs in the `Shoot` control plane
 
-Access to Vali is exposed via an ingress in the shoot control-plane. This will continue with VictoriaLogs as well. Log shippers will need to be configured via OTLP.
+Access to Vali is exposed via an ingress in the shoot control-plane.
+This will continue with VictoriaLogs as well.
+Log shippers will need to be configured via OTLP.
 
 ### 4. Migration from Vali to VictoriaLogs
 
 #### Data Migration
-During all the replacements of `Vali` we want to ensure that existing clusters do not get disrupted. For this reason, 3 strategies for migration have been considered:
-- "One-shot" migration. Reformat all the Vali data into the VictoriaLogs format (or OTLP). Could be done via the Collector since there is no tool that exists to do this OOTB. This would include:
+During all the replacements of `Vali` we want to ensure that existing clusters do not get disrupted.
+For this reason, 3 strategies for migration have been considered:
+- "One-shot" migration.
+Reformat all the Vali data into the VictoriaLogs format (or OTLP).
+Could be done via the OpenTelemetry Collector since there is no tool that exists to do this OOTB.
     Pros:
-    - Migrations step is quick.
+    - Migration step is quick.
     - No friction during the migration period since there is only one source of logs after the migration.
     Cons:
     - Development of the necessary tooling to do the migration.
     - Risk of data loss if something goes wrong during the migration.
-- "Rolling" migration. Get the VictoriaLogs instances up and reroute the logs to them without removing Vali. This would require both of them to be accessible for the whole rotation period of the logs and it would introduce friction for the time being since there would be 2 sources of logs.
+- "Rolling" migration.
+Get the VictoriaLogs instances up and reroute the logs to them without removing Vali.
+This would require both of them to be accessible for the whole rotation period of the logs and it would introduce friction for the time being since there would be 2 sources of logs.
     Pros:
     - No risk of data loss.
     - Easy to setup when using an OpenTelemetry Collector since it supports multiple backends.
     Cons:
-    - Operators would need to access 2 sources of logs until the rotation period is over. Vali (Plutono) for the logs before the migration point and VictoriaLogs (VictoriaUI) for the logs after the migration point.
-- "Dual" migration. Same thing as the "rolling" strategy but logs are sent to both backends simultaneously. This would remove the friction but would incur a higher storage cost due to the replication of the logs on both backends.
+    - Operators would need to access 2 sources of logs until the rotation period is over.
+    Vali (Plutono) for the logs before the migration point and VictoriaLogs (VictoriaUI) for the logs after the migration point.
+- "Dual" migration.
+Same thing as the "rolling" strategy but logs are sent to both backends simultaneously.
+This would remove the friction but would incur a higher storage cost due to the replication of the logs on both backends.
     Pros:
     - No risk of data loss.
     - No friction during the migration period since all logs are visible in both backends.
     Cons:
     - Higher storage cost due to the replication of the logs on both backends.
 
-All migration strategies are viable and the choice of which one to use will depend on the specific characteristics of the landscape.
-We recommend the "Rolling" migration strategy for most cases since it is the one that balances risk, cost and friction the best.
+All migration strategies are viable but it's decided that the "Rollout" migration strategy will be implemented since it balances risk, cost and friction the best.
+This will be done via a feature gate that will deploy an instance of `VictoriaLogs`, reroute the logs to it via `OTLP` and leave the existing `Vali` instance intact.
+During this period, until all logs have rotated out of `Vali`, operators will need to access both backends to see the full log history.
+
+When the feature gate matures, we'll remove `Vali`.
 
 #### UI Migration
 There are 2 main issues that we have with our current observability platform - Plutono:
-- Plutono is a fork of Grafana and as such it lags behind the new features in Grafana. Same as Vali, it only receives security updates.
+- Plutono is a fork of Grafana and as such it lags behind the new features in Grafana.
+Same as Vali, it only receives security updates.
 - Plutono does not support VictoriaLogs as a data source
 
-For this reason, our UI observability platform will temporarily be replaced with the built-in web UI that VictoriaLogs ships with.
+For this reason, our UI for logs will temporarily be replaced with the built-in web UI that VictoriaLogs ships with.
+Plutono will remain as the dashboard for visualising metrics & dashboards.
 There is a plan to migrate to [Perses](https://github.com/perses/perses) in the near future, but this is out of scope of this GEP.
 
 ---
@@ -157,7 +182,7 @@ In contrast, VictoriaLogs:
 - Is simple for deployment and operating
 - Has a query language that is more similar to the LogQL that `Vali` uses making the transition easier.
 
-As well as these 2 points, VictoriaLogs stood out with other great qualities, such as:
+Furthermore, VictoriaLogs stood out with other great qualities, such as:
 - Vibrant community support
 - Responsiveness of the code owners
 - Performance 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
GEP-35 Introduces [VictoriaLogs](https://github.com/VictoriaMetrics/VictoriaLogs) as a replacement of Vali for the Garden, Seed & Shoot clusters. This GEP is part of the [Observability 2.0](https://github.com/gardener/logging/blob/master/docs/observability-2.0/Observability%202.0.md) initiative.

**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Introduced GEP-35 that outlines a migration strategy from `Vali` to `VictoriaLogs` as a database for Garden, Seed & Shoot clusters.
```
