### PR TITLE
Improve input validations for the `SecretBinding` and `CredentialsBinding` resources

### DIFF
--- a/pkg/apis/core/validation/secretbinding.go
+++ b/pkg/apis/core/validation/secretbinding.go
@@ -7,6 +7,7 @@ package validation
 import (
 	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -69,6 +70,16 @@ func validateSecretReferenceOptionalNamespace(ref corev1.SecretReference, fldPat
 
 	if len(ref.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
+	} else {
+		for _, err := range validation.IsDNS1123Subdomain(ref.Name) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, err))
+		}
+	}
+
+	if len(ref.Namespace) > 0 {
+		for _, err := range validation.IsDNS1123Subdomain(ref.Namespace) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), ref.Namespace, err))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/secretbinding.go
+++ b/pkg/apis/core/validation/secretbinding.go
@@ -77,7 +77,7 @@ func validateSecretReferenceOptionalNamespace(ref corev1.SecretReference, fldPat
 	}
 
 	if len(ref.Namespace) > 0 {
-		for _, err := range validation.IsDNS1123Subdomain(ref.Namespace) {
+		for _, err := range apivalidation.ValidateNamespaceName(ref.Namespace, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), ref.Namespace, err))
 		}
 	}

--- a/pkg/apis/core/validation/secretbinding_test.go
+++ b/pkg/apis/core/validation/secretbinding_test.go
@@ -104,6 +104,30 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			))
 		})
 
+		It("should forbid a SecretBinding with non-DNS1123 name and namespace", func() {
+			secretBinding.ObjectMeta = metav1.ObjectMeta{
+				Name:      "name",
+				Namespace: "namespace",
+			}
+			secretBinding.SecretRef = corev1.SecretReference{
+				Name:      "name-non-valid-@",
+				Namespace: "-namespace-non-valid123",
+			}
+			secretBinding.Provider = &core.SecretBindingProvider{}
+
+			errorList := ValidateSecretBinding(secretBinding)
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("secretRef.name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("secretRef.namespace"),
+				})),
+			))
+		})
+
 		It("should forbid empty stated Quota names", func() {
 			secretBinding.Quotas = []corev1.ObjectReference{
 				{},

--- a/pkg/apis/core/validation/secretbinding_test.go
+++ b/pkg/apis/core/validation/secretbinding_test.go
@@ -76,8 +76,9 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			Entry("should forbid SecretBinding with '_' in the name (not a DNS-1123 subdomain)",
 				metav1.ObjectMeta{Name: "binding_test", Namespace: "garden"},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("metadata.name"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("metadata.name"),
+					"BadValue": Equal("binding_test"),
 				}))),
 			),
 		)
@@ -104,7 +105,7 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			))
 		})
 
-		It("should forbid a SecretBinding with non-DNS1123 name and namespace", func() {
+		It("should forbid a SecretBinding with invalid secretRef name and namespace", func() {
 			secretBinding.ObjectMeta = metav1.ObjectMeta{
 				Name:      "name",
 				Namespace: "namespace",
@@ -118,12 +119,14 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			errorList := ValidateSecretBinding(secretBinding)
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("secretRef.name"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("secretRef.name"),
+					"BadValue": Equal("name-non-valid-@"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("secretRef.namespace"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("secretRef.namespace"),
+					"BadValue": Equal("-namespace-non-valid123"),
 				})),
 			))
 		})

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -566,8 +566,7 @@ func ValidateObjectReferenceNameAndNamespace(ref corev1.ObjectReference, fldPath
 
 	if len(ref.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
-	}
-	if len(ref.Name) > 0 {
+	} else {
 		for _, err := range validation.IsDNS1123Subdomain(ref.Name) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, err))
 		}

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -567,8 +567,18 @@ func ValidateObjectReferenceNameAndNamespace(ref corev1.ObjectReference, fldPath
 	if len(ref.Name) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "must provide a name"))
 	}
+	if len(ref.Name) > 0 {
+		for _, err := range validation.IsDNS1123Subdomain(ref.Name) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("name"), ref.Name, err))
+		}
+	}
 	if requireNamespace && len(ref.Namespace) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), "must provide a namespace"))
+	}
+	if len(ref.Namespace) > 0 {
+		for _, err := range validation.IsDNS1123Subdomain(ref.Namespace) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), ref.Namespace, err))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -576,7 +576,7 @@ func ValidateObjectReferenceNameAndNamespace(ref corev1.ObjectReference, fldPath
 		allErrs = append(allErrs, field.Required(fldPath.Child("namespace"), "must provide a namespace"))
 	}
 	if len(ref.Namespace) > 0 {
-		for _, err := range validation.IsDNS1123Subdomain(ref.Namespace) {
+		for _, err := range apivalidation.ValidateNamespaceName(ref.Namespace, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), ref.Namespace, err))
 		}
 	}

--- a/pkg/apis/core/validation/utils_test.go
+++ b/pkg/apis/core/validation/utils_test.go
@@ -165,18 +165,20 @@ var _ = Describe("Utils tests", func() {
 			ref := corev1.ObjectReference{Name: "-name-"}
 			Expect(ValidateObjectReferenceNameAndNamespace(ref, fldPath, false)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal(fldPath.Child("name").String()),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal(fldPath.Child("name").String()),
+					"BadValue": Equal("-name-"),
 				})),
 			))
 		})
 
-		It("should deny a non-DNS1123 namespace", func() {
+		It("should deny an invalid namespace", func() {
 			ref := corev1.ObjectReference{Name: "name", Namespace: "namespace-123-@"}
 			Expect(ValidateObjectReferenceNameAndNamespace(ref, fldPath, true)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal(fldPath.Child("namespace").String()),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal(fldPath.Child("namespace").String()),
+					"BadValue": Equal("namespace-123-@"),
 				})),
 			))
 		})
@@ -200,8 +202,9 @@ var _ = Describe("Utils tests", func() {
 			corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: "Foo", Namespace: "bar"},
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("credentialsRef.name"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("credentialsRef.name"),
+					"BadValue": Equal("Foo"),
 				})),
 			),
 		),
@@ -209,8 +212,9 @@ var _ = Describe("Utils tests", func() {
 			corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Name: "foo", Namespace: "bar?"},
 			ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("credentialsRef.namespace"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("credentialsRef.namespace"),
+					"BadValue": Equal("bar?"),
 				})),
 			),
 		),
@@ -273,9 +277,10 @@ var _ = Describe("Utils tests", func() {
 					Expect(validationResult).
 						To(ConsistOf(
 							PointTo(MatchFields(IgnoreExtras, Fields{
-								"Type":   Equal(field.ErrorTypeInvalid),
-								"Field":  Equal("spec.machineImages[0].name"),
-								"Detail": ContainSubstring("machine image name must be a qualified name"),
+								"Type":     Equal(field.ErrorTypeInvalid),
+								"Field":    Equal("spec.machineImages[0].name"),
+								"BadValue": Equal(name),
+								"Detail":   ContainSubstring("machine image name must be a qualified name"),
 							})),
 						))
 				} else {
@@ -324,9 +329,10 @@ var _ = Describe("Utils tests", func() {
 					Expect(validationResult).
 						To(ConsistOf(
 							PointTo(MatchFields(IgnoreExtras, Fields{
-								"Type":   Equal(field.ErrorTypeInvalid),
-								"Field":  Equal("spec.machineTypes[0].name"),
-								"Detail": ContainSubstring("machine type name must be a qualified name"),
+								"Type":     Equal(field.ErrorTypeInvalid),
+								"Field":    Equal("spec.machineTypes[0].name"),
+								"BadValue": Equal(name),
+								"Detail":   ContainSubstring("machine type name must be a qualified name"),
 							})),
 						))
 				} else {
@@ -350,9 +356,10 @@ var _ = Describe("Utils tests", func() {
 					Expect(validationResult).
 						To(ConsistOf(
 							PointTo(MatchFields(IgnoreExtras, Fields{
-								"Type":   Equal(field.ErrorTypeInvalid),
-								"Field":  Equal("spec.volumeTypes[0].name"),
-								"Detail": ContainSubstring("volume type name must be a qualified name"),
+								"Type":     Equal(field.ErrorTypeInvalid),
+								"Field":    Equal("spec.volumeTypes[0].name"),
+								"BadValue": Equal(name),
+								"Detail":   ContainSubstring("volume type name must be a qualified name"),
 							})),
 						))
 				} else {

--- a/pkg/apis/core/validation/utils_test.go
+++ b/pkg/apis/core/validation/utils_test.go
@@ -160,6 +160,26 @@ var _ = Describe("Utils tests", func() {
 				})),
 			))
 		})
+
+		It("should deny a non-DNS1123 name", func() {
+			ref := corev1.ObjectReference{Name: "-name-"}
+			Expect(ValidateObjectReferenceNameAndNamespace(ref, fldPath, false)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(fldPath.Child("name").String()),
+				})),
+			))
+		})
+
+		It("should deny a non-DNS1123 namespace", func() {
+			ref := corev1.ObjectReference{Name: "name", Namespace: "namespace-123-@"}
+			Expect(ValidateObjectReferenceNameAndNamespace(ref, fldPath, true)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(fldPath.Child("namespace").String()),
+				})),
+			))
+		})
 	})
 
 	DescribeTable("#ValidateCredentialsRef",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:
Currently, in the storage layer, the `SecretBinding`'s `.secretRef.{name,namespace}` fields are not validated against the RFC 1123 naming convention. 
https://github.com/gardener/gardener/blob/15a7b4a31d3c5d8818edb3c24c4dd36c7c2a9cbd/pkg/apis/core/validation/secretbinding.go#L67-L75

This PR implements additional validations for the aforementioned fields.

Additionally, similar validations for the `.quotas.[].{name,namespace}` are also not implemented, and are added with this PR. 
https://github.com/gardener/gardener/blob/15a7b4a31d3c5d8818edb3c24c4dd36c7c2a9cbd/pkg/apis/core/validation/utils.go#L564-L575
https://github.com/gardener/gardener/blob/15a7b4a31d3c5d8818edb3c24c4dd36c7c2a9cbd/pkg/apis/core/validation/secretbinding.go#L21-L23

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Additional input validations for the SecurityBinding and CredentialsBinding resources are now implemented.
```
