### PR TITLE
Increase client-side rate limits for KCM

### DIFF
--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -798,6 +798,11 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		"--v=2",
 	)
 
+	command = append(command,
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
+	)
+
 	return command
 }
 

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -653,6 +653,8 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 			"--authentication-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
 			"--authorization-kubeconfig=" + gardenerutils.PathGenericKubeconfig,
 			"--kubeconfig=" + gardenerutils.PathGenericKubeconfig,
+			"--kube-api-qps=100",
+			"--kube-api-burst=200",
 		}
 
 		controllersToEnable  = sets.New("*", "bootstrapsigner", "tokencleaner")
@@ -796,11 +798,6 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(kubernetesutils.TLSCipherSuites, ",")),
 		"--use-service-account-credentials=true",
 		"--v=2",
-	)
-
-	command = append(command,
-		"--kube-api-qps=100",
-		"--kube-api-burst=200",
 	)
 
 	return command

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -1000,6 +1000,8 @@ func commandForKubernetesVersion(
 		"--authentication-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 		"--authorization-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 		"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
 	)
 
 	if !isWorkerless {
@@ -1163,11 +1165,6 @@ func commandForKubernetesVersion(
 	command = append(command,
 		"--use-service-account-credentials=true",
 		"--v=2",
-	)
-
-	command = append(command,
-		"--kube-api-qps=100",
-		"--kube-api-burst=200",
 	)
 
 	return command

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -1165,6 +1165,11 @@ func commandForKubernetesVersion(
 		"--v=2",
 	)
 
+	command = append(command,
+		"--kube-api-qps=100",
+		"--kube-api-burst=200",
+	)
+
 	return command
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Increase the client-side rate limits for KCM, like we already did for other components. We've seen clusters with many resources being client-side rate limited, causing issues due to slower reconciliation than expected.

**Special notes for your reviewer**:
[Defaults for KCM](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/) client-side rate limits are `--kube-api-burst=30` and `--kube-api-qps=20`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase client-side rate limits for kube-controller-manager to `--kube-api-qps=100` and `--kube-api-burst=200`
```
