### PR TITLE
Stop deploying `cache-node-exporter` ServiceMonitor on unmanaged `Seed`s

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/cache/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/servicemonitors.go
@@ -12,9 +12,12 @@ import (
 )
 
 // CentralServiceMonitors returns the central ServiceMonitor resources for the cache prometheus.
-func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
-	return []*monitoringv1.ServiceMonitor{
-		{
+func CentralServiceMonitors(seedIsShoot bool) []*monitoringv1.ServiceMonitor {
+	var serviceMonitors []*monitoringv1.ServiceMonitor
+
+	if seedIsShoot {
+		// add cache-node-exporter ServiceMonitor only to ManagedSeeds.
+		serviceMonitors = append(serviceMonitors, &monitoringv1.ServiceMonitor{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-exporter",
 				Namespace: metav1.NamespaceSystem,
@@ -53,6 +56,8 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 					),
 				}},
 			},
-		},
+		})
 	}
+
+	return serviceMonitors
 }

--- a/pkg/component/observability/monitoring/prometheus/cache/servicemonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/servicemonitors_test.go
@@ -16,8 +16,8 @@ import (
 
 var _ = Describe("ServiceMonitors", func() {
 	Describe("#CentralServiceMonitors", func() {
-		It("should return the expected objects", func() {
-			Expect(cache.CentralServiceMonitors()).To(HaveExactElements(&monitoringv1.ServiceMonitor{
+		It("should return the service monitors for ManagedSeeds", func() {
+			Expect(cache.CentralServiceMonitors(true)).To(HaveExactElements(&monitoringv1.ServiceMonitor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "node-exporter",
 					Namespace: "kube-system",
@@ -57,6 +57,10 @@ var _ = Describe("ServiceMonitors", func() {
 					}},
 				},
 			}))
+		})
+
+		It("should not return the service monitors for unmanaged Seeds", func() {
+			Expect(cache.CentralServiceMonitors(false)).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -597,7 +597,7 @@ func (r *Reconciler) newCachePrometheus(log logr.Logger, seed *seedpkg.Seed, see
 		},
 		CentralConfigs: prometheus.CentralConfigs{
 			AdditionalScrapeConfigs: additionalScrapeConfigs,
-			ServiceMonitors:         cacheprometheus.CentralServiceMonitors(),
+			ServiceMonitors:         cacheprometheus.CentralServiceMonitors(seedIsShoot),
 			PrometheusRules:         cacheprometheus.CentralPrometheusRules(),
 		},
 		AdditionalResources: []client.Object{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Gardener does not deploy the node-exporter DaemonSet on unmanaged seed clusters, i.e. seed clusters that are not simultaneously also shoot clusters.
With this change, it also stops deploying the ServiceMonitor in the `kube-system` namespace that is used by the prometheus-cache to scrape node-exporter instances on managed seeds.

**Special notes for your reviewer**:
/cc @matthias-horne @AndreasBurger 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener no longer deploys the `node-exporter` ServiceMonitor in the `kube-system` namespace on unmanaged `Seed`s.
```
