### PR TITLE
Increase client-side rate limits for provider-specific MCM container

### DIFF
--- a/pkg/component/nodemanagement/machinecontrollermanager/provider.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider.go
@@ -36,6 +36,8 @@ func ProviderSidecarContainer(shoot *gardencorev1beta1.Shoot, controlPlaneNamesp
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args: []string{
 			"--control-kubeconfig=inClusterConfig",
+			"--kube-api-qps=100",
+			"--kube-api-burst=200",
 			"--machine-creation-timeout=20m",
 			"--machine-drain-timeout=2h",
 			"--machine-health-timeout=10m",

--- a/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/provider_test.go
@@ -45,6 +45,8 @@ var _ = Describe("Provider", func() {
 			ImagePullPolicy: "IfNotPresent",
 			Args: []string{
 				"--control-kubeconfig=inClusterConfig",
+				"--kube-api-qps=100",
+				"--kube-api-burst=200",
 				"--machine-creation-timeout=20m",
 				"--machine-drain-timeout=2h",
 				"--machine-health-timeout=10m",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Increase the client-side rate limits for the provider-specific container in MCM, like we already did for other components. We've seen clusters with many resources being client-side rate limited, causing issues due to slower reconciliation than expected.

**Special notes for your reviewer**:
[Defaults for MCM](https://github.com/gardener/machine-controller-manager/blob/2cfbbcf40d54f91c1d51cf287b69acd8dc80dd23/pkg/util/provider/app/options/options.go#L101-L102) client-side rate limits are `--kube-api-burst=30` and `--kube-api-qps=20`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase client-side rate limits for provider-specific container in machine-controller-manager to `--kube-api-qps=100` and `--kube-api-burst=200`
```
