### PR TITLE
Deduplicate Collector Metrics

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -288,7 +288,9 @@ func (o *otelCollector) serviceMonitor() *monitoringv1.ServiceMonitor {
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
-				Port: "metrics",
+				// Value must be "monitoring" since the OpenTelemetry operator creates a 'monitoring' service
+				// that exposes the port via the name 'monitoring'. This currently cannot be configured with a different name.
+				Port: "monitoring",
 				RelabelConfigs: []monitoringv1.RelabelConfig{
 					// This service monitor is targeting the logging service. Without explicitly overriding the
 					// job label, prometheus-operator would choose job=logging (service name).
@@ -338,14 +340,6 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 					AllowPrivilegeEscalation: ptr.To(false),
 				},
 				ServiceAccount: collectorconstants.ServiceAccountName,
-				Ports: []otelv1beta1.PortsSpec{
-					{
-						ServicePort: corev1.ServicePort{
-							Name: metricsEndpointName,
-							Port: metricsPort,
-						},
-					},
-				},
 			},
 			Config: otelv1beta1.Config{
 				Receivers: otelv1beta1.AnyConfig{

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -253,7 +253,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 				Endpoints: []monitoringv1.Endpoint{{
-					Port: "metrics",
+					Port: "monitoring",
 					RelabelConfigs: []monitoringv1.RelabelConfig{
 						// This service monitor is targeting the logging service. Without explicitly overriding the
 						// job label, prometheus-operator would choose job=logging (service name).
@@ -303,14 +303,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 						},
 					},
 					ServiceAccount: "opentelemetry-collector",
-					Ports: []otelv1beta1.PortsSpec{
-						{
-							ServicePort: corev1.ServicePort{
-								Name: "metrics",
-								Port: 8888,
-							},
-						},
-					},
 				},
 				Config: otelv1beta1.Config{
 					Receivers: otelv1beta1.AnyConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
The OpenTelemetry operator creates a `monitoring` service based on the `telemetry` config in the OpenTelemetryCollector CR. 

This fix removes the explicit definition of the `metrics` port (since the Operator will set it automatically on the `monitoring` service), and setups the ServiceMonitor to scrape the `monitoring` port rather than the `metrics` port.
Before this fix, 2 services had a `metrics` port (the default collector service and a 'headless' service) leading to duplicate metrics, and was not scraping the `monitoring` service.
After this fix, Prometheus will scrape only the `monitoring` service.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
