### PR TITLE
Add documentation on how to deprecate and remove `Shoot` API fields

### DIFF
--- a/docs/development/changing-the-api.md
+++ b/docs/development/changing-the-api.md
@@ -57,7 +57,7 @@ Example of field removal can be found in the [Remove `seedTemplate` field from M
 
 #### Additional Steps When Removing a Field From the Shoot API
 
-Removing fields from the Shoot API requires special handling because the removal is tied to specific Kubernetes versions and backwards compatibility must be maintained.
+Removing fields from the `Shoot` API requires special handling because the removal is tied to specific Kubernetes versions and backwards compatibility must be maintained.
 When removing defaulted fields, extra care is needed because these fields already exist in storage even when users never explicitly set them.
 
 The deprecation and removal process takes two release cycles (three for defaulted fields):
@@ -65,7 +65,7 @@ The deprecation and removal process takes two release cycles (three for defaulte
     - Mark the field as deprecated.
     - Remove all code that uses the field (or ensure controllers can handle `nil` values for defaulted fields).
     - Forbid the field from being set for Kubernetes versions starting from the next minor version that will be supported by Gardener in a future release.
-    - Show a warning to users that the field is deprecated and will be forbidden after a specific Kubernetes versions. Use the [`WarningsOnCreate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L207-L209) and [`WarningsOnUpdate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L211-L214) functions for this.
+    - Show a warning to users that the field is deprecated and will be forbidden after a specific Kubernetes version. Use the [`WarningsOnCreate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L207-L209) and [`WarningsOnUpdate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L211-L214) functions for this.
     - Update the [maintenance reconciler](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/controllermanager/controller/shoot/maintenance/reconciler.go) to set the field to `nil` during forced upgrades to Kubernetes versions where the field is forbidden.
 2. *For defaulted fields only, in a subsequent release:*
     - Force the field to `nil` in the [`Canonicalize`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L186-L190) function.
@@ -75,7 +75,7 @@ The deprecation and removal process takes two release cycles (three for defaulte
 This approach prevents several problems:
   - Avoids issues when `gardener-apiserver` is upgraded to a version that sets fields to `nil` while other controllers are still running older versions.
   - Allows users to update `Shoot`s using `Get` and `{Update,Patch}` requests without manually setting deprecated fields to `nil`, even when those fields were automatically defaulted in previous releases.
-  - Shows warnings when users explicitly set deprecated fields that will be automatically changed to `nil` by the [`Canonicalize`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L186-L190) function. This warning is important because the update will increase the `Shoot`'s generation since the user's request (with the deprecated field set) differs from what is present in storage (where the field as `nil`).
+  - Shows warnings when users explicitly set deprecated fields that will be automatically changed to `nil` by the [`Canonicalize`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L186-L190) function. This warning is important because the update will increase the `Shoot`'s generation since the user's request (with the deprecated field set) differs from what is present in storage (where the field is `nil`).
 
 Examples for the above can be seen in the following PRs: [Deprecate CA flag `maxEmptyBulkDelete`](https://github.com/gardener/gardener/pull/12115), [Forbid setting the `Shoot`'s `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` field for Kubernetes versions >= 1.33](https://github.com/gardener/gardener/pull/12413), and [Explicitly set `maxEmptyBulkDelete` to nil in `Canonicalize`](https://github.com/gardener/gardener/pull/13054)
 

--- a/docs/development/changing-the-api.md
+++ b/docs/development/changing-the-api.md
@@ -7,7 +7,7 @@ title: Changing the API
 This document describes the steps that need to be performed when changing the API.
 It provides guidance for API changes to both (Gardener system in general or component configurations).
 
-Generally, as Gardener is a Kubernetes-native extension, it follows the same API conventions and guidelines like Kubernetes itself. The Kubernetes 
+Generally, as Gardener is a Kubernetes-native extension, it follows the same API conventions and guidelines like Kubernetes itself. The Kubernetes
 [API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) as well as [Changing the API](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md) topics already provide a good overview and general explanation of the basic concepts behind it.
 We are following the same approaches.
 
@@ -54,6 +54,30 @@ The steps for removing a field from the code base is:
 2. A unit test has to be added to make sure that a new field does not reuse the already reserved protobuf tag.
 
 Example of field removal can be found in the [Remove `seedTemplate` field from ManagedSeed API](https://github.com/gardener/gardener/pull/6972) PR.
+
+#### Additional Steps When Removing a Field From the Shoot API
+
+Removing fields from the Shoot API requires special handling because the removal is tied to specific Kubernetes versions and backwards compatibility must be maintained.
+When removing defaulted fields, extra care is needed because these fields already exist in storage even when users never explicitly set them.
+
+The deprecation and removal process takes two release cycles (three for defaulted fields):
+1. In the first release:
+    - Mark the field as deprecated.
+    - Remove all code that uses the field (or ensure controllers can handle `nil` values for defaulted fields).
+    - Forbid the field from being set for Kubernetes versions starting from the next minor version that will be supported by Gardener in a future release.
+    - Show a warning to users that the field is deprecated and will be forbidden after a specific Kubernetes versions. Use the [`WarningsOnCreate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L207-L209) and [`WarningsOnUpdate`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L211-L214) functions for this.
+    - Update the [maintenance reconciler](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/controllermanager/controller/shoot/maintenance/reconciler.go) to set the field to `nil` during forced upgrades to Kubernetes versions where the field is forbidden.
+2. *For defaulted fields only, in a subsequent release:*
+    - Force the field to `nil` in the [`Canonicalize`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L186-L190) function.
+    - Update the warning from step (1) to inform users that the field is being automatically set to `nil`.
+3. When Gardener drops support for the last Kubernetes version that allowed the deprecated field, remove the field completely from the API.
+
+This approach prevents several problems:
+  - Avoids issues when `gardener-apiserver` is upgraded to a version that sets fields to `nil` while other controllers are still running older versions.
+  - Allows users to update `Shoot`s using `Get` and `{Update,Patch}` requests without manually setting deprecated fields to `nil`, even when those fields were automatically defaulted in previous releases.
+  - Shows warnings when users explicitly set deprecated fields that will be automatically changed to `nil` by the [`Canonicalize`](https://github.com/gardener/gardener/blob/0bd160008f123cb268100f3316ef01d09c7fe84e/pkg/apiserver/registry/core/shoot/strategy.go#L186-L190) function. This warning is important because the update will increase the `Shoot`'s generation since the user's request (with the deprecated field set) differs from what is present in storage (where the field as `nil`).
+
+Examples for the above can be seen in the following PRs: [Deprecate CA flag `maxEmptyBulkDelete`](https://github.com/gardener/gardener/pull/12115), [Forbid setting the `Shoot`'s `.spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete` field for Kubernetes versions >= 1.33](https://github.com/gardener/gardener/pull/12413), and [Explicitly set `maxEmptyBulkDelete` to nil in `Canonicalize`](https://github.com/gardener/gardener/pull/13054)
 
 ## Component Configuration APIs
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds a short doc and clarification on how to remove fields from the `Shoot` API.
When deprecating fields from the `Shoot` API, the deprecation is tied to the Kubernetes version of the `Shoot` so that users don't miss the deprecation and are forced to drop the field when they also do an update for the `Shoot`'s kubernetes version.

Another detail that the documentation goes into is modifications that have to be done by the maintenance reconciler so that the dropped field is removed when the `Shoot` is force upgraded to a Kubernetes version in which the field is forbidden
This is often missed by PRs that deprecate `Shoot` API field.

And finally, if the field to be dropped was previously defaulted, the documentation suggests to set it to `nil` in Canonicalize so that it doesn't get unexpectedly reapplied when users update their shoots by doing a `Get` and `Patch` or `Update` requests either manually or via a script.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @shafeeqes @RadaBDimitrova @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
