### PR TITLE
Correct the `gardener-admission-controller` VPA name

### DIFF
--- a/pkg/component/gardener/admissioncontroller/admission_controller_test.go
+++ b/pkg/component/gardener/admissioncontroller/admission_controller_test.go
@@ -817,7 +817,7 @@ func vpa(namespace string) *vpaautoscalingv1.VerticalPodAutoscaler {
 
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gardener-admission-controller",
+			Name:      "gardener-admission-controller-vpa",
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app":  "gardener",

--- a/pkg/component/gardener/admissioncontroller/vpa.go
+++ b/pkg/component/gardener/admissioncontroller/vpa.go
@@ -17,7 +17,7 @@ func (a *gardenerAdmissionController) vpa() *vpaautoscalingv1.VerticalPodAutosca
 	updateMode := vpaautoscalingv1.UpdateModeRecreate
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName,
+			Name:      DeploymentName + "-vpa",
 			Namespace: a.namespace,
 			Labels:    GetLabels(),
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
With @RadaBDimitrova we noticed that we have 2 VPA for the gardener-admission-controller Deployment:
```
% k -n garden get vpa | grep gardener-admission-controller
gardener-admission-controller                           Recreate   71m    115778925    True       2y65d
gardener-admission-controller-vpa                       Auto       71m    115778925    True       2y339d
```

With https://github.com/gardener/gardener/pull/8244, the gardener-admission-controller component was introduced. 
The name of the VPA in the legacy controlplane chart is `gardener-admission-controller-vpa`: https://github.com/gardener/gardener/blob/a7029002ef6e68b9b37df11fea934bcc80ce6f2c/charts/gardener/controlplane/charts/runtime/templates/admission-controller/vpa.yaml#L5
The name of the VPA in the golang component is `gardener-admission-controller`: https://github.com/gardener/gardener/blob/384ce8754095018af4a9bd0595b1ba309260118d/pkg/component/gardener/admissioncontroller/admission_controller_test.go#L818

With the switch from the controlplane charts to the gardener-operator we ended up with 2 VPAs.

This PR updates the gardener-admission-controller VPA name to `gardener-admission-controller-vpa` so that it is in sync with the rest of the control plane components VPAs:
```
% k -n garden get vpa gardener-apiserver-vpa gardener-controller-manager-vpa gardener-scheduler-vpa
NAME                              MODE       CPU    MEM         PROVIDED   AGE
gardener-apiserver-vpa            Recreate   204m   742988292   True       510d
gardener-controller-manager-vpa   Recreate   32m    375052143   True       2y339d
gardener-scheduler-vpa            Recreate   10m    115778925   True       2y339d
```

The `gardener-admission-controller` VPA is deployed with GRM so GRM should take care to delete it.

**Which issue(s) this PR fixes**:
We found the issue as part of https://github.com/gardener/gardener/issues/12903

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-admission-controller VerticalPodAutoscaler name is changed from `gardener-admission-controller` to `gardener-admission-controller-vpa` to fix an issue with duplicate VPA resources for the gardener-admission-controller Deployment. The VPA resource name with the deprecated controlplane chart was `gardener-controller-manager-vpa`. Previously, switching to the gardener-operator created a VPA with name `gardener-controller-manager` that targets the same Deployment.
```
