### PR TITLE
Build `gardenadm` image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,9 @@ jobs:
           - name: controller-manager
             target: controller-manager
             oci-repository: gardener/controller-manager
+          - name: gardenadm
+            target: gardenadm
+            oci-repository: gardener/gardenadm
           - name: gardenlet
             target: gardenlet
             oci-repository: gardener/gardenlet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Since the pipelines were migrated to Github, the gardenadm image was no longer published:
```
crane ls europe-docker.pkg.dev/gardener-project/releases/gardener/gardenadm | sort | tail -n 5
v1.124.2-linux-amd64
v1.124.2-linux-arm64
v1.124.3
v1.124.3-linux-amd64
v1.124.3-linux-arm64
```

This image is used as part of the managed infrastructure flow, where we bootstrap the control plane node with the gardenadm binary from the image: https://github.com/gardener/gardener/blob/master/pkg/gardenadm/botanist/operatingsystemconfig.go#L233

**Which issue(s) this PR fixes**:
Fixes missing gardenadm images.

**Special notes for your reviewer**:
/cc @jamand 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
