### PR TITLE
Remove status field from istio `ServiceMonitor` test expectation 

### DIFF
--- a/pkg/component/networking/istio/test_charts/istiod_servicemonitor.yaml
+++ b/pkg/component/networking/istio/test_charts/istiod_servicemonitor.yaml
@@ -18,4 +18,3 @@ spec:
     matchLabels:
       app: istiod
       istio: pilot
-status: {}


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This fixes the prometheus-operator upgrade PR:

- https://github.com/gardener/gardener/pull/13388

The `status` field from a `ServiceMonitor` is also omitted if zero: 

- [prometheus-operator/pkg/apis/monitoring/v1/servicemonitor_types.go](https://github.com/prometheus-operator/prometheus-operator/blob/814f26fb56699bae5a6617c1430e2005d1f2720a/pkg/apis/monitoring/v1/servicemonitor_types.go#L58)

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:

```other operator
NONE
```
