### PR TITLE
Include Kernel Logs in Node Log Collector

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -98,11 +98,11 @@ receivers:
   journald/journal:
     start_at: beginning
     storage: file_storage
-    units:
-      - kernel
-      - kubelet.service
-      - containerd.service
-      - gardener-node-agent.service
+    matches:
+      - _TRANSPORT: kernel
+      - _SYSTEMD_UNIT: kubelet.service
+      - _SYSTEMD_UNIT: containerd.service
+      - _SYSTEMD_UNIT: gardener-node-agent.service
     operators:
       - type: move
         from: body._SYSTEMD_UNIT

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -14,11 +14,11 @@ receivers:
   journald/journal:
     start_at: beginning
     storage: file_storage
-    units:
-      - kernel
-      - kubelet.service
-      - containerd.service
-      - gardener-node-agent.service
+    matches:
+      - _TRANSPORT: kernel
+      - _SYSTEMD_UNIT: kubelet.service
+      - _SYSTEMD_UNIT: containerd.service
+      - _SYSTEMD_UNIT: gardener-node-agent.service
     operators:
       - type: move
         from: body._SYSTEMD_UNIT


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Previous config for collecting logs was invalid. Collecting kernel logs with the systemd unit logs requires a `matches` field.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue with the configuration for the `OpenTelemetryCollector` on the nodes that leads to missing kernel logs in `Vali` is now fixed.
```
