### PR TITLE
Update logging stack

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -596,7 +596,7 @@ images:
       name: fluent-bit-to-vali
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-to-vali
-    tag: "v0.67.0"
+    tag: "v0.68.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -631,7 +631,7 @@ images:
   - name: vali-curator
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vali-curator
-    tag: "v0.67.0"
+    tag: "v0.68.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -687,7 +687,7 @@ images:
       name: telegraf-iptables
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/telegraf-iptables
-    tag: "v0.67.0"
+    tag: "v0.68.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -707,7 +707,7 @@ images:
   - name: event-logger
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/event-logger
-    tag: "v0.67.0"
+    tag: "v0.68.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:
@@ -724,7 +724,7 @@ images:
   - name: tune2fs
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/tune2fs
-    tag: "v0.67.0"
+    tag: "v0.68.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -577,7 +577,7 @@ images:
   - name: fluent-bit
     sourceRepository: github.com/fluent/fluent-operator
     repository: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit
-    tag: "v4.0.9"
+    tag: "v4.1.1"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/pkg/component/observability/logging/fluentbit/fluentbit.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit.go
@@ -367,7 +367,7 @@ func (f *fluentBit) getFluentBit() *fluentbitv1alpha2.FluentBit {
 			Command: []string{
 				"/fluent-bit/bin/fluent-bit-watcher",
 				"-e",
-				"/fluent-bit/plugins/out_vali.so",
+				"/fluent-bit/plugins/output_plugin.so",
 				"-c",
 				"/fluent-bit/config/fluent-bit.conf",
 			},


### PR DESCRIPTION
**How to categorize this PR?**

/area logging
/kind enhancement

**What this PR does / why we need it**:

This PR brings latest fluent-bit [v4.1.1](https://fluentbit.io/announcements/v4.1.1/) together with logging plugin version [v0.68.0](https://github.com/gardener/logging/releases/tag/v0.68.0). It is a major update towards supporting OTLP endpoints.

```other operator
Logging stack has been upgraded to fluent-bit v4.1.1 and logging plugin v0.68.0.
```
