### PR TITLE
Remove ambiguity in CP health reporting when DWD prober scales down certain deployments

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -457,10 +457,8 @@ func CheckIfDependencyWatchdogProberScaledDownControllers(ctx context.Context, s
 			return nil, fmt.Errorf("failed reading Deployment %s for scale-down check: %w", deployment.Name, err)
 		}
 
-		if ptr.Deref(deployment.Spec.Replicas, 0) == 0 {
-			if _, ok := deployment.Annotations["dependency-watchdog.gardener.cloud/meltdown-protection-active"]; ok {
-				scaledDownDeploymentNames = append(scaledDownDeploymentNames, deployment.Name)
-			}
+		if _, ok := deployment.Annotations["dependency-watchdog.gardener.cloud/meltdown-protection-active"]; ok {
+			scaledDownDeploymentNames = append(scaledDownDeploymentNames, deployment.Name)
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
This PR ensures that Control Plane health reporting can deterministically state if dependency-watchdog-prober has scale down deployments it manages as pat of meltdown protection. 

Currently the control plane health status reports the following:
```yaml
The following deployments have been scaled down to 0 replicas (perhaps by dependency-watchdog-prober):.... 
```
The above statement is not conclusive if it was infact done by DWD and just gives the operator a hint instead and requires further confirmation if that's the case or if something else has brought down these deployments which are also under the purview of DWD.
However, with https://github.com/gardener/gardener/pull/12272 a new annotation `dependency-watchdog.gardener.cloud/meltdown-protection-active` is placed on deployment which are scaled down by DWD prober, so it makes it easier to deterministically identify and report this message only when DWD has acted upon such deployments.

Additionally if a certain deployment is ignored from DWD scaling with the `dependency-watchdog.gardener.cloud/ignore-scaling` annotation then DWD would not scale them down and such components will not be reported as being scaled down by DWD, further removing any ambiguity. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
