### PR TITLE
Add support for (local) multiplatform container images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,77 +1,79 @@
 # builder
-FROM golang:1.25.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.4 AS builder
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 ARG EFFECTIVE_VERSION
-RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+RUN make build EFFECTIVE_VERSION=$EFFECTIVE_VERSION GOOS=$TARGETOS GOARCH=$TARGETARCH BUILD_OUTPUT_FILE="/output/bin/"
 
 # distroless-static
 FROM gcr.io/distroless/static-debian12:nonroot AS distroless-static
 
 # apiserver
 FROM distroless-static AS apiserver
-COPY --from=builder /go/bin/gardener-apiserver /gardener-apiserver
+COPY --from=builder /output/bin/gardener-apiserver /gardener-apiserver
 WORKDIR /
 ENTRYPOINT ["/gardener-apiserver"]
 
 # controller-manager
 FROM distroless-static AS controller-manager
-COPY --from=builder /go/bin/gardener-controller-manager /gardener-controller-manager
+COPY --from=builder /output/bin/gardener-controller-manager /gardener-controller-manager
 WORKDIR /
 ENTRYPOINT ["/gardener-controller-manager"]
 
 # scheduler
 FROM distroless-static AS scheduler
-COPY --from=builder /go/bin/gardener-scheduler /gardener-scheduler
+COPY --from=builder /output/bin/gardener-scheduler /gardener-scheduler
 WORKDIR /
 ENTRYPOINT ["/gardener-scheduler"]
 
 # gardenlet
 FROM distroless-static AS gardenlet
-COPY --from=builder /go/bin/gardenlet /gardenlet
+COPY --from=builder /output/bin/gardenlet /gardenlet
 WORKDIR /
 ENTRYPOINT ["/gardenlet"]
 
 # gardenadm
 FROM distroless-static AS gardenadm
-COPY --from=builder /go/bin/gardenadm /gardenadm
+COPY --from=builder /output/bin/gardenadm /gardenadm
 WORKDIR /
 ENTRYPOINT ["/gardenadm"]
 
 # admission-controller
 FROM distroless-static AS admission-controller
-COPY --from=builder /go/bin/gardener-admission-controller /gardener-admission-controller
+COPY --from=builder /output/bin/gardener-admission-controller /gardener-admission-controller
 WORKDIR /
 ENTRYPOINT ["/gardener-admission-controller"]
 
 # resource-manager
 FROM distroless-static AS resource-manager
-COPY --from=builder /go/bin/gardener-resource-manager /gardener-resource-manager
+COPY --from=builder /output/bin/gardener-resource-manager /gardener-resource-manager
 WORKDIR /
 ENTRYPOINT ["/gardener-resource-manager"]
 
 # node-agent
 FROM distroless-static AS node-agent
-COPY --from=builder /go/bin/gardener-node-agent /gardener-node-agent
+COPY --from=builder /output/bin/gardener-node-agent /gardener-node-agent
 WORKDIR /
 ENTRYPOINT ["/gardener-node-agent"]
 
 # operator
 FROM distroless-static AS operator
-COPY --from=builder /go/bin/gardener-operator /gardener-operator
+COPY --from=builder /output/bin/gardener-operator /gardener-operator
 WORKDIR /
 ENTRYPOINT ["/gardener-operator"]
 
 # gardener-extension-provider-local
 FROM distroless-static AS gardener-extension-provider-local
-COPY --from=builder /go/bin/gardener-extension-provider-local /gardener-extension-provider-local
+COPY --from=builder /output/bin/gardener-extension-provider-local /gardener-extension-provider-local
 WORKDIR /
 ENTRYPOINT ["/gardener-extension-provider-local"]
 
 # gardener-extension-admission-local
 FROM distroless-static AS gardener-extension-admission-local
-COPY --from=builder /go/bin/gardener-extension-admission-local /gardener-extension-admission-local
+COPY --from=builder /output/bin/gardener-extension-admission-local /gardener-extension-admission-local
 WORKDIR /
 ENTRYPOINT ["/gardener-extension-admission-local"]

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ PARALLEL_E2E_TESTS                         ?= 5
 GARDENER_RELEASE_DOWNLOAD_PATH             := $(REPO_ROOT)/dev
 DEV_SETUP_WITH_LPP_RESIZE_SUPPORT          ?= false
 DEV_SETUP_WITH_WORKLOAD_IDENTITY_SUPPORT   ?= false
+TARGET_PLATFORMS                           ?= linux/$(shell go env GOARCH)
 PRINT_HELP ?=
 
 ifneq ($(SEED_NAME),provider-extensions)
@@ -91,18 +92,18 @@ build:
 
 .PHONY: docker-images
 docker-images:
-	@echo "Building docker images with version and tag $(EFFECTIVE_VERSION)"
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(APISERVER_IMAGE_REPOSITORY):latest                 -f Dockerfile --target apiserver .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)        -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):latest        -f Dockerfile --target controller-manager .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(SCHEDULER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(SCHEDULER_IMAGE_REPOSITORY):latest                 -f Dockerfile --target scheduler .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(ADMISSION_IMAGE_REPOSITORY):latest                 -f Dockerfile --target admission-controller .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(RESOURCE_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(RESOURCE_MANAGER_IMAGE_REPOSITORY):latest          -f Dockerfile --target resource-manager .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(NODE_AGENT_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                -t $(NODE_AGENT_IMAGE_REPOSITORY):latest                -f Dockerfile --target node-agent .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(OPERATOR_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                  -t $(OPERATOR_IMAGE_REPOSITORY):latest                  -f Dockerfile --target operator .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(GARDENLET_IMAGE_REPOSITORY):latest                 -f Dockerfile --target gardenlet .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(GARDENADM_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(GARDENADM_IMAGE_REPOSITORY):latest                 -f Dockerfile --target gardenadm .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(EXTENSION_PROVIDER_LOCAL_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)  -t $(EXTENSION_PROVIDER_LOCAL_IMAGE_REPOSITORY):latest  -f Dockerfile --target gardener-extension-provider-local .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION)  -t $(EXTENSION_ADMISSION_LOCAL_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) -t $(EXTENSION_ADMISSION_LOCAL_IMAGE_REPOSITORY):latest -f Dockerfile --target gardener-extension-admission-local .
+	@echo "Building docker images with version and tag $(EFFECTIVE_VERSION) for target platforms $(TARGET_PLATFORMS)"
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(APISERVER_IMAGE_REPOSITORY):latest                 -f Dockerfile --target apiserver .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)        -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):latest        -f Dockerfile --target controller-manager .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(SCHEDULER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(SCHEDULER_IMAGE_REPOSITORY):latest                 -f Dockerfile --target scheduler .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(ADMISSION_IMAGE_REPOSITORY):latest                 -f Dockerfile --target admission-controller .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(RESOURCE_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(RESOURCE_MANAGER_IMAGE_REPOSITORY):latest          -f Dockerfile --target resource-manager .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(NODE_AGENT_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                -t $(NODE_AGENT_IMAGE_REPOSITORY):latest                -f Dockerfile --target node-agent .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(OPERATOR_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                  -t $(OPERATOR_IMAGE_REPOSITORY):latest                  -f Dockerfile --target operator .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(GARDENLET_IMAGE_REPOSITORY):latest                 -f Dockerfile --target gardenlet .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(GARDENADM_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)                 -t $(GARDENADM_IMAGE_REPOSITORY):latest                 -f Dockerfile --target gardenadm .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(EXTENSION_PROVIDER_LOCAL_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)  -t $(EXTENSION_PROVIDER_LOCAL_IMAGE_REPOSITORY):latest  -f Dockerfile --target gardener-extension-provider-local .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) --platform $(TARGET_PLATFORMS) -t $(EXTENSION_ADMISSION_LOCAL_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) -t $(EXTENSION_ADMISSION_LOCAL_IMAGE_REPOSITORY):latest -f Dockerfile --target gardener-extension-admission-local .
 
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Add support for (local) multiplatform container images build.

Until now, `make docker-images` was able to build only in the host platform, this behaviour is preserved, however developers now have the option to enable multiplatform build via the variable `TARGET_PLATFORMS`, e.g.
```bash
make docker-images TARGET_PLATFORMS=linux/amd64,linux/arm64
```



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
When cross compiling, `go install` puts the binaries under subdirectory of `GOBIN`, e.g. `$GOBIN/$GOOS_$GOARCH/` (see https://github.com/golang/go/issues/74979 for more details), this is causing issues later when the binary needs to be copied from the build stage as the file `$GOBIN/<binary-name>` does not exist. 
Therefore, the building procedure is changed from `go install` to `go build` as the later allows to explicitly configure output dir for the build result. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Gardener container images now can be built for multiple platforms locally via the variable `TARGET_PLATFORMS`, e.g. `make docker-images TARGET_PLATFORMS=linux/amd64,linux/arm64`. If the variable is unset, the container images are built for the platform `linux/<host-arch>` only.
```
