### PR TITLE
Do not set `immutable: true` to `worker-pools-operatingsystemconfig-hashes` secret when restoring it

### DIFF
--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -130,6 +130,7 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 				// For secrets that have the `managed-by: secrets-manager` label this information is inferred from the
 				// secret data and handled by the `secretsmanager.Secret(objectMeta, data)` function above.
 				// Currently only opaque secrets that do not have the `managed-by: secrets-manager` are expected to be persisted and restored.
+				// For more details, see https://github.com/gardener/gardener/issues/13262.
 				// Note that the e2e and testmachinery tests, check that the restored type and immutability matches the original.
 				secret = &corev1.Secret{
 					ObjectMeta: objectMeta,

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -122,7 +122,22 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 				return err
 			}
 
-			secret := secretsmanager.Secret(objectMeta, data)
+			var secret *corev1.Secret
+			if objectMeta.Labels[secretsmanager.LabelKeyManagedBy] == secretsmanager.LabelValueSecretsManager {
+				secret = secretsmanager.Secret(objectMeta, data)
+			} else {
+				// TODO(plkokanov): Add ability to also restore the secret's immutability and type from the `ShootState`.
+				// For secrets that have the `managed-by: secrets-manager` label this information is inferred from the
+				// secret data and handled by the `secretsmanager.Secret(objectMeta, data)` function above.
+				// Currently only opaque secrets that do not have the `managed-by: secrets-manager` are expected to be persisted and restored.
+				// Note that the e2e and testmachinery tests, check that the restored type and immutability matches the original.
+				secret = &corev1.Secret{
+					ObjectMeta: objectMeta,
+					Data:       data,
+					Type:       corev1.SecretTypeOpaque,
+				}
+			}
+
 			return client.IgnoreAlreadyExists(b.SeedClientSet.Client().Create(ctx, secret))
 		})
 	}

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -487,16 +487,22 @@ var _ = Describe("Secrets", func() {
 				By("Verify non-CA secrets got restored")
 				secret := &corev1.Secret{}
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "non-ca-secret"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(PointTo(BeTrue()))
+				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity}))
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify external secrets got restored")
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "extension-foo-secret"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(PointTo(BeTrue()))
+				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": "extension-foo"}))
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
 				By("Verify secret without labels got restored")
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "secret-without-labels"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(BeNil())
+				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(secret.Labels).To(BeEmpty())
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
@@ -509,6 +515,7 @@ var _ = Describe("Secrets", func() {
 
 func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.GomegaMatcher) {
 	ExpectWithOffset(1, secret.Immutable).To(PointTo(BeTrue()))
+	ExpectWithOffset(1, secret.Type).To(Equal(corev1.SecretTypeOpaque))
 	ExpectWithOffset(1, secret.Labels).To(And(
 		HaveKeyWithValue("name", name),
 		HaveKeyWithValue("managed-by", "secrets-manager"),

--- a/test/utils/shoots/migration/migration.go
+++ b/test/utils/shoots/migration/migration.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -60,14 +61,30 @@ func ComparePersistedSecrets(secretsBefore, secretsAfter map[string]corev1.Secre
 	var errorMsg string
 	for name, secret := range secretsBefore {
 		if !reflect.DeepEqual(secret.Data, secretsAfter[name].Data) {
-			errorMsg += fmt.Sprintf("Secret %s/%s did not have it's data persisted.\n", secret.Namespace, secret.Name)
+			errorMsg += fmt.Sprintf("Secret %s/%s did not have its data persisted.\n", secret.Namespace, secret.Name)
 		}
 		if !maps.Equal(secret.Labels, secretsAfter[name].Labels) {
-			errorMsg += fmt.Sprintf("Secret %s/%s did not have it's labels persisted: labels before migration: %v, labels after migration: %v\n",
+			errorMsg += fmt.Sprintf("Secret %s/%s did not have its labels persisted: labels before migration: %v, labels after migration: %v\n",
 				secret.Namespace,
 				secret.Name,
 				secret.Labels,
 				secretsAfter[name].Labels,
+			)
+		}
+		if secret.Type != secretsAfter[name].Type {
+			errorMsg += fmt.Sprintf("Secret %s/%s did not have its type persisted: type before migration: %s, type after migration: %s\n",
+				secret.Namespace,
+				secret.Name,
+				secret.Type,
+				secretsAfter[name].Type,
+			)
+		}
+		if !ptr.Equal(secret.Immutable, secretsAfter[name].Immutable) {
+			errorMsg += fmt.Sprintf("Secret %s/%s did not have its immutability persisted: immutable before migration: %t, immutable after migration: %t\n",
+				secret.Namespace,
+				secret.Name,
+				ptr.Deref(secret.Immutable, false),
+				ptr.Deref(secretsAfter[name].Immutable, false),
 			)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR is an additional fix after https://github.com/gardener/gardener/pull/13056 which ensures that the `worker-pools-operatingsystemconfig-hashes` is not restored as `immutable` during the restore step of control plane migration.

The restoration previously relied on the `secretsmanager.Secret(objectMeta, data)` function to create the secret object, however that also set the `immutability` flag to true and inferred the secret type from it's data. This might not be the case for secrets that are managed outside of secrets manager.

This is a quick fix to unblock control plane migrations, however we could further pursue also restoring the type and immutability as described in https://github.com/gardener/gardener/issues/13262


The PR also adds checks in the tm and e2e tests that verify that the immutability and type of a secret that has to be restored during control plane migration do not change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
If a control plane migration has already been performed it is hard to automatically remove the immutability of the secret during subsequent reconciliations: the data has to be saved, the old secret deleted and then created with `immutable: false`. However, if the creation encounters an error and reconciliation is restarted, the data would be lost. I could implement the fix with a third, temporary secret: 
1. create a temp secret from the data of the immutable `worker-pools-operatingsystemconfig-hashes`
2. delete the immutable secret
3. create the `worker-pools-operatingsystemconfig-hashes` secret with data from the temp secret
However, I'm not sure this is worth it, since control plane migration is only triggered by operators and I don't expect it to have been used too much since the issue was introduced.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that caused the `worker-pools-operatingsystemconfig-hashes` secret to be created as immutable during the restore phase of control plane migration.
```
