### PR TITLE
Fix controller-gen markers for `core/v1` and `core/v1beta1` types

### DIFF
--- a/pkg/apis/core/v1/types_controllerdeployment.go
+++ b/pkg/apis/core/v1/types_controllerdeployment.go
@@ -15,6 +15,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
 
 // ControllerDeployment contains information about how this controller is deployed.
 type ControllerDeployment struct {

--- a/pkg/apis/core/v1beta1/types_backupbucket.go
+++ b/pkg/apis/core/v1beta1/types_backupbucket.go
@@ -13,6 +13,8 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 
 // BackupBucket holds details about backup bucket
 type BackupBucket struct {

--- a/pkg/apis/core/v1beta1/types_backupentry.go
+++ b/pkg/apis/core/v1beta1/types_backupentry.go
@@ -15,6 +15,8 @@ const (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:subresource:status
 
 // BackupEntry holds details about shoot backup.
 type BackupEntry struct {

--- a/pkg/apis/core/v1beta1/types_cloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_cloudprofile.go
@@ -19,6 +19,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
 
 // CloudProfile represents certain properties about a provider environment.
 type CloudProfile struct {

--- a/pkg/apis/core/v1beta1/types_controllerdeployment.go
+++ b/pkg/apis/core/v1beta1/types_controllerdeployment.go
@@ -14,6 +14,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
 
 // ControllerDeployment contains information about how this controller is deployed.
 type ControllerDeployment struct {

--- a/pkg/apis/core/v1beta1/types_controllerinstallation.go
+++ b/pkg/apis/core/v1beta1/types_controllerinstallation.go
@@ -13,6 +13,8 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 
 // ControllerInstallation represents an installation request for an external controller.
 type ControllerInstallation struct {

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -11,6 +11,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
 
 // ControllerRegistration represents a registration of an external controller.
 type ControllerRegistration struct {

--- a/pkg/apis/core/v1beta1/types_exposureclass.go
+++ b/pkg/apis/core/v1beta1/types_exposureclass.go
@@ -11,6 +11,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
 
 // ExposureClass represents a control plane endpoint exposure strategy.
 type ExposureClass struct {

--- a/pkg/apis/core/v1beta1/types_internalsecret.go
+++ b/pkg/apis/core/v1beta1/types_internalsecret.go
@@ -11,6 +11,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
 
 // InternalSecret holds secret data of a certain type. The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.

--- a/pkg/apis/core/v1beta1/types_namespacedcloudprofile.go
+++ b/pkg/apis/core/v1beta1/types_namespacedcloudprofile.go
@@ -11,6 +11,8 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:subresource:status
 
 // NamespacedCloudProfile represents certain properties about a provider environment.
 type NamespacedCloudProfile struct {

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -12,6 +12,8 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 
 // Project holds certain properties about a Gardener project.
 type Project struct {

--- a/pkg/apis/core/v1beta1/types_quota.go
+++ b/pkg/apis/core/v1beta1/types_quota.go
@@ -11,6 +11,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
 
 // Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 type Quota struct {

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -11,6 +11,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
 
 // SecretBinding represents a binding to a secret in the same or another namespace.
 //

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -14,6 +14,8 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:subresource:status
 
 // Seed represents an installation request for an external controller.
 type Seed struct {

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -19,6 +19,8 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:subresource:status
 
 // Shoot represents a Shoot cluster created and managed by Gardener.
 type Shoot struct {

--- a/pkg/apis/core/v1beta1/types_shootstate.go
+++ b/pkg/apis/core/v1beta1/types_shootstate.go
@@ -12,6 +12,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:scope=Namespaced
 
 // ShootState contains a snapshot of the Shoot's state required to migrate the Shoot's control plane to a new Seed.
 type ShootState struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

This PR adds the missing resource scope markers for the `core/v1beta1` and `core/v1` API types.

Because these markers are currently missing, the default resource scope is always `Namespaced`.

This results in invalid CRDs when generating via `controller-gen`. e.g. `Project`, `Seed`, `CloudProfile` (and others) become `Namespaced` scoped, which is wrong.

Also, add `status` markers for any of the resources, which provide a status field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
