### PR TITLE
Fix timing issue in bootstrap token test

### DIFF
--- a/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go
+++ b/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go
@@ -16,6 +16,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("bootstraptoken", func() {
@@ -30,6 +31,7 @@ var _ = Describe("bootstraptoken", func() {
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().Build()
+		DeferCleanup(test.WithVar(&Now, func() metav1.Time { return metav1.NewTime(time.Date(2050, 5, 5, 5, 5, 5, 0, time.UTC)) }))
 	})
 
 	Describe("#ComputeBootstrapToken", func() {
@@ -44,7 +46,7 @@ var _ = Describe("bootstraptoken", func() {
 				HaveKeyWithValue("token-id", Equal([]byte(tokenID))),
 				HaveKeyWithValue("token-secret", HaveLen(16)),
 				HaveKeyWithValue("description", Equal([]byte(description))),
-				HaveKeyWithValue("expiration", Equal([]byte(metav1.Now().Add(validity).Format(time.RFC3339)))),
+				HaveKeyWithValue("expiration", Equal([]byte(Now().Add(validity).Format(time.RFC3339)))),
 				HaveKeyWithValue("usage-bootstrap-authentication", Equal([]byte("true"))),
 				HaveKeyWithValue("usage-bootstrap-signing", Equal([]byte("true"))),
 			))
@@ -75,7 +77,7 @@ var _ = Describe("bootstraptoken", func() {
 				HaveKeyWithValue("token-id", Equal([]byte(tokenID))),
 				HaveKeyWithValue("token-secret", Equal([]byte(tokenSecret))),
 				HaveKeyWithValue("description", Equal([]byte(description))),
-				HaveKeyWithValue("expiration", Equal([]byte(metav1.Now().Add(validity).Format(time.RFC3339)))),
+				HaveKeyWithValue("expiration", Equal([]byte(Now().Add(validity).Format(time.RFC3339)))),
 				HaveKeyWithValue("usage-bootstrap-authentication", Equal([]byte("true"))),
 				HaveKeyWithValue("usage-bootstrap-signing", Equal([]byte("true"))),
 			))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area quality
/area testing
/kind flake

**What this PR does / why we need it**:

Fix timing issue in bootstrap token test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13333/pull-gardener-unit/1985375606509932544 showed the following failure:

```
[FAILED] [0.019 seconds]
bootstraptoken #ComputeBootstrapTokenWithSecret [It] should compute a new bootstrap token with a randomly generated secret
/home/prow/go/src/github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go:67
  [FAILED] Expected
      <map[string][]uint8 | len:6>: {
          "description": "test",
          "token-id": "abcdef",
          "token-secret": "1234567890abcdef",
          "expiration": "2025-11-03T17:23:27Z",
          "usage-bootstrap-authentication": "true",
          "usage-bootstrap-signing": "true",
      }
  to have {key: value} matching
      <map[interface {}]interface {} | len:1>: {
          <string>"expiration": <*matchers.EqualMatcher | 0xc000fd2170>{
              Expected: <[]uint8 | len:20, cap:24>"2025-11-03T17:23:28Z",
          },
      }
  In [It] at: /home/prow/go/src/github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken/bootstraptoken_test.go:74 @ 11/03/25 16:23:28.001
```

This indicated that the time progressed during the test and caused the expiration to cross the second boundary. Usually, this is not a problem, but we can make it more robust by simply using a fake time.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
