### PR TITLE
Remove unused logger field from configvalidator webhook

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -36,7 +35,6 @@ const (
 func AddToManager(mgr manager.Manager) error {
 	webhook := &admission.Webhook{
 		Handler: NewHandler(
-			mgr.GetLogger().WithName("webhook").WithName(HandlerName),
 			mgr.GetAPIReader(),
 			mgr.GetClient(),
 			admission.NewDecoder(mgr.GetScheme()),
@@ -49,9 +47,8 @@ func AddToManager(mgr manager.Manager) error {
 }
 
 // NewHandler returns a new handler for validating audit policies.
-func NewHandler(log logr.Logger, apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
+func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
 	return &configvalidator.Handler{
-		Logger:    log,
 		APIReader: apiReader,
 		Client:    c,
 		Decoder:   decoder,

--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -22,20 +21,17 @@ import (
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/auditpolicy"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("handler", func() {
 	var (
 		ctx = context.TODO()
-		log logr.Logger
 
 		request admission.Request
 		decoder admission.Decoder
@@ -130,7 +126,6 @@ rules:
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		testEncoder = &jsonserializer.Serializer{}
 
 		ctrl = gomock.NewController(GinkgoT())
@@ -139,7 +134,7 @@ rules:
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
-		handler = NewHandler(log, mockReader, fakeClient, decoder)
+		handler = NewHandler(mockReader, fakeClient, decoder)
 
 		request = admission.Request{}
 

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -40,7 +39,6 @@ const (
 func AddToManager(mgr manager.Manager) error {
 	webhook := &admission.Webhook{
 		Handler: NewHandler(
-			mgr.GetLogger().WithName("webhook").WithName(HandlerName),
 			mgr.GetAPIReader(),
 			mgr.GetClient(),
 			admission.NewDecoder(mgr.GetScheme()),
@@ -53,9 +51,8 @@ func AddToManager(mgr manager.Manager) error {
 }
 
 // NewHandler returns a new handler for validating authentication configuration.
-func NewHandler(log logr.Logger, apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
+func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
 	return &configvalidator.Handler{
-		Logger:    log,
 		APIReader: apiReader,
 		Client:    c,
 		Decoder:   decoder,

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -23,20 +22,17 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/authenticationconfig"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("handler", func() {
 	var (
 		ctx = context.TODO()
-		log logr.Logger
 
 		request admission.Request
 		decoder admission.Decoder
@@ -153,7 +149,6 @@ anonymous:
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		testEncoder = &jsonserializer.Serializer{}
 
 		ctrl = gomock.NewController(GinkgoT())
@@ -162,7 +157,7 @@ anonymous:
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
-		handler = NewHandler(log, mockReader, fakeClient, decoder)
+		handler = NewHandler(mockReader, fakeClient, decoder)
 
 		request = admission.Request{}
 

--- a/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/go-logr/logr"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -42,7 +41,6 @@ const (
 func AddToManager(mgr manager.Manager) error {
 	webhook := &admission.Webhook{
 		Handler: NewHandler(
-			mgr.GetLogger().WithName("webhook").WithName(HandlerName),
 			mgr.GetAPIReader(),
 			mgr.GetClient(),
 			admission.NewDecoder(mgr.GetScheme()),
@@ -55,9 +53,8 @@ func AddToManager(mgr manager.Manager) error {
 }
 
 // NewHandler returns a new handler for validating authorization configuration.
-func NewHandler(log logr.Logger, apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
+func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
 	return &configvalidator.Handler{
-		Logger:    log,
 		APIReader: apiReader,
 		Client:    c,
 		Decoder:   decoder,

--- a/pkg/admissioncontroller/webhook/admission/authorizationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authorizationconfig/add_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -22,20 +21,17 @@ import (
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/authorizationconfig"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("handler", func() {
 	var (
 		ctx = context.TODO()
-		log logr.Logger
 
 		request admission.Request
 		decoder admission.Decoder
@@ -120,7 +116,6 @@ authorizers:
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		testEncoder = &jsonserializer.Serializer{}
 
 		ctrl = gomock.NewController(GinkgoT())
@@ -129,7 +124,7 @@ authorizers:
 
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
 
-		handler = NewHandler(log, mockReader, fakeClient, decoder)
+		handler = NewHandler(mockReader, fakeClient, decoder)
 
 		request = admission.Request{}
 

--- a/pkg/webhook/configvalidator/handler.go
+++ b/pkg/webhook/configvalidator/handler.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -43,7 +42,6 @@ func init() {
 
 // Handler validates configuration part of ConfigMaps which are referenced in Shoot resources.
 type Handler struct {
-	Logger    logr.Logger
 	APIReader client.Reader
 	Client    client.Reader
 	Decoder   admission.Decoder

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -19,13 +18,11 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/webhook/configvalidator"
 )
 
@@ -33,7 +30,6 @@ var _ = Describe("Handler", func() {
 	var (
 		ctx = context.Background()
 
-		log        logr.Logger
 		fakeClient client.Client
 		encoder    runtime.Encoder
 		decoder    admission.Decoder
@@ -46,7 +42,6 @@ var _ = Describe("Handler", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		encoder = &jsonserializer.Serializer{}
 		decoder = admission.NewDecoder(kubernetes.GardenScheme)
@@ -74,7 +69,6 @@ var _ = Describe("Handler", func() {
 		}
 
 		handler = &Handler{
-			Logger:    log,
 			APIReader: fakeClient,
 			Client:    fakeClient,
 			Decoder:   decoder,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR removes unused logger field from configvalidator webhook.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
