### PR TITLE
Add labels to `DNSRecord`s

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -301,8 +301,6 @@ const (
 	GardenRoleHelmPullSecret = "helm-pull-secret"
 	// GardenRoleObservability is the value of the GardenRole key indicating type 'observability'.
 	GardenRoleObservability = "observability"
-	// GardenRoleIngress is the value of the GardenRole key indicating type 'ingress'.
-	GardenRoleIngress = "ingress"
 
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
@@ -617,6 +615,8 @@ const (
 	LabelDNSRecordExternal = "external"
 	// LabelDNSRecordInternal is a constant for a label value for internal DNSRecord
 	LabelDNSRecordInternal = "internal"
+	// LabelDNSRecordIngress is a constant for a label value for DNSRecord used for ingress
+	LabelDNSRecordIngress = "ingress"
 
 	// LabelShootNamespace is a constant for a label key that indicates a relationship to a shoot in the specified namespace.
 	LabelShootNamespace = "shoot.gardener.cloud/namespace"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -613,6 +613,10 @@ const (
 	LabelProxy = "proxy"
 	// LabelExtensionProjectRole is a constant for a label value for extension project roles
 	LabelExtensionProjectRole = "extension-project-role"
+	// LabelDNSRecordExternal is a constant for a label value for external DNSRecord
+	LabelDNSRecordExternal = "external"
+	// LabelDNSRecordInternal is a constant for a label value for internal DNSRecord
+	LabelDNSRecordInternal = "internal"
 
 	// LabelShootNamespace is a constant for a label key that indicates a relationship to a shoot in the specified namespace.
 	LabelShootNamespace = "shoot.gardener.cloud/namespace"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -611,11 +611,11 @@ const (
 	LabelProxy = "proxy"
 	// LabelExtensionProjectRole is a constant for a label value for extension project roles
 	LabelExtensionProjectRole = "extension-project-role"
-	// LabelDNSRecordExternal is a constant for a label value for external DNSRecord
+	// LabelDNSRecordExternal is a constant for a label value for external DNSRecord.
 	LabelDNSRecordExternal = "external"
-	// LabelDNSRecordInternal is a constant for a label value for internal DNSRecord
+	// LabelDNSRecordInternal is a constant for a label value for internal DNSRecord.
 	LabelDNSRecordInternal = "internal"
-	// LabelDNSRecordIngress is a constant for a label value for DNSRecord used for ingress
+	// LabelDNSRecordIngress is a constant for a label value for ingress DNSRecord.
 	LabelDNSRecordIngress = "ingress"
 
 	// LabelShootNamespace is a constant for a label key that indicates a relationship to a shoot in the specified namespace.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -301,6 +301,8 @@ const (
 	GardenRoleHelmPullSecret = "helm-pull-secret"
 	// GardenRoleObservability is the value of the GardenRole key indicating type 'observability'.
 	GardenRoleObservability = "observability"
+	// GardenRoleIngress is the value of the GardenRole key indicating type 'ingress'.
+	GardenRoleIngress = "ingress"
 
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`

--- a/pkg/gardenlet/operation/botanist/dnsrecord.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord.go
@@ -27,7 +27,7 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordExternal) || b.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
-			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordExternalName,
+			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordExternal,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		},
 	}
@@ -64,7 +64,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 			b.IsRestorePhase(),
 		IPStack: gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
-			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordInternalName,
+			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordInternal,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		},
 	}

--- a/pkg/gardenlet/operation/botanist/dnsrecord.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord.go
@@ -26,6 +26,10 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 		TTL:               b.dnsRecordTTLSeconds(),
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordExternal) || b.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
+		Labels: map[string]string{
+			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordExternalName,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+		},
 	}
 
 	if b.NeedsExternalDNS() {
@@ -59,6 +63,10 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 			controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordInternal) ||
 			b.IsRestorePhase(),
 		IPStack: gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
+		Labels: map[string]string{
+			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordInternalName,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+		},
 	}
 
 	if b.NeedsInternalDNS() {

--- a/pkg/gardenlet/operation/botanist/dnsrecord_test.go
+++ b/pkg/gardenlet/operation/botanist/dnsrecord_test.go
@@ -193,6 +193,10 @@ var _ = Describe("dnsrecord", func() {
 				Values:            []string{address},
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
+				Labels: map[string]string{
+					"role":                "external",
+					"gardener.cloud/role": "controlplane",
+				},
 			}))
 		})
 
@@ -239,6 +243,10 @@ var _ = Describe("dnsrecord", func() {
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
+					},
+					Labels: map[string]string{
+						"role":                "external",
+						"gardener.cloud/role": "controlplane",
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{
@@ -296,6 +304,10 @@ var _ = Describe("dnsrecord", func() {
 				Values:            []string{address},
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
+				Labels: map[string]string{
+					"role":                "internal",
+					"gardener.cloud/role": "controlplane",
+				},
 			}))
 		})
 
@@ -348,6 +360,10 @@ var _ = Describe("dnsrecord", func() {
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
+					Labels: map[string]string{
+						"role":                "internal",
+						"gardener.cloud/role": "controlplane",
+					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{
 					DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -397,7 +413,7 @@ var _ = Describe("dnsrecord", func() {
 		})
 
 		Context("restore", func() {
-			var shootState = &gardencorev1beta1.ShootState{}
+			shootState := &gardencorev1beta1.ShootState{}
 
 			JustBeforeEach(func() {
 				b.Shoot.SetShootState(shootState)
@@ -457,7 +473,7 @@ var _ = Describe("dnsrecord", func() {
 		})
 
 		Context("restore", func() {
-			var shootState = &gardencorev1beta1.ShootState{}
+			shootState := &gardencorev1beta1.ShootState{}
 
 			JustBeforeEach(func() {
 				b.Shoot.SetShootState(shootState)

--- a/pkg/gardenlet/operation/botanist/nginxingress.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress.go
@@ -111,8 +111,8 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
-			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordExternal,
-			v1beta1constants.GardenRole: v1beta1constants.GardenRoleIngress,
+			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordIngress,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		},
 	}
 

--- a/pkg/gardenlet/operation/botanist/nginxingress.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress.go
@@ -111,7 +111,7 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
 		Labels: map[string]string{
-			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordExternalName,
+			v1beta1constants.LabelRole:  v1beta1constants.LabelDNSRecordExternal,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleIngress,
 		},
 	}

--- a/pkg/gardenlet/operation/botanist/nginxingress.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress.go
@@ -110,6 +110,10 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		TTL:               b.dnsRecordTTLSeconds(),
 		AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployDNSRecordIngress) || b.IsRestorePhase(),
 		IPStack:           gardenerutils.GetIPStackForShoot(b.Shoot.GetInfo()),
+		Labels: map[string]string{
+			v1beta1constants.LabelRole:  v1beta1constants.DNSRecordExternalName,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleIngress,
+		},
 	}
 
 	// Set component values even if the nginx-ingress addons is not enabled.

--- a/pkg/gardenlet/operation/botanist/nginxingress_test.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress_test.go
@@ -224,6 +224,10 @@ var _ = Describe("NginxIngress", func() {
 				Values:            []string{address},
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
+				Labels: map[string]string{
+					"role":                "external",
+					"gardener.cloud/role": "ingress",
+				},
 			}))
 		})
 
@@ -271,6 +275,10 @@ var _ = Describe("NginxIngress", func() {
 				Values:            []string{address},
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
+				Labels: map[string]string{
+					"role":                "external",
+					"gardener.cloud/role": "ingress",
+				},
 			}))
 		})
 
@@ -296,6 +304,10 @@ var _ = Describe("NginxIngress", func() {
 					Annotations: map[string]string{
 						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
+					},
+					Labels: map[string]string{
+						"role":                "external",
+						"gardener.cloud/role": "ingress",
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{
@@ -346,7 +358,7 @@ var _ = Describe("NginxIngress", func() {
 		})
 
 		Context("restore", func() {
-			var shootState = &gardencorev1beta1.ShootState{}
+			shootState := &gardencorev1beta1.ShootState{}
 
 			BeforeEach(func() {
 				b.Shoot.SetShootState(shootState)

--- a/pkg/gardenlet/operation/botanist/nginxingress_test.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress_test.go
@@ -225,8 +225,8 @@ var _ = Describe("NginxIngress", func() {
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
 				Labels: map[string]string{
-					"role":                "external",
-					"gardener.cloud/role": "ingress",
+					"role":                "ingress",
+					"gardener.cloud/role": "controlplane",
 				},
 			}))
 		})
@@ -276,8 +276,8 @@ var _ = Describe("NginxIngress", func() {
 				AnnotateOperation: false,
 				IPStack:           "ipv4",
 				Labels: map[string]string{
-					"role":                "external",
-					"gardener.cloud/role": "ingress",
+					"role":                "ingress",
+					"gardener.cloud/role": "controlplane",
 				},
 			}))
 		})

--- a/pkg/gardenlet/operation/botanist/nginxingress_test.go
+++ b/pkg/gardenlet/operation/botanist/nginxingress_test.go
@@ -306,8 +306,8 @@ var _ = Describe("NginxIngress", func() {
 						v1beta1constants.GardenerTimestamp: now.UTC().Format(time.RFC3339Nano),
 					},
 					Labels: map[string]string{
-						"role":                "external",
-						"gardener.cloud/role": "ingress",
+						"role":                "ingress",
+						"gardener.cloud/role": "controlplane",
 					},
 				},
 				Spec: extensionsv1alpha1.DNSRecordSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Adds labels to DNSRecords created for each shoot. This allows to use label selectors to only get the DNSRecords that are used for the Kubernetes API server.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardenlet now adds labels for `DNSRecord` resources created for `Shoot` control planes. This allows using label selectors to target `DNSRecord`s used for `Shoot` control plane components.
```
