### PR TITLE
Add VPN note to getting started locally guide

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -329,8 +329,9 @@ For convenience a [helper script](../../hack/usage/generate-admin-kubeconf.sh) i
 ./hack/usage/generate-admin-kubeconf.sh > admin-kubeconf.yaml
 ```
 
-Keep in mind that using a VPN on your local machine could cause problems with the setup and the shoot's kubeconfig could fail with connection issues.
-If you do experience connection problems using the shoot's kubeconfig try first disabling the VPN.
+> [!NOTE]
+> Keep in mind that using a VPN on your local machine could cause problems with the setup, and the shoot's kubeconfig could fail with connection issues.
+> If you experience connection problems using the shoot's kubeconfig, try disabling the VPN first.
 
 If you want to change the default namespace or shoot name, you can do so by passing different values as arguments.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -329,8 +329,8 @@ For convenience a [helper script](../../hack/usage/generate-admin-kubeconf.sh) i
 ./hack/usage/generate-admin-kubeconf.sh > admin-kubeconf.yaml
 ```
 
-Keep in mind that using a VPN could cause problems with the setup and the shoot kubeconfig will fail with connection issue.
-If you do have problems using the shoot kubeconfig try first to disable VPN.
+Keep in mind that using a VPN could cause problems with the setup and the shoot's kubeconfig will fail with connection issues.
+If you do have connection problems using the shoot kubeconfig try first disabling the VPN.
 
 If you want to change the default namespace or shoot name, you can do so by passing different values as arguments.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -329,8 +329,8 @@ For convenience a [helper script](../../hack/usage/generate-admin-kubeconf.sh) i
 ./hack/usage/generate-admin-kubeconf.sh > admin-kubeconf.yaml
 ```
 
-Keep in mind that using a VPN could cause problems with the setup and the shoot's kubeconfig will fail with connection issues.
-If you do have connection problems using the shoot kubeconfig try first disabling the VPN.
+Keep in mind that using a VPN on your local machine could cause problems with the setup and the shoot's kubeconfig could fail with connection issues.
+If you do experience connection problems using the shoot's kubeconfig try first disabling the VPN.
 
 If you want to change the default namespace or shoot name, you can do so by passing different values as arguments.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -329,6 +329,9 @@ For convenience a [helper script](../../hack/usage/generate-admin-kubeconf.sh) i
 ./hack/usage/generate-admin-kubeconf.sh > admin-kubeconf.yaml
 ```
 
+Keep in mind that using a VPN could cause problems with the setup and the shoot kubeconfig will fail with connection issue.
+If you do have problems using the shoot kubeconfig try first to disable VPN.
+
 If you want to change the default namespace or shoot name, you can do so by passing different values as arguments.
 
 ```bash


### PR DESCRIPTION
Added a note about VPN issues affecting kubeconfig setup.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
As first time user, following the local setup, after generating the Shoot's kubeconfig and trying to use it fails with `Unable to connect to the server:` and `connection reset by peer`.
This happens because of VPN interfering with the local setup.
Disabling the VPN seems to resolve the issue. 

I was thinking of maybe adding a hint to the documentation to let other users know about such a problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
