### PR TITLE
Improve deploy earlier the ClusterRoleBindings granting access for Admin/ViewerKubeconfig credentials 

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -117,6 +117,10 @@ func migrateAdminViewerKubeconfigClusterRoleBindings(ctx context.Context, log lo
 				return fmt.Errorf("failed to get objects for ManagedResource %q: %w", gardenerAccessKey, err)
 			}
 
+			gardenerAccessObjects = slices.DeleteFunc(gardenerAccessObjects, func(obj client.Object) bool {
+				return slices.Contains(crbs, obj.GetName())
+			})
+
 			gardenerAccessObjects = append(gardenerAccessObjects, gardeneraccess.ShootAccessClusterRoleBindings()...)
 			gardenerAccessRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 			gardenerAccessResources, err := gardenerAccessRegistry.AddAllAndSerialize(gardenerAccessObjects...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Ensure already migrated CRBs are not duplicated in the gardeneraccess MR

If the migration fail some in the middle, the gardeneracces MR could have already contain the new MR, a consequent migration attempt fails with error like
```json
{"log":"\t\t* failed serializing objects for ManagedResource \"shoot--foo--bar/shoot-core-gardeneraccess\": duplicate filename in registry: \"rbac.authorization.k8s.io/v1, kind=clusterrolebinding____gardener.cloud_system_admins.yaml\""}
```

**Which issue(s) this PR fixes**:
Follow-up on #13270 

cc @ialidzhikov @dimitar-kostadinov 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
