### PR TITLE
Updated usage doc for node in-place update feature

### DIFF
--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -200,7 +200,7 @@ The `inPlaceUpdates.pendingWorkerUpdates.autoInPlaceUpdate` field in the Shoot s
 #### Manual In-Place Updates
 
 The `ManualInPlaceUpdate` strategy allows users to control and orchestrate the update process manually.
-Set `.spec.provider.workers[].updateStrategy` field in the `Shoot` spec to `ManualInPlaceUpdate`. Also one should not set `maxSurge` and `maxUnavailable` fields as `maxSurge` defaults to `0` and `maxUnavailable` to `1`.
+Set `.spec.provider.workers[].updateStrategy` field in the `Shoot` spec to `ManualInPlaceUpdate`. When doing this, do not set the `maxSurge` or `maxUnavailable` fields, as they do not apply to this update strategy.
 
 ```yaml
 spec:
@@ -219,17 +219,6 @@ kubectl label node <node-name> node.machine.sapcloud.io/selected-for-update=true
 The `ManualInPlaceWorkersUpdated` [constraint](../shoot/shoot_status.md#constraints) in the shoot status indicates that at least one worker pool with the `ManualInPlaceUpdate` strategy is pending an update. Shoot reconciliation will still succeed even if there are worker pools pending updates.
 
 The `inPlaceUpdates.pendingWorkerUpdates.manualInPlaceUpdate` field in the `Shoot` status lists the names of worker pools that are pending updates with this strategy.
-
-#### Limitations when Configuring In-Place Updates via Gardener Dashboard
-
-As of now, the Gardener Dashboard's `Worker` panel does not provide an option to set the update strategy or automatically select it based on the chosen machine image. Historically, only the `AutoRollingUpdate` strategy was supported and set as the default for all worker pools. Future improvements, such as the introduction of [machine-image-capabilities](../../proposals/33-machine-image-capabilities.md), are expected to simplify update strategy configuration. Until then, consider the following when configuring in-place updates:
-
-- ##### Configuring In-Place Update for a New Shoot
-  When creating a new shoot, select a `Machine Image` that supports in-place updates in the `Worker` panel and set the desired min/max/surge values. Before saving, use the YAML editor to specify the `updateStrategy` as either `AutoInPlaceUpdate` or `ManualInPlaceUpdate`, following the recommendations outlined in the sections above.
-
-- ##### Configuring In-Place Update Strategy in an Existing Shoot
-  For existing shoots with already defined worker pools, update the relevant worker pool definitions directly in the YAML editor, adhering to the recommendations for each strategy type.  
-  > Note: When adding a new worker pool through the Worker Groups settings, the strategy defaults to `AutoRollingUpdate` and is saved automatically. This cannot be changed later to `[Auto|Manual]InPlaceUpdate` in the YAML editor, as transitioning from `AutoRollingUpdate` to an in-place update strategy is not allowed.
 
 ## Related Documentation
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind task

**What this PR does / why we need it**:
The PR tries to enhance the usage doc of `Node` `In-Place` update feature from my experience of trying this feature and some challenges I face and feel might be relevant for other first time users of this nice feature with its current nuances on usage esp. in conjunction with Gardener dashboard and implication when creating fresh shoot or enhancing existing shoot specification. 

For folks who rely on pipeline to configure and deploy shoot cluster, this might not be of much help as they are already experts in configuring multiple worker pools, so it doesn't try to address any challenges faced there in. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Feel free to reject the PR if you feel this digresses from the standard usage guide practices followed overall within Gardener. I just raised it with my limited usage and may not be applicable to general usage of this feature. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
