### PR TITLE
[GEP-26] Fix backup migration from WorkloadIdentity to Secret

### DIFF
--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -132,6 +132,10 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, log logr.Logger, 
 			if token, ok := etcdSecret.Data[securityv1alpha1constants.DataKeyToken]; ok {
 				etcdSecretData[securityv1alpha1constants.DataKeyToken] = token
 			}
+		} else {
+			// Unset all annotations and labels when static credentials are used.
+			etcdSecret.Annotations = map[string]string{}
+			etcdSecret.Labels = nil
 		}
 
 		metav1.SetMetaDataAnnotation(&etcdSecret.ObjectMeta, AnnotationKeyCreatedByBackupEntry, be.Name)

--- a/pkg/gardenlet/controller/backupbucket/reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/reconciler.go
@@ -374,7 +374,8 @@ func (r *Reconciler) reconcileBackupBucketExtensionSecret(ctx context.Context, e
 	switch credentials := backupCredentials.(type) {
 	case *corev1.Secret:
 		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, now)
+			extensionSecret.Annotations = map[string]string{v1beta1constants.GardenerTimestamp: now}
+			extensionSecret.Labels = nil
 			extensionSecret.Data = credentials.Data
 			return nil
 		})

--- a/pkg/gardenlet/controller/backupentry/reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/reconciler.go
@@ -667,7 +667,8 @@ func (r *Reconciler) reconcileBackupEntryExtensionSecret(ctx context.Context, ex
 	switch credentials := backupCredentials.(type) {
 	case *corev1.Secret:
 		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.SeedClient, extensionSecret, func() error {
-			metav1.SetMetaDataAnnotation(&extensionSecret.ObjectMeta, v1beta1constants.GardenerTimestamp, now)
+			extensionSecret.Annotations = map[string]string{v1beta1constants.GardenerTimestamp: now}
+			extensionSecret.Labels = nil
 			extensionSecret.Data = credentials.Data
 			return nil
 		})


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area security ipcei
/label ipcei/workload-identity

**What this PR does / why we need it**:
Fix backup migration from WorkloadIdentity to Secret

When the WorkloadIdentity relevant annotations and labels are left on the backup bucket/entry secret in the seed, other controllers decides that indeed WorkloadIdentity credentials are being used, however they fail to reconcile because data fields like 'config' are not set. Therefore, the backupbucket and backupentry controllers now cleanup all unknown annotations and labels. Data fields are already being cleaned up.


**Which issue(s) this PR fixes**:
Fixes #13245
Part of #9586 

**Special notes for your reviewer**:

/cc @dimityrmirchev
cc @ialidzhikov @dimitar-kostadinov @plkokanov @vitanovs 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardenlet's backupbucket and backupentry controllers are now unsetting all unknown labels and annotations on the extension secrets in the seed cluster, this fixes a bug that occurs after migration from `WorkloadIdentity` to `Secret` credentials the workload identity annotations and labels were kept in the secrets causing other controllers to keep trying to use the WorkloadIdentity credentials.
```

```bugfix developer
Backupentry generic actuator is fixed to clean all unknown annotations and labels from the `etcd-backup` secret, this change fixes issues when the credentials are switched between static secret and workload identity.
```
