### PR TITLE
Make the `.spec.provider.workers[].machine.image` field required for the Shoot resource (part 8)

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2038,12 +2038,22 @@ func ValidateWorker(worker core.Worker, kubernetes core.Kubernetes, shootNamespa
 	if len(worker.Machine.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machine", "type"), "must specify a machine type"))
 	}
-	if worker.Machine.Image != nil {
-		if len(worker.Machine.Image.Name) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "name"), "must specify a machine image name"))
+	if inTemplate {
+		if worker.Machine.Image != nil {
+			if len(worker.Machine.Image.Name) == 0 {
+				allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "name"), "must specify a machine image name"))
+			}
 		}
-		if !inTemplate && len(worker.Machine.Image.Version) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "version"), "must specify a machine image version"))
+	} else {
+		if worker.Machine.Image == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image"), "must specify a machine image"))
+		} else {
+			if len(worker.Machine.Image.Name) == 0 {
+				allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "name"), "must specify a machine image name"))
+			}
+			if len(worker.Machine.Image.Version) == 0 {
+				allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "version"), "must specify a machine image version"))
+			}
 		}
 	}
 	if worker.Minimum < 0 {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1396,6 +1396,11 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Detail": ContainSubstring("must specify a machine type"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.provider.workers[0].machine.image"),
+						"Detail": ContainSubstring("must specify a machine image"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.provider.workers[0].minimum"),
 						"Detail": ContainSubstring("minimum value must not be negative"),
@@ -4864,6 +4869,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 							Name: "worker-1",
 							Machine: core.Machine{
 								Type: "xlarge",
+								Image: &core.ShootMachineImage{
+									Name:    "image-name",
+									Version: "1.0.0",
+								},
 							},
 							Maximum:  1,
 							Minimum:  0,
@@ -4873,6 +4882,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 							Name: "worker-2",
 							Machine: core.Machine{
 								Type: "xlarge",
+								Image: &core.ShootMachineImage{
+									Name:    "image-name",
+									Version: "1.0.0",
+								},
 							},
 							Maximum:  1,
 							Minimum:  0,
@@ -7416,8 +7429,21 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Architecture: ptr.To("amd64"),
 				},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("machine.type"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("machine.type"),
+					"Detail": Equal("must specify a machine type"),
+				}))),
+			),
+			Entry("nil machine image",
+				core.Machine{
+					Type:         "large",
+					Image:        nil,
+					Architecture: ptr.To("amd64"),
+				},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("machine.image"),
+					"Detail": Equal("must specify a machine image"),
 				}))),
 			),
 			Entry("empty machine image name",
@@ -7430,8 +7456,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Architecture: ptr.To("amd64"),
 				},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("machine.image.name"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("machine.image.name"),
+					"Detail": Equal("must specify a machine image name"),
 				}))),
 			),
 			Entry("empty machine image version",
@@ -7444,8 +7471,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Architecture: ptr.To("amd64"),
 				},
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("machine.image.version"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("machine.image.version"),
+					"Detail": Equal("must specify a machine image version"),
 				}))),
 			),
 			Entry("nil machine architecture",
@@ -7982,6 +8010,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 				}
 				fldPath = field.NewPath("workers").Index(0)
@@ -8155,6 +8187,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 				}
 
@@ -8242,6 +8278,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
 					Machine: core.Machine{
 						Type: "xlarge",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 				}
 
@@ -8389,6 +8429,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker",
 				Machine: core.Machine{
 					Type: "xlarge",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxUnavailable: ptr.To(intstr.FromInt(1)),
 				Priority:       ptr.To(int32(-2)),

--- a/test/integration/controllermanager/bastion/bastion_test.go
+++ b/test/integration/controllermanager/bastion/bastion_test.go
@@ -59,6 +59,10 @@ var _ = Describe("Bastion controller tests", func() {
 							Maximum: 2,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -92,7 +92,13 @@ var _ = Describe("CredentialsBinding controller test", func() {
 							Name:    "cpu-worker",
 							Minimum: 2,
 							Maximum: 2,
-							Machine: gardencorev1beta1.Machine{Type: "large"},
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
+							},
 						},
 					},
 				},

--- a/test/integration/controllermanager/exposureclass/exposureclass_test.go
+++ b/test/integration/controllermanager/exposureclass/exposureclass_test.go
@@ -57,7 +57,13 @@ var _ = Describe("ExposureClass controller test", func() {
 							Name:    "cpu-worker",
 							Minimum: 2,
 							Maximum: 2,
-							Machine: gardencorev1beta1.Machine{Type: "large"},
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
+							},
 						},
 					},
 				},

--- a/test/integration/controllermanager/gardenletlifecycle/lifecycle_test.go
+++ b/test/integration/controllermanager/gardenletlifecycle/lifecycle_test.go
@@ -138,6 +138,10 @@ var _ = Describe("Gardenlet Lifecycle controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/managedseedset/managedseedset_test.go
+++ b/test/integration/controllermanager/managedseedset/managedseedset_test.go
@@ -191,7 +191,11 @@ var _ = Describe("ManagedSeedSet controller test", func() {
 						{
 							Name: "some-worker",
 							Machine: gardencorev1beta1.Machine{
-								Type:         "some-machine-type",
+								Type: "some-machine-type",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 								Architecture: ptr.To("amd64"),
 							},
 							Maximum:        2,

--- a/test/integration/controllermanager/project/activity/activity_test.go
+++ b/test/integration/controllermanager/project/activity/activity_test.go
@@ -206,6 +206,10 @@ var _ = Describe("Project Activity controller tests", func() {
 									Maximum: 3,
 									Machine: gardencorev1beta1.Machine{
 										Type: "large",
+										Image: &gardencorev1beta1.ShootMachineImage{
+											Name:    "some-image",
+											Version: ptr.To("1.0.0"),
+										},
 									},
 								},
 							},

--- a/test/integration/controllermanager/project/project/project_test.go
+++ b/test/integration/controllermanager/project/project/project_test.go
@@ -70,6 +70,10 @@ var _ = Describe("Project controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/project/stale/stale_test.go
+++ b/test/integration/controllermanager/project/stale/stale_test.go
@@ -111,6 +111,10 @@ var _ = Describe("Project Stale controller tests", func() {
 								Maximum: 3,
 								Machine: gardencorev1beta1.Machine{
 									Type: "large",
+									Image: &gardencorev1beta1.ShootMachineImage{
+										Name:    "some-image",
+										Version: ptr.To("1.0.0"),
+									},
 								},
 							},
 						},

--- a/test/integration/controllermanager/secretbinding/secretbinding_test.go
+++ b/test/integration/controllermanager/secretbinding/secretbinding_test.go
@@ -85,7 +85,13 @@ var _ = Describe("SecretBinding controller test", func() {
 							Name:    "cpu-worker",
 							Minimum: 2,
 							Maximum: 2,
-							Machine: gardencorev1beta1.Machine{Type: "large"},
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
+							},
 						},
 					},
 				},

--- a/test/integration/controllermanager/shoot/conditions/conditions_test.go
+++ b/test/integration/controllermanager/shoot/conditions/conditions_test.go
@@ -45,6 +45,10 @@ var _ = Describe("Shoot Conditions controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/hibernation/hibernation_test.go
+++ b/test/integration/controllermanager/shoot/hibernation/hibernation_test.go
@@ -36,6 +36,10 @@ var _ = Describe("Shoot Hibernation controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/migration/migration_test.go
+++ b/test/integration/controllermanager/shoot/migration/migration_test.go
@@ -46,6 +46,10 @@ var _ = Describe("Shoot Migration controller tests", Ordered, func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/quota/quota_test.go
+++ b/test/integration/controllermanager/shoot/quota/quota_test.go
@@ -96,6 +96,10 @@ var _ = Describe("Shoot Quota controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/reference/reference_test.go
+++ b/test/integration/controllermanager/shoot/reference/reference_test.go
@@ -69,6 +69,10 @@ var _ = Describe("Shoot Reference controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/retry/retry_test.go
+++ b/test/integration/controllermanager/shoot/retry/retry_test.go
@@ -35,6 +35,10 @@ var _ = Describe("Shoot retry controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shoot/statuslabel/statuslabel_test.go
+++ b/test/integration/controllermanager/shoot/statuslabel/statuslabel_test.go
@@ -37,6 +37,10 @@ var _ = Describe("Shoot StatusLabel controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/controllermanager/shootstate/shootstate_test.go
+++ b/test/integration/controllermanager/shootstate/shootstate_test.go
@@ -44,6 +44,10 @@ var _ = Describe("ShootState controller test", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -218,6 +218,10 @@ var _ = Describe("BackupEntry controller tests", func() {
 							Maximum: 2,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/gardenlet/bastion/bastion_test.go
+++ b/test/integration/gardenlet/bastion/bastion_test.go
@@ -121,6 +121,10 @@ var _ = Describe("Bastion controller tests", func() {
 							Maximum: 2,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -132,7 +132,11 @@ var _ = Describe("ManagedSeed controller test", func() {
 						{
 							Name: "some-worker",
 							Machine: gardencorev1beta1.Machine{
-								Type:         "some-machine-type",
+								Type: "some-machine-type",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 								Architecture: ptr.To("amd64"),
 							},
 							Maximum: 2,

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -94,6 +94,10 @@ var _ = Describe("Shoot Care controller tests", func() {
 							Maximum: 3,
 							Machine: gardencorev1beta1.Machine{
 								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-image",
+									Version: ptr.To("1.0.0"),
+								},
 							},
 						},
 					},

--- a/test/integration/gardenlet/shoot/lease/lease_suite_test.go
+++ b/test/integration/gardenlet/shoot/lease/lease_suite_test.go
@@ -129,6 +129,10 @@ var _ = BeforeSuite(func() {
 						Maximum: 2,
 						Machine: gardencorev1beta1.Machine{
 							Type: "large",
+							Image: &gardencorev1beta1.ShootMachineImage{
+								Name:    "some-image",
+								Version: ptr.To("1.0.0"),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR is part 8 of https://github.com/gardener/gardener/issues/2158. The end goal of https://github.com/gardener/gardener/issues/2158 is to move all mutations from the `ShootValidator` admission plugin to the new `ShootMutator` admission plugin.

This PR addresses is a follow-up after the ShootValidator is now a validating admission plugin.

https://github.com/gardener/gardener/commit/a2b4ac263ca2b98fc25de13add40ec302fd75c3b made the Shoot `.spec.provider.workers[].machine.image` field required. With the introduction of the ManagedSeedSet API, the mentioned validation was relaxed with https://github.com/gardener/gardener/pull/3643/commits/ab4e094e5fc4e89f57468b633f9bfcada4d99d28. The last commit adapted the validation so that the `.spec.provider.workers[].machine.image` field is no longer required for the Shoot resource. I am not sure if this was the desired behaviour. The field might not be required for the Shoot template in the ManagedSeedSet API but it is required for a Shoot.

My motivation for this follow-up PR is the following:

Before the changes from https://github.com/gardener/gardener/issues/2158 the `ShootValidator` admission plugin was mutating one. It was defaulting the `.spec.provider.workers[].machine.image` field if it was not specified. https://github.com/gardener/gardener/pull/13138 recently introduced a change in the ShootValidator to access `.spec.provider.workers[].machine.image.version` assuming that `.spec.provider.workers[].machine` is already defaulted.

If you create a Shoot before the split of the `ShootValidator` admission plugin with `.spec.provider.workers[].machine=nil` and with the `ShootValidator` admission plugin disabled, then the Shoot creation fails. The OSCs are created with `.spec.type=""` and are not reconciled at all.

If you create a Shoot after the split of the `ShootValidator` admission plugin with `.spec.provider.workers[].machine=nil`  and with the `ShootMutator` admission plugin disabled, then `ShootValidator` panics accessing the `.spec.provider.workers[].machine.image.version` field.

That's why I decided to add validation in the storage layer `.spec.provider.workers[].machine.image` to be a required field. It is required for a successful Shoot creation. 

**Which issue(s) this PR fixes**:
Last part of https://github.com/gardener/gardener/issues/2158

**Special notes for your reviewer**:
~~This PR is based on https://github.com/gardener/gardener/pull/13352. Hence, it is in draft state until https://github.com/gardener/gardener/pull/13352 is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-apiserver:  The Shoot `.spec.provider.workers[].machine.image` field  is now a required field. This change has impact only when the `ShootMutator` admission plugin (which defaults the machine image) is disabled. The admission plugin is enabled by default.
```
