### PR TITLE
Use --skip-metadata for `ctr images pull` in `gardener-node-agent`'s `init` script

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -85,7 +85,7 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardenadm image and mount it to the temporary directory"
-CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1 | sed 's/[a-zA-Z]//g')
 CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -85,7 +85,12 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardenadm image and mount it to the temporary directory"
-ctr images pull --hosts-dir "/etc/containerd/certs.d" "` + image + `"
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_EXTRA_ARGS=""
+if [ "$CTR_MAJOR" -gt 1 ]; then
+    CTR_EXTRA_ARGS="--skip-metadata"
+fi
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "` + image + `"
 ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardenadm binary to host (/opt/bin) and make it executable"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -127,7 +127,7 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
-CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1 | sed 's/[a-zA-Z]//g')
 CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -127,7 +127,12 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull gardener-node-agent image and mount it to the temporary directory"
-ctr images pull --hosts-dir "/etc/containerd/certs.d" "` + image + `"
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_EXTRA_ARGS=""
+if [ "$CTR_MAJOR" -gt 1 ]; then
+    CTR_EXTRA_ARGS="--skip-metadata"
+fi
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "` + image + `"
 ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -17,7 +17,7 @@ ctr v2 pulls manifests for all platforms of a multi-arch image by default. Mirro
 might not copy manifests for unused architectures, which causes the default pull command to fail.
 Ref: https://github.com/containerd/containerd/pull/9029#issuecomment-1706963854
 */}}
-CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1 | sed 's/[a-zA-Z]//g')
 CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -12,7 +12,17 @@ unmount() {
 trap unmount EXIT
 
 echo "> Pull {{ .binaryName }} image and mount it to the temporary directory"
-ctr images pull --hosts-dir "/etc/containerd/certs.d" "{{ .image }}"
+{{- /*
+ctr v2 pulls manifests for all platforms of a multi-arch image by default. Mirror registries
+might not copy manifests for unused architectures, which causes the default pull command to fail.
+Ref: https://github.com/containerd/containerd/pull/9029#issuecomment-1706963854
+*/}}
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1)
+CTR_EXTRA_ARGS=""
+if [ "$CTR_MAJOR" -gt 1 ]; then
+    CTR_EXTRA_ARGS="--skip-metadata"
+fi
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "{{ .image }}"
 ctr images mount "{{ .image }}" "$tmp_dir"
 
 echo "> Copy {{ .binaryName }} binary to host ({{ .binaryDirectory }}) and make it executable"


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind bug

**What this PR does / why we need it**:

`ctr` v2 pulls metadata manifests for all platforms of a multi-platform image (such as the node-agent). Certain registries might only mirror manifests for a single platform, causing `ctr images pull` to fail and hence the node bootstrap fails as well. Adding `--skip-metadata` avoids fetching metadata for platforms not mirrored.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add `--skip-metadata` flag to `ctr images pull` in the node-agent init script for better container registry compatibility.
```
