### PR TITLE
feat: add readiness probe to vpn tunnel-controller

### DIFF
--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -667,6 +667,19 @@ func (v *vpnShoot) tunnelControllerContainer() *corev1.Container {
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
 		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.FromInt32(8080),
+				},
+			},
+			SuccessThreshold:    2, // Check twice to buy enough time to establish more than one kube apiserver route.
+			FailureThreshold:    1,
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      2,
+		},
 	}
 }
 

--- a/pkg/component/networking/vpn/shoot/shoot_test.go
+++ b/pkg/component/networking/vpn/shoot/shoot_test.go
@@ -706,6 +706,19 @@ var _ = Describe("VPNShoot", func() {
 							},
 						},
 						ImagePullPolicy: corev1.PullIfNotPresent,
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/readyz",
+									Port: intstr.FromInt32(8080),
+								},
+							},
+							SuccessThreshold:    2,
+							FailureThreshold:    1,
+							InitialDelaySeconds: 5,
+							PeriodSeconds:       5,
+							TimeoutSeconds:      2,
+						},
 					})
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

- Makes use of the recently added readiness check added in [vpn2](https://github.com/gardener/vpn2/pull/180/files#diff-d1249eac3066061e2010aa1f30297aa7292555446b82f6e9c2c21e6eab09aeb8)

- The readiness probe makes sure that during restart / reconciliation of vpn-shoot, the second instance is not torn down until the first instance has fully restarted and actually has established routed to the kube-apiservers. 

- Without the readiness probe, there are small time periods where both vpn-shoot instances are down in a network connectivity sense, ie. an instance may be up but no network traffic can pass through yet, because the routes haven't been fully reestablished yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Readiness probe was added to vpn-shoot tunnel-controller to improve VPN availability during shoot reconciliation.
```
