### PR TITLE
Revert overlay change(#13332)

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -6,14 +6,11 @@ package shoot
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -154,11 +151,6 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 	}
 
 	canEnableNodeAgentAuthorizerWebhook, err := botanist.CanEnableNodeAgentAuthorizerWebhook(ctx)
-	if err != nil {
-		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
-	}
-
-	isOverlayDisablementInProgress, err := isOverlayDisablementInProgress(ctx, o.Shoot.GetInfo(), botanist.SeedClientSet.Client(), botanist.Shoot.ControlPlaneNamespace)
 	if err != nil {
 		return v1beta1helper.NewWrappedLastErrors(v1beta1helper.FormatLastErrDescription(err), err)
 	}
@@ -617,7 +609,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Name:         "Deploying shoot network plugin",
 			Fn:           flow.TaskFn(botanist.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       o.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady).InsertIf(isOverlayDisablementInProgress, waitUntilControlPlaneReady),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilGardenerResourceManagerReady, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		waitUntilNetworkIsReady = g.Add(flow.Task{
 			Name: "Waiting until shoot network plugin has been reconciled",
@@ -1089,65 +1081,4 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 func shootHasPendingInPlaceUpdateWorkers(shoot *gardencorev1beta1.Shoot) bool {
 	return shoot.Status.InPlaceUpdates != nil && shoot.Status.InPlaceUpdates.PendingWorkerUpdates != nil &&
 		(len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate) > 0 || len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate) > 0)
-}
-
-func isOverlayDisablementInProgress(ctx context.Context, shoot *gardencorev1beta1.Shoot, seedClient client.Client, shootControlPlaneNamespace string) (bool, error) {
-	shootOverlayEnabled, err := getOverlayEnabledFromShootSpec(shoot)
-	if err != nil {
-		return false, fmt.Errorf("failed to get overlay enabled status from shoot spec: %w", err)
-	}
-
-	networkObj := &extensionsv1alpha1.Network{}
-	if err = seedClient.Get(ctx, client.ObjectKey{Name: shoot.Name, Namespace: shootControlPlaneNamespace}, networkObj); err != nil {
-		// If network doesn't exist yet, no switch in progress
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to get network object: %w", err)
-	}
-
-	networkOverlayEnabled, err := getOverlayEnabledFromProviderConfig(networkObj.Spec.ProviderConfig)
-	if err != nil {
-		return false, fmt.Errorf("failed to get overlay enabled status from provider config: %w", err)
-	}
-
-	// If settings differ, overlay switch is in progress - need to wait for control plane
-	return !shootOverlayEnabled && networkOverlayEnabled, nil
-}
-
-func getOverlayEnabledFromShootSpec(shoot *gardencorev1beta1.Shoot) (bool, error) {
-	if shoot.Spec.Networking == nil || shoot.Spec.Networking.ProviderConfig == nil {
-		return true, nil
-	}
-
-	return getOverlayEnabledFromProviderConfig(shoot.Spec.Networking.ProviderConfig)
-}
-
-func getOverlayEnabledFromProviderConfig(providerConfig *runtime.RawExtension) (bool, error) {
-	if providerConfig == nil {
-		return true, nil
-	}
-
-	var config map[string]interface{}
-	if err := json.Unmarshal(providerConfig.Raw, &config); err != nil {
-		return false, fmt.Errorf("failed to unmarshal provider config: %w", err)
-	}
-
-	if overlay, exists := config["overlay"]; exists {
-		if overlayMap, ok := overlay.(map[string]interface{}); ok {
-			if enabled, exists := overlayMap["enabled"]; exists {
-				if enabledStr, ok := enabled.(string); ok {
-					enabledBool, err := strconv.ParseBool(enabledStr)
-					if err != nil {
-						return false, fmt.Errorf("failed to get overlay enabled status from provider config: %w", err)
-					}
-
-					return enabledBool, nil
-				}
-			}
-		}
-	}
-
-	return true, nil
 }


### PR DESCRIPTION
This reverts commit 341416d59fc06977fcf0f69ea326b33bd114286b.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind technical-debt

**What this PR does / why we need it**:
Revert overlay change(#13332) as we do not want to introduce extension specific knowledge into gardenlet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
