### PR TITLE
[GEP-26] Update the proposal to depict how extensions will use `WorkloadIdentity`

### DIFF
--- a/docs/proposals/26-workload-identity.md
+++ b/docs/proposals/26-workload-identity.md
@@ -274,8 +274,8 @@ behind this GEP, various extensions can benefit of this feature as well. For
 this purpose, `shoot.spec.resources` will be extended to allow `WorkloadIdentity`
 references next to the currently supported `Secret` and `ConfigMap`. Extensions,
 via their own `shoot.spec.extensions.providerConfig`, will specify which
-referenced resources they are using. This way, multiple extensions can reuse the
-same `WorkloadIdentity` and it will not need to be mount multiple times. For
+referenced resources they are using. This would allow extensions to reuse the
+same `WorkloadIdentity` without the need for multiple resource references. For
 every `WorkloadIdentity` referenced by the shoot, gardenlet will create a secret
 in the control plane namespace bearing the workload identity features - the token
 and the config. It will be up to the extension controller to make use of the


### PR DESCRIPTION
**How to categorize this PR?**
/kind discussion
/area security ipcei
/label ipcei/workload-identity

**What this PR does / why we need it**:
Update GEP-26 to depict how extensions will use `WorkloadIdentity`
Also, addresses the changes in the Seed API w.r.t. DNS and reflects the changes already made for backups.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @dimityrmirchev @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
