### PR TITLE
Adjust Istio Gateway dashboard to show correct resource consumption

### DIFF
--- a/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-ingress-gateway-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-ingress-gateway-dashboard.json
@@ -15,8 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 23,
-  "iteration": 1679041083994,
+  "iteration": 1762761234731,
   "links": [],
   "panels": [
     {
@@ -58,7 +57,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -169,7 +168,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -280,7 +279,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -383,7 +382,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -486,7 +485,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -589,7 +588,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -692,7 +691,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -796,7 +795,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.43",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -885,9 +884,13 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": "${datasource}",
         "definition": "container_cpu_usage_seconds_total{container=\"istio-proxy\"}",
@@ -917,7 +920,6 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],

--- a/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-ingress-gateway-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden-seed/istio/istio-ingress-gateway-dashboard.json
@@ -64,9 +64,17 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$istio_proxy_pod\"}[$__rate_interval]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "_total",
+          "refId": "B"
+        },
         {
           "exemplar": true,
           "expr": "rate(container_cpu_usage_seconds_total{pod=~\"$istio_proxy_pod\"}[$__rate_interval])",
@@ -167,9 +175,17 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(container_memory_working_set_bytes{pod=~\"istio-ingress.*\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "_total",
+          "refId": "A"
+        },
         {
           "exemplar": true,
           "expr": "container_memory_working_set_bytes{pod=~\"$istio_proxy_pod\"}",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Prior to this change, a bug with stacked graphs caused Plutono to show
only the resource usage of pods that were running at the end of the query
time range. For time ranges longer than the default 30m, this caused the
visual effect of istio ingressgateway resource consumption rising when pods
were replaced.

This commit removes the stacking and introduces a `_total` metric that
sums over all *selected* istio ingressgateway pods. It can still be hidden
by shift-clicking it in the legend below the graph.

To illustrate, a few screenshots:
<details>
 <summary>Before:</summary>
 
<img width="1447" height="306" alt="Screenshot 2025-11-10 at 16 07 00" src="https://github.com/user-attachments/assets/236dbb15-0c55-4bdc-9654-53846678b237" />

</details>

<details>
 <summary>After (with total):</summary>
 
<img width="1439" height="317" alt="Screenshot 2025-11-10 at 16 06 29" src="https://github.com/user-attachments/assets/57dbb6af-c476-4a09-a1b8-b0f7614392bf" />

</details>

<details>
 <summary>After (total deselected):</summary>
 
<img width="1456" height="355" alt="Screenshot 2025-11-10 at 16 06 44" src="https://github.com/user-attachments/assets/c5530038-a790-4ac8-862e-304007bd344c" />

</details>

**Which issue(s) this PR fixes**:
Fixes an issue with the istio gateway dashboard 📈 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The Istio Gateway dashboard now correctly displays the total resource usage across pod restarts.
```
