### PR TITLE
[GEP-28] `gardenadm init`: Deploy/restore `DNSRecord`

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -30,8 +30,7 @@ case "$COMMAND" in
   down)
     kubectl --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" annotate projects local garden confirmation.gardener.cloud/deletion=true || true
     kubectl annotate garden local confirmation.gardener.cloud/deletion=true || true
-
-    kubectl delete -k "$(dirname "$0")/garden/overlays/$SCENARIO" --ignore-not-found
+    kubectl delete garden local --wait=false --ignore-not-found
 
     echo "Waiting for the garden to be deleted..."
     kubectl wait --for=delete                            garden                             local          --timeout=300s
@@ -39,6 +38,9 @@ case "$COMMAND" in
     kubectl wait --for=condition=RequiredRuntime="False" extensions.operator.gardener.cloud provider-local --timeout=120s
     kubectl wait --for=condition=RequiredVirtual="False" extensions.operator.gardener.cloud provider-local --timeout=30s
     kubectl wait --for=condition=Installed="False"       extensions.operator.gardener.cloud provider-local --timeout=30s
+
+    # cleanup the remaining resources required for successful deletion of the garden
+    kubectl delete -k "$(dirname "$0")/garden/overlays/$SCENARIO" --ignore-not-found
     ;;
 
   *)

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -63,7 +63,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	if gardenerutils.IsShootNamespace(dns.Namespace) {
+	if isShootNamespace, err := gardenerutils.IsShootNamespace(ctx, r.client, dns.Namespace); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error checking if DNSRecord is in a shoot namespace: %w", err)
+	} else if isShootNamespace {
 		var err error
 		cluster, err = extensionscontroller.GetCluster(ctx, r.client, dns.Namespace)
 		if err != nil {

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -72,7 +72,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	var cluster *extensions.Cluster
-	if gardenerutils.IsShootNamespace(ex.Namespace) {
+	if isShootNamespace, err := gardenerutils.IsShootNamespace(ctx, r.client, ex.Namespace); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error checking if Extension is in a shoot namespace: %w", err)
+	} else if isShootNamespace {
 		var err error
 		cluster, err = extensionscontroller.GetCluster(ctx, r.client, ex.Namespace)
 		if err != nil {

--- a/extensions/pkg/predicate/preconditions.go
+++ b/extensions/pkg/predicate/preconditions.go
@@ -45,7 +45,10 @@ func (p *shootNotFailedPredicate) Create(e event.CreateEvent) bool {
 		return false
 	}
 
-	if !gardenerutils.IsShootNamespace(e.Object.GetNamespace()) {
+	if isShootNamespace, err := gardenerutils.IsShootNamespace(p.ctx, p.reader, e.Object.GetNamespace()); err != nil {
+		logger.Error(err, "Error checking if extension object is in a shoot namespace")
+		return true
+	} else if !isShootNamespace {
 		return true
 	}
 

--- a/extensions/pkg/predicate/preconditions_test.go
+++ b/extensions/pkg/predicate/preconditions_test.go
@@ -82,6 +82,14 @@ var _ = Describe("Preconditions", func() {
 
 			fakeClient = fakeclient.NewClientBuilder().
 				WithScheme(kubernetes.SeedScheme).
+				WithObjects(&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+						Labels: map[string]string{
+							v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
+						},
+					},
+				}).
 				Build()
 
 			// Create fake manager
@@ -140,19 +148,6 @@ var _ = Describe("Preconditions", func() {
 				})
 
 				It("should return false if it is a shoot namespace, but cluster is not existing", func() {
-					ns := &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: namespace,
-							Labels: map[string]string{
-								v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
-							},
-						},
-					}
-					Expect(fakeClient.Create(ctx, ns)).To(Succeed())
-					DeferCleanup(func() {
-						Expect(fakeClient.Delete(ctx, ns)).To(Succeed())
-					})
-
 					Expect(run()).To(BeFalse())
 				})
 			}

--- a/extensions/pkg/predicate/predicate_suite_test.go
+++ b/extensions/pkg/predicate/predicate_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package predicate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Predicate Suite")
+}

--- a/pkg/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord.go
@@ -251,8 +251,12 @@ func (d *dnsRecord) Migrate(ctx context.Context) error {
 
 // Destroy deletes the DNSRecord resource.
 func (d *dnsRecord) Destroy(ctx context.Context) error {
-	if err := d.deploySecret(ctx); err != nil {
-		return err
+	// Deploy the provider secret if desired, so that the extension controller can use it to delete the DNSRecord.
+	// The SecretName value might be empty during destruction, i.e., for using the existing secret on the cluster.
+	if d.values.SecretName != "" {
+		if err := d.deploySecret(ctx); err != nil {
+			return err
+		}
 	}
 
 	return extensions.DeleteExtensionObject(

--- a/pkg/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord_test.go
@@ -182,7 +182,7 @@ var _ = Describe("DNSRecord", func() {
 		})
 
 		It("should only deploy the DNSRecord resource but not the secret", func() {
-			values.SecretData = nil
+			values.UseExistingSecret = true
 			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 			Expect(dnsRecord.Deploy(ctx)).To(Succeed())
 

--- a/pkg/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord_test.go
@@ -678,6 +678,28 @@ var _ = Describe("DNSRecord", func() {
 			Expect(dnsRecord.Destroy(ctx)).To(Succeed())
 		})
 
+		It("should skip updating the DNSRecord secret if SecretName is empty", func() {
+			values.SecretName = ""
+
+			dns := &extensionsv1alpha1.DNSRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"confirmation.gardener.cloud/deletion": "true",
+						v1beta1constants.GardenerTimestamp:     now.UTC().Format(time.RFC3339Nano),
+					},
+				},
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any())
+			mc.EXPECT().Delete(ctx, dns)
+
+			dnsRecord := dnsrecord.New(log, mc, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
+			Expect(dnsRecord.Destroy(ctx)).To(Succeed())
+		})
+
 		It("should succeed if the resource does not exist", func() {
 			Expect(dnsRecord.Destroy(ctx)).To(Succeed())
 		})

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -269,6 +269,14 @@ func RestoreExtensionObjectState(
 	extensionObj extensionsv1alpha1.Object,
 	kind string,
 ) error {
+	if extensionObj.GetExtensionStatus().GetLastOperation() != nil {
+		// Extension controller has already started restoration/reconciliation of this extension object.
+		// Don't overwrite its status anymore to avoid conflicts and potential state loss.
+		// This can happen if `gardenadm init` is re-run with a `ShootState` manifest because it always sets the operation
+		// of the in-memory Shoot object to `Restore` which triggers restoration of all extension objects.
+		return nil
+	}
+
 	var resourceRefs []autoscalingv1.CrossVersionObjectReference
 	if shootState.Spec.Extensions != nil {
 		resourceName := extensionObj.GetName()

--- a/pkg/gardenadm/botanist/dnsrecord.go
+++ b/pkg/gardenadm/botanist/dnsrecord.go
@@ -6,7 +6,14 @@ package botanist
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/component"
 )
@@ -21,13 +28,57 @@ func (b *GardenadmBotanist) DeployBootstrapDNSRecord(ctx context.Context) error 
 		return err
 	}
 
-	machineAddr, err := PreferredAddressForMachine(machine)
+	machineAddr, err := PreferredAddress(machine.Status.Addresses)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed getting preferred address for machine %q: %w", machine.Name, err)
 	}
 
 	b.Shoot.Components.Extensions.ExternalDNSRecord.SetRecordType(extensionsv1alpha1helper.GetDNSRecordType(machineAddr))
 	b.Shoot.Components.Extensions.ExternalDNSRecord.SetValues([]string{machineAddr})
 
 	return component.OpWait(b.Shoot.Components.Extensions.ExternalDNSRecord).Deploy(ctx)
+}
+
+// RestoreBootstrapDNSRecord restores the external DNSRecord pointing to the first control plane node for bootstrapping
+// the self-hosted shoot cluster.
+func (b *GardenadmBotanist) RestoreBootstrapDNSRecord(ctx context.Context) error {
+	// The DNSRecord values are not persisted in the ShootState, so we need to recalculate them from the Node objects.
+	// This is the same logic as in DeployBootstrapDNSRecord, but we fetch the control plane Node objects using a label
+	// selector instead of fetching the Machine objects.
+	// Also, there might be more than one control plane node, so we just pick the oldest one, which should be the one
+	// provisioned by `gardenadm bootstrap`. We expect that any bootstrapped control plane node accepts traffic on its
+	// internal address, so picking one should be sufficient during the bootstrap procedure.
+	// Putting all control plane nodes in the DNSRecord would require consistent address types across all nodes, so we
+	// avoid that handling for now. After all, the DNSRecord is only temporary until the LoadBalancer is ready.
+	controlPlaneWorkerPool := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers)
+	if controlPlaneWorkerPool == nil {
+		return fmt.Errorf("failed fetching the control plane worker pool for the shoot")
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := b.SeedClientSet.Client().List(ctx, nodeList, client.MatchingLabels{v1beta1constants.LabelWorkerPool: controlPlaneWorkerPool.Name}); err != nil {
+		return fmt.Errorf("failed to list machines: %w", err)
+	}
+	if len(nodeList.Items) == 0 {
+		return fmt.Errorf("no control plane nodes founds")
+	}
+
+	// pick the oldest node
+	slices.SortStableFunc(nodeList.Items, func(a, b corev1.Node) int {
+		return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
+	})
+	node := &nodeList.Items[0]
+
+	nodeAddr, err := PreferredAddress(node.Status.Addresses)
+	if err != nil {
+		return fmt.Errorf("failed getting preferred address for node %q: %w", node.Name, err)
+	}
+
+	b.Shoot.Components.Extensions.ExternalDNSRecord.SetRecordType(extensionsv1alpha1helper.GetDNSRecordType(nodeAddr))
+	b.Shoot.Components.Extensions.ExternalDNSRecord.SetValues([]string{nodeAddr})
+
+	if err := b.Shoot.Components.Extensions.ExternalDNSRecord.Restore(ctx, b.Shoot.GetShootState()); err != nil {
+		return err
+	}
+	return b.Shoot.Components.Extensions.ExternalDNSRecord.Wait(ctx)
 }

--- a/pkg/gardenadm/botanist/dnsrecord_test.go
+++ b/pkg/gardenadm/botanist/dnsrecord_test.go
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	mockdnsrecord "github.com/gardener/gardener/pkg/component/extensions/dnsrecord/mock"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("DNSRecord", func() {
+	const controlPlaneWorkerPoolName = "control-plane"
+
+	var (
+		b *GardenadmBotanist
+
+		fakeClient client.Client
+
+		externalDNSRecord *mockdnsrecord.MockInterface
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeClientSet := fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+
+		ctrl := gomock.NewController(GinkgoT())
+		externalDNSRecord = mockdnsrecord.NewMockInterface(ctrl)
+
+		b = &GardenadmBotanist{
+			Botanist: &botanistpkg.Botanist{Operation: &operation.Operation{
+				SeedClientSet:  fakeClientSet,
+				ShootClientSet: fakeClientSet,
+				Shoot: &shoot.Shoot{
+					ControlPlaneNamespace: "kube-system",
+					Components: &shoot.Components{
+						Extensions: &shoot.Extensions{
+							ExternalDNSRecord: externalDNSRecord,
+						},
+					},
+				},
+			},
+			},
+		}
+
+		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			Spec: gardencorev1beta1.ShootSpec{
+				Provider: gardencorev1beta1.Provider{
+					Workers: []gardencorev1beta1.Worker{{
+						Name:         controlPlaneWorkerPoolName,
+						ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+					}},
+				},
+			},
+		})
+		b.Shoot.SetShootState(&gardencorev1beta1.ShootState{})
+	})
+
+	Describe("#RestoreExternalDNSRecord", func() {
+		It("should fail if there is no control plane worker pool", func(ctx SpecContext) {
+			shoot := b.Shoot.GetInfo()
+			shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{{
+				Name: "worker",
+			}}
+			b.Shoot.SetInfo(shoot)
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("failed fetching the control plane worker pool for the shoot"))
+		})
+
+		It("should fail if there are no control plane nodes", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Labels: map[string]string{
+						"worker.gardener.cloud/pool": "worker",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("no control plane nodes founds"))
+		})
+
+		It("should fail if the control plane node doesn't have any addresses", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controlPlaneWorkerPoolName + "-1",
+					Labels: map[string]string{
+						"worker.gardener.cloud/pool": controlPlaneWorkerPoolName,
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("no addresses found in status")))
+		})
+
+		It("should fail if the control plane nodes have different address types", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controlPlaneWorkerPoolName + "-1",
+					Labels: map[string]string{
+						"worker.gardener.cloud/pool": controlPlaneWorkerPoolName,
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{
+						Type:    corev1.NodeInternalIP,
+						Address: "10.0.0.1",
+					}},
+				},
+			}
+
+			node2 := node.DeepCopy()
+			node2.Name = controlPlaneWorkerPoolName + "-2"
+			node2.Status.Addresses = []corev1.NodeAddress{{
+				Type:    corev1.NodeHostName,
+				Address: node2.Name,
+			}}
+
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			Expect(fakeClient.Create(ctx, node2)).To(Succeed())
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("inconsistent address types")))
+		})
+
+		It("should set the correct values and restore the DNSRecord", func(ctx SpecContext) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controlPlaneWorkerPoolName + "-1",
+					Labels: map[string]string{
+						"worker.gardener.cloud/pool": controlPlaneWorkerPoolName,
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{{
+						Type:    corev1.NodeInternalIP,
+						Address: "10.0.0.1",
+					}},
+				},
+			}
+
+			node2 := node.DeepCopy()
+			node2.Name = controlPlaneWorkerPoolName + "-2"
+			node2.Status.Addresses[0].Address = "10.0.0.2"
+
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			Expect(fakeClient.Create(ctx, node2)).To(Succeed())
+
+			externalDNSRecord.EXPECT().SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			externalDNSRecord.EXPECT().SetValues([]string{node.Status.Addresses[0].Address, node2.Status.Addresses[0].Address})
+			externalDNSRecord.EXPECT().Restore(gomock.Any(), gomock.Any()).Return(nil)
+			externalDNSRecord.EXPECT().Wait(gomock.Any()).Return(nil)
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(Succeed())
+		})
+	})
+})

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -36,7 +36,7 @@ func (b *GardenadmBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machi
 	return &b.controlPlaneMachines[index], nil
 }
 
-// addressTypePreference when retrieving the SSH Address of a machine. Higher value means higher priority.
+// addressTypePreference when retrieving the SSH Address of a node/machine. Higher value means higher priority.
 // Unknown address types have the lowest priority (0).
 var addressTypePreference = map[corev1.NodeAddressType]int{
 	// internal names have priority, as we jump via a bastion host
@@ -48,11 +48,11 @@ var addressTypePreference = map[corev1.NodeAddressType]int{
 	corev1.NodeHostName: 1,
 }
 
-// PreferredAddress returns the preferred address of the given machine based on addressTypePreference.
-// If the machine has no addresses, an error is returned.
+// PreferredAddress returns the preferred address of the given node/machine addresses based on addressTypePreference.
+// If the node/machine has no addresses, an error is returned.
 func PreferredAddress(addresses []corev1.NodeAddress) (string, error) {
 	if len(addresses) == 0 {
-		return "", fmt.Errorf("no addresses found in status of machine")
+		return "", fmt.Errorf("no addresses found in status")
 	}
 
 	address := slices.MaxFunc(addresses, func(a, b corev1.NodeAddress) int {

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -48,14 +48,14 @@ var addressTypePreference = map[corev1.NodeAddressType]int{
 	corev1.NodeHostName: 1,
 }
 
-// PreferredAddressForMachine returns the preferred address of the given machine based on addressTypePreference.
+// PreferredAddress returns the preferred address of the given machine based on addressTypePreference.
 // If the machine has no addresses, an error is returned.
-func PreferredAddressForMachine(machine *machinev1alpha1.Machine) (string, error) {
-	if len(machine.Status.Addresses) == 0 {
-		return "", fmt.Errorf("no addresses found in status of machine %s", machine.Name)
+func PreferredAddress(addresses []corev1.NodeAddress) (string, error) {
+	if len(addresses) == 0 {
+		return "", fmt.Errorf("no addresses found in status of machine")
 	}
 
-	address := slices.MaxFunc(machine.Status.Addresses, func(a, b corev1.NodeAddress) int {
+	address := slices.MaxFunc(addresses, func(a, b corev1.NodeAddress) int {
 		return addressTypePreference[a.Type] - addressTypePreference[b.Type]
 	})
 

--- a/pkg/gardenadm/botanist/machines_test.go
+++ b/pkg/gardenadm/botanist/machines_test.go
@@ -5,63 +5,58 @@
 package botanist_test
 
 import (
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
 )
 
 var _ = Describe("Machines", func() {
-	Describe("#PreferredAddressForMachine", func() {
-		var machine *machinev1alpha1.Machine
+	Describe("#PreferredAddress", func() {
+		var addresses []corev1.NodeAddress
 
 		BeforeEach(func() {
-			machine = &machinev1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-machine"},
-				Status:     machinev1alpha1.MachineStatus{},
-			}
+			addresses = []corev1.NodeAddress{}
 		})
 
 		It("should return error if no addresses are present", func() {
-			Expect(PreferredAddressForMachine(machine)).Error().To(MatchError(ContainSubstring("no addresses found")))
+			Expect(PreferredAddress(addresses)).Error().To(MatchError(ContainSubstring("no addresses found")))
 		})
 
 		It("should return the only address present", func() {
-			machine.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}}
-			Expect(PreferredAddressForMachine(machine)).To(Equal("1.2.3.4"))
+			addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}}
+			Expect(PreferredAddress(addresses)).To(Equal("1.2.3.4"))
 		})
 
 		It("should return the address with the highest preference", func() {
-			machine.Status.Addresses = []corev1.NodeAddress{
+			addresses = []corev1.NodeAddress{
 				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
 				{Type: corev1.NodeHostName, Address: "host.local"},
 				{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
 			}
-			Expect(PreferredAddressForMachine(machine)).To(Equal("10.0.0.2"))
+			Expect(PreferredAddress(addresses)).To(Equal("10.0.0.2"))
 		})
 
 		It("should prefer InternalDNS over ExternalIP", func() {
-			machine.Status.Addresses = []corev1.NodeAddress{
+			addresses = []corev1.NodeAddress{
 				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
 				{Type: corev1.NodeInternalDNS, Address: "internal.dns"},
 			}
-			Expect(PreferredAddressForMachine(machine)).To(Equal("internal.dns"))
+			Expect(PreferredAddress(addresses)).To(Equal("internal.dns"))
 		})
 
 		It("should return unknown type if only unknown is present", func() {
-			machine.Status.Addresses = []corev1.NodeAddress{{Type: "UnknownType", Address: "unknown.addr"}}
-			Expect(PreferredAddressForMachine(machine)).To(Equal("unknown.addr"))
+			addresses = []corev1.NodeAddress{{Type: "UnknownType", Address: "unknown.addr"}}
+			Expect(PreferredAddress(addresses)).To(Equal("unknown.addr"))
 		})
 
 		It("should prefer known type over unknown type", func() {
-			machine.Status.Addresses = []corev1.NodeAddress{
+			addresses = []corev1.NodeAddress{
 				{Type: "UnknownType", Address: "unknown.addr"},
 				{Type: corev1.NodeExternalDNS, Address: "external.dns"},
 			}
-			Expect(PreferredAddressForMachine(machine)).To(Equal("external.dns"))
+			Expect(PreferredAddress(addresses)).To(Equal("external.dns"))
 		})
 	})
 })

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -33,9 +33,9 @@ func (b *GardenadmBotanist) ConnectToControlPlaneMachine(ctx context.Context) er
 		return err
 	}
 
-	machineAddr, err := PreferredAddressForMachine(machine)
+	machineAddr, err := PreferredAddress(machine.Status.Addresses)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed getting preferred address for machine %q: %w", machine.Name, err)
 	}
 	sshAddr := net.JoinHostPort(machineAddr, "22")
 

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -249,6 +249,14 @@ func run(ctx context.Context, opts *Options) error {
 			waitUntilExtensionControllersInPodNetworkReady,
 		)
 
+		// Later on, we will expose the control plane via a LoadBalancer and point the DNSRecord to it.
+		// TODO(timebertt): skip this step if the external LoadBalancer is already available
+		_ = g.Add(flow.Task{
+			Name:         "Restoring DNSRecord pointing to the first control plane machine",
+			Fn:           b.RestoreBootstrapDNSRecord,
+			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
+		})
 		reconcileBackupBucket = g.Add(flow.Task{
 			Name:         "Deploying BackupBucket for ETCD data",
 			Fn:           b.ReconcileBackupBucket,

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -250,10 +250,10 @@ func run(ctx context.Context, opts *Options) error {
 		)
 
 		// Later on, we will expose the control plane via a LoadBalancer and point the DNSRecord to it.
-		// TODO(timebertt): skip this step if the external LoadBalancer is already available
+		// TODO(timebertt): adapt this step to consider the external LoadBalancer if it is already available
 		_ = g.Add(flow.Task{
-			Name:         "Restoring DNSRecord pointing to the first control plane machine",
-			Fn:           b.RestoreBootstrapDNSRecord,
+			Name:         "Restoring external DNSRecord",
+			Fn:           b.RestoreExternalDNSRecord,
 			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
 		})

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1205,6 +1205,7 @@ func (r *Reconciler) reconcileDNSRecords(ctx context.Context, log logr.Logger, g
 					Type:                         provider.Type,
 					Class:                        ptr.To(extensionsv1alpha1.ExtensionClassGarden),
 					SecretName:                   provider.SecretRef.Name,
+					UseExistingSecret:            true,
 					ReconcileOnlyOnChangeOrError: true,
 				},
 				dnsrecord.DefaultInterval,

--- a/pkg/provider-local/controller/dnsrecord/add.go
+++ b/pkg/provider-local/controller/dnsrecord/add.go
@@ -35,7 +35,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddOptions) error {
 	return dnsrecord.Add(mgr, dnsrecord.AddArgs{
 		Actuator: &Actuator{
-			Client: mgr.GetClient(),
+			RuntimeClient: mgr.GetClient(),
 		},
 		ControllerOptions: opts.Controller,
 		Predicates:        dnsrecord.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),

--- a/pkg/provider-local/controller/extension/shoot/actuator.go
+++ b/pkg/provider-local/controller/extension/shoot/actuator.go
@@ -6,6 +6,7 @@ package shoot
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -82,7 +83,9 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, ex *extensionsv
 		return err
 	}
 
-	if gardenerutils.IsShootNamespace(ex.Namespace) {
+	if isShootNamespace, err := gardenerutils.IsShootNamespace(ctx, a.client, ex.Namespace); err != nil {
+		return fmt.Errorf("error checking if Extension is in a shoot namespace: %w", err)
+	} else if isShootNamespace {
 		cluster, err := extensionscontroller.GetCluster(ctx, a.client, ex.Namespace)
 		if err != nil {
 			return err

--- a/pkg/provider-local/controller/networkpolicy/add.go
+++ b/pkg/provider-local/controller/networkpolicy/add.go
@@ -16,7 +16,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/provider-local/local"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of the controller.
@@ -46,7 +45,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 // IsShootNamespace returns a predicate that returns true if the namespace is a shoot namespace.
 func IsShootNamespace() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return gardenerutils.IsShootNamespace(obj.GetName())
+		return obj.GetLabels()[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot
 	})
 }
 

--- a/pkg/provider-local/controller/networkpolicy/add_test.go
+++ b/pkg/provider-local/controller/networkpolicy/add_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -20,7 +21,7 @@ var _ = Describe("Add", func() {
 		p         predicate.Predicate
 	)
 
-	Describe("#IsShootNamespacePredicate", func() {
+	Describe("#IsShootNamespace", func() {
 		BeforeEach(func() {
 			p = IsShootNamespace()
 			namespace = &corev1.Namespace{}
@@ -28,6 +29,7 @@ var _ = Describe("Add", func() {
 
 		It("should return true because the namespace is a shoot namespace", func() {
 			namespace.Name = "shoot-garden-local"
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, "gardener.cloud/role", "shoot")
 
 			Expect(p.Create(event.CreateEvent{Object: namespace})).To(BeTrue())
 			Expect(p.Update(event.UpdateEvent{ObjectNew: namespace})).To(BeTrue())
@@ -37,6 +39,7 @@ var _ = Describe("Add", func() {
 
 		It("should return true because the namespace is a shoot namespace", func() {
 			namespace.Name = "shoot--local-local"
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, "gardener.cloud/role", "shoot")
 
 			Expect(p.Create(event.CreateEvent{Object: namespace})).To(BeTrue())
 			Expect(p.Update(event.UpdateEvent{ObjectNew: namespace})).To(BeTrue())
@@ -44,7 +47,7 @@ var _ = Describe("Add", func() {
 			Expect(p.Generic(event.GenericEvent{Object: namespace})).To(BeTrue())
 		})
 
-		It("should return true because the namespace is not a shoot namespace", func() {
+		It("should return false because the namespace is not a shoot namespace", func() {
 			namespace.Name = "foo"
 
 			Expect(p.Create(event.CreateEvent{Object: namespace})).To(BeFalse())

--- a/pkg/provider-local/local/client.go
+++ b/pkg/provider-local/local/client.go
@@ -17,28 +17,28 @@ import (
 )
 
 // GetProviderClient returns a Kubernetes client for the cluster in which provider-local should manage infrastructure
-// resources, e.g., Services, NetworkPolicies, machine Pods, etc. If the cloudprovider secret contains a kubeconfig,
+// resources, e.g., Services, NetworkPolicies, machine Pods, etc. If the provider secret contains a kubeconfig,
 // a client for that kubeconfig is created. Otherwise, the given client for the runtime cluster is returned.
 // See https://github.com/gardener/gardener/blob/master/docs/extensions/provider-local.md#credentials.
 func GetProviderClient(ctx context.Context, log logr.Logger, runtimeClient client.Client, secretRef corev1.SecretReference) (client.Client, error) {
-	cloudProviderSecret, err := kubernetesutils.GetSecretByReference(ctx, runtimeClient, &secretRef)
+	providerSecret, err := kubernetesutils.GetSecretByReference(ctx, runtimeClient, &secretRef)
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve cloudprovider secret: %w", err)
+		return nil, fmt.Errorf("could not retrieve provider secret: %w", err)
 	}
 
-	if len(cloudProviderSecret.Data[kubernetes.KubeConfig]) == 0 {
-		log.Info("Using in-cluster config for provider client as no kubeconfig is specified in the cloudprovider secret")
+	if len(providerSecret.Data[kubernetes.KubeConfig]) == 0 {
+		log.Info("Using in-cluster config for provider client as no kubeconfig is specified in the provider secret")
 		return runtimeClient, nil
 	}
 
-	clientSet, err := kubernetes.NewClientFromBytes(cloudProviderSecret.Data[kubernetes.KubeConfig],
+	clientSet, err := kubernetes.NewClientFromBytes(providerSecret.Data[kubernetes.KubeConfig],
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 		kubernetes.WithDisabledCachedClient(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not create client from cloudprovider secret: %w", err)
+		return nil, fmt.Errorf("could not create client from provider secret: %w", err)
 	}
 
-	log.Info("Using kubeconfig from cloudprovider secret for provider client")
+	log.Info("Using kubeconfig from provider secret for provider client")
 	return clientSet.Client(), nil
 }

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -784,9 +784,15 @@ func ComputeTechnicalID(projectName string, shoot *gardencorev1beta1.Shoot) stri
 	return fmt.Sprintf("%s-%s--%s", v1beta1constants.TechnicalIDPrefix, projectName, shoot.Name)
 }
 
-// IsShootNamespace returns true if the given namespace is a shoot namespace, i.e. it starts with the technical id prefix.
-func IsShootNamespace(namespace string) bool {
-	return strings.HasPrefix(namespace, v1beta1constants.TechnicalIDPrefix)
+// IsShootNamespace returns true if the given namespace is a shoot control plane namespace, i.e., if it has the
+// garden.cloud/role=shoot label.
+func IsShootNamespace(ctx context.Context, reader client.Reader, namespaceName string) (bool, error) {
+	namespace := &corev1.Namespace{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: namespaceName}, namespace); err != nil {
+		return false, err
+	}
+
+	return namespace.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot, nil
 }
 
 // GetShootConditionTypes returns all known shoot condition types.

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -265,6 +265,11 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 			Eventually(ctx, Get(service)).Should(Succeed())
 		}, SpecTimeout(time.Minute))
 
+		It("should deploy/restore the DNSRecord in the shoot", func(ctx SpecContext) {
+			dnsRecord := &extensionsv1alpha1.DNSRecord{ObjectMeta: metav1.ObjectMeta{Name: shootName + "-external", Namespace: "kube-system"}}
+			Eventually(ctx, shootKomega.Object(dnsRecord)).Should(BeHealthy(health.CheckExtensionObject))
+		}, SpecTimeout(time.Minute))
+
 		It("should finish successfully", func(ctx SpecContext) {
 			Wait(ctx, session)
 			Eventually(ctx, session.Out).Should(gbytes.Say("work in progress"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Similar to https://github.com/gardener/gardener/pull/13353, this PR adds the deployment of the `DNSRecord` resource within the shoot cluster. Its state from the bootstrap cluster is restored by `gardenadm init` from the `ShootState` compiled by `gardenadm bootstrap`.
In contrast to `gardenadm bootstrap`, the `DNSRecord` values are calculated from the shoot's `Nodes` instead of the `Machines` in `gardenadm init`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

- [x] in draft until https://github.com/gardener/gardener/pull/13353 has been merged, opened for early CI feedback

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
