### PR TITLE
Correct the version of the `VPAInPlaceUpdates` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,7 +32,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | DoNotCopyBackupCredentials               | `true`  | `Beta`  | `1.123` |         |
 | OpenTelemetryCollector                   | `false` | `Alpha` | `1.124` |         |
 | UseUnifiedHTTPProxyPort                  | `false` | `Alpha` | `1.130` |         |
-| VPAInPlaceUpdates                        | `false` | `Alpha` | `1.132` |         |
+| VPAInPlaceUpdates                        | `false` | `Alpha` | `1.133` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -78,7 +78,7 @@ const (
 	// VPAInPlaceUpdates enables the usage of in-place Pod resource updates in the Vertical Pod Autoscaler resources
 	// to perform in-place Pod resource updates.
 	// owner: @vitanovs @ialidzhikov
-	// alpha: v1.132.0
+	// alpha: v1.133.0
 	VPAInPlaceUpdates featuregate.Feature = "VPAInPlaceUpdates"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/12940 will be released with v1.133, not v1.132. We somehow missed this in https://github.com/gardener/gardener/pull/12940.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
