### PR TITLE
add new panel for node load average to the node details dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1421,8 +1421,8 @@
         "allValue": ".*",
         "current": {
           "selected": false,
-          "text": "ip-10-254-18-110.eu-west-1.compute.internal",
-          "value": "ip-10-254-18-110.eu-west-1.compute.internal"
+          "text": "ip-10-250-12-170.eu-west-1.compute.internal",
+          "value": "ip-10-250-12-170.eu-west-1.compute.internal"
         },
         "datasource": "prometheus",
         "definition": "",
@@ -1452,6 +1452,7 @@
         "allValue": null,
         "current": {
           "selected": true,
+          "tags": [],
           "text": [
             "Ready"
           ],

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -774,7 +774,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "System Load Average",
+      "title": "System Load Average ($Node)",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": 2115,
   "graphTooltip": 0,
-  "iteration": 1761553002146,
+  "iteration": 1761637646458,
   "links": [],
   "panels": [
     {
@@ -818,7 +818,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 23
       },
       "id": 79,
       "panels": [],
@@ -843,7 +843,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 81,
@@ -940,7 +940,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 31
       },
       "id": 69,
       "panels": [],
@@ -970,7 +970,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 32
       },
       "height": "",
       "hiddenSeries": false,
@@ -1094,7 +1094,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 39
       },
       "height": "",
       "hiddenSeries": false,
@@ -1199,7 +1199,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 46
       },
       "id": 76,
       "panels": [
@@ -1421,8 +1421,8 @@
         "allValue": ".*",
         "current": {
           "selected": false,
-          "text": "ip-10-254-51-111.eu-west-1.compute.internal",
-          "value": "ip-10-254-51-111.eu-west-1.compute.internal"
+          "text": "ip-10-254-18-110.eu-west-1.compute.internal",
+          "value": "ip-10-254-18-110.eu-west-1.compute.internal"
         },
         "datasource": "prometheus",
         "definition": "",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -717,7 +717,7 @@
         "defaults": {},
         "overrides": []
       },
-      "fill": 1,
+      "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 7,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -16,8 +16,7 @@
   "editable": true,
   "gnetId": 2115,
   "graphTooltip": 0,
-  "id": 32,
-  "iteration": 1622621007137,
+  "iteration": 1761553002146,
   "links": [],
   "panels": [
     {
@@ -107,7 +106,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "targets": [
         {
           "expr": "sum(rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) * 100",
@@ -195,7 +194,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "targets": [
         {
           "expr": "sum((node_memory_MemTotal_bytes{node=~\"$Node\"} - node_memory_MemAvailable_bytes{node=~\"$Node\"}) / node_memory_MemTotal_bytes{node=~\"$Node\"}) * 100",
@@ -253,7 +252,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -383,7 +382,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -517,7 +516,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -633,7 +632,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -708,13 +707,118 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Load average figure gives the number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 1 minute. See https://linux.die.net/man/5/proc",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "node_load1{node=\"$Node\"}",
+          "interval": "",
+          "legendFormat": "Load Average (1min)",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) ",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "CPU count",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "System Load Average",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 30
       },
       "id": 79,
       "panels": [],
@@ -739,7 +843,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 81,
@@ -759,7 +863,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -836,7 +940,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "id": 69,
       "panels": [],
@@ -866,7 +970,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 39
       },
       "height": "",
       "hiddenSeries": false,
@@ -892,7 +996,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -990,7 +1094,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 46
       },
       "height": "",
       "hiddenSeries": false,
@@ -1016,7 +1120,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.16",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1095,7 +1199,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 53
       },
       "id": 76,
       "panels": [
@@ -1317,8 +1421,8 @@
         "allValue": ".*",
         "current": {
           "selected": false,
-          "text": "ip-10-250-12-170.eu-west-1.compute.internal",
-          "value": "ip-10-250-12-170.eu-west-1.compute.internal"
+          "text": "ip-10-254-51-111.eu-west-1.compute.internal",
+          "value": "ip-10-254-51-111.eu-west-1.compute.internal"
         },
         "datasource": "prometheus",
         "definition": "",
@@ -1348,7 +1452,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "Ready"
           ],


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind enhancement


**What this PR does / why we need it**:
adds new panel to show System Load Average (1 min avg) in the Node Details dashboard to easily check also the system load when debugging issues

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is what the dashboard should look like:
<img width="1284" height="311" alt="system_threshold" src="https://github.com/user-attachments/assets/3e3f4dd6-6913-420c-af50-f148fa16f300" />

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add system load average (1min avg) panel to the Node Details dashboard
```
