### PR TITLE
Deploy earlier the ClusterRoleBindings granting  access for Admin/ViewerKubeconfig credentials

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -308,7 +308,7 @@ rules:
 - apiGroups:
   - resources.gardener.cloud
   resources:
-  - managedresources/status # TODO(vpnachev): Remove patch managedresources/status permissions after v1.132.0 is released.
+  - managedresources/status # TODO(vpnachev): Remove patch managedresources/status permissions after v1.133.0 is released.
   verbs:
   - patch
 - apiGroups:

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -306,6 +306,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - resources.gardener.cloud
+  resources:
+  - managedresources/status # TODO(vpnachev): Remove patch managedresources/status permissions after v1.132.0 is released.
+  verbs:
+  - patch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -296,6 +296,12 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
 			{
+				// TODO(vpnachev): Drop patch managedresources/status permissions after v1.132.0 is released.
+				APIGroups: []string{"resources.gardener.cloud"},
+				Resources: []string{"managedresources/status"},
+				Verbs:     []string{"patch"},
+			},
+			{
 				APIGroups: []string{"networking.k8s.io"},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -296,7 +296,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
 			{
-				// TODO(vpnachev): Drop patch managedresources/status permissions after v1.132.0 is released.
+				// TODO(vpnachev): Drop patch managedresources/status permissions after v1.133.0 is released.
 				APIGroups: []string{"resources.gardener.cloud"},
 				Resources: []string{"managedresources/status"},
 				Verbs:     []string{"patch"},

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -35,10 +35,10 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 // migrateAdminViewerKubeconfigClusterRoleBindings moves the ClusterRoleBindings granting access to the
 // shoot/adminkubeconfig and shoot/viewerkubeconfig subresources from the shoot-core-system managed resource to the
 // shoot-core-gardeneraccess managed resource.
-// TODO(vpnachev): Remove this after v1.132.0 has been released.
+// TODO(vpnachev): Remove this after v1.133.0 has been released.
 func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log logr.Logger, seedClient client.Client) error {
 	namespaceList := &corev1.NamespaceList{}
-	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
+	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot}); err != nil {
 		return fmt.Errorf("failed listing namespaces: %w", err)
 	}
 
@@ -71,6 +71,7 @@ func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log lo
 			}
 
 			if shootSystemManagedResource.DeletionTimestamp != nil {
+				log.Info("Managed resource is in deletion, skipping migration", "managedResource", shootSystemKey)
 				return nil
 			}
 
@@ -89,7 +90,7 @@ func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log lo
 			})
 
 			if oldShootSystemObjectsCount == len(shootSystemObjects) {
-				log.Info("ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig have already been migrated, skipping", "managedResource", shootSystemKey)
+				log.Info("ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig have already been migrated, skipping migration", "managedResource", shootSystemKey)
 				return nil
 			}
 
@@ -103,6 +104,7 @@ func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log lo
 			}
 
 			if gardenerAccessManagedResource.DeletionTimestamp != nil {
+				log.Info("Managed resource is in deletion, skipping migration", "managedResource", gardenerAccessKey)
 				return nil
 			}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -6,10 +6,150 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardeneraccess "github.com/gardener/gardener/pkg/component/gardener/access"
+	shootsystem "github.com/gardener/gardener/pkg/component/shoot/system"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
-func (g *garden) runMigrations(_ context.Context, _ logr.Logger) error {
+func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
+	log.Info("Migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig")
+	if err := migrateAdminViewerKubeconfigClusterRoleBindings(ctx, log, g.mgr.GetClient()); err != nil {
+		return fmt.Errorf("failed migrating ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig: %w", err)
+	}
+
 	return nil
+}
+
+// migrateAdminViewerKubeconfigClusterRoleBindings moves the ClusterRoleBindings granting access to the
+// shoot/adminkubeconfig and shoot/viewerkubeconfig subresources from the shoot-core-system managed resource to the
+// shoot-core-gardeneraccess managed resource.
+// TODO(vpnachev): Remove this after v1.132.0 has been released.
+func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log logr.Logger, seedClient client.Client) error {
+	namespaceList := &corev1.NamespaceList{}
+	if err := seedClient.List(ctx, namespaceList, client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot})); err != nil {
+		return fmt.Errorf("failed listing namespaces: %w", err)
+	}
+
+	var (
+		tasks []flow.TaskFn
+		crbs  = []string{v1beta1constants.ShootProjectAdminsGroupName, v1beta1constants.ShootProjectViewersGroupName, v1beta1constants.ShootSystemAdminsGroupName, v1beta1constants.ShootSystemViewersGroupName}
+	)
+
+	for _, namespace := range namespaceList.Items {
+		if namespace.DeletionTimestamp != nil || namespace.Status.Phase == corev1.NamespaceTerminating {
+			continue
+		}
+
+		tasks = append(tasks, func(ctx context.Context) error {
+			var (
+				shootSystemKey             = client.ObjectKey{Namespace: namespace.Name, Name: shootsystem.ManagedResourceName}
+				shootSystemManagedResource = &resourcesv1alpha1.ManagedResource{}
+
+				gardenerAccessKey             = client.ObjectKey{Namespace: namespace.Name, Name: gardeneraccess.ManagedResourceName}
+				gardenerAccessManagedResource = &resourcesv1alpha1.ManagedResource{}
+			)
+
+			// Get the shoot-core-system managed resource and check if it is already migrated.
+			if err := seedClient.Get(ctx, shootSystemKey, shootSystemManagedResource); err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Managed resource not found, skipping migration", "managedResource", shootSystemKey)
+					return nil
+				}
+				return fmt.Errorf("failed to get ManagedResource %q: %w", shootSystemKey, err)
+			}
+
+			if shootSystemManagedResource.DeletionTimestamp != nil {
+				return nil
+			}
+
+			shootSystemObjects, err := managedresources.GetObjects(ctx, seedClient, shootSystemManagedResource.Namespace, shootSystemManagedResource.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Managed resource secret not found, skipping migration", "managedResource", shootSystemKey)
+					return nil
+				}
+				return fmt.Errorf("failed to get objects for ManagedResource %q: %w", shootSystemKey, err)
+			}
+
+			oldShootSystemObjectsCount := len(shootSystemObjects)
+			shootSystemObjects = slices.DeleteFunc(shootSystemObjects, func(obj client.Object) bool {
+				return slices.Contains(crbs, obj.GetName())
+			})
+
+			if oldShootSystemObjectsCount == len(shootSystemObjects) {
+				log.Info("ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig have already been migrated, skipping", "managedResource", shootSystemKey)
+				return nil
+			}
+
+			// Move the ClusterRoleBindings to the shoot-core-gardeneraccess managed resource firstly.
+			if err := seedClient.Get(ctx, gardenerAccessKey, gardenerAccessManagedResource); err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Managed resource not found, skipping migration", "managedResource", gardenerAccessKey)
+					return nil
+				}
+				return fmt.Errorf("failed to get ManagedResource %q: %w", gardenerAccessKey, err)
+			}
+
+			if gardenerAccessManagedResource.DeletionTimestamp != nil {
+				return nil
+			}
+
+			gardenerAccessObjects, err := managedresources.GetObjects(ctx, seedClient, gardenerAccessManagedResource.Namespace, gardenerAccessManagedResource.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					log.Info("Managed resource secret not found, skipping migration", "managedResource", gardenerAccessKey)
+					return nil
+				}
+				return fmt.Errorf("failed to get objects for ManagedResource %q: %w", gardenerAccessKey, err)
+			}
+
+			gardenerAccessObjects = append(gardenerAccessObjects, gardeneraccess.ShootAccessClusterRoleBindings()...)
+			gardenerAccessRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+			gardenerAccessResources, err := gardenerAccessRegistry.AddAllAndSerialize(gardenerAccessObjects...)
+			if err != nil {
+				return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", gardenerAccessKey, err)
+			}
+
+			if err := managedresources.CreateForShoot(ctx, seedClient, gardenerAccessManagedResource.Namespace, gardenerAccessManagedResource.Name, managedresources.LabelValueGardener, false, gardenerAccessResources); err != nil {
+				return fmt.Errorf("failed updating ManagedResource %q: %w", gardenerAccessKey, err)
+			}
+
+			// Remove the ClusterRoleBindings from the shoot-core-system managed resource.
+			log.Info("Updating ManagedResource status to remove migrated ClusterRoleBindings", "managedResource", shootSystemKey)
+			patch := client.MergeFrom(shootSystemManagedResource.DeepCopy())
+			shootSystemManagedResource.Status.Resources = slices.DeleteFunc(shootSystemManagedResource.Status.Resources, func(objRef resourcesv1alpha1.ObjectReference) bool {
+				return objRef.APIVersion == "rbac.authorization.k8s.io/v1" && objRef.Kind == "ClusterRoleBinding" && slices.Contains(crbs, objRef.Name)
+			})
+
+			if err := seedClient.Status().Patch(ctx, shootSystemManagedResource, patch); err != nil {
+				return fmt.Errorf("failed updating status of ManagedResource %q: %w", shootSystemKey, err)
+			}
+
+			log.Info("Cleaning ClusterRoleBindings for shoot/adminkubeconfig and shoot/viewerkubeconfig access in managed resource", "managedResource", shootSystemKey)
+			shootSystemRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+			shootSystemResources, err := shootSystemRegistry.AddAllAndSerialize(shootSystemObjects...)
+			if err != nil {
+				return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", shootSystemKey, err)
+			}
+			if err := managedresources.CreateForShoot(ctx, seedClient, shootSystemManagedResource.Namespace, shootSystemManagedResource.Name, managedresources.LabelValueGardener, false, shootSystemResources); err != nil {
+				return fmt.Errorf("failed updating ManagedResource %q: %w", shootSystemKey, err)
+			}
+
+			return nil
+		})
+	}
+
+	return flow.Parallel(tasks...)(ctx)
 }

--- a/pkg/component/gardener/access/access.go
+++ b/pkg/component/gardener/access/access.go
@@ -249,8 +249,8 @@ func viewerClusterRoleBindings() []client.Object {
 
 // ShootAccessClusterRoleBindings returns all ClusterRoleBindings granting access to credentials obtained via the shoot/adminkubeconfig and shoot/viewerkubeconfig subresources.
 //
-// Deprecated: The function is just temporary exported for migration purposes. It will be removed after v1.132.0 is released.
+// Deprecated: The function is just temporary exported for migration purposes. It will be removed after v1.133.0 is released.
 func ShootAccessClusterRoleBindings() []client.Object {
-	// TODO(vpnachev): Remove this function after v1.132.0 has been released.
+	// TODO(vpnachev): Remove this function after v1.133.0 has been released.
 	return append(adminClusterRoleBindings(), viewerClusterRoleBindings()...)
 }

--- a/pkg/component/gardener/access/access.go
+++ b/pkg/component/gardener/access/access.go
@@ -171,7 +171,6 @@ func adminClusterRoleBindings() []client.Object {
 				Name: v1beta1constants.ShootSystemAdminsGroupName,
 				Annotations: map[string]string{
 					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -190,7 +189,6 @@ func adminClusterRoleBindings() []client.Object {
 				Name: v1beta1constants.ShootProjectAdminsGroupName,
 				Annotations: map[string]string{
 					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -215,7 +213,6 @@ func viewerClusterRoleBindings() []client.Object {
 				Name: v1beta1constants.ShootSystemViewersGroupName,
 				Annotations: map[string]string{
 					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -234,7 +231,6 @@ func viewerClusterRoleBindings() []client.Object {
 				Name: v1beta1constants.ShootProjectViewersGroupName,
 				Annotations: map[string]string{
 					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -249,4 +245,12 @@ func viewerClusterRoleBindings() []client.Object {
 			}},
 		},
 	}
+}
+
+// ShootAccessClusterRoleBindings returns all ClusterRoleBindings granting access to credentials obtained via the shoot/adminkubeconfig and shoot/viewerkubeconfig subresources.
+//
+// Deprecated: The function is just temporary exported for migration purposes. It will be removed after v1.132.0 is released.
+func ShootAccessClusterRoleBindings() []client.Object {
+	// TODO(vpnachev): Remove this function after v1.132.0 has been released.
+	return append(adminClusterRoleBindings(), viewerClusterRoleBindings()...)
 }

--- a/pkg/component/gardener/access/access.go
+++ b/pkg/component/gardener/access/access.go
@@ -168,8 +168,11 @@ func adminClusterRoleBindings() []client.Object {
 	return []client.Object{
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootSystemAdminsGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+				Name: v1beta1constants.ShootSystemAdminsGroupName,
+				Annotations: map[string]string{
+					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
+				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -184,8 +187,11 @@ func adminClusterRoleBindings() []client.Object {
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootProjectAdminsGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+				Name: v1beta1constants.ShootProjectAdminsGroupName,
+				Annotations: map[string]string{
+					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
+				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -206,8 +212,11 @@ func viewerClusterRoleBindings() []client.Object {
 	return []client.Object{
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootSystemViewersGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+				Name: v1beta1constants.ShootSystemViewersGroupName,
+				Annotations: map[string]string{
+					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
+				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -222,8 +231,11 @@ func viewerClusterRoleBindings() []client.Object {
 		},
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootProjectViewersGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+				Name: v1beta1constants.ShootProjectViewersGroupName,
+				Annotations: map[string]string{
+					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+					resourcesv1alpha1.KeepObject:            "true", // TODO(vpnachev): Remove the keep-object annotation after v1.132.0 is released.
+				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,

--- a/pkg/component/gardener/access/access_test.go
+++ b/pkg/component/gardener/access/access_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:system:viewers",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
+					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -90,6 +91,7 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:project:viewers",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
+					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -109,6 +111,7 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:system:admins",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
+					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -128,6 +131,7 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:project:admins",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
+					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{

--- a/pkg/component/gardener/access/access_test.go
+++ b/pkg/component/gardener/access/access_test.go
@@ -71,7 +71,6 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:system:viewers",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
-					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -91,7 +90,6 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:project:viewers",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
-					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -111,7 +109,6 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:system:admins",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
-					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
@@ -131,7 +128,6 @@ var _ = Describe("Access", func() {
 				Name: "gardener.cloud:project:admins",
 				Annotations: map[string]string{
 					"resources.gardener.cloud/delete-on-invalid-update": "true",
-					"resources.gardener.cloud/keep-object":              "true",
 				},
 			},
 			RoleRef: rbacv1.RoleRef{

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -23,7 +23,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
@@ -315,13 +314,9 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 	}
 
 	if len(s.values.APIResourceList) > 0 {
-		if err := registry.Add(s.readOnlyRBACResources()...); err != nil {
+		if err := registry.Add(s.readOnlyClusterRole()); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := registry.Add(adminClusterRoleBindings()...); err != nil {
-		return nil, err
 	}
 
 	return registry.SerializedObjects()
@@ -387,7 +382,7 @@ func (s *shootSystem) shootInfoData() map[string]string {
 	return data
 }
 
-func (s *shootSystem) readOnlyRBACResources() []client.Object {
+func (s *shootSystem) readOnlyClusterRole() client.Object {
 	allowedSubResources := map[string]map[string][]string{
 		corev1.GroupName: {
 			"pods": {"log"},
@@ -449,7 +444,7 @@ func (s *shootSystem) readOnlyRBACResources() []client.Object {
 		})
 	}
 
-	return append(viewerClusterRoleBindings(), clusterRole)
+	return clusterRole
 }
 
 func (s *shootSystem) isEncryptedResource(resource, group string) bool {
@@ -466,79 +461,5 @@ func addNetworkToMap(name string, cidrs []net.IPNet, data map[string]string) {
 	networks := netutils.JoinByComma(cidrs)
 	if networks != "" {
 		data[name] = networks
-	}
-}
-
-func adminClusterRoleBindings() []client.Object {
-	return []client.Object{
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootSystemAdminsGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "cluster-admin",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.GroupKind,
-				Name:     v1beta1constants.ShootSystemAdminsGroupName,
-			}},
-		},
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootProjectAdminsGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     "cluster-admin",
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.GroupKind,
-				Name:     v1beta1constants.ShootProjectAdminsGroupName,
-			}},
-		},
-	}
-}
-
-func viewerClusterRoleBindings() []client.Object {
-	return []client.Object{
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootSystemViewersGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.GroupKind,
-				Name:     v1beta1constants.ShootSystemViewersGroupName,
-			}},
-		},
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        v1beta1constants.ShootProjectViewersGroupName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     v1beta1constants.ShootReadOnlyClusterRoleName,
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     rbacv1.GroupKind,
-				Name:     v1beta1constants.ShootProjectViewersGroupName,
-			}},
-		},
 	}
 }

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -463,16 +463,6 @@ var _ = Describe("ShootSystem", func() {
 					ContainSubstring("name: gardener.cloud:system:read-only"),
 					ContainSubstring("kind: ClusterRole"),
 				)))
-				Expect(manifests).To(ContainElements(
-					And(
-						ContainSubstring("name: gardener.cloud:system:admins"),
-						ContainSubstring("kind: ClusterRoleBinding"),
-					),
-					And(
-						ContainSubstring("name: gardener.cloud:project:admins"),
-						ContainSubstring("kind: ClusterRoleBinding"),
-					),
-				))
 			})
 
 			When("API resource list is set", func() {
@@ -562,83 +552,7 @@ var _ = Describe("ShootSystem", func() {
 						},
 					}
 
-					systemViewersClusterRoleBinding := &rbacv1.ClusterRoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "gardener.cloud:system:viewers",
-							Annotations: map[string]string{
-								"resources.gardener.cloud/delete-on-invalid-update": "true",
-							},
-						},
-						RoleRef: rbacv1.RoleRef{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "ClusterRole",
-							Name:     "gardener.cloud:system:read-only",
-						},
-						Subjects: []rbacv1.Subject{{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Group",
-							Name:     "gardener.cloud:system:viewers",
-						}},
-					}
-
-					projectViewersClusterRoleBinding := &rbacv1.ClusterRoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "gardener.cloud:project:viewers",
-							Annotations: map[string]string{
-								"resources.gardener.cloud/delete-on-invalid-update": "true",
-							},
-						},
-						RoleRef: rbacv1.RoleRef{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "ClusterRole",
-							Name:     "gardener.cloud:system:read-only",
-						},
-						Subjects: []rbacv1.Subject{{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Group",
-							Name:     "gardener.cloud:project:viewers",
-						}},
-					}
-
-					systemAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "gardener.cloud:system:admins",
-							Annotations: map[string]string{
-								"resources.gardener.cloud/delete-on-invalid-update": "true",
-							},
-						},
-						RoleRef: rbacv1.RoleRef{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "ClusterRole",
-							Name:     "cluster-admin",
-						},
-						Subjects: []rbacv1.Subject{{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Group",
-							Name:     "gardener.cloud:system:admins",
-						}},
-					}
-
-					projectAdminClusterRoleBinding := &rbacv1.ClusterRoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "gardener.cloud:project:admins",
-							Annotations: map[string]string{
-								"resources.gardener.cloud/delete-on-invalid-update": "true",
-							},
-						},
-						RoleRef: rbacv1.RoleRef{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "ClusterRole",
-							Name:     "cluster-admin",
-						},
-						Subjects: []rbacv1.Subject{{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Group",
-							Name:     "gardener.cloud:project:admins",
-						}},
-					}
-
-					Expect(managedResource).To(contain(clusterRole, systemViewersClusterRoleBinding, projectViewersClusterRoleBinding, systemAdminClusterRoleBinding, projectAdminClusterRoleBinding))
+					Expect(managedResource).To(contain(clusterRole))
 				})
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
Deploy earlier in the shoot reconciliation flow the ClusterRoleBindings granting  access for Admin/ViewerKubeconfig credentials.

Before https://github.com/gardener/gardener/pull/12674, `AdminKubeconfig` credentials were bound to the `system:masters` group that is granted with `cluster-admin` permissions as part of the kube-apiserer own bootstrapping on start-up. Now, the `AdminKubeconfig` is bound to dedicated gardener own groups which ClusterRoleBindings were deployed as part of the shoot system resources deployed (quite) some time after the APIServer is available. 

With this change respective ClusterRoleBindings are deployed as early as possible so that  credentials issued via AdminKubeconfig to be considered valid.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I deliberately have not moved the read-only ClusterRole in the gardener access component because it is doing API discovery and could eventually miss CRDs deployed after the gardener access but before the shoot system components. Even before #12674 ViewerKubeconfig shouldn't have been working until shoot system components are deployed, i.e. the behaviour was preserved.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The early access (before the cluster creation is completed) to a `Shoot` cluster via `AdminKubeconfig` credentials is restored now when dedicated groups `gardener.cloud:system:admins` and `gardener.cloud:project:admins` are used for authorization.
```
