### PR TITLE
Do not set `Cache{Una,A}uthorizedRequests` fields in authorization configuration of `kube-apiserver`.

### DIFF
--- a/pkg/component/kubernetes/apiserver/authorization.go
+++ b/pkg/component/kubernetes/apiserver/authorization.go
@@ -56,6 +56,12 @@ func (k *kubeAPIServer) reconcileConfigMapAuthorizationConfig(ctx context.Contex
 	}
 
 	for _, webhook := range k.values.AuthorizationWebhooks {
+		// For Kubernetes versions < 1.34 the Cache{Una,A}uthorizedRequests fields do not exist.
+		if versionutils.ConstraintK8sLess134.Check(k.values.Version) {
+			webhook.CacheAuthorizedRequests = nil
+			webhook.CacheUnauthorizedRequests = nil
+		}
+
 		config := apiserverv1beta1.AuthorizerConfiguration{
 			Type:    "Webhook",
 			Name:    webhook.Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:

Do not set `Cache{Una,A}uthorizedRequests` fields in authorization configuration of `kube-apiserver`.

These fields are automatically defaulted, but they are not understood by older kubernetes releases as they are not present. Therefore, we need to unset them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

After #13238 shoot clusters < `v1.34` using the authorization configuration ran into the following issue because the new `Cache{Una,A}uthorizedRequests` fields are defaulted. 

```
E1110 09:40:36.960859       1 run.go:72] "command failed" err="failed to load AuthorizationConfiguration from file: strict decoding error: unknown field \"authorizers[2].webhook.cacheAuthorizedRequests\", unknown field \"authorizers[2].webhook.cacheUnauthorizedRequests\""
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```

Co-authored-by: @AleksandarSavchev 