### PR TITLE
Refactor extension health checker types

### DIFF
--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -115,8 +115,6 @@ type HealthCheck interface {
 	Check(context.Context, types.NamespacedName) (*SingleCheckResult, error)
 	// SetLoggerSuffix injects the logger
 	SetLoggerSuffix(string, string)
-	// DeepCopy clones the healthCheck
-	DeepCopy() HealthCheck
 }
 
 // SingleCheckResult is the result for a health check

--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -44,7 +44,7 @@ var (
 	_ healthcheck.ShootClient = (*ShootDaemonSetHealthChecker)(nil)
 )
 
-// NewSeedDaemonSetHealthChecker is a healthCheck function to check DaemonSets
+// NewSeedDaemonSetHealthChecker is a healthCheck function to check DaemonSets in the Seed cluster
 func NewSeedDaemonSetHealthChecker(name string) *SeedDaemonSetHealthChecker {
 	return &SeedDaemonSetHealthChecker{
 		daemonSetHealthChecker: daemonSetHealthChecker{
@@ -53,7 +53,7 @@ func NewSeedDaemonSetHealthChecker(name string) *SeedDaemonSetHealthChecker {
 	}
 }
 
-// NewShootDaemonSetHealthChecker is a healthCheck function to check DaemonSets
+// NewShootDaemonSetHealthChecker is a healthCheck function to check DaemonSets in the Shoot cluster
 func NewShootDaemonSetHealthChecker(name string) *ShootDaemonSetHealthChecker {
 	return &ShootDaemonSetHealthChecker{
 		daemonSetHealthChecker: daemonSetHealthChecker{

--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -20,84 +20,81 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
-// DaemonSetHealthChecker contains all the information for the DaemonSet HealthCheck
-type DaemonSetHealthChecker struct {
-	logger      logr.Logger
-	seedClient  client.Client
-	shootClient client.Client
-	name        string
-	checkType   DaemonSetCheckType
+// daemonSetHealthChecker contains all the information for the DaemonSet HealthCheck
+type daemonSetHealthChecker struct {
+	logger logr.Logger
+	client client.Client
+	name   string
 }
 
-// DaemonSetCheckType in which cluster the check will be executed
-type DaemonSetCheckType string
+// SeedDaemonSetHealthChecker is a healthCheck for DaemonSets in the Seed cluster
+type SeedDaemonSetHealthChecker struct {
+	daemonSetHealthChecker
+}
 
-const (
-	daemonSetCheckTypeSeed  DaemonSetCheckType = "Seed"
-	daemonSetCheckTypeShoot DaemonSetCheckType = "Shoot"
+// ShootDaemonSetHealthChecker is a healthCheck for DaemonSets in the Shoot cluster
+type ShootDaemonSetHealthChecker struct {
+	daemonSetHealthChecker
+}
+
+var (
+	_ healthcheck.HealthCheck = (*SeedDaemonSetHealthChecker)(nil)
+	_ healthcheck.SeedClient  = (*SeedDaemonSetHealthChecker)(nil)
+	_ healthcheck.HealthCheck = (*ShootDaemonSetHealthChecker)(nil)
+	_ healthcheck.ShootClient = (*ShootDaemonSetHealthChecker)(nil)
 )
 
 // NewSeedDaemonSetHealthChecker is a healthCheck function to check DaemonSets
-func NewSeedDaemonSetHealthChecker(name string) healthcheck.HealthCheck {
-	return &DaemonSetHealthChecker{
-		name:      name,
-		checkType: daemonSetCheckTypeSeed,
+func NewSeedDaemonSetHealthChecker(name string) *SeedDaemonSetHealthChecker {
+	return &SeedDaemonSetHealthChecker{
+		daemonSetHealthChecker: daemonSetHealthChecker{
+			name: name,
+		},
 	}
 }
 
 // NewShootDaemonSetHealthChecker is a healthCheck function to check DaemonSets
-func NewShootDaemonSetHealthChecker(name string) healthcheck.HealthCheck {
-	return &DaemonSetHealthChecker{
-		name:      name,
-		checkType: daemonSetCheckTypeShoot,
+func NewShootDaemonSetHealthChecker(name string) *ShootDaemonSetHealthChecker {
+	return &ShootDaemonSetHealthChecker{
+		daemonSetHealthChecker: daemonSetHealthChecker{
+			name: name,
+		},
 	}
 }
 
 // InjectSeedClient injects the seed client
-func (healthChecker *DaemonSetHealthChecker) InjectSeedClient(seedClient client.Client) {
-	healthChecker.seedClient = seedClient
+func (h *SeedDaemonSetHealthChecker) InjectSeedClient(seedClient client.Client) {
+	h.client = seedClient
 }
 
 // InjectShootClient injects the shoot client
-func (healthChecker *DaemonSetHealthChecker) InjectShootClient(shootClient client.Client) {
-	healthChecker.shootClient = shootClient
+func (h *ShootDaemonSetHealthChecker) InjectShootClient(shootClient client.Client) {
+	h.client = shootClient
 }
 
 // SetLoggerSuffix injects the logger
-func (healthChecker *DaemonSetHealthChecker) SetLoggerSuffix(provider, extension string) {
-	healthChecker.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-deployment", provider, extension))
-}
-
-// DeepCopy clones the healthCheck struct by making a copy and returning the pointer to that new copy
-// Actually, it does not perform a *deep* copy.
-func (healthChecker *DaemonSetHealthChecker) DeepCopy() healthcheck.HealthCheck {
-	shallowCopy := *healthChecker
-	return &shallowCopy
+func (h *daemonSetHealthChecker) SetLoggerSuffix(provider, extension string) {
+	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-daemonset", provider, extension))
 }
 
 // Check executes the health check
-func (healthChecker *DaemonSetHealthChecker) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
+func (h *daemonSetHealthChecker) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
 	daemonSet := &appsv1.DaemonSet{}
-	var err error
-	if healthChecker.checkType == daemonSetCheckTypeSeed {
-		err = healthChecker.seedClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, daemonSet)
-	} else {
-		err = healthChecker.shootClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, daemonSet)
-	}
-	if err != nil {
+
+	if err := h.client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: h.name}, daemonSet); err != nil {
 		if apierrors.IsNotFound(err) {
 			return &healthcheck.SingleCheckResult{
 				Status: gardencorev1beta1.ConditionFalse,
-				Detail: fmt.Sprintf("DaemonSet %q in namespace %q not found", healthChecker.name, request.Namespace),
+				Detail: fmt.Sprintf("DaemonSet %q in namespace %q not found", h.name, request.Namespace),
 			}, nil
 		}
 
-		err := fmt.Errorf("failed to retrieve DaemonSet %q in namespace %q: %w", healthChecker.name, request.Namespace, err)
-		healthChecker.logger.Error(err, "Health check failed")
+		err := fmt.Errorf("failed to retrieve DaemonSet %q in namespace %q: %w", h.name, request.Namespace, err)
+		h.logger.Error(err, "Health check failed")
 		return nil, err
 	}
 	if isHealthy, err := DaemonSetIsHealthy(daemonSet); !isHealthy {
-		healthChecker.logger.Error(err, "Health check failed")
+		h.logger.Error(err, "Health check failed")
 		return &healthcheck.SingleCheckResult{
 			Status: gardencorev1beta1.ConditionFalse,
 			Detail: err.Error(),

--- a/extensions/pkg/controller/healthcheck/general/managed_resource.go
+++ b/extensions/pkg/controller/healthcheck/general/managed_resource.go
@@ -28,8 +28,13 @@ type ManagedResourceHealthChecker struct {
 	managedResourceName string
 }
 
+var (
+	_ healthcheck.HealthCheck = (*ManagedResourceHealthChecker)(nil)
+	_ healthcheck.SeedClient  = (*ManagedResourceHealthChecker)(nil)
+)
+
 // CheckManagedResource is a healthCheck function to check ManagedResources
-func CheckManagedResource(managedResourceName string) healthcheck.HealthCheck {
+func CheckManagedResource(managedResourceName string) *ManagedResourceHealthChecker {
 	return &ManagedResourceHealthChecker{
 		managedResourceName: managedResourceName,
 	}
@@ -43,13 +48,6 @@ func (healthChecker *ManagedResourceHealthChecker) InjectSeedClient(seedClient c
 // SetLoggerSuffix injects the logger
 func (healthChecker *ManagedResourceHealthChecker) SetLoggerSuffix(provider, extension string) {
 	healthChecker.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-managed-resource", provider, extension))
-}
-
-// DeepCopy clones the healthCheck struct by making a copy and returning the pointer to that new copy
-// Actually, it does not perform a *deep* copy.
-func (healthChecker *ManagedResourceHealthChecker) DeepCopy() healthcheck.HealthCheck {
-	shallowCopy := *healthChecker
-	return &shallowCopy
 }
 
 // configurationProblemRegex is used to check if a not healthy managed resource has a configuration problem.

--- a/extensions/pkg/controller/healthcheck/general/statefulsets.go
+++ b/extensions/pkg/controller/healthcheck/general/statefulsets.go
@@ -44,7 +44,7 @@ var (
 	_ healthcheck.ShootClient = (*ShootStatefulSetHealthChecker)(nil)
 )
 
-// NewSeedStatefulSetChecker is a healthCheck function to check StatefulSets
+// NewSeedStatefulSetChecker is a healthCheck function to check StatefulSets in the Seed cluster
 func NewSeedStatefulSetChecker(name string) *SeedStatefulSetHealthChecker {
 	return &SeedStatefulSetHealthChecker{
 		statefulSetHealthChecker: statefulSetHealthChecker{
@@ -53,7 +53,7 @@ func NewSeedStatefulSetChecker(name string) *SeedStatefulSetHealthChecker {
 	}
 }
 
-// NewShootStatefulSetChecker is a healthCheck function to check StatefulSets
+// NewShootStatefulSetChecker is a healthCheck function to check StatefulSets in the Shoot cluster
 func NewShootStatefulSetChecker(name string) *ShootStatefulSetHealthChecker {
 	return &ShootStatefulSetHealthChecker{
 		statefulSetHealthChecker: statefulSetHealthChecker{

--- a/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
@@ -83,8 +83,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 	)
 
 	for _, hc := range a.healthChecks {
-		// clone to avoid problems during parallel execution
-		check := hc.HealthCheck.DeepCopy()
+		check := hc.HealthCheck
 		SeedClientInto(a.seedClient, check)
 		if _, ok := check.(ShootClient); ok {
 			if shootClient == nil {

--- a/extensions/pkg/controller/healthcheck/worker/nodes.go
+++ b/extensions/pkg/controller/healthcheck/worker/nodes.go
@@ -42,6 +42,12 @@ type DefaultHealthChecker struct {
 	scaleDownProgressingThreshold *time.Duration
 }
 
+var (
+	_ healthcheck.HealthCheck = (*DefaultHealthChecker)(nil)
+	_ healthcheck.SeedClient  = (*DefaultHealthChecker)(nil)
+	_ healthcheck.ShootClient = (*DefaultHealthChecker)(nil)
+)
+
 // NewNodesChecker is a health check function which performs certain checks about the nodes registered in the cluster.
 // It implements the healthcheck.HealthCheck interface.
 func NewNodesChecker() *DefaultHealthChecker {
@@ -79,13 +85,6 @@ func (h *DefaultHealthChecker) InjectShootClient(shootClient client.Client) {
 // SetLoggerSuffix injects the logger.
 func (h *DefaultHealthChecker) SetLoggerSuffix(provider, extension string) {
 	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-nodes", provider, extension))
-}
-
-// DeepCopy clones the healthCheck struct by making a copy and returning the pointer to that new copy.
-// Actually, it does not perform a *deep* copy.
-func (h *DefaultHealthChecker) DeepCopy() healthcheck.HealthCheck {
-	shallowCopy := *h
-	return &shallowCopy
 }
 
 // Check executes the health check.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind bug

**What this PR does / why we need it**:
This PR refactors the extension health checker types to only require clients that they actually use. For example before this PR the deployment health checker requires both clients for seed and shoot although it uses only one of them.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13174

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed a bug causing types part of the [extension healthcheck package](https://github.com/gardener/gardener/tree/master/extensions/pkg/controller/healthcheck/general) to be injected with clients that they do not actually use.
```

```breaking developer
The types from the  [extension healthcheck package](https://github.com/gardener/gardener/tree/v1.133.0/extensions/pkg/controller/healthcheck/general) which perform health checks on Deployments, StatefulSets and DaemonSets have been renamed. The respective constructor functions now return the concrete types instead of an interface. The types still implement the interface that was returned before. We do not expect this change to affect existing code in the majority of cases. 
```
