### PR TITLE
Use `kubernetes.io/metadata.name` label instead of `gardener.cloud/purpose` in GRM webhook namespace selectors

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1990,7 +1990,7 @@ func (r *resourceManager) buildWebhookNamespaceSelector() *metav1.LabelSelector 
 
 	return &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
-			Key:      v1beta1constants.GardenerPurpose,
+			Key:      corev1.LabelMetadataName,
 			Operator: operator,
 			Values:   []string{metav1.NamespaceSystem, "kubernetes-dashboard"},
 		}},

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -925,13 +925,13 @@ var _ = Describe("ResourceManager", func() {
 			switch responsibilityMode {
 			case ForSource:
 				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
-					Key:      "gardener.cloud/purpose",
+					Key:      "kubernetes.io/metadata.name",
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"kube-system", "kubernetes-dashboard"},
 				}}
 			case ForTarget:
 				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
-					Key:      "gardener.cloud/purpose",
+					Key:      "kubernetes.io/metadata.name",
 					Operator: metav1.LabelSelectorOpIn,
 					Values:   []string{"kube-system", "kubernetes-dashboard"},
 				}}
@@ -1323,7 +1323,7 @@ webhooks:
   name: projected-token-mount.resources.gardener.cloud
   namespaceSelector:
     matchExpressions:
-    - key: gardener.cloud/purpose
+    - key: kubernetes.io/metadata.name
       operator: In
       values:
       - kube-system
@@ -1357,7 +1357,7 @@ webhooks:
   name: high-availability-config.resources.gardener.cloud
   namespaceSelector:
     matchExpressions:
-    - key: gardener.cloud/purpose
+    - key: kubernetes.io/metadata.name
       operator: In
       values:
       - kube-system
@@ -1513,7 +1513,7 @@ webhooks:
   name: system-components-config.resources.gardener.cloud
   namespaceSelector:
     matchExpressions:
-    - key: gardener.cloud/purpose
+    - key: kubernetes.io/metadata.name
       operator: In
       values:
       - kube-system
@@ -1547,7 +1547,7 @@ webhooks:
   name: pod-topology-spread-constraints.resources.gardener.cloud
   namespaceSelector:
     matchExpressions:
-    - key: gardener.cloud/purpose
+    - key: kubernetes.io/metadata.name
       operator: In
       values:
       - kube-system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Use `kubernetes.io/metadata.name` label instead of `gardener.cloud/purpose` in GRM webhook namespace selectors. This can fix issues like https://github.com/gardener/gardener/issues/13345 where the GRM is deployed in a non-gardener-managed cluster. It's better to rely on the `kubernetes.io/metadata.name` label which is added to all namespaces automatically by Kubernetes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13345

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-resource-manager` now uses `kubernetes.io/metadata.name` label instead of `gardener.cloud/purpose` in its webhook namespace selectors. The `kubernetes.io/metadata.name` is added to all namespaces automatically by Kubernetes.
```
