### PR TITLE
Update remote local setup with hosts for end-to-end tests and IPv6 support

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -94,12 +94,12 @@ spec:
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
                  api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade,upg-ha}{,-wl}.local.{internal,external}.local.gardener.cloud \
                  api.e2e-upd-node-ovr.local.{internal,external}.local.gardener.cloud \
-                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,auth-{one,two},layer4-lb,default-ip,rot-{ip,noroll}}.local.{internal,external}.local.gardener.cloud \
-                 gu-local--e2e-{rotate{,-wl},rot-{ip,noroll}}.ingress.local.seed.local.gardener.cloud
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,auth-{one,two},layer4-lb,default-ip,rot-{{,nr-}ip,noroll,etcd}}.local.{internal,external}.local.gardener.cloud \
+                 gu-local--e2e-{rotate{,-wl},rot-{{,nr-}ip,noroll,etcd}}.ingress.local.seed.local.gardener.cloud
             " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
           echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
           echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts
-          
+
           # Resolve e.g. gu-local--e2e-rot{ate{-wl},-noroll}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '
           address=/.seed.local.gardener.cloud/127.0.0.1

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -491,10 +491,17 @@ spec:
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             watch -c "k get -n garden-local shoot local -o yaml | yq -P -C '[.status.conditions[] | del(.lastTransitionTime, .lastUpdateTime)]' | grep --color=Always -E '\"False\"| Unknown| Progressing|$'"
           EOF
-          new_window "shoot lifecycle" "Create" <<"EOF"
-            export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/shoot-ipv6.yaml; else k apply -f example/provider-local/shoot.yaml; fi
+          if [[ "$IPFAMILY" == "ipv6" ]]; then
+            new_window "shoot lifecycle" "Create" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/shoot-ipv6.yaml
           EOF
+          else
+            new_window "shoot lifecycle" "Create" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/shoot.yaml
+          EOF
+          fi
           new_pane "Reconcile" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             k annotate shoot local -n garden-local 'gardener.cloud/operation=reconcile'
@@ -507,14 +514,28 @@ spec:
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             watch k get -A seeds,shoots,managedseeds
           EOF
-          new_pane "create shoot" <<"EOF"
-            export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml; fi
+          if [[ "$IPFAMILY" == "ipv6" ]]; then
+            new_pane "create shoot" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml
           EOF
-          new_pane "create managed seed" <<"EOF"
-            export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/managedseed.yaml; fi
+          else
+            new_pane "create shoot" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml
           EOF
+          fi
+          if [[ "$IPFAMILY" == "ipv6" ]]; then
+            new_pane "create managed seed" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/managedseeds/managedseed-ipv6.yaml
+          EOF
+          else
+            new_pane "create managed seed" <<"EOF"
+              export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
+              k apply -f example/provider-local/managedseeds/managedseed.yaml
+          EOF
+          fi
           new_pane "managed seed pods" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             generate-admin-kubeconf.sh --namespace garden --shoot-name managedseed > /tmp/shoot.kubeconfig && while true; do clear; k --kubeconfig /tmp/shoot.kubeconfig get pods -A -o wide; sleep 10s; done

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -89,6 +89,8 @@ spec:
           echo stern           && go install github.com/stern/stern@latest
           echo neat            && krew install neat
           echo node-shell      && krew install node-shell
+          echo ""                                                                        >> /etc/hosts
+          echo "### Gardener IPv4 hosts ###"                                             >> /etc/hosts
           bash -c "
             echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
                  api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
@@ -102,6 +104,21 @@ spec:
           echo "172.18.255.3 dashboard.ingress.runtime-garden.local.gardener.cloud"      >> /etc/hosts
           echo "172.18.255.3 discovery.ingress.runtime-garden.local.gardener.cloud"      >> /etc/hosts
           echo "127.0.0.1 garden.local.gardener.cloud"                                   >> /etc/hosts
+          echo ""                                                                        >> /etc/hosts
+          echo "### Gardener IPv6 hosts ###"                                             >> /etc/hosts
+          bash -c "
+            echo {{p,g}-seed,{gu,p,v}-local--local}.ingress.local.seed.local.gardener.cloud \
+                 api.{e2e-managedseed.garden,local.local}.{internal,external}.local.gardener.cloud \
+                 api.e2e-{hib,upg-hib,wake-up,wake-up-ncp,migrate,rotate,default,upd-node,upgrade,upg-ha}{,-wl}.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-upd-node-ovr.local.{internal,external}.local.gardener.cloud \
+                 api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,auth-{one,two},layer4-lb,default-ip,rot-{{,nr-}ip,noroll,etcd}}.local.{internal,external}.local.gardener.cloud \
+                 gu-local--e2e-{rotate{,-wl},rot-{{,nr-}ip,noroll,etcd}}.ingress.local.seed.local.gardener.cloud
+              " | sed 's/ /\n/g' | sed 's/^/::1 /' | sort                                >> /etc/hosts
+          echo "::3 api.virtual-garden.local.gardener.cloud"                             >> /etc/hosts
+          echo "::3 plutono-garden.ingress.runtime-garden.local.gardener.cloud"          >> /etc/hosts
+          echo "::3 dashboard.ingress.runtime-garden.local.gardener.cloud"               >> /etc/hosts
+          echo "::3 discovery.ingress.runtime-garden.local.gardener.cloud"               >> /etc/hosts
+          echo "::1 garden.local.gardener.cloud"                                         >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rot{ate{-wl},-noroll}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -145,11 +145,13 @@ spec:
           There are multiple variants of the local setup of Gardener
           that can be prepared in a tmux session for convenience:
 
-          - '${g}prepare-gardener.sh${n}'          A basic 'make kind-up gardener-up' setup
-          - '${g}prepare-operator.sh${n}'          A 'make kind-multi-zone-up operator-up' setup
-             ${g}                   ${n}           with several tmux windows
-          - '${g}prepare-operator-complete.sh${n}' A 'make kind-multi-zone-up operator-up operator-seed-up' setup,
-             ${g}                            ${n}  a complete local "development landscape"
+          - '${g}prepare-gardener.sh${n}'                        A basic 'make kind-up gardener-up' setup
+          - '${g}prepare-operator.sh${n}'                        A 'make kind-multi-zone-up operator-up' setup
+             ${g}                   ${n}                         with several tmux windows
+          - '${g}prepare-operator-complete.sh${n}'               A 'make kind-multi-zone-up operator-up operator-seed-up' setup,
+             ${g}                            ${n}                a complete local "development landscape"
+          - '${g}IPFAMILY=ipv6 prepare-operator-complete.sh${n}' As 'prepare-operator-complete.sh' but using IPv6. It requires
+             ${g}                                          ${n}  a shoot with IPv6 enabled.
 
           The "Gardener HA" tmux session is prepared by default.
           To switch to another tmux session, please run the respective script.

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -96,9 +96,12 @@ spec:
                  api.e2e-upd-node-ovr.local.{internal,external}.local.gardener.cloud \
                  api.e2e-{unpriv,mgr-hib,force-delete,fd-hib,auth-{one,two},layer4-lb,default-ip,rot-{{,nr-}ip,noroll,etcd}}.local.{internal,external}.local.gardener.cloud \
                  gu-local--e2e-{rotate{,-wl},rot-{{,nr-}ip,noroll,etcd}}.ingress.local.seed.local.gardener.cloud
-            " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort      >> /etc/hosts
-          echo "172.18.255.3 api.virtual-garden.local.gardener.cloud" >> /etc/hosts
-          echo "127.0.0.1 garden.local.gardener.cloud"                >> /etc/hosts
+            " | sed 's/ /\n/g' | sed 's/^/172.18.255.1 /' | sort                         >> /etc/hosts
+          echo "172.18.255.3 api.virtual-garden.local.gardener.cloud"                    >> /etc/hosts
+          echo "172.18.255.3 plutono-garden.ingress.runtime-garden.local.gardener.cloud" >> /etc/hosts
+          echo "172.18.255.3 dashboard.ingress.runtime-garden.local.gardener.cloud"      >> /etc/hosts
+          echo "172.18.255.3 discovery.ingress.runtime-garden.local.gardener.cloud"      >> /etc/hosts
+          echo "127.0.0.1 garden.local.gardener.cloud"                                   >> /etc/hosts
 
           # Resolve e.g. gu-local--e2e-rot{ate{-wl},-noroll}.ingress.$seed_name. ... to 127.0.0.1 for the e2e tests:
           echo '

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -507,11 +507,11 @@ spec:
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             watch k get -A seeds,shoots,managedseeds
           EOF
-          new_pane "create shoot" Enter <<"EOF"
+          new_pane "create shoot" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml; fi
           EOF
-          new_pane "create managed seed" Enter <<"EOF"
+          new_pane "create managed seed" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
             if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/managedseed.yaml; fi
           EOF

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -509,11 +509,11 @@ spec:
           EOF
           new_pane "create shoot" Enter <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml
+            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/shoot-managedseed.yaml; fi
           EOF
           new_pane "create managed seed" Enter <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            k apply -f example/provider-local/managedseeds/managedseed.yaml
+            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/managedseeds/managedseed-ipv6.yaml; else k apply -f example/provider-local/managedseeds/managedseed.yaml; fi
           EOF
           new_pane "managed seed pods" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -493,7 +493,7 @@ spec:
           EOF
           new_window "shoot lifecycle" "Create" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig
-            k apply -f example/provider-local/shoot.yaml
+            if [[ "$IPFAMILY" == "ipv6" ]]; then k apply -f example/provider-local/shoot-ipv6.yaml; else k apply -f example/provider-local/shoot.yaml; fi
           EOF
           new_pane "Reconcile" <<"EOF"
             export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig

--- a/example/provider-local/managedseeds/managedseed-ipv6.yaml
+++ b/example/provider-local/managedseeds/managedseed-ipv6.yaml
@@ -1,0 +1,24 @@
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: managedseed
+  namespace: garden
+spec:
+  shoot:
+    name: managedseed
+  gardenlet:
+    config:
+      apiVersion: gardenlet.config.gardener.cloud/v1alpha1
+      kind: GardenletConfiguration
+      seedConfig:
+        spec:
+          networks:
+            ipFamilies:
+            - IPv6
+          settings:
+            excessCapacityReservation:
+              enabled: false
+            scheduling:
+              visible: false
+            verticalPodAutoscaler:
+              enabled: false

--- a/example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml
+++ b/example/provider-local/managedseeds/shoot-managedseed-ipv6.yaml
@@ -1,0 +1,40 @@
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: managedseed
+  namespace: garden
+  annotations:
+    shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
+spec:
+  cloudProfile:
+    name: local
+  credentialsBindingName: local
+  region: local
+  networking:
+    type: calico
+    ipFamilies:
+    - IPv6
+    # Must be within fd00:10:1:100::/56 (subnet of kind pod CIDR fd00:10:1::/48, but disjoint with seed pod CIDR fd00:10:1::/56).
+    nodes: fd00:10:1:100::/56
+    providerConfig:
+      ipv6:
+        sourceNATEnabled: true
+  provider:
+    type: local
+    workers:
+    - name: local
+      machine:
+        type: local
+      cri:
+        name: containerd
+      minimum: 1
+      maximum: 1
+      maxSurge: 1
+      maxUnavailable: 0
+  kubernetes:
+    kubelet:
+      serializeImagePulls: false
+      registryPullQPS: 10
+      registryBurst: 20
+    verticalPodAutoscaler:
+      enabled: true

--- a/example/provider-local/managedseeds/shoot-managedseed.yaml
+++ b/example/provider-local/managedseeds/shoot-managedseed.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   cloudProfile:
     name: local
-  secretBindingName: local
+  credentialsBindingName: local
   region: local
   networking:
     type: calico

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   cloudProfile:
     name: local
-  secretBindingName: local # dummy, doesn't contain any credentials
+  credentialsBindingName: local # dummy, doesn't contain any credentials
   region: local
   networking:
     type: calico


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

During startup, the remote local setup automatically updates `/etc/hosts` with entries needed for end-to-end tests. As more tests are added, new entries might be required, making the current `/etc/hosts` in the remote local setup outdated. This PR updates the setup to include the latest entries.

Additionally, it provides support for running the `prepare-operator-complete.sh` variant on IPv6. This variant runs the `operator-seed-up` setup. In short, `tmux` sessions can be created with `IPFAMILY=ipv6`, which passes the variable into the session and then to the KinD cluster when `make kind-multi-zone-up` and similar commands are executed.

**Special notes for your reviewer**:

/cc @istvanballok 

**Release note**:

```other developer
Update remote local setup with most recent hosts for end-to-end tests and instructions for an IPv6 setup
```
