### PR TITLE
[GEP-34] Enable `Collector` Passthrough Directly to `Vali`

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -248,6 +248,7 @@ cat <<EOF | sudo tee -a /etc/hosts
 172.18.255.1 gu-local--local.ingress.local.seed.local.gardener.cloud
 172.18.255.1 p-local--local.ingress.local.seed.local.gardener.cloud
 172.18.255.1 v-local--local.ingress.local.seed.local.gardener.cloud
+172.18.255.1 otc-local--local.ingress.local.seed.local.gardener.cloud
 
 # E2E tests
 172.18.255.1 api.e2e-managedseed.garden.external.local.gardener.cloud

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -438,7 +438,6 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 	}
 
 	if o.values.WithRBACProxy {
-		// TODO(rrhubenov): Remove the rbac-proxy container when the `OpenTelemetryCollector` feature gate is promoted to GA.
 		obj.Spec.Ports = append(obj.Spec.Ports, otelv1beta1.PortsSpec{
 			ServicePort: corev1.ServicePort{
 				Name: kubeRBACProxyName + "-vali",
@@ -452,7 +451,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 			},
 		})
 		obj.Spec.AdditionalContainers = []corev1.Container{
-			// TODO(rrhubenov): Remove the rbac-proxy container when the `OpenTelemetryCollector` feature gate is promoted to GA.
+			// TODO(rrhubenov): Remove the rbac-proxy-vali container when the `OpenTelemetryCollector` feature gate is promoted to GA.
 			{
 				Name:  kubeRBACProxyName + "-vali",
 				Image: o.values.KubeRBACProxyImage,
@@ -556,6 +555,7 @@ func (o *otelCollector) getIngress(secretName string) *networkingv1.Ingress {
 						},
 					},
 				},
+				// TODO(rrhubenov): Clean up the vali Ingress rule when the `OpenTelemetryCollector` feature gate is promoted to GA.
 				{
 					Host: o.values.ValiHost,
 					IngressRuleValue: networkingv1.IngressRuleValue{

--- a/pkg/component/observability/opentelemetry/collector/constants/constants.go
+++ b/pkg/component/observability/opentelemetry/collector/constants/constants.go
@@ -24,9 +24,9 @@ const (
 	PushEndpoint = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
 	// PushPort is the port that the OTLP receiver listens on in the OpenTelemetry Collector deployment.
 	PushPort = 4317
-	// KubeRBACProxyLokiReceiverPort is the port that the KubeRBACProxy that forwards to the `loki` receiver listens on in the OpenTelemetry Collector deployment.
-	KubeRBACProxyLokiReceiverPort int32 = 8081
-	// KubeRBACProxyOTLPReceiverPort is the port that the KubeRBACProxy that forwards to the `otlp` receiver listens on in the OpenTelemetry Collector deployment.
+	// KubeRBACProxyValiPort defines the port of the KubeRBACProxy within the OpenTelemetryCollector deployment responsible for forwarding authenticated traffic directly to `Vali`.
+	KubeRBACProxyValiPort int32 = 8081
+	// KubeRBACProxyOTLPReceiverPort defines the port of the KubeRBACProxy within the OpenTelemetryCollector deployment responsible for forwarding authenticated traffic to the OTLP receiver of the OpenTelemetry Collector.
 	KubeRBACProxyOTLPReceiverPort int32 = 8080
 	// OpenTelemetryCollectorSecretName is the name of a secret in the kube-system namespace in the target cluster containing
 	// opentelemetry-collector's token for communication with the kube-apiserver.

--- a/pkg/component/observability/opentelemetry/collector/constants/constants.go
+++ b/pkg/component/observability/opentelemetry/collector/constants/constants.go
@@ -24,9 +24,9 @@ const (
 	PushEndpoint = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
 	// PushPort is the port that the OTLP receiver listens on in the OpenTelemetry Collector deployment.
 	PushPort = 4317
-	// KubeRBACProxyLokiReceiverPort is the port that the KubeRBACProxy that forwrads to the `loki` receiver listens on in the OpenTelemetry Collector deployment.
+	// KubeRBACProxyLokiReceiverPort is the port that the KubeRBACProxy that forwards to the `loki` receiver listens on in the OpenTelemetry Collector deployment.
 	KubeRBACProxyLokiReceiverPort int32 = 8081
-	// KubeRBACProxyOTLPReceiverPort is the port that the KubeRBACProxy that forwrads to the `otlp` receiver listens on in the OpenTelemetry Collector deployment.
+	// KubeRBACProxyOTLPReceiverPort is the port that the KubeRBACProxy that forwards to the `otlp` receiver listens on in the OpenTelemetry Collector deployment.
 	KubeRBACProxyOTLPReceiverPort int32 = 8080
 	// OpenTelemetryCollectorSecretName is the name of a secret in the kube-system namespace in the target cluster containing
 	// opentelemetry-collector's token for communication with the kube-apiserver.

--- a/pkg/component/observability/opentelemetry/collector/constants/constants.go
+++ b/pkg/component/observability/opentelemetry/collector/constants/constants.go
@@ -24,8 +24,10 @@ const (
 	PushEndpoint = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
 	// PushPort is the port that the OTLP receiver listens on in the OpenTelemetry Collector deployment.
 	PushPort = 4317
-	// KubeRBACProxyPort is the port that the KubeRBACProxy listens on in the OpenTelemetry Collector deployment.
-	KubeRBACProxyPort int32 = 8080
+	// KubeRBACProxyLokiReceiverPort is the port that the KubeRBACProxy that forwrads to the `loki` receiver listens on in the OpenTelemetry Collector deployment.
+	KubeRBACProxyLokiReceiverPort int32 = 8081
+	// KubeRBACProxyOTLPReceiverPort is the port that the KubeRBACProxy that forwrads to the `otlp` receiver listens on in the OpenTelemetry Collector deployment.
+	KubeRBACProxyOTLPReceiverPort int32 = 8080
 	// OpenTelemetryCollectorSecretName is the name of a secret in the kube-system namespace in the target cluster containing
 	// opentelemetry-collector's token for communication with the kube-apiserver.
 	OpenTelemetryCollectorSecretName = "gardener-opentelemetry-collector"

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -152,6 +152,7 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 			Replicas:                b.Shoot.GetReplicas(1),
 			ShootNodeLoggingEnabled: b.isShootNodeLoggingEnabled(),
 			IngressHost:             b.ComputeOpenTelemetryCollectorHost(),
+			ValiHost:                b.ComputeValiHost(),
 		},
 		b.SecretsManager,
 	), nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
It was discovered that there are other components that rely on the `Vali` ingress to send logs. 
The change that was brought with the `OpenTelemetryCollector` featureGate renamed the ingress and forced the use of `OTLP` for sending logs. [Ref](https://github.com/gardener/gardener/pull/12568).

This change allows the continued use of the`Vali` ingress that will allow direct pushing of logs bypassing the collector entirely. This is temporary and will be removed when the `OpenTelemetryCollector` featureGate reaches GA status.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`Vali` can now ingest logs through the standard ingress in the `Shoot` control plane even when the `OpenTelemetryCollector` feature gate is enabled. This allows other parties that rely on it to migrate at their pace while it matures.
```
