### PR TITLE
Validate issuer URLs in ServiceAccountConfig

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1665,14 +1665,19 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("serviceAccountConfig", "maxTokenExpiration"), "must be at most 2160h (90d)"))
 			}
 		}
+
+		if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
+			allErrs = append(allErrs, ValidateOIDCIssuerURL(*kubeAPIServer.ServiceAccountConfig.Issuer, fldPath.Child("serviceAccountConfig", "issuer"))...)
+		}
 		if len(kubeAPIServer.ServiceAccountConfig.AcceptedIssuers) > 0 {
 			issuers := sets.New[string]()
 			if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
 				issuers.Insert(*kubeAPIServer.ServiceAccountConfig.Issuer)
 			}
 			for i, acceptedIssuer := range kubeAPIServer.ServiceAccountConfig.AcceptedIssuers {
+				path := fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i)
+				allErrs = append(allErrs, ValidateOIDCIssuerURL(acceptedIssuer, path)...)
 				if issuers.Has(acceptedIssuer) {
-					path := fldPath.Child("serviceAccountConfig", "acceptedIssuers").Index(i)
 					if issuer := kubeAPIServer.ServiceAccountConfig.Issuer; issuer != nil && *issuer == acceptedIssuer {
 						allErrs = append(allErrs, field.Invalid(path, acceptedIssuer, fmt.Sprintf("acceptedIssuers cannot contains the issuer field value: %s", acceptedIssuer)))
 					} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Added validation for issuer URLs in both the 'issuer' and 'acceptedIssuers' fields of KubeAPIServer's ServiceAccountConfig.
Issuer URL should adhere to the ` OpenID Discovery 1.0 spec`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13105

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The Shoot `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.{issuer,acceptedIssuers}` fields are now validated against the OpenID Discovery 1.0 specification.
```
