### PR TITLE
Deflake lease controller integration tests

### DIFF
--- a/test/integration/gardenlet/seed/lease/lease_test.go
+++ b/test/integration/gardenlet/seed/lease/lease_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Seed lease controller tests", func() {
 	Describe("do not update the Lease object and set the internal health status to false", Ordered, func() {
 		var fakeError error
 
-		BeforeEach(OncePerOrdered, func() {
+		BeforeAll(func() {
 			DeferCleanup(test.WithVar(&leasecontroller.CheckConnection, func(context.Context, rest.Interface) error { return fakeError }))
 		})
 

--- a/test/integration/gardenlet/shoot/lease/lease_test.go
+++ b/test/integration/gardenlet/shoot/lease/lease_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Shoot lease controller tests", func() {
 	Describe("do not update the Lease object and set the internal health status to false", Ordered, func() {
 		var fakeError error
 
-		BeforeEach(OncePerOrdered, func() {
+		BeforeAll(func() {
 			DeferCleanup(test.WithVar(&leasecontroller.CheckConnection, func(context.Context, rest.Interface) error { return fakeError }))
 		})
 

--- a/test/integration/operator/controllerregistrar/controllerregistrar_test.go
+++ b/test/integration/operator/controllerregistrar/controllerregistrar_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Controller Registrar controller tests", Ordered, func() {
+var _ = Describe("Controller Registrar controller tests", func() {
 	var (
 		operatorCtx, operatorCancel = context.WithCancel(ctx)
 		garden                      *operatorv1alpha1.Garden


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

After switching to `Ordered` tests in https://github.com/gardener/gardener/pull/13342, the lease controller integration tests are flaky:

```
$ cd ./test/integration/gardenlet/shoot/lease
$ ginkgo build .
$ stress -ignore "unable to grab random port" -count 1000 -p 200 ./lease.test -ginkgo.focus="do not update the Lease object and set the internal health status to false"
...
• [FAILED] [0.215 seconds]
Shoot lease controller tests do not update the Lease object and set the internal health status to false [It] should ensure the Lease object is not updated and the internal health status remains false
/Users/ebertti/go/src/github.com/gardener/gardener/test/integration/gardenlet/shoot/lease/lease_test.go:114

  [FAILED] Failed after 0.214s.
  The function passed to Consistently failed at /Users/ebertti/go/src/github.com/gardener/gardener/test/integration/gardenlet/shoot/lease/lease_test.go:117 with:
  Expected
      <time.Duration>: 0
  to be >=
      <time.Duration>: 3600000000000
  In [It] at: /Users/ebertti/go/src/github.com/gardener/gardener/test/integration/gardenlet/shoot/lease/lease_test.go:121 @ 11/13/25 11:39:55.299
------------------------------

Summarizing 1 Failure:
  [FAIL] Shoot lease controller tests do not update the Lease object and set the internal health status to false [It] should ensure the Lease object is not updated and the internal health status remains false
  /Users/ebertti/go/src/github.com/gardener/gardener/test/integration/gardenlet/shoot/lease/lease_test.go:121
...
43s: 1000 runs total, 6 failures (0.60%)
```

I suspect that this is because the `BeforeEach` is executed before each `It`, even with the `OncePerOrdered` decorator. The decorator only seems to work outside the `Ordered` container.

With this change:
```
$ stress -ignore "unable to grab random port" -count 4000 -p 200 ./lease.test -ginkgo.focus="do not update the Lease object and set the internal health status to false"
...
2m35s: 4000 runs total, 0 failures
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
