### PR TITLE
[GEP-28] Update `gardenadm connect` docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,9 @@ operator-seed-up operator-seed-dev: $(SKAFFOLD) $(HELM) $(KUBECTL) operator-up g
 	TIMEOUT=900 ./hack/usage/wait-for.sh garden local VirtualGardenAPIServerAvailable RuntimeComponentsHealthy VirtualComponentsHealthy
 operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL) seed-down garden-down
 
+# gardenadm
+gardenadm:
+	go build -o ./bin/gardenadm ./cmd/gardenadm
 # gardenadm-{up,down}
 gardenadm-%: export SKAFFOLD_FILENAME = skaffold-gardenadm.yaml
 gardenadm-up: $(SKAFFOLD) $(KUBECTL)

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ operator-seed-down: $(SKAFFOLD) $(HELM) $(KUBECTL) seed-down garden-down
 
 # gardenadm
 gardenadm:
-	go build -o ./bin/gardenadm ./cmd/gardenadm
+	BUILD_OUTPUT_FILE=./bin/ BUILD_PACKAGES=./cmd/gardenadm $(MAKE) build
 # gardenadm-{up,down}
 gardenadm-%: export SKAFFOLD_FILENAME = skaffold-gardenadm.yaml
 gardenadm-up: $(SKAFFOLD) $(KUBECTL)

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -199,12 +199,50 @@ This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Ga
 Find all information about it [here](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
 Note, that in this setup, no `Seed` will be registered in the Gardener - it's just a plain garden cluster without the ability to create regular shoot clusters.
 
-Once above command is finished, you can connect the self-hosted shoot cluster to this Gardener instance:
+Once above command is finished, you can generate a command, using `gardenadm` to connect shoot cluster to this Gardener instance.
+For this, you will need the `gardenadm` binary locally installed. You can build it via:
 
 ```shell
-$ kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- bash
-root@machine-0:/# gardenadm connect
-2025-07-03T12:21:49.586Z	INFO	Command is work in progress
+make gardenadm
+```
+
+This will install it to `./bin/gardenadm`, from where you can call it.
+
+After you have this completed, you need to [target the Gardener instance](../concepts/operator.md#accessing-the-virtual-garden-cluster) from your local machine.
+Using the `gardenadm` binary you just built, you can generate the `gardenadm connect`, like this:
+
+```shell
+$ `./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root`
+# This will output a command similar to:
+gardenadm connect --bootstrap-token ... --ca-certificate ... https://api.virtual-garden.local.gardener.cloud
+```
+
+Now, exec once again into one of the control-plane machines of your self-hosted shoot cluster, and run the generated `gardenadm connect` command there:
+
+```shell
+root@machine-0:/# gardenadm connect --bootstrap-token ... --ca-certificate ... https://api.virtual-garden.local.gardener.cloud
+2025-11-10T08:12:32.287Z	INFO	Using resources from directory	{"configDir": "/gardenadm/resources/"}
+2025-11-10T08:12:32.334Z	INFO	Initializing gardenadm botanist with fake client set	{"cloudProfile": {"apiVersion": "core.gardener.cloud/v1beta1", "kind": "CloudProfile", "name": "local"}, "project": {"apiVersion": "core.gardener.cloud/v1beta1", "kind": "Project", "name": "garden"}, "shoot": {"apiVersion": "core.gardener.cloud/v1beta1", "kind": "Shoot", "namespace": "garden", "name": "root"}}
+2025-11-10T08:12:32.345Z	INFO	Starting	{"flow": "connect"}
+...
+2025-11-10T08:13:04.571Z	INFO	Succeeded	{"flow": "connect", "task": "Waiting until gardenlet is ready"}
+2025-11-10T08:13:04.571Z	INFO	Finished	{"flow": "connect"}
+```
+
+Once this is done, you can observe that there is now a `gardenlet` running in the self-hosted shoot cluster, which connects it to the Gardener instance:
+
+```shell
+root@machine-0:/# kubectl get pods -n kube-system | grep gardenlet
+gardenlet-6cbcb676f5-prh8f                           1/1     Running   0             40m
+gardenlet-6cbcb676f5-wwn8w                           1/1     Running   0             40m
+````
+
+Looking back into the Gardener instance, you can see that the self-hosted shoot cluster is now registered as a shoot cluster in Gardener:
+
+```shell
+kubectl get Shoots -A
+NAMESPACE   NAME   CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPERATION   STATUS    AGE
+garden      root   local          local      local    1.33.0        Awake         <pending>        healthy   42m
 ```
 
 ## Running E2E Tests for `gardenadm`

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -199,8 +199,8 @@ This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Ga
 Find all information about it [here](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
 Note, that in this setup, no `Seed` will be registered in the Gardener - it's just a plain garden cluster without the ability to create regular shoot clusters.
 
-Once above command is finished, you can generate a command, using `gardenadm` to connect shoot cluster to this Gardener instance.
-For this, you will need the `gardenadm` binary locally installed. You can build it via:
+Once above command is finished, you can generate a bootstrap token using `gardenadm` to connect the shoot cluster to this Gardener instance.
+For this, you must have installed the `gardenadm` binary locally. You can build it via:
 
 ```shell
 make gardenadm
@@ -208,16 +208,18 @@ make gardenadm
 
 This will install it to `./bin/gardenadm`, from where you can call it.
 
-After you have this completed, you need to [target the Gardener instance](../concepts/operator.md#accessing-the-virtual-garden-cluster) from your local machine.
-Using the `gardenadm` binary you just built, you can generate the `gardenadm connect`, like this:
+After you have completed this, you need to get a kubeconfig for [the Gardener instance](../concepts/operator.md#accessing-the-virtual-garden-cluster) you want to connect the self-hosted shoot to.
+We will refer to the path of this kubeconfig as `<path-to-garden-kubeconfig>` in the following.
+
+Now you can generate the bootstrap token and the full `gardenadm connect` command like this:
 
 ```shell
-$ `./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root`
+$ KUBECONFIG=<path-to-garden-kubeconfig> ./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root
 # This will output a command similar to:
 gardenadm connect --bootstrap-token ... --ca-certificate ... https://api.virtual-garden.local.gardener.cloud
 ```
 
-Now, exec once again into one of the control-plane machines of your self-hosted shoot cluster, and run the generated `gardenadm connect` command there:
+Copy the full output, exec once again into one of the control-plane machines of your self-hosted shoot cluster, and paste and run the generated `gardenadm connect` command there:
 
 ```shell
 root@machine-0:/# gardenadm connect --bootstrap-token ... --ca-certificate ... https://api.virtual-garden.local.gardener.cloud
@@ -237,10 +239,10 @@ gardenlet-6cbcb676f5-prh8f                           1/1     Running   0        
 gardenlet-6cbcb676f5-wwn8w                           1/1     Running   0             40m
 ````
 
-Looking back into the Gardener instance, you can see that the self-hosted shoot cluster is now registered as a shoot cluster in Gardener:
+You can also observe that the self-hosted shoot cluster is now registered as a shoot cluster in Gardener:
 
 ```shell
-kubectl get Shoots -A
+kubectl --kubeconfig=<path-to-garden-kubeconfig> get Shoots -A
 NAMESPACE   NAME   CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPERATION   STATUS    AGE
 garden      root   local          local      local    1.33.0        Awake         <pending>        healthy   42m
 ```


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

This PR updates the `gardenadm` docs to instruct how to connect a self-hosted shoot cluster to a Garden.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
