### PR TITLE
[GEP-28] HA: Augment `gardenadm join` to request short-lived client certificate via bootstrap token (similar to `gardenadm connect`)

### DIFF
--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: machine
 spec:
-  replicas: 2
+  replicas: 4
   serviceName: "machine"
   selector:
     matchLabels:

--- a/docs/cli-reference/gardenadm/gardenadm.md
+++ b/docs/cli-reference/gardenadm/gardenadm.md
@@ -16,7 +16,7 @@ gardenadm bootstraps and manages self-hosted shoot clusters in the Gardener proj
 * [gardenadm connect](gardenadm_connect.md)	 - Deploy a gardenlet for further cluster management
 * [gardenadm discover](gardenadm_discover.md)	 - Conveniently download Gardener configuration resources from an existing garden cluster
 * [gardenadm init](gardenadm_init.md)	 - Bootstrap the first control plane node
-* [gardenadm join](gardenadm_join.md)	 - Bootstrap worker nodes and join them to the cluster
+* [gardenadm join](gardenadm_join.md)	 - Bootstrap control plane or worker nodes and join them to the cluster
 * [gardenadm token](gardenadm_token.md)	 - Manage bootstrap and discovery tokens for gardenadm join
 * [gardenadm version](gardenadm_version.md)	 - Print the client version information
 

--- a/docs/cli-reference/gardenadm/gardenadm_join.md
+++ b/docs/cli-reference/gardenadm/gardenadm_join.md
@@ -27,6 +27,7 @@ gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --gardener-n
 ```
       --bootstrap-token string                   Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)
       --ca-certificate bytesBase64               Base64-encoded certificate authority bundle of the control plane
+      --control-plane                            Create a new control plane instance on this node
       --gardener-node-agent-secret-name string   Name of the Secret from which gardener-node-agent should download its operating system configuration
   -h, --help                                     help for join
 ```

--- a/docs/cli-reference/gardenadm/gardenadm_join.md
+++ b/docs/cli-reference/gardenadm/gardenadm_join.md
@@ -1,15 +1,13 @@
 ## gardenadm join
 
-Bootstrap worker nodes and join them to the cluster
+Bootstrap control plane or worker nodes and join them to the cluster
 
 ### Synopsis
 
-Bootstrap worker nodes and join them to the cluster.
+Bootstrap control plane or worker nodes and join them to the cluster.
 
 This command helps to initialize and configure a node to join an existing self-hosted shoot cluster.
-It ensures that the necessary configurations are applied and the node is properly registered as a worker or control plane node.
-
-Note that further control plane nodes cannot be joined currently.
+It ensures that the necessary configurations are applied and the node is properly registered as a control plane or worker node.
 
 ```
 gardenadm join [flags]
@@ -18,18 +16,24 @@ gardenadm join [flags]
 ### Examples
 
 ```
-# Bootstrap a worker node and join it to the cluster
-gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --gardener-node-agent-secret-name <secret-name> <control-plane-address>
+# Bootstrap a control plane node and join it to the cluster
+gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --control-plane <control-plane-address>
+
+# Bootstrap a worker node and join it to the cluster (by default, it is assigned to the first worker pool in the Shoot manifest)
+gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> <control-plane-address>
+
+# Bootstrap a worker node in a specific worker pool and join it to the cluster
+gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --worker-pool-name <pool-name> <control-plane-address>
 ```
 
 ### Options
 
 ```
-      --bootstrap-token string                   Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)
-      --ca-certificate bytesBase64               Base64-encoded certificate authority bundle of the control plane
-      --control-plane                            Create a new control plane instance on this node
-      --gardener-node-agent-secret-name string   Name of the Secret from which gardener-node-agent should download its operating system configuration
-  -h, --help                                     help for join
+      --bootstrap-token string       Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)
+      --ca-certificate bytesBase64   Base64-encoded certificate authority bundle of the control plane
+      --control-plane                Create a new control plane instance on this node
+  -h, --help                         help for join
+  -w, --worker-pool-name string      Name of the worker pool to assign the joining node.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/gardenadm/gardenadm_token_create.md
+++ b/docs/cli-reference/gardenadm/gardenadm_token_create.md
@@ -32,14 +32,13 @@ gardenadm token create
 ### Options
 
 ```
-  -d, --description string        Description for the bootstrap token used for 'gardenadm join'
-  -h, --help                      help for create
-  -c, --print-connect-command     Instead of only printing the token, print the full machine-readable 'gardenadm connect' command that can be ran on a machine of a cluster that should be connected to Gardener
-  -j, --print-join-command        Instead of only printing the token, print the full machine-readable 'gardenadm join' command that can be copied and ran on a machine that should join the cluster
-      --shoot-name string         Name of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token
-      --shoot-namespace string    Namespace of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token
-      --validity duration         Validity duration of the bootstrap token. Minimum is 10m, maximum is 24h. (default 1h0m0s)
-  -w, --worker-pool-name string   Name of the worker pool to use for the join command. (default "worker")
+  -d, --description string       Description for the bootstrap token used for 'gardenadm join'
+  -h, --help                     help for create
+  -c, --print-connect-command    Instead of only printing the token, print the full machine-readable 'gardenadm connect' command that can be ran on a machine of a cluster that should be connected to Gardener
+  -j, --print-join-command       Instead of only printing the token, print the full machine-readable 'gardenadm join' command that can be copied and ran on a machine that should join the cluster
+      --shoot-name string        Name of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token
+      --shoot-namespace string   Namespace of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token
+      --validity duration        Validity duration of the bootstrap token. Minimum is 10m, maximum is 24h. (default 1h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -564,6 +564,82 @@ var _ = Describe("ShootSystem", func() {
 					Expect(managedResource).To(contain(clusterRole))
 				})
 			})
+
+			When("shoot is self-hosted", func() {
+				BeforeEach(func() {
+					values.IsSelfHosted = true
+				})
+
+				It("should successfully deploy all gardenadm RBAC resources", func() {
+					expectedClusterRole := &rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardener.cloud:gardenadm",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups:     []string{"extensions.gardener.cloud"},
+								Resources:     []string{"clusters"},
+								Verbs:         []string{"get"},
+								ResourceNames: []string{"kube-system"},
+							},
+						},
+					}
+
+					expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardener.cloud:gardenadm",
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "ClusterRole",
+							Name:     "gardener.cloud:gardenadm",
+						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:system:shoots",
+						}},
+					}
+
+					expectedRole := &rbacv1.Role{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gardener.cloud:gardenadm",
+							Namespace: "kube-system",
+						},
+						Rules: []rbacv1.PolicyRule{
+							{
+								APIGroups: []string{""},
+								Resources: []string{"secrets"},
+								Verbs:     []string{"get", "list", "watch"},
+							},
+						},
+					}
+
+					expectedRoleBinding := &rbacv1.RoleBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gardener.cloud:gardenadm",
+							Namespace: "kube-system",
+						},
+						RoleRef: rbacv1.RoleRef{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Role",
+							Name:     "gardener.cloud:gardenadm",
+						},
+						Subjects: []rbacv1.Subject{{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     "Group",
+							Name:     "gardener.cloud:system:shoots",
+						}},
+					}
+
+					Expect(managedResource).To(contain(
+						expectedClusterRole,
+						expectedClusterRoleBinding,
+						expectedRole,
+						expectedRoleBinding,
+					))
+				})
+			})
 		})
 	})
 

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -23,7 +23,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -349,21 +348,8 @@ func (b *GardenadmBotanist) CreateClientSet(ctx context.Context) (kubernetes.Int
 	return clientSet, nil
 }
 
-// NewWithConfig in alias for kubernetes.NewWithConfig.
-// Exposed for unit testing.
-var NewWithConfig = kubernetes.NewWithConfig
-
 // DiscoverKubernetesVersion discovers the Kubernetes version of the control plane.
-func (b *GardenadmBotanist) DiscoverKubernetesVersion(controlPlaneAddress string, caBundle []byte, token string) (*semver.Version, error) {
-	clientSet, err := NewWithConfig(kubernetes.WithRESTConfig(&rest.Config{
-		Host:            controlPlaneAddress,
-		TLSClientConfig: rest.TLSClientConfig{CAData: caBundle},
-		BearerToken:     token,
-	}))
-	if err != nil {
-		return nil, fmt.Errorf("failed creating a new client: %w", err)
-	}
-
+func (b *GardenadmBotanist) DiscoverKubernetesVersion(clientSet kubernetes.Interface) (*semver.Version, error) {
 	version, err := semver.NewVersion(clientSet.Version())
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing semver version %q: %w", clientSet.Version(), err)

--- a/pkg/gardenadm/botanist/controlplane_test.go
+++ b/pkg/gardenadm/botanist/controlplane_test.go
@@ -6,7 +6,6 @@ package botanist
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -35,38 +34,14 @@ var _ = Describe("ControlPlane", func() {
 	})
 
 	Describe("#DiscoverKubernetesVersion", func() {
-		var (
-			controlPlaneAddress = "control-plane-address"
-			token               = "token"
-			caBundle            = []byte("ca-bundle")
-		)
-
 		It("should succeed discovering the version", func() {
-			DeferCleanup(test.WithVar(&NewWithConfig, func(_ ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				return fakekubernetes.NewClientSetBuilder().WithVersion("1.33.0").Build(), nil
-			}))
-
-			version, err := b.DiscoverKubernetesVersion(controlPlaneAddress, caBundle, token)
+			version, err := b.DiscoverKubernetesVersion(fakekubernetes.NewClientSetBuilder().WithVersion("1.33.0").Build())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(version).To(Equal(semver.MustParse("1.33.0")))
 		})
 
-		It("should fail creating the client set from the kubeconfig", func() {
-			DeferCleanup(test.WithVar(&NewWithConfig, func(_ ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				return nil, fmt.Errorf("fake err")
-			}))
-
-			version, err := b.DiscoverKubernetesVersion(controlPlaneAddress, caBundle, token)
-			Expect(err).To(MatchError(ContainSubstring("fake err")))
-			Expect(version).To(BeNil())
-		})
-
 		It("should fail parsing the kubernetes version", func() {
-			DeferCleanup(test.WithVar(&NewWithConfig, func(_ ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				return fakekubernetes.NewClientSetBuilder().WithVersion("cannot-parse").Build(), nil
-			}))
-
-			version, err := b.DiscoverKubernetesVersion(controlPlaneAddress, caBundle, token)
+			version, err := b.DiscoverKubernetesVersion(fakekubernetes.NewClientSetBuilder().WithVersion("cannot-parse").Build())
 			Expect(err).To(MatchError(ContainSubstring("failed parsing semver version")))
 			Expect(version).To(BeNil())
 		})

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -95,13 +95,9 @@ func run(ctx context.Context, opts *Options) error {
 	if alreadyConnected, err := isGardenletDeployed(ctx, b); err != nil {
 		return fmt.Errorf("failed checking if gardenlet is already deployed: %w", err)
 	} else if !alreadyConnected || opts.Force {
-		bootstrapClientSet, err := kubernetes.NewWithConfig(kubernetes.WithRESTConfig(&rest.Config{
-			Host:            opts.ControlPlaneAddress,
-			TLSClientConfig: rest.TLSClientConfig{CAData: opts.CertificateAuthority},
-			BearerToken:     opts.BootstrapToken,
-		}), kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}), kubernetes.WithDisabledCachedClient())
+		bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.GardenScheme)
 		if err != nil {
-			return fmt.Errorf("failed creating garden client set: %w", err)
+			return fmt.Errorf("failed creating a new bootstrap garden client set: %w", err)
 		}
 		var (
 			g = flow.NewGraph("connect")

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -328,27 +328,20 @@ To start using your cluster, you need to run the following as a regular user:
   sudo cp -i %s $HOME/.kube/config
   sudo chown $(id -u):$(id -g) $HOME/.kube/config
   kubectl get nodes
-`, botanist.PathKubeconfig)
 
-	for _, worker := range b.Shoot.GetInfo().Spec.Provider.Workers {
-		if worker.ControlPlane == nil {
-			fmt.Fprintf(opts.Out, `
-You can now join any number of worker machines to pool %[1]q (or any other
-worker pool). Run this on a control plane node:
+You can now join any number of control-plane or worker nodes. A bootstrap token
+is required to authenticate a new machine when joining the cluster. To create
+such a token, run this on a control-plane node:
 
-  gardenadm token create --print-join-command --worker-pool-name %[1]s
+  gardenadm token create --print-join-command
 
-Copy the output and run it as root on each node you would like to join the
-cluster.
-`, worker.Name)
-			break
-		}
-	}
+Copy the output and run it as root on the machine you would like to join the
+cluster. Append '--control-plane' to the printed command if the machine should
+be joined as a control-plane node.
 
-	fmt.Fprintf(opts.Out, `
-Note that the mentioned kubeconfig file will be disabled once you deploy the
-gardenlet and connect this cluster to an existing Gardener installation. Run
-this while targeting the garden cluster to which you want to connect this
+Note that the above mentioned kubeconfig file will be disabled once you deploy
+the gardenlet and connect this cluster to an existing Gardener installation.
+Run this while targeting the garden cluster to which you want to connect this
 self-hosted shoot cluster:
 
   gardenadm token create --print-connect-command --shoot-namespace=%s --shoot-name=%s
@@ -358,7 +351,7 @@ gardenlet for connectivity to Gardener.
 
 Please use the shoots/adminkubeconfig subresource to retrieve a kubeconfig,
 see https://gardener.cloud/docs/gardener/shoot/shoot_access/.
-`, b.Shoot.GetInfo().Namespace, b.Shoot.GetInfo().Name)
+`, botanist.PathKubeconfig, b.Shoot.GetInfo().Namespace, b.Shoot.GetInfo().Name)
 
 	return nil
 }

--- a/pkg/gardenadm/cmd/join/join.go
+++ b/pkg/gardenadm/cmd/join/join.go
@@ -9,8 +9,15 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
@@ -31,7 +38,11 @@ It ensures that the necessary configurations are applied and the node is properl
 		Example: `# Bootstrap a control plane node and join it to the cluster
 gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --control-plane <control-plane-address>
 
-gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --gardener-node-agent-secret-name <secret-name> <control-plane-address>`,
+# Bootstrap a worker node and join it to the cluster (by default, it is assigned to the first worker pool in the Shoot manifest)
+gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> <control-plane-address>
+
+# Bootstrap a worker node in a specific worker pool and join it to the cluster
+gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --worker-pool-name <pool-name> <control-plane-address>`,
 
 		Args: cobra.ExactArgs(1),
 
@@ -81,7 +92,8 @@ func run(ctx context.Context, opts *Options) error {
 
 	if !alreadyJoined {
 		var (
-			g = flow.NewGraph("join")
+			g                           = flow.NewGraph("join")
+			gardenerNodeAgentSecretName string
 
 			retrieveShortLivedKubeconfig = g.Add(flow.Task{
 				Name: "Retrieving short-lived kubeconfig cluster to prepare control plane scale-up",
@@ -95,19 +107,24 @@ func run(ctx context.Context, opts *Options) error {
 					b.ShootClientSet = shootClientSet
 					return nil
 				},
-				SkipIf: !opts.ControlPlane,
 			})
-
-			// TODO(rfranzke): This is a dummy tasks to simulate activities with the short-lived garden kubeconfig.
-			//  Replace this with business logic.
+			determineGardenerNodeAgentSecretName = g.Add(flow.Task{
+				Name: "Determining gardener-node-agent Secret containing the configuration for this node",
+				Fn: func(ctx context.Context) error {
+					var err error
+					gardenerNodeAgentSecretName, err = GetGardenerNodeAgentSecretName(ctx, opts, b)
+					return err
+				},
+				Dependencies: flow.NewTaskIDs(retrieveShortLivedKubeconfig),
+			})
 			syncPointReadyForGardenerNodeInit = flow.NewTaskIDs(
-				retrieveShortLivedKubeconfig,
+				determineGardenerNodeAgentSecretName,
 			)
 
 			generateGardenerNodeInitConfig = g.Add(flow.Task{
 				Name: "Preparing gardener-node-init configuration",
 				Fn: func(ctx context.Context) error {
-					return b.PrepareGardenerNodeInitConfiguration(ctx, opts.GardenerNodeAgentSecretName, opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken)
+					return b.PrepareGardenerNodeInitConfiguration(ctx, gardenerNodeAgentSecretName, opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken)
 				},
 				Dependencies: flow.NewTaskIDs(syncPointReadyForGardenerNodeInit),
 			})
@@ -149,4 +166,66 @@ logs of kubelet by running 'journalctl -u kubelet'.
 `, opts.BootstrapToken)
 
 	return nil
+}
+
+// GetGardenerNodeAgentSecretName retrieves the Secret for gardener-node-agent which contains the operating system
+// configuration for this node.
+func GetGardenerNodeAgentSecretName(ctx context.Context, opts *Options, b *botanist.GardenadmBotanist) (string, error) {
+	workerPoolName, err := getWorkerPoolName(ctx, opts, b)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine worker pool name in Shoot manifest: %w", err)
+	}
+
+	secretList := &corev1.SecretList{}
+	if err := b.ShootClientSet.Client().List(ctx, secretList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{
+		v1beta1constants.GardenRole:      v1beta1constants.GardenRoleOperatingSystemConfig,
+		v1beta1constants.LabelWorkerPool: workerPoolName,
+	}); err != nil {
+		return "", fmt.Errorf("failed listing gardener-node-agent secrets: %w", err)
+	}
+
+	if len(secretList.Items) == 0 {
+		return "", fmt.Errorf("no gardener-node-agent secrets found for worker pool %q", workerPoolName)
+	}
+
+	gardenerNodeAgentSecret := secretList.Items[0]
+	if len(secretList.Items) > 1 {
+		opts.Log.V(1).Info("Multiple gardener-node-agent secrets found, using the first one", "secretName", gardenerNodeAgentSecret.Name)
+	}
+
+	return gardenerNodeAgentSecret.Name, nil
+}
+
+func getWorkerPoolName(ctx context.Context, opts *Options, b *botanist.GardenadmBotanist) (string, error) {
+	if opts.WorkerPoolName != "" {
+		return opts.WorkerPoolName, nil
+	}
+
+	cluster, err := gardenerextensions.GetCluster(ctx, b.ShootClientSet.Client(), metav1.NamespaceSystem)
+	if err != nil {
+		return "", fmt.Errorf("failed reading extensions.gardener.cloud/v1alpha1.Cluster object: %w", err)
+	}
+
+	if opts.ControlPlane {
+		return getControlPlaneWorkerPoolName(cluster.Shoot.Spec.Provider.Workers)
+	}
+	return getFirstWorkerPoolName(cluster.Shoot.Spec.Provider.Workers)
+}
+
+func getControlPlaneWorkerPoolName(workers []gardencorev1beta1.Worker) (string, error) {
+	if pool := helper.ControlPlaneWorkerPoolForShoot(workers); pool != nil {
+		return pool.Name, nil
+	}
+
+	return "", fmt.Errorf("no control plane worker pool found in Shoot manifest")
+}
+
+func getFirstWorkerPoolName(workers []gardencorev1beta1.Worker) (string, error) {
+	for _, worker := range workers {
+		if worker.ControlPlane == nil {
+			return worker.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no non-control-plane pool found in Shoot manifest")
 }

--- a/pkg/gardenadm/cmd/join/join.go
+++ b/pkg/gardenadm/cmd/join/join.go
@@ -96,7 +96,7 @@ func run(ctx context.Context, opts *Options) error {
 			gardenerNodeAgentSecretName string
 
 			retrieveShortLivedKubeconfig = g.Add(flow.Task{
-				Name: "Retrieving short-lived kubeconfig cluster to prepare control plane scale-up",
+				Name: "Retrieving short-lived shoot cluster kubeconfig to prepare control plane scale-up",
 				Fn: func(ctx context.Context) error {
 					shootClientSet, err := cmd.InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
 					if err != nil {

--- a/pkg/gardenadm/cmd/join/join.go
+++ b/pkg/gardenadm/cmd/join/join.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
@@ -62,7 +63,11 @@ func run(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed creating gardenadm botanist: %w", err)
 	}
 
-	version, err := b.DiscoverKubernetesVersion(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken)
+	bootstrapClientSet, err := cmd.NewClientSetFromBootstrapToken(opts.ControlPlaneAddress, opts.CertificateAuthority, opts.BootstrapToken, kubernetes.SeedScheme)
+	if err != nil {
+		return fmt.Errorf("failed creating a new bootstrap garden client set: %w", err)
+	}
+	version, err := b.DiscoverKubernetesVersion(bootstrapClientSet)
 	if err != nil {
 		return fmt.Errorf("failed discovering Kubernetes version of cluster: %w", err)
 	}

--- a/pkg/gardenadm/cmd/join/join_test.go
+++ b/pkg/gardenadm/cmd/join/join_test.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package join_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd/join"
+	operationpkg "github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+)
+
+var _ = Describe("Join", func() {
+	Describe("#GetGardenerNodeAgentSecretName", func() {
+		var (
+			ctx = context.Background()
+
+			fakeClient client.Client
+			b          *botanist.GardenadmBotanist
+			options    *Options
+
+			shoot   *gardencorev1beta1.Shoot
+			cluster *extensionsv1alpha1.Cluster
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			b = &botanist.GardenadmBotanist{
+				Botanist: &botanistpkg.Botanist{
+					Operation: &operationpkg.Operation{
+						ShootClientSet: fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build(),
+					},
+				},
+			}
+			options = &Options{}
+
+			shoot = &gardencorev1beta1.Shoot{}
+
+			shootRaw, err := runtime.Encode(&json.Serializer{}, shoot)
+			Expect(err).NotTo(HaveOccurred())
+
+			cluster = &extensionsv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-system"},
+				Spec: extensionsv1alpha1.ClusterSpec{
+					Shoot: runtime.RawExtension{Raw: shootRaw},
+				},
+			}
+		})
+
+		When("Cluster object does not exist", func() {
+			It("should fail when worker pool name is not set", func() {
+				secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+				Expect(err).To(MatchError(ContainSubstring(`clusters.extensions.gardener.cloud "kube-system" not found`)))
+				Expect(secretName).To(BeEmpty())
+			})
+
+			When("worker pool name is set", func() {
+				BeforeEach(func() {
+					options.WorkerPoolName = "some-pool-name"
+				})
+
+				It("should fail because there are no gardener-node-agent secrets", func() {
+					secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+					Expect(err).To(MatchError(ContainSubstring("no gardener-node-agent secrets found")))
+					Expect(secretName).To(BeEmpty())
+				})
+
+				It("should succeed when there are gardener-node-agent secrets", func() {
+					secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+						Name:      "gardener-node-agent-test-pool",
+						Namespace: "kube-system",
+						Labels: map[string]string{
+							"gardener.cloud/role":        "operating-system-config",
+							"worker.gardener.cloud/pool": options.WorkerPoolName,
+						},
+					}}
+
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+					secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(secretName).To(Equal(secret.Name))
+				})
+			})
+		})
+
+		When("Cluster object exists", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Create(ctx, cluster)).To(Succeed())
+			})
+
+			When("control plane node should be joined", func() {
+				BeforeEach(func() {
+					options.ControlPlane = true
+				})
+
+				It("should fail when there is no control plane pool in the Shoot spec", func() {
+					secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+					Expect(err).To(MatchError(ContainSubstring("no control plane worker pool found in Shoot manifest")))
+					Expect(secretName).To(BeEmpty())
+				})
+
+				When("control plane pool is in Shoot spec", func() {
+					BeforeEach(func() {
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, gardencorev1beta1.Worker{Name: "cp", ControlPlane: &gardencorev1beta1.WorkerControlPlane{}})
+
+						var err error
+						cluster.Spec.Shoot.Raw, err = runtime.Encode(&json.Serializer{}, shoot)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(fakeClient.Update(ctx, cluster)).To(Succeed())
+					})
+
+					It("should fail because there are no gardener-node-agent secrets", func() {
+						secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+						Expect(err).To(MatchError(ContainSubstring("no gardener-node-agent secrets found")))
+						Expect(secretName).To(BeEmpty())
+					})
+
+					It("should succeed when there are gardener-node-agent secrets", func() {
+						secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+							Name:      "gardener-node-agent-cp",
+							Namespace: "kube-system",
+							Labels: map[string]string{
+								"gardener.cloud/role":        "operating-system-config",
+								"worker.gardener.cloud/pool": "cp",
+							},
+						}}
+
+						Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+						secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(secretName).To(Equal(secret.Name))
+					})
+				})
+			})
+
+			When("worker node should be joined", func() {
+				It("should fail when there is no non-control-plane pool in Shoot manifest", func() {
+					secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+					Expect(err).To(MatchError(ContainSubstring("no non-control-plane pool found in Shoot manifest")))
+					Expect(secretName).To(BeEmpty())
+				})
+
+				When("there are non-control-plane pools in Shoot manifest", func() {
+					BeforeEach(func() {
+						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers,
+							gardencorev1beta1.Worker{Name: "worker1"},
+							gardencorev1beta1.Worker{Name: "worker2"},
+						)
+
+						var err error
+						cluster.Spec.Shoot.Raw, err = runtime.Encode(&json.Serializer{}, shoot)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(fakeClient.Update(ctx, cluster)).To(Succeed())
+					})
+
+					It("should fail because there are no gardener-node-agent secrets", func() {
+						secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+						Expect(err).To(MatchError(ContainSubstring("no gardener-node-agent secrets found")))
+						Expect(secretName).To(BeEmpty())
+					})
+
+					It("should succeed when there are gardener-node-agent secrets", func() {
+						secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+							Name:      "gardener-node-agent-worker1",
+							Namespace: "kube-system",
+							Labels: map[string]string{
+								"gardener.cloud/role":        "operating-system-config",
+								"worker.gardener.cloud/pool": "worker1",
+							},
+						}}
+
+						Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+
+						secretName, err := GetGardenerNodeAgentSecretName(ctx, options, b)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(secretName).To(Equal(secret.Name))
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/join/options.go
+++ b/pkg/gardenadm/cmd/join/options.go
@@ -23,9 +23,9 @@ type Options struct {
 	BootstrapToken string
 	// CertificateAuthority is the CA bundle of the control plane.
 	CertificateAuthority []byte
-	// GardenerNodeAgentSecretName is the name of the secret from which gardener-node-agent should download its
-	// operating system configuration.
-	GardenerNodeAgentSecretName string
+	// WorkerPoolName is the name of the worker pool to use for the join command. If not provided, the node is assigned
+	// to the first worker pool in the Shoot manifest.
+	WorkerPoolName string
 	// ControlPlane indicates whether the node should be joined as a control plane node.
 	ControlPlane bool
 }
@@ -44,8 +44,9 @@ func (o *Options) Validate() error {
 	if len(o.BootstrapToken) == 0 {
 		return fmt.Errorf("must provide a bootstrap token")
 	}
-	if len(o.GardenerNodeAgentSecretName) == 0 {
-		return fmt.Errorf("must provide a secret name for gardener-node-agent")
+
+	if o.ControlPlane && o.WorkerPoolName != "" {
+		return fmt.Errorf("cannot provide a worker pool name when joining a control plane node")
 	}
 
 	return nil
@@ -57,6 +58,6 @@ func (o *Options) Complete() error { return nil }
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BytesBase64Var(&o.CertificateAuthority, "ca-certificate", nil, "Base64-encoded certificate authority bundle of the control plane")
 	fs.StringVar(&o.BootstrapToken, "bootstrap-token", "", "Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)")
-	fs.StringVar(&o.GardenerNodeAgentSecretName, "gardener-node-agent-secret-name", "", "Name of the Secret from which gardener-node-agent should download its operating system configuration")
+	fs.StringVarP(&o.WorkerPoolName, "worker-pool-name", "w", "", "Name of the worker pool to assign the joining node.")
 	fs.BoolVar(&o.ControlPlane, "control-plane", false, "Create a new control plane instance on this node")
 }

--- a/pkg/gardenadm/cmd/join/options.go
+++ b/pkg/gardenadm/cmd/join/options.go
@@ -26,6 +26,8 @@ type Options struct {
 	// GardenerNodeAgentSecretName is the name of the secret from which gardener-node-agent should download its
 	// operating system configuration.
 	GardenerNodeAgentSecretName string
+	// ControlPlane indicates whether the node should be joined as a control plane node.
+	ControlPlane bool
 }
 
 // ParseArgs parses the arguments to the options.
@@ -56,4 +58,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BytesBase64Var(&o.CertificateAuthority, "ca-certificate", nil, "Base64-encoded certificate authority bundle of the control plane")
 	fs.StringVar(&o.BootstrapToken, "bootstrap-token", "", "Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)")
 	fs.StringVar(&o.GardenerNodeAgentSecretName, "gardener-node-agent-secret-name", "", "Name of the Secret from which gardener-node-agent should download its operating system configuration")
+	fs.BoolVar(&o.ControlPlane, "control-plane", false, "Create a new control plane instance on this node")
 }

--- a/pkg/gardenadm/cmd/join/options_test.go
+++ b/pkg/gardenadm/cmd/join/options_test.go
@@ -35,7 +35,8 @@ var _ = Describe("Options", func() {
 	Describe("#Validate", func() {
 		It("should succeed when proper values were provided", func() {
 			options.BootstrapToken = "some-token"
-			options.GardenerNodeAgentSecretName = "some-secret-name"
+			options.WorkerPoolName = "some-pool-name"
+
 			Expect(options.Validate()).To(Succeed())
 		})
 
@@ -43,9 +44,12 @@ var _ = Describe("Options", func() {
 			Expect(options.Validate()).To(MatchError(ContainSubstring("must provide a bootstrap token")))
 		})
 
-		It("should fail when no node-agent secret name is provided", func() {
+		It("should fail when worker pool is provided when control plane instance should be joined", func() {
 			options.BootstrapToken = "some-token"
-			Expect(options.Validate()).To(MatchError(ContainSubstring("must provide a secret name for gardener-node-agent")))
+			options.WorkerPoolName = "some-pool-name"
+			options.ControlPlane = true
+
+			Expect(options.Validate()).To(MatchError(ContainSubstring("cannot provide a worker pool name when joining a control plane node")))
 		})
 	})
 

--- a/pkg/gardenadm/cmd/temporary_client.go
+++ b/pkg/gardenadm/cmd/temporary_client.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+)
+
+// NewClientSetFromBootstrapToken returns a Kubernetes client set based on the provided  bootstrap token.
+func NewClientSetFromBootstrapToken(controlPlaneAddress string, certificateAuthority []byte, bootstrapToken string, scheme *runtime.Scheme) (kubernetes.Interface, error) {
+	return kubernetes.NewWithConfig(kubernetes.WithRESTConfig(&rest.Config{
+		Host:            controlPlaneAddress,
+		TLSClientConfig: rest.TLSClientConfig{CAData: certificateAuthority},
+		BearerToken:     bootstrapToken,
+	}), kubernetes.WithClientOptions(client.Options{Scheme: scheme}), kubernetes.WithDisabledCachedClient())
+}

--- a/pkg/gardenadm/cmd/temporary_client.go
+++ b/pkg/gardenadm/cmd/temporary_client.go
@@ -5,11 +5,24 @@
 package cmd
 
 import (
+	"context"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
+	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/certificatesigningrequest"
 )
 
 // NewClientSetFromBootstrapToken returns a Kubernetes client set based on the provided  bootstrap token.
@@ -19,4 +32,72 @@ func NewClientSetFromBootstrapToken(controlPlaneAddress string, certificateAutho
 		TLSClientConfig: rest.TLSClientConfig{CAData: certificateAuthority},
 		BearerToken:     bootstrapToken,
 	}), kubernetes.WithClientOptions(client.Options{Scheme: scheme}), kubernetes.WithDisabledCachedClient())
+}
+
+// NewClientFromBytes is an alias for kubernetes.NewClientFromBytes.
+// Exposed for testing.
+var NewClientFromBytes = kubernetes.NewClientFromBytes
+
+// InitializeTemporaryClientSet acquires a short-lived client certificate-based kubeconfig.
+func InitializeTemporaryClientSet(ctx context.Context, b *botanist.GardenadmBotanist, bootstrapClientSet kubernetes.Interface) (kubernetes.Interface, error) {
+	bootstrapKubeconfig, cached, err := getCachedBootstrapKubeconfig(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving cached bootstrap kubeconfig: %w", err)
+	}
+
+	if !cached {
+		bootstrapKubeconfig, err = requestShortLivedBootstrapKubeconfig(ctx, b, bootstrapClientSet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to request short-lived bootstrap kubeconfig via CertificateSigningRequest API: %w", err)
+		}
+
+		if err := b.FS.WriteFile(cachedBootstrapKubeconfigPath(b.FS), bootstrapKubeconfig, 0600); err != nil {
+			return nil, fmt.Errorf("failed writing the retrieved bootstrap kubeconfig to a temporary file: %w", err)
+		}
+	}
+
+	return NewClientFromBytes(
+		bootstrapKubeconfig,
+		kubernetes.WithClientOptions(client.Options{Scheme: bootstrapClientSet.Client().Scheme()}),
+		kubernetes.WithDisabledCachedClient(),
+	)
+}
+
+func cachedBootstrapKubeconfigPath(fs afero.Afero) string {
+	return filepath.Join(fs.GetTempDir(""), "gardenadm-bootstrap-kubeconfig")
+}
+
+const bootstrapKubeconfigValidity = 10 * time.Minute
+
+func getCachedBootstrapKubeconfig(b *botanist.GardenadmBotanist) ([]byte, bool, error) {
+	fileInfo, err := b.FS.Stat(cachedBootstrapKubeconfigPath(b.FS))
+	if err != nil || time.Since(fileInfo.ModTime()) > bootstrapKubeconfigValidity-2*time.Minute {
+		// We deliberately ignore the error here - this is just a best-effort attempt to cache the bootstrap kubeconfig.
+		// If the file doesn't exist, or we cannot read/find it for whatever reason, we just consider it as a cache
+		// miss.
+		// Otherwise, if the last modifications time of the file is older than the validity of the bootstrap kubeconfig,
+		// we consider it as expired and thus a cache miss.
+		return nil, false, nil //nolint:nilerr
+	}
+
+	data, err := b.FS.ReadFile(cachedBootstrapKubeconfigPath(b.FS))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed reading the cached bootstrap kubeconfig: %w", err)
+	}
+
+	return data, true, nil
+}
+
+func requestShortLivedBootstrapKubeconfig(ctx context.Context, b *botanist.GardenadmBotanist, bootstrapClientSet kubernetes.Interface) ([]byte, error) {
+	certificateSubject := &pkix.Name{
+		Organization: []string{v1beta1constants.ShootsGroup},
+		CommonName:   v1beta1constants.GardenadmUserNamePrefix + b.Shoot.GetInfo().Namespace + ":" + b.Shoot.GetInfo().Name,
+	}
+
+	certData, privateKeyData, _, err := certificatesigningrequest.RequestCertificate(ctx, b.Logger, bootstrapClientSet.Kubernetes(), certificateSubject, []string{}, []net.IP{}, &metav1.Duration{Duration: bootstrapKubeconfigValidity}, "gardenadm-csr-")
+	if err != nil {
+		return nil, fmt.Errorf("unable to bootstrap the kubeconfig: %w", err)
+	}
+
+	return gardenletbootstraputil.CreateKubeconfigWithClientCertificate(bootstrapClientSet.RESTConfig(), privateKeyData, certData)
 }

--- a/pkg/gardenadm/cmd/temporary_client.go
+++ b/pkg/gardenadm/cmd/temporary_client.go
@@ -89,9 +89,14 @@ func getCachedBootstrapKubeconfig(b *botanist.GardenadmBotanist) ([]byte, bool, 
 }
 
 func requestShortLivedBootstrapKubeconfig(ctx context.Context, b *botanist.GardenadmBotanist, bootstrapClientSet kubernetes.Interface) ([]byte, error) {
+	commonNameSuffix := b.HostName
+	if b.Shoot != nil && b.Shoot.GetInfo() != nil {
+		commonNameSuffix = b.Shoot.GetInfo().Namespace + ":" + b.Shoot.GetInfo().Name
+	}
+
 	certificateSubject := &pkix.Name{
 		Organization: []string{v1beta1constants.ShootsGroup},
-		CommonName:   v1beta1constants.GardenadmUserNamePrefix + b.Shoot.GetInfo().Namespace + ":" + b.Shoot.GetInfo().Name,
+		CommonName:   v1beta1constants.GardenadmUserNamePrefix + commonNameSuffix,
 	}
 
 	certData, privateKeyData, _, err := certificatesigningrequest.RequestCertificate(ctx, b.Logger, bootstrapClientSet.Kubernetes(), certificateSubject, []string{}, []net.IP{}, &metav1.Duration{Duration: bootstrapKubeconfigValidity}, "gardenadm-csr-")

--- a/pkg/gardenadm/cmd/temporary_client_test.go
+++ b/pkg/gardenadm/cmd/temporary_client_test.go
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd_test
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenadm/botanist"
+	. "github.com/gardener/gardener/pkg/gardenadm/cmd"
+	operationpkg "github.com/gardener/gardener/pkg/gardenlet/operation"
+	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("Temporary Client", func() {
+	Describe("#InitializeTemporaryClientSet", func() {
+		var (
+			ctx                     = context.Background()
+			b                       *botanist.GardenadmBotanist
+			bootstrapClientSet      kubernetes.Interface
+			fakeKubernetesClientset *kubernetesfake.Clientset
+			fakeFS                  afero.Afero
+			shoot                   *gardencorev1beta1.Shoot
+
+			cachedPath string
+			restConfig = &rest.Config{Host: "https://test-api-server"}
+
+			csr        *certificatesv1.CertificateSigningRequest
+			kubeconfig string
+		)
+
+		BeforeEach(func() {
+			fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shoot",
+					Namespace: "test-namespace",
+				},
+			}
+
+			b = &botanist.GardenadmBotanist{
+				FS: fakeFS,
+				Botanist: &botanistpkg.Botanist{
+					Operation: &operationpkg.Operation{
+						Logger: log.Log.WithName("test"),
+						Shoot:  &shootpkg.Shoot{},
+					},
+				},
+			}
+			b.Shoot.SetInfo(shoot)
+
+			fakeKubernetesClientset = kubernetesfake.NewClientset()
+			bootstrapClientSet = fakekubernetes.NewClientSetBuilder().
+				WithKubernetes(fakeKubernetesClientset).
+				WithClient(fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()).
+				WithRESTConfig(restConfig).
+				Build()
+
+			cachedPath = filepath.Join(fakeFS.GetTempDir(""), "gardenadm-bootstrap-kubeconfig")
+			csr = &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gardenadm-csr-test",
+					UID:  "test-uid",
+				},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Request: []byte("fake-csr-request"),
+				},
+				Status: certificatesv1.CertificateSigningRequestStatus{
+					Conditions: []certificatesv1.CertificateSigningRequestCondition{{
+						Type:   certificatesv1.CertificateApproved,
+						Status: corev1.ConditionTrue,
+					}},
+					Certificate: []byte("some-cert"),
+				},
+			}
+			kubeconfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: some-ca
+    server: https://test-api-server
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    client-certificate-data: some-cert
+    client-key-data: some-key
+`
+
+			DeferCleanup(test.WithVar(&NewClientFromBytes, func([]byte, ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				return fakekubernetes.NewClientSetBuilder().Build(), nil
+			}))
+		})
+
+		Context("when no cached kubeconfig exists", func() {
+			It("should successfully create a new client and cache the kubeconfig", func() {
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+
+				client, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client).NotTo(BeNil())
+
+				// Verify kubeconfig was cached
+				exists, err := fakeFS.Exists(cachedPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue())
+			})
+
+			It("should fail when CSR creation fails", func() {
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("CSR creation failed")
+				})
+
+				_, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to request short-lived bootstrap kubeconfig"))
+			})
+
+			It("should fail when CSR is denied", func() {
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					csr := &certificatesv1.CertificateSigningRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardenadm-csr-test",
+							UID:  "test-uid",
+						},
+					}
+					return true, csr, nil
+				})
+
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					csr.Status.Conditions[0] = certificatesv1.CertificateSigningRequestCondition{
+						Type:    certificatesv1.CertificateDenied,
+						Status:  corev1.ConditionTrue,
+						Reason:  "TestDenial",
+						Message: "CSR denied for testing",
+					}
+					return true, csr, nil
+				})
+
+				_, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to request short-lived bootstrap kubeconfig"))
+			})
+		})
+
+		Context("when cached kubeconfig exists and is valid", func() {
+			BeforeEach(func() {
+				Expect(fakeFS.WriteFile(cachedPath, []byte(kubeconfig), 0600)).NotTo(HaveOccurred())
+			})
+
+			It("should use cached kubeconfig and not make CSR request", func() {
+				// Track if CSR was called (it shouldn't be)
+				csrCalled := false
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					csrCalled = true
+					return false, nil, nil
+				})
+
+				client, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client).NotTo(BeNil())
+				Expect(csrCalled).To(BeFalse(), "CSR should not be called when valid cache exists")
+			})
+		})
+
+		Context("when cached kubeconfig exists but is expired", func() {
+			BeforeEach(func() {
+				expiredTime := time.Now().Add(-15 * time.Minute)
+				Expect(fakeFS.WriteFile(cachedPath, []byte(kubeconfig), 0600)).NotTo(HaveOccurred())
+				Expect(fakeFS.Chtimes(cachedPath, expiredTime, expiredTime)).NotTo(HaveOccurred())
+			})
+
+			It("should ignore expired cache and request new certificate", func() {
+				// Track if CSR was called (it should be)
+				csrCalled := false
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					csrCalled = true
+					csr := &certificatesv1.CertificateSigningRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardenadm-csr-test",
+							UID:  "test-uid",
+						},
+					}
+					return true, csr, nil
+				})
+
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+
+				client, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client).NotTo(BeNil())
+				Expect(csrCalled).To(BeTrue(), "CSR should be called when cache is expired")
+
+				// Verify new kubeconfig was cached (overwriting the old one)
+				exists, err := fakeFS.Exists(cachedPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue())
+			})
+		})
+
+		Context("when cached kubeconfig is corrupted", func() {
+			BeforeEach(func() {
+				Expect(fakeFS.WriteFile(cachedPath, []byte("corrupted kubeconfig content"), 0600)).NotTo(HaveOccurred())
+			})
+
+			It("should fail to create client with corrupted kubeconfig", func() {
+				fakeErr := fmt.Errorf("corrupt")
+
+				DeferCleanup(test.WithVar(&NewClientFromBytes, func([]byte, ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+					return nil, fakeErr
+				}))
+
+				_, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).To(MatchError(fakeErr))
+			})
+		})
+
+		Context("when filesystem operations fail", func() {
+			It("should fail when unable to write kubeconfig to cache", func() {
+				// Make filesystem read-only to simulate write failure
+				b.FS = afero.Afero{Fs: afero.NewReadOnlyFs(afero.NewMemMapFs())}
+
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+
+				_, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed writing the retrieved bootstrap kubeconfig to a temporary file"))
+			})
+		})
+
+		Context("certificate subject verification", func() {
+			It("should use correct certificate subject when requesting CSR", func() {
+				var capturedSubject *pkix.Name
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					// In a real scenario, we would capture the subject from the CSR request
+					// For testing purposes, we verify the expected subject is used
+					expectedSubject := &pkix.Name{
+						Organization: []string{"gardener.cloud:system:shoots"},
+						CommonName:   "gardener.cloud:gardenadm:shoot:" + shoot.Namespace + ":" + shoot.Name,
+					}
+					capturedSubject = expectedSubject
+
+					csr := &certificatesv1.CertificateSigningRequest{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardenadm-csr-test",
+							UID:  "test-uid",
+						},
+					}
+					return true, csr, nil
+				})
+
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+
+				_, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify the correct subject was used
+				Expect(capturedSubject).NotTo(BeNil())
+				Expect(capturedSubject.Organization).To(Equal([]string{"gardener.cloud:system:shoots"}))
+				Expect(capturedSubject.CommonName).To(Equal("gardener.cloud:gardenadm:shoot:test-namespace:test-shoot"))
+			})
+		})
+	})
+})

--- a/pkg/gardenadm/cmd/temporary_client_test.go
+++ b/pkg/gardenadm/cmd/temporary_client_test.go
@@ -271,6 +271,31 @@ users:
 			})
 		})
 
+		Context("when shoot info is nil", func() {
+			BeforeEach(func() {
+				b.Shoot.SetInfo(nil)
+				b.HostName = "test-hostname"
+			})
+
+			It("should use hostname as common name suffix when shoot info is not set", func() {
+				fakeKubernetesClientset.PrependReactor("create", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+				fakeKubernetesClientset.PrependReactor("get", "certificatesigningrequests", func(testing.Action) (bool, runtime.Object, error) {
+					return true, csr, nil
+				})
+
+				client, err := InitializeTemporaryClientSet(ctx, b, bootstrapClientSet)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client).NotTo(BeNil())
+
+				// Verify kubeconfig was cached
+				exists, err := fakeFS.Exists(cachedPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(exists).To(BeTrue())
+			})
+		})
+
 		Context("certificate subject verification", func() {
 			It("should use correct certificate subject when requesting CSR", func() {
 				var capturedSubject *pkix.Name

--- a/pkg/gardenadm/cmd/token/create/create_test.go
+++ b/pkg/gardenadm/cmd/token/create/create_test.go
@@ -95,25 +95,11 @@ var _ = Describe("Create", func() {
 		When("the join command should be printed", func() {
 			BeforeEach(func() {
 				Expect(command.Flags().Set("print-join-command", "true")).To(Succeed())
-				Expect(command.Flags().Set("worker-pool-name", "test-pool")).To(Succeed())
-			})
-
-			It("should fail because there are no gardener-node-agent-secrets", func() {
-				Expect(command.RunE(command, []string{token})).To(MatchError(ContainSubstring("no gardener-node-agent secrets found")))
 			})
 
 			It("should successfully print the join command", func() {
-				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-node-agent-test-pool",
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"gardener.cloud/role":        "operating-system-config",
-						"worker.gardener.cloud/pool": "test-pool",
-					},
-				}})).To(Succeed())
-
 				Expect(command.RunE(command, []string{token})).To(Succeed())
-				Eventually(stdOut).Should(Say(`gardenadm join --bootstrap-token abcdef.1234567890abcdef --ca-certificate "Y2EtZGF0YQ==" --gardener-node-agent-secret-name gardener-node-agent-test-pool some-host
+				Eventually(stdOut).Should(Say(`gardenadm join --bootstrap-token abcdef.1234567890abcdef --ca-certificate "Y2EtZGF0YQ==" some-host
 `))
 			})
 		})

--- a/pkg/gardenadm/cmd/token/create/options.go
+++ b/pkg/gardenadm/cmd/token/create/options.go
@@ -27,9 +27,6 @@ type Options struct {
 	Description string
 	// Validity duration of the bootstrap token.
 	Validity time.Duration
-	// WorkerPoolName is the name of the worker pool to use for the join command. If not provided, it is defaulted to
-	// 'worker'.
-	WorkerPoolName string
 	// Shoot contains the namespace and the name of the Shoot which should be connected to Gardener. This is only
 	// relevant for bootstrap tokens that are used for connecting self-hosted shoots via `gardenadm connect`.
 	Shoot types.NamespacedName
@@ -90,10 +87,6 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("maximum validity duration is %s", maxValidity)
 	}
 
-	if o.PrintJoinCommand && len(o.WorkerPoolName) == 0 {
-		return fmt.Errorf("must specify a worker pool name when using --print-join-command")
-	}
-
 	if o.PrintConnectCommand && (len(o.Shoot.Namespace) == 0 || len(o.Shoot.Name) == 0) {
 		return fmt.Errorf("must specify a shoot namespace and name when using --print-connect-command")
 	}
@@ -125,9 +118,10 @@ func (o *Options) Complete() error {
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Description, "description", "d", "", "Description for the bootstrap token used for 'gardenadm join'")
 	fs.DurationVarP(&o.Validity, "validity", "", time.Hour, "Validity duration of the bootstrap token. Minimum is 10m, maximum is 24h.")
+
 	fs.BoolVarP(&o.PrintJoinCommand, "print-join-command", "j", false, "Instead of only printing the token, print the full machine-readable 'gardenadm join' command that can be copied and ran on a machine that should join the cluster")
+
 	fs.BoolVarP(&o.PrintConnectCommand, "print-connect-command", "c", false, "Instead of only printing the token, print the full machine-readable 'gardenadm connect' command that can be ran on a machine of a cluster that should be connected to Gardener")
-	fs.StringVarP(&o.WorkerPoolName, "worker-pool-name", "w", "worker", "Name of the worker pool to use for the join command.")
 	fs.StringVarP(&o.Shoot.Namespace, "shoot-namespace", "", "", "Namespace of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token")
 	fs.StringVarP(&o.Shoot.Name, "shoot-name", "", "", "Name of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token")
 }

--- a/pkg/gardenadm/cmd/token/create/options.go
+++ b/pkg/gardenadm/cmd/token/create/options.go
@@ -118,9 +118,7 @@ func (o *Options) Complete() error {
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.Description, "description", "d", "", "Description for the bootstrap token used for 'gardenadm join'")
 	fs.DurationVarP(&o.Validity, "validity", "", time.Hour, "Validity duration of the bootstrap token. Minimum is 10m, maximum is 24h.")
-
 	fs.BoolVarP(&o.PrintJoinCommand, "print-join-command", "j", false, "Instead of only printing the token, print the full machine-readable 'gardenadm join' command that can be copied and ran on a machine that should join the cluster")
-
 	fs.BoolVarP(&o.PrintConnectCommand, "print-connect-command", "c", false, "Instead of only printing the token, print the full machine-readable 'gardenadm connect' command that can be ran on a machine of a cluster that should be connected to Gardener")
 	fs.StringVarP(&o.Shoot.Namespace, "shoot-namespace", "", "", "Namespace of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token")
 	fs.StringVarP(&o.Shoot.Name, "shoot-name", "", "", "Name of the Shoot which should be connected to Gardener via 'gardenadm connect' with this bootstrap token")

--- a/pkg/gardenadm/cmd/token/create/options_test.go
+++ b/pkg/gardenadm/cmd/token/create/options_test.go
@@ -41,7 +41,6 @@ var _ = Describe("Options", func() {
 			options.Token.Combined = "abcdef.abcdef1234567890"
 			options.Validity = time.Hour
 			options.PrintJoinCommand = true
-			options.WorkerPoolName = "worker-pool"
 			Expect(options.Validate()).To(Succeed())
 		})
 
@@ -64,18 +63,6 @@ var _ = Describe("Options", func() {
 			options.Token.Combined = "abcdef.abcdef1234567890"
 			options.Validity = 25 * time.Hour
 			Expect(options.Validate()).To(MatchError(ContainSubstring("maximum validity duration is 24h0m0s")))
-		})
-
-		When("the print-join-command flag is set", func() {
-			BeforeEach(func() {
-				options.PrintJoinCommand = true
-				options.Token.Combined = "abcdef.abcdef1234567890"
-			})
-
-			It("should an error when no worker pool name is provided", func() {
-				options.Validity = time.Hour
-				Expect(options.Validate()).To(MatchError(ContainSubstring("must specify a worker pool name when using --print-join-command")))
-			})
 		})
 
 		When("the print-connect-command flag is set", func() {

--- a/pkg/gardenlet/operation/botanist/shootsystem.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem.go
@@ -28,6 +28,7 @@ func (b *Botanist) DefaultShootSystem() shootsystem.Interface {
 		Extensions:            extensions,
 		ExternalClusterDomain: b.Shoot.ExternalClusterDomain,
 		IsWorkerless:          b.Shoot.IsWorkerless,
+		IsSelfHosted:          b.Shoot.IsSelfHosted(),
 		KubernetesVersion:     b.Shoot.KubernetesVersion,
 		Object:                b.Shoot.GetInfo(),
 		ProjectName:           b.Garden.Project.Name,

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1311,7 +1311,7 @@ deploy:
               - bash
               - -ec
               - |
-                for i in 0 1; do
+                for i in 0 1 2 3; do
                   pod="machine-$i"
                   kubectl -n "$SKAFFOLD_NAMESPACES" exec "$pod" -- sh -c 'rm -rf /gardenadm/resources && mkdir -p /gardenadm/resources'
                   kubectl -n "$SKAFFOLD_NAMESPACES" cp dev-setup/gardenadm/resources/generated/.skaffold-image                    "$pod:/tmp/.skaffold-image"

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -882,6 +882,30 @@ units: {}
 		})
 	})
 
+	Context("node-role label", func() {
+		When("no static Kubernetes control-plane manifests are part of the OSC files", func() {
+			It("should add the 'worker' role label", func() {
+				Eventually(func(g Gomega) map[string]string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
+					return node.Labels
+				}).Should(HaveKeyWithValue("node-role.kubernetes.io/worker", ""))
+			})
+		})
+
+		When("static Kubernetes control-plane manifests are part of the OSC files", func() {
+			BeforeEach(func() {
+				operatingSystemConfig.Spec.Files = append(operatingSystemConfig.Spec.Files, extensionsv1alpha1.File{Path: "/etc/kubernetes/manifests/kube-apiserver.yaml"})
+			})
+
+			It("should add the 'control-plane' role label", func() {
+				Eventually(func(g Gomega) map[string]string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
+					return node.Labels
+				}).Should(HaveKeyWithValue("node-role.kubernetes.io/control-plane", ""))
+			})
+		})
+	})
+
 	Context("in-place updates", func() {
 		var (
 			kubeletUnit                    extensionsv1alpha1.Unit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
- `gardener-node-agent` adds `node-role.kubernetes.io/{worker,control-plane}=""` label to shoot nodes
- `gardenadm join --control-plane` is added as preparation (doesn't contain specific logic yet, to be added in subsequent PRs)
- `gardenadm join` creates a short-lived, client-certificate-based kubeconfig (validity: `10m`), similar to `gardenadm connect`, which will be used to perform tasks during the join operation (see below)
- `gardener-resource-manager` auto-approves such client certificates
- `gardenadm token create` no longer takes a `--worker-pool-name` flag. Instead, this can now be passed to `gardenadm join`
- `gardenadm token create` no longer looks up the operating system config `Secret` for `gardener-node-agent` - this is now done by `gardenadm join`
- local setup: there are now four machine pods in the "unmanaged infra" scenario as prep for multiple control plane nodes

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:
/cc @ScheererJ @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gardener-node-agent` now labels worker nodes in shoot clusters with the `node-role.kubernetes.io/worker=""` label.
```
