### PR TITLE
Deactivate `UnauthenticatedHTTP2DOSMitigation` for kube-apiservers where `IstioTLSTermination` is active

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           protocolDetectionTimeout: 100ms
           runtimeValues:
             "overload.global_downstream_max_connections": "750000"
+            # Limits for mitigating HTTP/2 "Rapid Reset" DoS Vulnerability
+            # See also https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76
+            "overload.premature_reset_total_stream_count": "100"
+            "overload.premature_reset_min_stream_lifetime_seconds": "1"
     spec:
       serviceAccountName: istio-ingressgateway-service-account
       securityContext:

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -33,6 +33,10 @@ spec:
           protocolDetectionTimeout: 100ms
           runtimeValues:
             "overload.global_downstream_max_connections": "750000"
+            # Limits for mitigating HTTP/2 "Rapid Reset" DoS Vulnerability
+            # See also https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76
+            "overload.premature_reset_total_stream_count": "100"
+            "overload.premature_reset_min_stream_lifetime_seconds": "1"
     spec:
       serviceAccountName: istio-ingressgateway-service-account
       securityContext:

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -65,6 +65,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		v1beta1constants.PriorityClassNameShootControlPlane500,
 		b.Shoot.IsWorkerless,
 		b.Shoot.RunsControlPlane(),
+		b.ShootUsesIstioTLSTermination(),
 		nil,
 		nil,
 		nil,

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -740,6 +740,7 @@ func (r *Reconciler) newKubeAPIServer(
 		v1beta1constants.PriorityClassNameGardenSystem500,
 		true,
 		false,
+		features.DefaultFeatureGate.Enabled(features.IstioTLSTermination),
 		auditWebhookConfig,
 		authenticationWebhookConfig,
 		authorizationWebhookConfigs,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane robustness
/kind bug

**What this PR does / why we need it**:
Kubernetes `UnauthenticatedHTTP2DOSMitigation` feature gate does not work well Gardener feature gate `IstioTLSTermination` aka L7 load-balancing.

With `UnauthenticatedHTTP2DOSMitigation` enabled the kube-apiserver closes the connection after each unauthenticated request ([ref](https://github.com/kubernetes/kubernetes/blob/7f80af819776159ba397fff39cef8b69196c8755/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go#L111-L121)).
In the L7 load-balancing case this means the connection between the istio-ingressgateway and kube-apiserver is closed while the connection between the client and istio-ingressgateway remains untouched. This is not desired since the connection between istio-ingressgateway and kube-apiserver can be shared by multiple clients. A single unauthenticated request could interrupt multiple watches established by other clients.

Thus, this PR sets `UnauthenticatedHTTP2DOSMitigation` feature gate to `false` for all kube-apiservers which use L7 load-balancing. This is also recommended in the PR https://github.com/kubernetes/kubernetes/pull/121120 which implemented this feature. It also overwrites the feature gate to false, if the it is explicitly set to true in the shoot configuration.
Security wise this has no impact, since it does not affect the connection between the client and the kube-apiserver anyway in this scenario.

When L7 load-balancing is used Istio/Envoy are responsible to mitigate attacks. Envoy took measurement to mitigate the HTTP/2 "Rapid Reset" DoS Vulnerability. 
It uses a different approach and counts the number of RST_STREAM frames in a time frame. If it is too high, the connection is closed (for details please see https://github.com/envoyproxy/envoy/security/advisories/GHSA-jhv4-f7mr-xx76).
The mitigation implemented in Envoy considers unauthenticated and authenticated users, while the latter are still an open issue for Kubernetes (see https://github.com/kubernetes/kubernetes/issues/121197)
This PR also tightens the default limit and reduces `overload.premature_reset_total_stream_count` to `100` (500 by default).

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ @plkokanov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`UnauthenticatedHTTP2DOSMitigation` feature gate is now always disabled for kube-apiservers where `IstioTLSTermination` (aka L7 load-balancing) is activated. This prevents unwanted side-effects when unauthenticated requests are sent. HTTP/2 "Rapid Reset" DoS Vulnerability is mitigated by Envoy in this case.
```
