### PR TITLE
[GEP-28] Clean up some TODOs

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -304,6 +304,7 @@ var _ = Describe("ResourceManager", func() {
 			AlwaysUpdate:                                     &alwaysUpdate,
 			ClusterIdentity:                                  &clusterIdentity,
 			ConcurrentSyncs:                                  &concurrentSyncs,
+			HighAvailabilityConfigWebhookEnabled:             true,
 			DefaultNotReadyToleration:                        defaultNotReadyTolerationSeconds,
 			DefaultUnreachableToleration:                     defaultUnreachableTolerationSeconds,
 			NetworkPolicyAdditionalNamespaceSelectors:        additionalNetworkPolicyNamespaceSelectors,
@@ -2681,9 +2682,9 @@ subjects:
 					}))
 
 					configMap = configMapFor(&watchedNamespace, ForSourceAndTarget, false, true)
-					cfg.BootstrapControlPlaneNode = true
 					resourceManager = New(c, deployNamespace, sm, cfg)
 					resourceManager.SetSecrets(secrets)
+					resourceManager.SetBootstrapControlPlaneNode(true)
 
 					deployment = deploymentFor(configMap.Name, false, nil, true)
 

--- a/pkg/gardenadm/botanist/customresourcedefinitions.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions.go
@@ -55,10 +55,7 @@ func (b *AutonomousBotanist) ReconcileCustomResourceDefinitions(ctx context.Cont
 		"ETCD":       etcdCRDDeployer,
 	}
 
-	// For now, we only deploy the machine CRDs in `gardenadm bootstrap`.
-	// See https://github.com/gardener/gardener/pull/12152#discussion_r2101790385
-	// TODO(timebertt): distinguish between scenarios in `gardenadm init`
-	if !b.Shoot.RunsControlPlane() {
+	if b.Shoot.HasManagedInfrastructure() {
 		deployers["Machine"], err = machinecontrollermanager.NewCRD(b.SeedClientSet.Client())
 		if err != nil {
 			return fmt.Errorf("failed creating machine CRD deployer: %w", err)

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -294,6 +294,7 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.SeedClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
+		HighAvailabilityConfigWebhookEnabled:      true,
 		DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 		DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
 		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -35,6 +35,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 
 		values = resourcemanager.Values{
 			ClusterIdentity:                           b.Seed.GetInfo().Status.ClusterIdentity,
+			HighAvailabilityConfigWebhookEnabled:      true,
 			DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 			DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
 			IsWorkerless:                              b.Shoot.IsWorkerless,
@@ -65,7 +66,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 			values.TargetNamespaces = nil
 		} else {
 			newFunc = shared.NewRuntimeGardenerResourceManager
-			// TODO(timebertt): consider disabling the highavailabilityconfig webhook
+			values.HighAvailabilityConfigWebhookEnabled = false
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
 		}
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -396,6 +396,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 
 	return sharedcomponent.NewRuntimeGardenerResourceManager(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:              features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
+		HighAvailabilityConfigWebhookEnabled:      true,
 		DefaultNotReadyToleration:                 defaultNotReadyTolerationSeconds,
 		DefaultUnreachableToleration:              defaultUnreachableTolerationSeconds,
 		EndpointSliceHintsEnabled:                 endpointSliceHintsEnabled,


### PR DESCRIPTION
Previously, we only deployed the machine CRDs in `gardenadm bootstrap`.
With this, we also deploy it in `gardenadm init` for shoots with managed infrastructure.**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up two TODOs with my name on them:
- Use the proper way to distinguish scenarios when deploying CRDs
- Disable the high availability config in `gardenadm bootstrap`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
