### PR TITLE
[GEP-28] Unify `gardenadm` node directories

### DIFF
--- a/pkg/gardenadm/cmd/options_manifests.go
+++ b/pkg/gardenadm/cmd/options_manifests.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 )
 
 // ManifestOptions contains options related to handling the manifest files.
@@ -40,4 +42,4 @@ func (o *ManifestOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 // ConfigDirLocation is the location where `gardenadm init` stores the config directory path.
-const ConfigDirLocation = "/etc/gardenadm/config-directory"
+const ConfigDirLocation = botanist.GardenadmBaseDir + "/config-directory"

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -200,7 +200,7 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 
 		It("should ensure that the config dir location has been stored in the well-known location", func(ctx SpecContext) {
 			Eventually(ctx, func(g Gomega) string {
-				stdOut, _, err := execute(ctx, 0, "cat", "/etc/gardenadm/config-directory")
+				stdOut, _, err := execute(ctx, 0, "cat", "/var/lib/gardenadm/config-directory")
 				g.Expect(err).NotTo(HaveOccurred())
 				return string(stdOut.Contents())
 			}).Should(Equal(configDirectory))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind cleanup

**What this PR does / why we need it**:

Small follow-up to https://github.com/gardener/gardener/pull/12920 (https://github.com/gardener/gardener/pull/12920/commits/b0a142ab4634f061f5b051bd93ea6cb655509e6c):

We already have the `/var/lib/gardenadm` directory on the nodes in the `gardenadm bootstrap` case. Here, it hosts the script for downloading `gardenadm` and the copied manifests.
This PR proposes to move the `/etc/gardenadm/config-directory` file into the existing directory for simplicity.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
