### PR TITLE
Fix typo in logging documentation

### DIFF
--- a/docs/usage/observability/logging.md
+++ b/docs/usage/observability/logging.md
@@ -66,7 +66,7 @@ If you are searching for logs for the past one hour, do not expect to see labels
 By clicking on a value, Plutono automatically eliminates all other labels and/or values with which no valid log stream can be made.
 After choosing the right labels and their values, click on the `Show logs` button.
 This will build `Log query` and execute it.
-This approach is convenient when you don't know the labels names or they values.
+This approach is convenient when you don't know the label names or their values.
 ![](./images/explore-button-usage.png)
 
 Once you feel comfortable, you can start to use the [LogQL](https://github.com/credativ/plutono) language to search for logs.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
small typo fix

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
