### PR TITLE
Improve validation of `sysctl` parameters to Shoot worker pools

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -3375,7 +3375,7 @@ func ValidateControlPlaneAutoscaling(autoscaling *core.ControlPlaneAutoscaling, 
 }
 
 // sysctlKeyRegex is used to validate the key of a sysctl
-var sysctlKeyRegex = regexp.MustCompile(`^(?:(?:[a-zA-Z0-9_/-]+|\*)\.)*[a-zA-Z0-9_/-]*[a-zA-Z0-9]$`)
+var sysctlKeyRegex = regexp.MustCompile(`^(?:(?:[a-zA-Z0-9-][a-zA-Z0-9_/-]*|\*)\.)*[a-zA-Z0-9_/-]*[a-zA-Z0-9]$`)
 
 // ValidateSysctls validates sysctls for valid keys and non-empty values
 func ValidateSysctls(sysctls map[string]string, fldPath *field.Path) field.ErrorList {
@@ -3394,9 +3394,9 @@ func ValidateSysctls(sysctls map[string]string, fldPath *field.Path) field.Error
 			allErrs = append(allErrs, field.TooLong(fldPath.Child(sysctlKey), sysctlKey, maxPathLen))
 		}
 
-		for _, v := range strings.Split(sysctlKey, ".") {
-			if len(v) > 255 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child(sysctlKey), v, "sub key of sysctl must not exceed 255 bytes"))
+		for subkey := range strings.SplitSeq(sysctlKey, ".") {
+			if len(subkey) > 255 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child(sysctlKey), subkey, "sub key of sysctl must not exceed 255 bytes"))
 			}
 		}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -8212,6 +8212,73 @@ var _ = Describe("Shoot Validation Tests", func() {
 				"Detail": Equal("can not be less than -1"),
 			}))))
 		})
+
+		DescribeTable("sysctl setting validation", func(sysctls map[string]string, matcher gomegatypes.GomegaMatcher) {
+			errList := ValidateSysctls(sysctls, field.NewPath("sysctls"))
+			Expect(errList).To(matcher)
+		},
+			Entry("accept valid sysctl keys",
+				map[string]string{
+					"foo.bar":                        "123",
+					"fs.aio-nr":                      "192",
+					"fs.binfmt_misc.python3/13":      "enabled",
+					"net.ipv4.conf.eth0.forwarding":  "1",
+					"net.ipv4.tcp_mem":               "374874	499832	749748",
+					"-net.ipv4.conf.all.proxy_arp":   "0",
+					"net.ipv4.conf.*.route_localnet": "1",
+				},
+				BeEmpty(),
+			),
+			Entry("reject invalid sysctl keys not matching regex",
+				map[string]string{
+					".foo.bar":   "123",
+					"foo..bar":   "abc",
+					"foo.bar.":   "123",
+					"foo.bar_":   "abc",
+					"foo.bar/":   "123",
+					"foo.bar-":   "abc",
+					"foo\"bar":   "123",
+					"foo=bar":    "abc",
+					"foo;bar":    "123",
+					"foo.**.bar": "abc",
+					"foo.bar*":   "123",
+					"foo.bar.*":  "abc",
+				}, SatisfyAll(
+					HaveLen(12),
+					HaveEach(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  ContainSubstring("sysctls."),
+						"Detail": ContainSubstring("sysctl key must must match regex"),
+					}))),
+				),
+			),
+			Entry("reject sysctl keys with too long subkeys",
+				map[string]string{
+					func(size int) string {
+						// create a very long string
+						var b strings.Builder
+						for range size {
+							fmt.Fprint(&b, "s")
+						}
+						return b.String()
+					}(256): "abc",
+				}, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  ContainSubstring("sysctls.sss"),
+					"Detail": Equal("sub key of sysctl must not exceed 255 bytes"),
+				}))),
+			),
+			Entry("reject empty sysctl values",
+				map[string]string{
+					"foo": "",
+				}, ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("sysctls.foo"),
+					})),
+				),
+			),
+		)
 	})
 
 	Describe("#ValidateWorkers", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -8243,8 +8243,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"foo.**.bar": "abc",
 					"foo.bar*":   "123",
 					"foo.bar.*":  "abc",
+					"_foo.bar":   "123",
+					"/foo.bar":   "abc",
 				}, SatisfyAll(
-					HaveLen(12),
+					HaveLen(14),
 					HaveEach(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  ContainSubstring("sysctls."),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/area quality
/area robustness
/area security
/kind enhancement

**What this PR does / why we need it**:

Validating the input provided for `Shoot` resources and returning errors early helps cluster owners understand the issues better. The input to `sysctls` for Shoot worker pools allowed for sysctl keys that do not conform to their general structure which would lead to them not getting applied - or worse - no sysctl getting applied at all. This would leave Shoot worker node in an actual state that does not match the desired state as expressed in the Shoot manifest.

This PR implements validation for a Shoots `.spec.provider.workers[].sysctls` field.

For sysctl keys to be valid, they generally must follow the criteria as outlined in [sysctl.d(5)](https://man7.org/linux/man-pages/man5/sysctl.d.5.html).

A sysctl key:
- must start with an alphanumeric character
- may start with a `-` to signify to systemd that failure to set this sysctl is not an error but a warning
- may contain `.`, `/`, `-`, `_`
- may contain wildcards `*` but not in a leaf node
- must not contain consecutive dots `..` or wildcards `**`
- must not have a subkey that is longer than 255 bytes
- must not be longer than 4096 bytes when prefixed with `/proc/sys/`

Empty values to a sysctl are rejected but otherwise, it is permissible to submit almost anything as value to a sysctl.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The Shoot `.spec.provider.workers[].sysctls` field is now validated for valid sysctl keys and non-empty values.
```
