### PR TITLE
📖 Gardener Upgrade Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -254,6 +254,7 @@
 ## Operations
 
 * [Gardener configuration and usage](operations/configuration.md)
+* [Gardener Upgrade Guide](operations/upgrade-gardener.md)
 * [Control Plane Migration](operations/control_plane_migration.md)
 * [Immutable Backup Buckets](operations/immutable-backup-buckets.md)
 * [Istio](operations/istio.md)

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -16,8 +16,8 @@ For more information, see the [Releases document](../development/process.md#rele
 ### Supported Version Skew
 
 Technically, we follow the same [policy](https://kubernetes.io/releases/version-skew-policy/) as the Kubernetes project.
-However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip versions, though we do not test these upgrade paths.
-Consequently, in general it might not work, and to be on the safe side, it is highly recommended to follow the described policy.
+However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip minor versions, though we do not test these upgrade paths.
+Consequently, in general it might not work, and to be on the safe side, it is highly recommended to follow the described policy and increment the minor version only one step at a time.
 
 🚨 Note that downgrading Gardener versions is generally not tested during development and should be considered unsupported.
 

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -19,7 +19,10 @@ Technically, we follow the same [policy](https://kubernetes.io/releases/version-
 However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it might be possible to skip minor versions, though we do not test these upgrade paths.
 Consequently, in general it might not work, and to be on the safe side, it is highly recommended to follow the described policy and increment the minor version only one step at a time.
 
-🚨 Note that downgrading Gardener versions is generally not tested during development and should be considered unsupported.
+>[!NOTE]
+> 🚨 Downgrading Gardener versions is generally not tested during development and should be considered unsupported.
+
+Please also take a look at the [Gardener upgrade guide](../operations/upgrade-gardener.md).
 
 #### gardener-apiserver
 

--- a/docs/operations/upgrade-gardener.md
+++ b/docs/operations/upgrade-gardener.md
@@ -1,0 +1,107 @@
+# Gardener Upgrade Guide
+
+Upgrading Gardener affects the operator, the control plane, `gardenlet`s, managed seeds, shoots, and node operating system configurations.
+A safe upgrade follows a predictable sequence and respects Gardener's reconciliation and rollout behavior.
+
+## 1. Prepare Before Touching Anything
+
+Familiarize yourself with the [version skew policy](../deployment/version_skew_policy.md).
+
+Start by reading the [release notes](https://github.com/gardener/gardener/releases) of the target version you would like to deploy.
+They describe breaking changes, new features, bug fixes and version increments.
+
+Make sure to apply the breaking changes (if there are any) to your deployment manifests before increasing any version fields.
+This prevents the Gardener components from starting with incompatible configuration.
+
+### Deprecations and Backwards-Compatibility
+
+Gardener's breaking change policy is conservative.
+You can read all about it [here](../development/process.md#deprecations-and-backwards-compatibility).
+Release notes clearly signal when manual migrations are required.
+
+- Changes that affect the `Shoot` API surface are usually bundled with a Kubernetes minor version upgrade.
+  For example, if a field may no longer be set, this usually takes only effect with a new Kubernetes minor version.
+- Changes that affect operator-related APIs (those, end-users cannot write, like `Garden` or `Seed`) are usually deprecated first and only removed after three Gardener minor releases.
+- Changes that affect extensions or their related APIs are usually deprecated first and only removed after nine Gardener minor versions.
+
+## 2. Upgrade `gardener-operator` and Gardener Control Plane
+
+Once your manifests match the target release, deploy the new `gardener-operator` [Helm chart](../../charts/gardener/operator).
+After it comes up, it starts reconciling the `Garden` resource.
+This also rolls out new versions of the Gardener control plane components (`gardener-apiserver`, `gardener-controller-manager`, etc.).
+
+### Verify Readiness
+
+Before continuing, wait for the `Garden` reconciliation to be successful and ensure that
+
+- the `gardener.cloud/operation` annotation is no longer set.
+- `.status.gardener.version` matches your target version.
+- `.status.observedGeneration` matches `.metadata.generation`.
+- `.status.lastOperation.state` is `Succeeded`
+
+At this point, the `gardenlet`s still run the old version.
+This is normal and expected/supported (similar to Kubernetes where the control plane is updated before the `kubelet`s).
+
+Verify that the `.status.conditions[]` in the `Garden` resource (health checks) report status `True`.
+
+## 3. Upgrade Your `gardenlet`s and Extensions
+
+### Unmanaged Seeds
+
+We start by upgrading the `gardenlet`s responsible for unmanaged seed clusters (i.e., `Seed`s which are not backed by a `Shoot`).
+Unmanaged seed clusters should be represented by `Gardenlet` resources in the `garden` namespace (see [this](../deployment/deploy_gardenlet_manually.md#self-upgrades) for more information).
+
+After a successful `Garden` reconciliation, `gardener-operator` automatically updates the `.spec.deployment.helm.ociRepository.ref` to its own version in all `Gardenlet` resources labeled with `operator.gardener.cloud/auto-update-gardenlet-helm-chart-ref=true`.
+`gardenlet`s then update themselves via their "self-upgrade" functionality.
+
+If you prefer to manage the `Gardenlet` resources via GitOps, Flux, or similar tools, then you should better manage the `.spec.deployment.helm.ociRepository.ref` field yourself and not label the resources as mentioned above (to prevent `gardener-operator` from interfering with your desired state).
+In this case, make sure to now apply your `Gardenlet` resources (potentially containing a new version).
+
+### Managed Seeds
+
+When a `gardenlet` comes up, it starts reconciling `ManagedSeed` resources automatically.
+No manual action from your side is required.
+If the backing `Shoot` is currently reconciled, this must be finished first before the `ManagedSeed` reconciliation can be started.
+
+Note that such reconciliations are jittered, so they will not converge instantly.
+This protects the system from bursts of control-plane load.
+The jitter period is `5m` by default and can be changed in `gardenlet`'s [component configuration](../../example/20-componentconfig-gardenlet.yaml) by setting `.controllers.managedSeed.syncJitterPeriod`.
+You can set it to `0` if you don't want to have this behaviour (thus, speed up the rollouts of `gardenlet`s in `ManagedSeed`s), or increase this if you have a lot of seed clusters in your installation.
+
+### Extensions
+
+Extensions might be updated by bumping the version in their respective `ControllerDeployment` resource.
+You can do this in parallel or after the `gardenlet` deployment — just make sure that compatibility is ensured by being aware of the extension's release notes.
+
+### Verify Readiness
+
+To ensure your seed clusters are updated (i.e., `gardenlet`s got rolled out everywhere), check your `Seed` resources and ensure that
+
+- `.status.gardener.version` matches your target version. 
+
+Verify that the `.status.conditions[]` in the `Seed` resource (health checks) report status `True`.
+
+## 4. Shoot Reconciliations
+
+By default, `Shoot`s are reconciled immediately after `gardenlet` comes up.
+This might be fine for small Gardener installations, but usually, end-users don't expect such behaviour and rather want their clusters getting reconciled within a maintenance time window they specified.
+You can read more about this [here](../usage/shoot/shoot_maintenance.md#cluster-reconciliation).
+Change the behaviour by setting `.controllers.shoot.reconcileInMaintenanceOnly=true` in the `gardenlet` [component configuration](../../example/20-componentconfig-gardenlet.yaml).
+
+If this is turned on, all `Shoot`s will be reconciled within the next 24 hours.
+
+### Operating System Config Updates
+
+Similar to how `ManagedSeed` reconciliations are jittered, the updates of the operating system config on worker nodes of shoot clusters is also jittered.
+Such changes might involve `kubelet` restarts or other things, and in order to spread the load, nodes are not all updated in parallel.
+By default, all nodes are updated within `5m`.
+If you want to lower or increase this (minimum is `0` meaning all nodes are updated in parallel, maximum is `1800`) you can annotate your `Shoot`s with `shoot.gardener.cloud/cloud-config-execution-max-delay-seconds`.
+
+## Image Vector and Overwrites
+
+`gardener-operator`, `gardenlet`, and extensions have [image vectors](../../imagevector/containers.yaml) that describe the list of container images they deploy.
+If you prefer to not use the images from the open-source repositories but rather replicate them into your own registry, please follow the instructions described [here](../deployment/image_vector.md).
+
+Generally, each Gardener (and extension) release contains a GitHub release asset called `component-descriptor.yaml`.
+You can look it up to examine the complete list of container images deployed by this component.
+Use it to replicate them to your own registry and generate the overwrite as described in the document linked above.

--- a/docs/operations/upgrade-gardener.md
+++ b/docs/operations/upgrade-gardener.md
@@ -59,7 +59,14 @@ You can upgrade extensions by updating the version in their `ControllerDeploymen
 
 ### Verify Readiness
 
-To confirm that all your seed clusters are updated, check each `Seed` resource and verify that its `.status.gardener.version` matches your target version. Also, ensure all health checks in the `Seed`'s status conditions report `True`.
+To confirm that all your seed clusters are updated, check the following for each `Seed` resource:
+
+- The `gardener.cloud/operation` annotation is removed, indicating the operation is complete.
+- The `.status.gardener.version` field shows your target version.
+- The `.status.observedGeneration` matches the `.metadata.generation`, meaning the latest configuration has been processed.
+- The `.status.lastOperation.state` is `Succeeded`.
+
+Finally, check the health conditions (`.status.conditions[]`) in the `Seed` resources to ensure they all report `True`.
 
 ## 4. Shoot Reconciliations
 

--- a/docs/operations/upgrade-gardener.md
+++ b/docs/operations/upgrade-gardener.md
@@ -49,6 +49,15 @@ Gardener components and extensions use an "image vector" to define the specific 
 
 Each Gardener release includes a `component-descriptor.yaml` file as a release asset. This file lists all container images for that version. You can use this list to pull the images, push them to your private registry, and generate the necessary configuration overwrite.
 
+### Extensions
+
+With `gardener-operator`, extensions should always be installed via the `operator.gardener.cloud/v1alpha1.Extension` API in the runtime cluster.
+In order to upgrade them, update their OCI references in these `Extension` resources.
+
+In case you also have extensions manually deployed to the (virtual) garden cluster (not recommended), update the version in their `ControllerDeployment` resources.
+
+In both cases, make sure to always check the extension's release notes to ensure compatibility with the Gardener version.
+
 ### Verify Readiness
 
 Before moving to the next step, you must verify that the `Garden` resource has been successfully updated. Check the following:
@@ -61,10 +70,11 @@ Before moving to the next step, you must verify that the `Garden` resource has b
 At this stage, it's normal for the `gardenlet`s to still be running the old version. This is similar to how Kubernetes upgrades its control plane before the `kubelet`s on worker nodes.
 
 Finally, check the health conditions (`.status.conditions[]`) in the `Garden` resource to ensure they all report `True`.
+Also check the health conditions in the `operator.gardener.cloud/v1alpha1.Extension` resources and ensure they all report `True`.
 
-## 3. Upgrade Your `gardenlet`s and Extensions
+## 3. Upgrade Your `gardenlet`s
 
-Next, upgrade the `gardenlet`s (and optionally your Gardener extensions).
+Next, upgrade the `gardenlet`s.
 
 ### Unmanaged Seeds
 
@@ -79,15 +89,6 @@ Alternatively, if you manage your `Gardenlet` resources with a GitOps tool like 
 Once a `gardenlet` is upgraded, it automatically begins upgrading any "managed" seeds it controls. No manual action is needed for this step. Note that a `ManagedSeed` upgrade will wait until any ongoing reconciliation of its underlying `Shoot` cluster is complete.
 
 To prevent overloading the system, these upgrades are staggered using a "jitter" period, so they won't all start at once. By default, this period is 5 minutes. You can adjust it in the `gardenlet`'s [component configuration](../../example/20-componentconfig-gardenlet.yaml) by setting `.controllers.managedSeed.syncJitterPeriod`. Set it to `0` to start all upgrades immediately, or increase it if you have many seed clusters to manage the load.
-
-### Extensions
-
-With `gardener-operator`, extensions should always be installed via the `operator.gardener.cloud/v1alpha1.Extension` API in the runtime cluster.
-In order to upgrade them, update their OCI references in these `Extension` resources.
-
-In case you also have extensions manually deployed to the (virtual) garden cluster (not recommended), update the version in their `ControllerDeployment` resources.
-
-In both cases, make sure to always check the extension's release notes to ensure compatibility with the Gardener version.
 
 ### Verify Readiness
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new document describing the steps and good information for how to upgrade a Gardener installation.

**Special notes for your reviewer**:
cc @Nuckal777 @defo89 @goerangudat @videlov @SchwarzM @databus23 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
A new guide has been added containing instruction and information about how to upgrade a Gardener installation.
```
