### PR TITLE
Do not wait for VPA CRDs when VPA is not enabled

### DIFF
--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -709,6 +709,7 @@ func (r *Reconciler) runRuntimeSetupFlow(ctx context.Context, log logr.Logger, g
 			Name:         "Waiting for custom resource definitions for VPA",
 			Fn:           c.vpaCRD.Wait,
 			Dependencies: flow.NewTaskIDs(deployVPACRD),
+			SkipIf:       !vpaEnabled(garden.Spec.RuntimeCluster.Settings),
 		})
 
 		waitForIstioCRD = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
There is already a check for the existence of the required VPA CRD ([ref](https://github.com/gardener/gardener/blob/b552e4362f99ab968cc259a245b5ebd48ed6ef8c/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L99-L105)).

**Which issue(s) this PR fixes**:
Fixes #12937

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gardener-operator now does not wait for `verticalpodautoscalercheckpoints.autoscaling.k8s.io` to be present when the `Garden`s `.spec.runtimeCluster.settings.verticalPodAutoscaler.enabled` is false. This allows externally managed VPAs, that do not use the vpa checkpoint api, to be used with the gardener-operator.
```
