### PR TITLE
fix: overlap validation of shoot defaults with seed networks

### DIFF
--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -284,46 +284,94 @@ func validateSeedNetworks(seedNetworks core.SeedNetworks, fldPath *field.Path, i
 		return append(allErrs, errs...)
 	}
 
+	// Four buckets: all cidrs, seed cidrs and shoot defaults V4 and V6
+	// - all cidrs: must be valid CIDRs, must not overlap with reserved ranges
+	// - seed cidrs: must not overlap with each other
+	// - shoot defaults (V4): must not overlap with each other
+	// - shoot defaults (V6): must not overlap with each other, must not overlap with seed networks
 	var (
-		primaryIPFamily          = helper.DeterminePrimaryIPFamily(seedNetworks.IPFamilies)
-		networks                 []cidrvalidation.CIDR
-		reservedSeedServiceRange = cidrvalidation.NewCIDR(v1beta1constants.ReservedKubeApiServerMappingRange, field.NewPath(""))
+		primaryIPFamily                   = helper.DeterminePrimaryIPFamily(seedNetworks.IPFamilies)
+		allCIDRs                          []cidrvalidation.CIDR
+		seedCIDRs                         []cidrvalidation.CIDR
+		shootDefaultsV4                   []cidrvalidation.CIDR
+		shootDefaultsV6                   []cidrvalidation.CIDR
+		pods                              cidrvalidation.CIDR
+		services                          cidrvalidation.CIDR
+		nodes                             cidrvalidation.CIDR
+		shootPods                         cidrvalidation.CIDR
+		shootServices                     cidrvalidation.CIDR
+		reservedKubeApiServerMappingRange = cidrvalidation.NewCIDR(v1beta1constants.ReservedKubeApiServerMappingRange, field.NewPath(""))
 	)
 
 	if !inTemplate || len(seedNetworks.Pods) > 0 {
-		networks = append(networks, cidrvalidation.NewCIDR(seedNetworks.Pods, fldPath.Child("pods")))
+		pods = cidrvalidation.NewCIDR(seedNetworks.Pods, fldPath.Child("pods"))
+		allCIDRs = append(allCIDRs, pods)
+		seedCIDRs = append(seedCIDRs, pods)
 	}
 	if !inTemplate || len(seedNetworks.Services) > 0 {
-		services := cidrvalidation.NewCIDR(seedNetworks.Services, fldPath.Child("services"))
-		networks = append(networks, services)
+		services = cidrvalidation.NewCIDR(seedNetworks.Services, fldPath.Child("services"))
+		allCIDRs = append(allCIDRs, services)
+		seedCIDRs = append(seedCIDRs, services)
 		// Service range must not be larger than /8 for ipv4
 		if services.IsIPv4() {
-			maxSize, _ := reservedSeedServiceRange.GetIPNet().Mask.Size()
+			maxSize, _ := reservedKubeApiServerMappingRange.GetIPNet().Mask.Size()
 			allErrs = append(allErrs, services.ValidateMaxSize(maxSize)...)
 		}
 	}
 	if seedNetworks.Nodes != nil {
-		networks = append(networks, cidrvalidation.NewCIDR(*seedNetworks.Nodes, fldPath.Child("nodes")))
+		nodes = cidrvalidation.NewCIDR(*seedNetworks.Nodes, fldPath.Child("nodes"))
+		allCIDRs = append(allCIDRs, nodes)
+		seedCIDRs = append(seedCIDRs, nodes)
 	}
 	if shootDefaults := seedNetworks.ShootDefaults; shootDefaults != nil {
 		if shootDefaults.Pods != nil {
-			networks = append(networks, cidrvalidation.NewCIDR(*shootDefaults.Pods, fldPath.Child("shootDefaults", "pods")))
+			shootPods = cidrvalidation.NewCIDR(*shootDefaults.Pods, fldPath.Child("shootDefaults", "pods"))
+			allCIDRs = append(allCIDRs, shootPods)
+			if shootPods.IsIPv4() {
+				shootDefaultsV4 = append(shootDefaultsV4, shootPods)
+			} else {
+				shootDefaultsV6 = append(shootDefaultsV6, shootPods)
+			}
 		}
 		if shootDefaults.Services != nil {
-			networks = append(networks, cidrvalidation.NewCIDR(*shootDefaults.Services, fldPath.Child("shootDefaults", "services")))
+			shootServices = cidrvalidation.NewCIDR(*shootDefaults.Services, fldPath.Child("shootDefaults", "services"))
+			allCIDRs = append(allCIDRs, shootServices)
+			if shootServices.IsIPv4() {
+				shootDefaultsV4 = append(shootDefaultsV4, shootServices)
+			} else {
+				shootDefaultsV6 = append(shootDefaultsV6, shootServices)
+			}
 		}
 	}
 
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(networks...)...)
+	// All CIDRs must be valid
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(allCIDRs...)...)
 	// Don't check IP family in dualstack case.
 	if len(seedNetworks.IPFamilies) != 2 {
-		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIPFamily(networks, string(primaryIPFamily))...)
+		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIPFamily(allCIDRs, string(primaryIPFamily))...)
 	}
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, false)...)
 
-	allErrs = append(allErrs, reservedSeedServiceRange.ValidateNotOverlap(networks...)...)
-	vpnRangeV6 := cidrvalidation.NewCIDR(v1beta1constants.DefaultVPNRangeV6, field.NewPath(""))
-	allErrs = append(allErrs, vpnRangeV6.ValidateNotOverlap(networks...)...)
+	// In case any IP ranges are incorrect, there is no benefit in checking for intersections.
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	// Seed CIDRs must not overlap with each other
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(seedCIDRs, false)...)
+	// Shoot default CIDRs must not overlap with each other
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(shootDefaultsV4, false)...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(shootDefaultsV6, false)...)
+	// Shoot default CIDRs (V6) must not overlap with seed CIDRs
+	for _, seedCIDR := range seedCIDRs {
+		allErrs = append(allErrs, seedCIDR.ValidateNotOverlap(shootDefaultsV6...)...)
+	}
+
+	// All CIDRs must not overlap with reserved ranges
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlapWithReservedRanges(pods, "pod")...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlapWithReservedRanges(services, "service")...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlapWithReservedRanges(nodes, "node")...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlapWithReservedRanges(shootPods, "pod")...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlapWithReservedRanges(shootServices, "service")...)
 
 	return allErrs
 }

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -60,33 +60,51 @@ func validateOverlapWithSeed(fldPath *field.Path, shootNetwork []string, network
 				allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with seed node network", networkType)))
 			}
 		}
-
-		if NetworksIntersect(v1beta1constants.DefaultVPNRangeV6, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with default vpn network (%s)", networkType, v1beta1constants.DefaultVPNRangeV6)))
-		}
-
-		if NetworksIntersect(v1beta1constants.ReservedKubeApiServerMappingRange, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with reserved kube-apiserver mapping range (%s)", networkType, v1beta1constants.ReservedKubeApiServerMappingRange)))
-		}
-
-		if NetworksIntersect(v1beta1constants.ReservedSeedPodNetworkMappedRange, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with reserved seed pod network mapping range (%s)", networkType, v1beta1constants.ReservedSeedPodNetworkMappedRange)))
-		}
-
-		if NetworksIntersect(v1beta1constants.ReservedShootNodeNetworkMappedRange, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with reserved shoot node network mapping range (%s)", networkType, v1beta1constants.ReservedShootNodeNetworkMappedRange)))
-		}
-
-		if NetworksIntersect(v1beta1constants.ReservedShootServiceNetworkMappedRange, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with reserved shoot service network mapping range (%s)", networkType, v1beta1constants.ReservedShootServiceNetworkMappedRange)))
-		}
-
-		if NetworksIntersect(v1beta1constants.ReservedShootPodNetworkMappedRange, network) {
-			allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("shoot %s network intersects with reserved shoot pod network mapping range (%s)", networkType, v1beta1constants.ReservedShootPodNetworkMappedRange)))
-		}
+		allErrs = append(allErrs, validateOverlapWithReservedRanges(fldPath, network, networkType)...)
 	}
 	if len(shootNetwork) == 0 && networkRequired {
 		allErrs = append(allErrs, field.Required(fldPath, networkType+"s is required"))
+	}
+
+	return allErrs
+}
+
+// ValidateCIDROverlapWithReservedRanges validates that the given CIDR does not overlap with reserved ranges.
+func ValidateCIDROverlapWithReservedRanges(cidr CIDR, networkType string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if cidr == nil {
+		return allErrs
+	}
+	allErrs = append(allErrs, validateOverlapWithReservedRanges(cidr.GetFieldPath(), cidr.GetCIDR(), networkType)...)
+	return allErrs
+}
+
+func validateOverlapWithReservedRanges(fldPath *field.Path, network, networkType string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if NetworksIntersect(v1beta1constants.DefaultVPNRangeV6, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with default vpn network (%s)", networkType, v1beta1constants.DefaultVPNRangeV6)))
+	}
+
+	if NetworksIntersect(v1beta1constants.ReservedKubeApiServerMappingRange, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with reserved kube-apiserver mapping range (%s)", networkType, v1beta1constants.ReservedKubeApiServerMappingRange)))
+	}
+
+	if NetworksIntersect(v1beta1constants.ReservedSeedPodNetworkMappedRange, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with reserved seed pod network mapping range (%s)", networkType, v1beta1constants.ReservedSeedPodNetworkMappedRange)))
+	}
+
+	if NetworksIntersect(v1beta1constants.ReservedShootNodeNetworkMappedRange, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with reserved shoot node network mapping range (%s)", networkType, v1beta1constants.ReservedShootNodeNetworkMappedRange)))
+	}
+
+	if NetworksIntersect(v1beta1constants.ReservedShootServiceNetworkMappedRange, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with reserved shoot service network mapping range (%s)", networkType, v1beta1constants.ReservedShootServiceNetworkMappedRange)))
+	}
+
+	if NetworksIntersect(v1beta1constants.ReservedShootPodNetworkMappedRange, network) {
+		allErrs = append(allErrs, field.Invalid(fldPath, network, fmt.Sprintf("%s network intersects with reserved shoot pod network mapping range (%s)", networkType, v1beta1constants.ReservedShootPodNetworkMappedRange)))
 	}
 
 	return allErrs

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -188,17 +188,17 @@ var _ = Describe("utils", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("[].nodes"),
-					"Detail": ContainSubstring("shoot node network intersects with reserved shoot service network mapping range (243.0.0.0/8)"),
+					"Detail": ContainSubstring("node network intersects with reserved shoot service network mapping range (243.0.0.0/8)"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("[].services"),
-					"Detail": ContainSubstring("shoot service network intersects with reserved shoot node network mapping range (242.0.0.0/8)"),
+					"Detail": ContainSubstring("service network intersects with reserved shoot node network mapping range (242.0.0.0/8)"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("[].pods"),
-					"Detail": ContainSubstring("shoot pod network intersects with reserved seed pod network mapping range (241.0.0.0/8)"),
+					"Detail": ContainSubstring("pod network intersects with reserved seed pod network mapping range (241.0.0.0/8)"),
 				})),
 			))
 		})
@@ -224,7 +224,7 @@ var _ = Describe("utils", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("[].pods"),
-					"Detail": ContainSubstring("shoot pod network intersects with reserved shoot pod network mapping range (244.0.0.0/8)"),
+					"Detail": ContainSubstring("pod network intersects with reserved shoot pod network mapping range (244.0.0.0/8)"),
 				})),
 			))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

- With overlapping CIDRs allowed for both HA and non-HA shoots we can also remove the validation for shoot defaults in seed networks.
- Also added tests to make sure IPv6 ranges are still checked for overlap
- Also added check for all reserved ranges

**Which issue(s) this PR fixes**:
Fixes #13335 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed obsolete validation for `shootDefaults` network disjointedness with `SeedNetworks`.
```
