### PR TITLE
`*Binding`: Skip read permissions for `gardenadm` user

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
@@ -817,20 +818,22 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 		}
 	}
 
-	readAttributes := authorizer.AttributesRecord{
-		User:            attributes.GetUserInfo(),
-		Verb:            "get",
-		APIGroup:        credentialsAPIGroup,
-		APIVersion:      credentialsAPIVersion,
-		Resource:        credentialsResource,
-		Namespace:       credentialsNamespace,
-		Name:            credentialsName,
-		ResourceRequest: true,
-	}
-	if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
-		return fmt.Errorf("could not authorize read request for credentials: %w", err)
-	} else if decision != authorizer.DecisionAllow {
-		return fmt.Errorf("%s cannot reference a %s you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind, credentialsKind)
+	if !isGardenadmUser(attributes.GetUserInfo()) {
+		readAttributes := authorizer.AttributesRecord{
+			User:            attributes.GetUserInfo(),
+			Verb:            "get",
+			APIGroup:        credentialsAPIGroup,
+			APIVersion:      credentialsAPIVersion,
+			Resource:        credentialsResource,
+			Namespace:       credentialsNamespace,
+			Name:            credentialsName,
+			ResourceRequest: true,
+		}
+		if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
+			return fmt.Errorf("could not authorize read request for credentials: %w", err)
+		} else if decision != authorizer.DecisionAllow {
+			return fmt.Errorf("%s cannot reference a %s you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind, credentialsKind)
+		}
 	}
 
 	switch credentialsKind {
@@ -862,22 +865,24 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 	)
 
 	for _, quotaRef := range quotas {
-		readAttributes := authorizer.AttributesRecord{
-			User:            attributes.GetUserInfo(),
-			Verb:            "get",
-			APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
-			APIVersion:      gardencorev1beta1.SchemeGroupVersion.Version,
-			Resource:        "quotas",
-			Subresource:     "",
-			Namespace:       quotaRef.Namespace,
-			Name:            quotaRef.Name,
-			ResourceRequest: true,
-			Path:            "",
-		}
-		if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
-			return fmt.Errorf("could not authorize read request for quota: %w", err)
-		} else if decision != authorizer.DecisionAllow {
-			return fmt.Errorf("%s cannot reference a quota you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind)
+		if !isGardenadmUser(attributes.GetUserInfo()) {
+			readAttributes := authorizer.AttributesRecord{
+				User:            attributes.GetUserInfo(),
+				Verb:            "get",
+				APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+				APIVersion:      gardencorev1beta1.SchemeGroupVersion.Version,
+				Resource:        "quotas",
+				Subresource:     "",
+				Namespace:       quotaRef.Namespace,
+				Name:            quotaRef.Name,
+				ResourceRequest: true,
+				Path:            "",
+			}
+			if decision, _, err := r.authorizer.Authorize(ctx, readAttributes); err != nil {
+				return fmt.Errorf("could not authorize read request for quota: %w", err)
+			} else if decision != authorizer.DecisionAllow {
+				return fmt.Errorf("%s cannot reference a quota you are not allowed to read", binding.GetObjectKind().GroupVersionKind().Kind)
+			}
 		}
 
 		quota, err := r.quotaLister.Quotas(quotaRef.Namespace).Get(quotaRef.Name)
@@ -1389,4 +1394,8 @@ func (r *ReferenceManager) sanityCheckProviderSecret(ctx context.Context, namesp
 	}
 
 	return nil
+}
+
+func isGardenadmUser(userInfo user.Info) bool {
+	return slices.Contains(userInfo.GetGroups(), v1beta1constants.ShootsGroup) && strings.HasPrefix(userInfo.GetName(), v1beta1constants.GardenadmUserNamePrefix)
 }

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -818,7 +818,7 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 		}
 	}
 
-	if !isGardenadmUser(attributes.GetUserInfo()) {
+	if !isGardenadmUser(attributes.GetUserInfo()) || credentialsNamespace != attributes.GetNamespace() {
 		readAttributes := authorizer.AttributesRecord{
 			User:            attributes.GetUserInfo(),
 			Verb:            "get",
@@ -865,7 +865,7 @@ func (r *ReferenceManager) ensureBindingReferences(ctx context.Context, attribut
 	)
 
 	for _, quotaRef := range quotas {
-		if !isGardenadmUser(attributes.GetUserInfo()) {
+		if !isGardenadmUser(attributes.GetUserInfo()) || quotaRef.Namespace != attributes.GetNamespace() {
 			readAttributes := authorizer.AttributesRecord{
 				User:            attributes.GetUserInfo(),
 				Verb:            "get",

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -600,6 +600,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
+			It("should allow even though the user is not allowed to read the referenced secret because it's the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -621,6 +631,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow even though the user is not allowed to read the referenced quota because it's the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -790,6 +810,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
+			It("should allow even though the user is not allowed to read the referenced secret because it's the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -811,6 +841,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow even though the user is not allowed to read the referenced secret because it's the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -963,6 +1003,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
+			It("should allow even though the user is not allowed to read the referenced WorkloadIdentity because it's the gardenadm-user", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -984,6 +1034,16 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow even though the user is not allowed to read the referenced secret because it's the gardenadm-user", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -610,6 +610,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				coreSecretBindingCopy := coreSecretBinding.DeepCopy()
+				coreSecretBindingCopy.Quotas[0].Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(coreSecretBindingCopy, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBindingCopy.Namespace, coreSecretBindingCopy.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a quota you are not allowed to read")))
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -641,6 +654,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				attrs := admission.NewAttributesRecord(&coreSecretBinding, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBinding.Namespace, coreSecretBinding.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				coreSecretBindingCopy := coreSecretBinding.DeepCopy()
+				coreSecretBindingCopy.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(coreSecretBindingCopy, nil, core.Kind("SecretBinding").WithVersion("version"), coreSecretBindingCopy.Namespace, coreSecretBindingCopy.Name, core.Resource("secretbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a Secret you are not allowed to read")))
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -820,6 +846,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefSecretCopy := securityCredentialsBindingRefSecret.DeepCopy()
+				securityCredentialsBindingRefSecretCopy.CredentialsRef.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefSecretCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecretCopy.Namespace, securityCredentialsBindingRefSecretCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a Secret you are not allowed to read")))
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -851,6 +890,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefSecret, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecret.Namespace, securityCredentialsBindingRefSecret.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefSecretCopy := securityCredentialsBindingRefSecret.DeepCopy()
+				securityCredentialsBindingRefSecretCopy.Quotas[0].Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefSecretCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefSecretCopy.Namespace, securityCredentialsBindingRefSecretCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a quota you are not allowed to read")))
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {
@@ -1013,6 +1065,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 			})
 
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefWorkloadIdentityCopy := securityCredentialsBindingRefWorkloadIdentity.DeepCopy()
+				securityCredentialsBindingRefWorkloadIdentityCopy.CredentialsRef.Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefWorkloadIdentityCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentityCopy.Namespace, securityCredentialsBindingRefWorkloadIdentityCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a WorkloadIdentity you are not allowed to read")))
+			})
+
 			It("should reject because one of the referenced quotas does not exist", func() {
 				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&secret)).To(Succeed())
 
@@ -1044,6 +1109,19 @@ var _ = Describe("resourcereferencemanager", func() {
 				attrs := admission.NewAttributesRecord(&securityCredentialsBindingRefWorkloadIdentity, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentity.Namespace, securityCredentialsBindingRefWorkloadIdentity.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
 				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+			})
+
+			It("should deny cross-namespace references even for the gardenadm-user", func() {
+				Expect(gardenSecurityInformerFactory.Security().V1alpha1().WorkloadIdentities().Informer().GetStore().Add(&workloadIdentity)).To(Succeed())
+				Expect(gardenCoreInformerFactory.Core().V1beta1().Quotas().Informer().GetStore().Add(&quota)).To(Succeed())
+
+				securityCredentialsBindingRefWorkloadIdentityCopy := securityCredentialsBindingRefWorkloadIdentity.DeepCopy()
+				securityCredentialsBindingRefWorkloadIdentityCopy.Quotas[0].Namespace = "other-namespace"
+
+				user := &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}
+				attrs := admission.NewAttributesRecord(securityCredentialsBindingRefWorkloadIdentityCopy, nil, security.Kind("CredentialsBinding").WithVersion("version"), securityCredentialsBindingRefWorkloadIdentityCopy.Namespace, securityCredentialsBindingRefWorkloadIdentityCopy.Name, security.Resource("credentialsbindings").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
+
+				Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring("cannot reference a quota you are not allowed to read")))
 			})
 
 			It("should pass because exact one quota per scope is referenced", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This change adjusts the resource reference admission logic to not perform read permission checks for the `gardenadm` user.  

This change simplifies the workflow described in GEP-28, where `gardenadm connect` creates short-lived client certificates via the `CertificateSigningRequest` API to establish autonomous shoots. Without this adjustment, this client would need additional read permissions on `Secret`s, which is undesirable.

**Which issue(s) this PR fixes**:
Related of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
Follow-up of https://github.com/gardener/gardener/pull/13118
/cc @dimityrmirchev @vpnachev @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
