### PR TITLE
[GEP-28] Introduce `.spec.files[].hostName` in `OperatingSystemConfig` to allow node-specific configuration/files

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3262,6 +3262,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>NodeName contains the name of the node for node-specific configurations.
 If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.</p>
 </td>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3256,15 +3256,15 @@ FileContent
 </tr>
 <tr>
 <td>
-<code>nodeName</code></br>
+<code>hostName</code></br>
 <em>
 string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeName contains the name of the node for node-specific configurations.
-If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.</p>
+<p>HostName contains the name of the host for host-specific configurations.
+If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3254,6 +3254,18 @@ FileContent
 <p>Content describe the file&rsquo;s content.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>nodeName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>NodeName contains the name of the node for node-specific configurations.
+If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="extensions.gardener.cloud/v1alpha1.FileCodecID">FileCodecID

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -3264,7 +3264,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>HostName contains the name of the host for host-specific configurations.
-If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.</p>
+If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/extensions/resources/operatingsystemconfig.md
+++ b/docs/extensions/resources/operatingsystemconfig.md
@@ -298,9 +298,9 @@ If the `hostName` field is not set, the file will be applied to all nodes of the
 
 > [!NOTE]
 > Files need to be unique per `OperatingSystemConfig` resource, meaning that you cannot have two files with the same `path`.
-The rule is enforced by the `OperatingSystemConfig` validation.
-The only exception to this rule are host-specific files.
-You can have duplicate `path` entries in the same `OperatingSystemConfig` if `hostName` is set for all of them and the values of the `hostName` fields are different.
+> The rule is enforced by the `OperatingSystemConfig` validation.
+> The only exception to this rule are host-specific files.
+> You can have duplicate `path` entries in the same `OperatingSystemConfig` if `hostName` is set for all of them and the values of the `hostName` fields are different.
 
 ## CRI Support
 

--- a/docs/extensions/resources/operatingsystemconfig.md
+++ b/docs/extensions/resources/operatingsystemconfig.md
@@ -296,7 +296,8 @@ For example, this allows to have node-specific certificates to be distributed to
 
 If the `hostName` field is not set, the file will be applied to all nodes of the worker pool as usual.
 
-:information_source: Files need to be unique per `OperatingSystemConfig` resource, meaning that you cannot have two files with the same `path`.
+> [!NOTE]
+> Files need to be unique per `OperatingSystemConfig` resource, meaning that you cannot have two files with the same `path`.
 The rule is enforced by the `OperatingSystemConfig` validation.
 The only exception to this rule are host-specific files.
 You can have duplicate `path` entries in the same `OperatingSystemConfig` if `hostName` is set for all of them and the values of the `hostName` fields are different.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -252,10 +252,10 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
-                    nodeName:
+                    hostName:
                       description: |-
-                        NodeName contains the name of the node for node-specific configurations.
-                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                        HostName contains the name of the host for host-specific configurations.
+                        If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
                       type: string
                     path:
                       description: Path is the path of the file system where the file
@@ -515,10 +515,10 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
-                    nodeName:
+                    hostName:
                       description: |-
-                        NodeName contains the name of the node for node-specific configurations.
-                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                        HostName contains the name of the host for host-specific configurations.
+                        If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
                       type: string
                     path:
                       description: Path is the path of the file system where the file

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -252,6 +252,11 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
+                    nodeName:
+                      description: |-
+                        NodeName contains the name of the node for node-specific configurations.
+                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                      type: string
                     path:
                       description: Path is the path of the file system where the file
                         should get written to.
@@ -510,6 +515,11 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
+                    nodeName:
+                      description: |-
+                        NodeName contains the name of the node for node-specific configurations.
+                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                      type: string
                     path:
                       description: Path is the path of the file system where the file
                         should get written to.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -256,6 +256,7 @@ spec:
                       description: |-
                         HostName contains the name of the host for host-specific configurations.
                         If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+                        Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.
                       type: string
                     path:
                       description: Path is the path of the file system where the file
@@ -519,6 +520,7 @@ spec:
                       description: |-
                         HostName contains the name of the host for host-specific configurations.
                         If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+                        Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.
                       type: string
                     path:
                       description: Path is the path of the file system where the file

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -148,7 +148,8 @@ type File struct {
 	Content FileContent `json:"content"`
 	// NodeName contains the name of the node for node-specific configurations.
 	// If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
-	NodeName string `json:"nodeName,omitempty"`
+	// +optional
+	NodeName *string `json:"nodeName,omitempty"`
 }
 
 // FileContent can either reference a secret or contain inline configuration.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -146,6 +146,9 @@ type File struct {
 	Permissions *uint32 `json:"permissions,omitempty"`
 	// Content describe the file's content.
 	Content FileContent `json:"content"`
+	// NodeName contains the name of the node for node-specific configurations.
+	// If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+	NodeName string `json:"nodeName,omitempty"`
 }
 
 // FileContent can either reference a secret or contain inline configuration.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -146,10 +146,10 @@ type File struct {
 	Permissions *uint32 `json:"permissions,omitempty"`
 	// Content describe the file's content.
 	Content FileContent `json:"content"`
-	// NodeName contains the name of the node for node-specific configurations.
-	// If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+	// HostName contains the name of the host for host-specific configurations.
+	// If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
 	// +optional
-	NodeName *string `json:"nodeName,omitempty"`
+	HostName *string `json:"hostName,omitempty"`
 }
 
 // FileContent can either reference a secret or contain inline configuration.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -148,6 +148,7 @@ type File struct {
 	Content FileContent `json:"content"`
 	// HostName contains the name of the host for host-specific configurations.
 	// If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+	// Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.
 	// +optional
 	HostName *string `json:"hostName,omitempty"`
 }

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1142,8 +1142,8 @@ func (in *File) DeepCopyInto(out *File) {
 		**out = **in
 	}
 	in.Content.DeepCopyInto(&out.Content)
-	if in.NodeName != nil {
-		in, out := &in.NodeName, &out.NodeName
+	if in.HostName != nil {
+		in, out := &in.HostName, &out.HostName
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -1142,6 +1142,11 @@ func (in *File) DeepCopyInto(out *File) {
 		**out = **in
 	}
 	in.Content.DeepCopyInto(&out.Content)
+	if in.NodeName != nil {
+		in, out := &in.NodeName, &out.NodeName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -342,9 +342,9 @@ func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.E
 			}
 		}
 
-		if file.NodeName != nil {
-			for _, msg := range apivalidation.NameIsDNSSubdomain(*file.NodeName, false) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("nodeName"), *file.NodeName, msg))
+		if file.HostName != nil {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(*file.HostName, false) {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("hostName"), *file.HostName, msg))
 			}
 		}
 	}

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -341,6 +341,12 @@ func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.E
 				allErrs = append(allErrs, field.Required(idxPath.Child("content", "imageRef", "filePathInImage"), "field is required"))
 			}
 		}
+
+		if len(file.NodeName) > 0 {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(file.NodeName, false) {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("nodeName"), file.NodeName, msg))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -342,9 +342,9 @@ func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.E
 			}
 		}
 
-		if len(file.NodeName) > 0 {
-			for _, msg := range apivalidation.NameIsDNSSubdomain(file.NodeName, false) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("nodeName"), file.NodeName, msg))
+		if file.NodeName != nil {
+			for _, msg := range apivalidation.NameIsDNSSubdomain(*file.NodeName, false) {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("nodeName"), *file.NodeName, msg))
 			}
 		}
 	}

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -222,6 +222,11 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 					Path:    "path6",
 					Content: osc.Spec.Files[0].Content,
 				},
+				{
+					Path:     "path7",
+					Content:  osc.Spec.Files[0].Content,
+					NodeName: "-&#39;invalid&#39;",
+				},
 			}
 
 			Expect(ValidateOperatingSystemConfig(oscCopy)).To(ConsistOf(
@@ -274,6 +279,9 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),
 					"Field": Equal("status.extensionFiles[4].path"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.extensionFiles[5].nodeName"),
 				})),
 			))
 		})

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -225,7 +225,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				{
 					Path:     "path7",
 					Content:  osc.Spec.Files[0].Content,
-					NodeName: "-&#39;invalid&#39;",
+					NodeName: ptr.To("-&#39;invalid&#39;"),
 				},
 			}
 

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -225,7 +225,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				{
 					Path:     "path7",
 					Content:  osc.Spec.Files[0].Content,
-					NodeName: ptr.To("-&#39;invalid&#39;"),
+					HostName: ptr.To("-&#39;invalid&#39;"),
 				},
 			}
 
@@ -281,7 +281,7 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 					"Field": Equal("status.extensionFiles[4].path"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("status.extensionFiles[5].nodeName"),
+					"Field": Equal("status.extensionFiles[5].hostName"),
 				})),
 			))
 		})

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -237,6 +237,15 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 					Content:  osc.Spec.Files[0].Content,
 					HostName: ptr.To("my-node"),
 				},
+				{
+					Path:    "path9",
+					Content: osc.Spec.Files[0].Content,
+				},
+				{
+					Path:     "path9",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node"),
+				},
 			}
 
 			Expect(ValidateOperatingSystemConfig(oscCopy)).To(ConsistOf(
@@ -295,6 +304,9 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),
 					"Field": Equal("status.extensionFiles[7].path"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("status.extensionFiles[9].path"),
 				})),
 			))
 		})
@@ -304,21 +316,12 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 			oscCopy.Spec.Units = nil
 			oscCopy.Spec.Files = []extensionsv1alpha1.File{
 				{
-					Path:    "path1",
-					Content: osc.Spec.Files[0].Content,
-				},
-				{
 					Path:     "path1",
 					Content:  osc.Spec.Files[0].Content,
 					HostName: ptr.To("my-node"),
 				},
 				{
-					Path:     "path2",
-					Content:  osc.Spec.Files[0].Content,
-					HostName: ptr.To("my-node"),
-				},
-				{
-					Path:     "path2",
+					Path:     "path1",
 					Content:  osc.Spec.Files[0].Content,
 					HostName: ptr.To("my-node-2"),
 				},

--- a/pkg/apis/extensions/validation/operatingsystemconfig_test.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig_test.go
@@ -227,6 +227,16 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 					Content:  osc.Spec.Files[0].Content,
 					HostName: ptr.To("-&#39;invalid&#39;"),
 				},
+				{
+					Path:     "path8",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node"),
+				},
+				{
+					Path:     "path8",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node"),
+				},
 			}
 
 			Expect(ValidateOperatingSystemConfig(oscCopy)).To(ConsistOf(
@@ -282,8 +292,39 @@ var _ = Describe("OperatingSystemConfig validation tests", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("status.extensionFiles[5].hostName"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("status.extensionFiles[7].path"),
 				})),
 			))
+		})
+
+		It("should allow duplicate files as long as host name is different", func() {
+			oscCopy := osc.DeepCopy()
+			oscCopy.Spec.Units = nil
+			oscCopy.Spec.Files = []extensionsv1alpha1.File{
+				{
+					Path:    "path1",
+					Content: osc.Spec.Files[0].Content,
+				},
+				{
+					Path:     "path1",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node"),
+				},
+				{
+					Path:     "path2",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node"),
+				},
+				{
+					Path:     "path2",
+					Content:  osc.Spec.Files[0].Content,
+					HostName: ptr.To("my-node-2"),
+				},
+			}
+
+			Expect(ValidateOperatingSystemConfig(oscCopy)).To(BeEmpty())
 		})
 
 		It("should forbid an empty OperatingSystemConfigs plugin path", func() {

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -254,6 +254,11 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
+                    nodeName:
+                      description: |-
+                        NodeName contains the name of the node for node-specific configurations.
+                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                      type: string
                     path:
                       description: Path is the path of the file system where the file
                         should get written to.
@@ -512,6 +517,11 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
+                    nodeName:
+                      description: |-
+                        NodeName contains the name of the node for node-specific configurations.
+                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                      type: string
                     path:
                       description: Path is the path of the file system where the file
                         should get written to.

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -254,10 +254,10 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
-                    nodeName:
+                    hostName:
                       description: |-
-                        NodeName contains the name of the node for node-specific configurations.
-                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                        HostName contains the name of the host for host-specific configurations.
+                        If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
                       type: string
                     path:
                       description: Path is the path of the file system where the file
@@ -517,10 +517,10 @@ spec:
                             This for example can be used to manipulate the clear-text content before it reaches the node.
                           type: boolean
                       type: object
-                    nodeName:
+                    hostName:
                       description: |-
-                        NodeName contains the name of the node for node-specific configurations.
-                        If NodeName is not empty the corresponding file will only be rolled out to the node with the specified name.
+                        HostName contains the name of the host for host-specific configurations.
+                        If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
                       type: string
                     path:
                       description: Path is the path of the file system where the file

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -258,6 +258,7 @@ spec:
                       description: |-
                         HostName contains the name of the host for host-specific configurations.
                         If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+                        Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.
                       type: string
                     path:
                       description: Path is the path of the file system where the file
@@ -521,6 +522,7 @@ spec:
                       description: |-
                         HostName contains the name of the host for host-specific configurations.
                         If HostName is not empty the corresponding file will only be rolled out to the host with the specified name.
+                        Duplicate paths are only allowed if HostName is specified for all of them, none is nil and all values differ.
                       type: string
                     path:
                       description: Path is the path of the file system where the file

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -61,7 +61,7 @@ func computeOperatingSystemConfigChanges(
 	newOSCChecksum string,
 	currentOSVersion *string,
 	skipPersist bool,
-	nodeName string,
+	hostName string,
 ) (*operatingSystemConfigChanges, error) {
 	changes := &operatingSystemConfigChanges{
 		fs:                            fs,
@@ -100,7 +100,7 @@ func computeOperatingSystemConfigChanges(
 
 	// osc.files and osc.unit.files should be changed the same way by OSC controller.
 	// The reason for assigning files to units is the detection of changes which require the restart of a unit.
-	newOSCFiles := CollectAllFiles(newOSC, nodeName)
+	newOSCFiles := CollectAllFiles(newOSC, hostName)
 
 	oldOSCRaw, err := fs.ReadFile(lastAppliedOperatingSystemConfigFilePath)
 	if err != nil {
@@ -153,7 +153,7 @@ func computeOperatingSystemConfigChanges(
 		return nil, fmt.Errorf("unable to decode the old OSC read from file path %s: %w", lastAppliedOperatingSystemConfigFilePath, err)
 	}
 
-	oldOSCFiles := CollectAllFiles(oldOSC, nodeName)
+	oldOSCFiles := CollectAllFiles(oldOSC, hostName)
 	// File changes have to be computed in one step for all files,
 	// because moving a file from osc.unit.files to osc.files or vice versa should not result in a change and a delete event.
 	changes.Files = computeFileDiffs(oldOSCFiles, newOSCFiles)
@@ -511,10 +511,10 @@ func mergeUnits(specUnits, statusUnits []extensionsv1alpha1.Unit) []extensionsv1
 }
 
 // CollectAllFiles returns the list of all files from spec and status of the given OSC, optionally filtered for the given node.
-func CollectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig, nodeName string) []extensionsv1alpha1.File {
+func CollectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig, hostName string) []extensionsv1alpha1.File {
 	clone := slices.Clone(append(osc.Spec.Files, osc.Status.ExtensionFiles...))
 	return slices.DeleteFunc(clone, func(file extensionsv1alpha1.File) bool {
-		return file.NodeName != nil && *file.NodeName != nodeName
+		return file.HostName != nil && *file.HostName != hostName
 	})
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -54,7 +54,15 @@ func extractOSCFromSecret(secret *corev1.Secret) (*extensionsv1alpha1.OperatingS
 	return osc, secret.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig], nil
 }
 
-func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC *extensionsv1alpha1.OperatingSystemConfig, newOSCChecksum string, currentOSVersion *string, skipPersist bool) (*operatingSystemConfigChanges, error) {
+func computeOperatingSystemConfigChanges(
+	log logr.Logger,
+	fs afero.Afero,
+	newOSC *extensionsv1alpha1.OperatingSystemConfig,
+	newOSCChecksum string,
+	currentOSVersion *string,
+	skipPersist bool,
+	nodeName string,
+) (*operatingSystemConfigChanges, error) {
 	changes := &operatingSystemConfigChanges{
 		fs:                            fs,
 		OperatingSystemConfigChecksum: newOSCChecksum,
@@ -92,7 +100,7 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 
 	// osc.files and osc.unit.files should be changed the same way by OSC controller.
 	// The reason for assigning files to units is the detection of changes which require the restart of a unit.
-	newOSCFiles := collectAllFiles(newOSC)
+	newOSCFiles := CollectAllFiles(newOSC, nodeName)
 
 	oldOSCRaw, err := fs.ReadFile(lastAppliedOperatingSystemConfigFilePath)
 	if err != nil {
@@ -145,7 +153,7 @@ func computeOperatingSystemConfigChanges(log logr.Logger, fs afero.Afero, newOSC
 		return nil, fmt.Errorf("unable to decode the old OSC read from file path %s: %w", lastAppliedOperatingSystemConfigFilePath, err)
 	}
 
-	oldOSCFiles := collectAllFiles(oldOSC)
+	oldOSCFiles := CollectAllFiles(oldOSC, nodeName)
 	// File changes have to be computed in one step for all files,
 	// because moving a file from osc.unit.files to osc.files or vice versa should not result in a change and a delete event.
 	changes.Files = computeFileDiffs(oldOSCFiles, newOSCFiles)
@@ -502,8 +510,12 @@ func mergeUnits(specUnits, statusUnits []extensionsv1alpha1.Unit) []extensionsv1
 	return out
 }
 
-func collectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig) []extensionsv1alpha1.File {
-	return append(osc.Spec.Files, osc.Status.ExtensionFiles...)
+// CollectAllFiles returns the list of all files from spec and status of the given OSC, optionally filtered for the given node.
+func CollectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig, nodeName string) []extensionsv1alpha1.File {
+	clone := slices.Clone(append(osc.Spec.Files, osc.Status.ExtensionFiles...))
+	return slices.DeleteFunc(clone, func(file extensionsv1alpha1.File) bool {
+		return len(file.NodeName) != 0 && file.NodeName != nodeName
+	})
 }
 
 func computeContainerdRegistryDiffs(newRegistries, oldRegistries []extensionsv1alpha1.RegistryConfig) containerdRegistries {

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -514,7 +514,7 @@ func mergeUnits(specUnits, statusUnits []extensionsv1alpha1.Unit) []extensionsv1
 func CollectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig, nodeName string) []extensionsv1alpha1.File {
 	clone := slices.Clone(append(osc.Spec.Files, osc.Status.ExtensionFiles...))
 	return slices.DeleteFunc(clone, func(file extensionsv1alpha1.File) bool {
-		return len(file.NodeName) != 0 && file.NodeName != nodeName
+		return file.NodeName != nil && *file.NodeName != nodeName
 	})
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -512,8 +512,8 @@ func mergeUnits(specUnits, statusUnits []extensionsv1alpha1.Unit) []extensionsv1
 
 // CollectAllFiles returns the list of all files from spec and status of the given OSC, optionally filtered for the given node.
 func CollectAllFiles(osc *extensionsv1alpha1.OperatingSystemConfig, hostName string) []extensionsv1alpha1.File {
-	clone := slices.Clone(append(osc.Spec.Files, osc.Status.ExtensionFiles...))
-	return slices.DeleteFunc(clone, func(file extensionsv1alpha1.File) bool {
+	allFiles := slices.Clone(append(osc.Spec.Files, osc.Status.ExtensionFiles...))
+	return slices.DeleteFunc(allFiles, func(file extensionsv1alpha1.File) bool {
 		return file.HostName != nil && *file.HostName != hostName
 	})
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -183,21 +183,20 @@ var _ = Describe("Changes", func() {
 			osc := &extensionsv1alpha1.OperatingSystemConfig{
 				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 					Files: []extensionsv1alpha1.File{
-						{Path: "/etc/foo", NodeName: ""},
-						{Path: "/etc/bar", NodeName: ""},
+						{Path: "/etc/foo", NodeName: nil},
+						{Path: "/etc/bar", NodeName: nil},
 					},
 				},
 				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
 					ExtensionFiles: []extensionsv1alpha1.File{
-						{Path: "/etc/baz", NodeName: ""},
+						{Path: "/etc/baz", NodeName: nil},
 					},
 				},
 			}
-			files := CollectAllFiles(osc, "node-1")
-			Expect(files).To(ConsistOf(
-				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: ""},
-				extensionsv1alpha1.File{Path: "/etc/bar", NodeName: ""},
-				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: ""},
+			Expect(CollectAllFiles(osc, "node-1")).To(ConsistOf(
+				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: nil},
+				extensionsv1alpha1.File{Path: "/etc/bar", NodeName: nil},
+				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: nil},
 			))
 		})
 
@@ -205,25 +204,24 @@ var _ = Describe("Changes", func() {
 			osc := &extensionsv1alpha1.OperatingSystemConfig{
 				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 					Files: []extensionsv1alpha1.File{
-						{Path: "/etc/foo", NodeName: "node-1"},
-						{Path: "/etc/bar", NodeName: "node-2"},
-						{Path: "/etc/all", NodeName: ""},
+						{Path: "/etc/foo", NodeName: ptr.To("node-1")},
+						{Path: "/etc/bar", NodeName: ptr.To("node-2")},
+						{Path: "/etc/all", NodeName: nil},
 					},
 				},
 				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
 					ExtensionFiles: []extensionsv1alpha1.File{
-						{Path: "/etc/baz", NodeName: "node-1"},
-						{Path: "/etc/qux", NodeName: "node-3"},
-						{Path: "/etc/sts", NodeName: ""},
+						{Path: "/etc/baz", NodeName: ptr.To("node-1")},
+						{Path: "/etc/qux", NodeName: ptr.To("node-3")},
+						{Path: "/etc/sts", NodeName: nil},
 					},
 				},
 			}
-			files := CollectAllFiles(osc, "node-1")
-			Expect(files).To(ConsistOf(
-				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: "node-1"},
-				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: "node-1"},
-				extensionsv1alpha1.File{Path: "/etc/all", NodeName: ""},
-				extensionsv1alpha1.File{Path: "/etc/sts", NodeName: ""},
+			Expect(CollectAllFiles(osc, "node-1")).To(ConsistOf(
+				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: ptr.To("node-1")},
+				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: ptr.To("node-1")},
+				extensionsv1alpha1.File{Path: "/etc/all", NodeName: nil},
+				extensionsv1alpha1.File{Path: "/etc/sts", NodeName: nil},
 			))
 		})
 	})

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -177,4 +177,54 @@ var _ = Describe("Changes", func() {
 			Expect(saKeyRotation).To(BeFalse())
 		})
 	})
+
+	Describe("CollectAllFiles", func() {
+		It("should return all files when NodeName is empty", func() {
+			osc := &extensionsv1alpha1.OperatingSystemConfig{
+				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+					Files: []extensionsv1alpha1.File{
+						{Path: "/etc/foo", NodeName: ""},
+						{Path: "/etc/bar", NodeName: ""},
+					},
+				},
+				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
+					ExtensionFiles: []extensionsv1alpha1.File{
+						{Path: "/etc/baz", NodeName: ""},
+					},
+				},
+			}
+			files := CollectAllFiles(osc, "node-1")
+			Expect(files).To(ConsistOf(
+				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: ""},
+				extensionsv1alpha1.File{Path: "/etc/bar", NodeName: ""},
+				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: ""},
+			))
+		})
+
+		It("should filter files by NodeName", func() {
+			osc := &extensionsv1alpha1.OperatingSystemConfig{
+				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+					Files: []extensionsv1alpha1.File{
+						{Path: "/etc/foo", NodeName: "node-1"},
+						{Path: "/etc/bar", NodeName: "node-2"},
+						{Path: "/etc/all", NodeName: ""},
+					},
+				},
+				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
+					ExtensionFiles: []extensionsv1alpha1.File{
+						{Path: "/etc/baz", NodeName: "node-1"},
+						{Path: "/etc/qux", NodeName: "node-3"},
+						{Path: "/etc/sts", NodeName: ""},
+					},
+				},
+			}
+			files := CollectAllFiles(osc, "node-1")
+			Expect(files).To(ConsistOf(
+				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: "node-1"},
+				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: "node-1"},
+				extensionsv1alpha1.File{Path: "/etc/all", NodeName: ""},
+				extensionsv1alpha1.File{Path: "/etc/sts", NodeName: ""},
+			))
+		})
+	})
 })

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes_test.go
@@ -183,20 +183,20 @@ var _ = Describe("Changes", func() {
 			osc := &extensionsv1alpha1.OperatingSystemConfig{
 				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 					Files: []extensionsv1alpha1.File{
-						{Path: "/etc/foo", NodeName: nil},
-						{Path: "/etc/bar", NodeName: nil},
+						{Path: "/etc/foo", HostName: nil},
+						{Path: "/etc/bar", HostName: nil},
 					},
 				},
 				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
 					ExtensionFiles: []extensionsv1alpha1.File{
-						{Path: "/etc/baz", NodeName: nil},
+						{Path: "/etc/baz", HostName: nil},
 					},
 				},
 			}
 			Expect(CollectAllFiles(osc, "node-1")).To(ConsistOf(
-				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: nil},
-				extensionsv1alpha1.File{Path: "/etc/bar", NodeName: nil},
-				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: nil},
+				extensionsv1alpha1.File{Path: "/etc/foo", HostName: nil},
+				extensionsv1alpha1.File{Path: "/etc/bar", HostName: nil},
+				extensionsv1alpha1.File{Path: "/etc/baz", HostName: nil},
 			))
 		})
 
@@ -204,24 +204,24 @@ var _ = Describe("Changes", func() {
 			osc := &extensionsv1alpha1.OperatingSystemConfig{
 				Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
 					Files: []extensionsv1alpha1.File{
-						{Path: "/etc/foo", NodeName: ptr.To("node-1")},
-						{Path: "/etc/bar", NodeName: ptr.To("node-2")},
-						{Path: "/etc/all", NodeName: nil},
+						{Path: "/etc/foo", HostName: ptr.To("node-1")},
+						{Path: "/etc/bar", HostName: ptr.To("node-2")},
+						{Path: "/etc/all", HostName: nil},
 					},
 				},
 				Status: extensionsv1alpha1.OperatingSystemConfigStatus{
 					ExtensionFiles: []extensionsv1alpha1.File{
-						{Path: "/etc/baz", NodeName: ptr.To("node-1")},
-						{Path: "/etc/qux", NodeName: ptr.To("node-3")},
-						{Path: "/etc/sts", NodeName: nil},
+						{Path: "/etc/baz", HostName: ptr.To("node-1")},
+						{Path: "/etc/qux", HostName: ptr.To("node-3")},
+						{Path: "/etc/sts", HostName: nil},
 					},
 				},
 			}
 			Expect(CollectAllFiles(osc, "node-1")).To(ConsistOf(
-				extensionsv1alpha1.File{Path: "/etc/foo", NodeName: ptr.To("node-1")},
-				extensionsv1alpha1.File{Path: "/etc/baz", NodeName: ptr.To("node-1")},
-				extensionsv1alpha1.File{Path: "/etc/all", NodeName: nil},
-				extensionsv1alpha1.File{Path: "/etc/sts", NodeName: nil},
+				extensionsv1alpha1.File{Path: "/etc/foo", HostName: ptr.To("node-1")},
+				extensionsv1alpha1.File{Path: "/etc/baz", HostName: ptr.To("node-1")},
+				extensionsv1alpha1.File{Path: "/etc/all", HostName: nil},
+				extensionsv1alpha1.File{Path: "/etc/sts", HostName: nil},
 			))
 		})
 	})

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed getting OS version: %w", err)
 	}
 
-	oscChanges, err := computeOperatingSystemConfigChanges(log, r.FS, osc, oscChecksum, osVersion, r.SkipWritingStateFiles, r.getNodeOrHostName())
+	oscChanges, err := computeOperatingSystemConfigChanges(log, r.FS, osc, oscChecksum, osVersion, r.SkipWritingStateFiles, r.HostName)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
 	}
@@ -1086,11 +1086,4 @@ func (r *Reconciler) restartNodeAgent(oscChanges *operatingSystemConfigChanges, 
 	}
 	r.CancelContext()
 	return reconcile.Result{RequeueAfter: RequeueAfterRestart}, nil
-}
-
-func (r *Reconciler) getNodeOrHostName() string {
-	if len(r.NodeName) > 0 {
-		return r.NodeName
-	}
-	return r.HostName
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed getting OS version: %w", err)
 	}
 
-	oscChanges, err := computeOperatingSystemConfigChanges(log, r.FS, osc, oscChecksum, osVersion, r.SkipWritingStateFiles)
+	oscChanges, err := computeOperatingSystemConfigChanges(log, r.FS, osc, oscChecksum, osVersion, r.SkipWritingStateFiles, r.getNodeOrHostName())
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
 	}
@@ -1086,4 +1086,11 @@ func (r *Reconciler) restartNodeAgent(oscChanges *operatingSystemConfigChanges, 
 	}
 	r.CancelContext()
 	return reconcile.Result{RequeueAfter: RequeueAfterRestart}, nil
+}
+
+func (r *Reconciler) getNodeOrHostName() string {
+	if len(r.NodeName) > 0 {
+		return r.NodeName
+	}
+	return r.HostName
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Allow node-specific configuration to be applied by `gardener-node-agent`.

Previously, the operating system configuration for a worker pool was applied to all nodes the worker pool in the same way, i.e. all files, systemd units etc were equal for all nodes of the worker pool.
However, with self-hosted clusters running in a highly-available manner, the individual control plane nodes may require node-specific TLS certificates, which reflect the IP address of the corresponding node. With the existing implementation, this would require to have node-specific operating system configurations, which are mostly the same, but only contain very small changes.
Instead of duplicating the operating system configuration, this change lays the ground work to support entries in the operating system configuration, which are only rolled out to a particular node. Therefore, a single operating system configuration can be used for a highly available control plane worker pool with a single file being present multiple times, each time with a different `hostName`.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

/cc @rfranzke @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
gardener-node-agent now supports node-specific configuration files, i.e. files which are only applied to a specified node.
```
