### PR TITLE
[GEP-28] `gardenadm connect`: Enable `vpaevictionrequirements` controller in `gardenlet`

### DIFF
--- a/pkg/controller/vpaevictionrequirements/add.go
+++ b/pkg/controller/vpaevictionrequirements/add.go
@@ -51,13 +51,13 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, seedCluster cluster.Clust
 			MaxConcurrentReconciles: ptr.Deref(r.ConcurrentSyncs, 0),
 			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,
 		}).
-		WatchesRawSource(
-			source.Kind[client.Object](seedCluster.GetCache(),
-				&vpaautoscalingv1.VerticalPodAutoscaler{},
-				&handler.EnqueueRequestForObject{},
-				vpaEvictionRequirementsManagedByControllerPredicate,
-				predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update),
-				predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})),
-		).
+		WatchesRawSource(source.Kind[client.Object](
+			seedCluster.GetCache(),
+			&vpaautoscalingv1.VerticalPodAutoscaler{},
+			&handler.EnqueueRequestForObject{},
+			vpaEvictionRequirementsManagedByControllerPredicate,
+			predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update),
+			predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}),
+		)).
 		Complete(r)
 }

--- a/pkg/controller/vpaevictionrequirements/reconciler.go
+++ b/pkg/controller/vpaevictionrequirements/reconciler.go
@@ -31,8 +31,8 @@ var upscaleOnlyRequirement = []*vpaautoscalingv1.EvictionRequirement{{
 
 // Reconciler implements the reconciliation logic for adding/removing EvictionRequirements to VPA objects.
 type Reconciler struct {
-	ConcurrentSyncs *int
 	SeedClient      client.Client
+	ConcurrentSyncs *int
 	Clock           clock.Clock
 }
 

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -102,6 +102,10 @@ func AddToManager(
 			return fmt.Errorf("failed adding ShootState controller: %w", err)
 		}
 
+		if err := vpaevictionrequirements.AddToManager(ctx, mgr, gardenletCancel, *cfg.Controllers.VPAEvictionRequirements, seedCluster); err != nil {
+			return fmt.Errorf("failed adding VPAEvictionRequirements controller: %w", err)
+		}
+
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/vpaevictionrequirements/add.go
+++ b/pkg/gardenlet/controller/vpaevictionrequirements/add.go
@@ -35,7 +35,20 @@ func AddToManager(
 		return fmt.Errorf("failed checking whether the seed is the garden cluster: %w", err)
 	}
 	if seedIsGarden {
-		return nil // When the seed is the garden cluster at the same time, the gardener-operator runs this controller.
+		// When the seed is the garden cluster, the gardener-operator runs this controller.
+		return nil
+	}
+
+	if !gardenletutils.IsResponsibleForSelfHostedShoot() {
+		seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+		if err != nil {
+			return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
+		}
+		if seedIsSelfHostedShoot {
+			// When the seed is a self-hosted shoot cluster, the gardenlet responsible for the self-hosted shoot in the
+			// kube-system namespace runs this controller.
+			return nil
+		}
 	}
 
 	if err := (&vpaevictionrequirements.Reconciler{
@@ -44,25 +57,43 @@ func AddToManager(
 		return err
 	}
 
-	// At this point, the seed is not the garden cluster at the same time. However, this could change during the runtime
-	// of gardenlet. If so, gardener-operator will take over responsibility of the VPA eviction requirements and will run
-	// this controller. Since there is no way to stop a controller after it started, we cancel the manager context in
-	// case the seed is registered as garden during runtime. This way, gardenlet will restart and not add the controller
-	// again.
+	// At this point, the seed is not the garden cluster. However, this could change during the runtime of gardenlet.
+	// If so, gardener-operator will take over responsibility of the VPA eviction requirements and will run this
+	// controller.
+	// Similarly, the seed is not a self-hosted shoot cluster (at least not detectable right now, maybe because it was
+	// not yet connected to Gardener, i.e., a gardenlet deployment in the kube-system namespace does not exist, but this
+	// could change during the runtime of gardenlet). If so, the gardenlet in the kube-system namespace will take over
+	// responsibility of the VPA eviction requirements and will run this controller.
+	// Since there is no way to stop a controller after it started, we cancel the manager context in such cases. This
+	// way, gardenlet will restart and not add the controller again.
 	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		wait.Until(func() {
 			seedIsGarden, err = gardenletutils.SeedIsGarden(ctx, seedCluster.GetClient())
 			if err != nil {
-				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster at the same time")
+				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster")
 				return
 			}
-			if !seedIsGarden {
+			if seedIsGarden {
+				mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been registered as garden cluster. " +
+					"This effectively stops the VPAEvictionRequirements controller (gardener-operator takes over now).")
+				gardenletCancel()
 				return
 			}
 
-			mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been registered as garden cluster. " +
-				"This effectively stops the VPAEvictionRequirements controller (gardener-operator takes over now).")
-			gardenletCancel()
+			if !gardenletutils.IsResponsibleForSelfHostedShoot() {
+				seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+				if err != nil {
+					mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is a self-hosted shoot cluster")
+					return
+				}
+				if seedIsSelfHostedShoot {
+					mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been detect to be a self-hosted " +
+						"shoot cluster. This effectively stops the VPAEvictionRequirements controller (gardenlet in the " +
+						"kube-system namespace takes over now).")
+					gardenletCancel()
+					return
+				}
+			}
 		}, SeedIsGardenCheckInterval, ctx.Done())
 		return nil
 	}))

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,31 @@ var _ = Describe("Gardenlet", func() {
 					return &meta.NoResourceMatchError{}
 				})
 			Expect(SeedIsGarden(ctx, mockReader)).To(BeFalse())
+		})
+	})
+
+	Describe("#SeedIsSelfHostedShoot", func() {
+		var (
+			ctx        = context.Background()
+			fakeClient client.Client
+		)
+
+		BeforeEach(func() {
+			fakeClient = fake.NewClientBuilder().Build()
+		})
+
+		It("should return that the seed is a self-hosted shoot", func() {
+			Expect(fakeClient.Create(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gardenlet",
+					Namespace: "kube-system",
+				},
+			})).To(Succeed())
+			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
+		})
+
+		It("should return that the seed is not a self-hosted shoot because no gardenlet deployment found", func() {
+			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR enables the `vpa-eviction-requirements` controller for self-hosted shoot `gardenlet`s.
It adds a helper to detect whether a seed is backed by a self-hosted shoot and adjusts the controller startup logic so that the controller is only activated when appropriate.  
This improves support for self-hosted shoot `gardenlet`s and ensures the VPA eviction requirements logic is consistently applied in these environments.

| Self-Hosted Shoot? | Is Seed? | Is Garden? | Who runs this controller?    |
| ------------------ | -------- | ---------- | ---------------------------- |
|         0          |    0     |     0      | nobody                       |
|         0          |    0     |     1      | `gardener-operator`          |
|         0          |    1     |     0      | `gardenlet` in `garden`      |
|         0          |    1     |     1      | `gardener-operator`          |
|         1          |    0     |     0      | `gardenlet` in `kube-system` |
|         1          |    0     |     1      | `gardener-operator`          |
|         1          |    1     |     0      | `gardenlet` in `kube-system` |
|         1          |    1     |     1      | `gardener-operator`          |

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @ScheererJ @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
