### PR TITLE
Set `useClientProtocol` in destination rules to `true` when `IstioTLSTermination` is enabled

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -479,6 +479,9 @@ var _ = Describe("#SNI", func() {
 			BeforeEach(func() {
 				istioTLSTermination = true
 
+				expectedDestinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+					UseClientProtocol: true,
+				}
 				expectedDestinationRule.Spec.TrafficPolicy.LoadBalancer = &istioapinetworkingv1beta1.LoadBalancerSettings{
 					LbPolicy: &istioapinetworkingv1beta1.LoadBalancerSettings_Simple{
 						Simple: istioapinetworkingv1beta1.LoadBalancerSettings_LEAST_REQUEST,
@@ -544,6 +547,9 @@ var _ = Describe("#SNI", func() {
 					Hosts:     wildcardHosts,
 				}
 
+				expectedDestinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+					UseClientProtocol: true,
+				}
 				expectedDestinationRule.Spec.TrafficPolicy.LoadBalancer = &istioapinetworkingv1beta1.LoadBalancerSettings{
 					LbPolicy: &istioapinetworkingv1beta1.LoadBalancerSettings_Simple{
 						Simple: istioapinetworkingv1beta1.LoadBalancerSettings_LEAST_REQUEST,
@@ -625,6 +631,9 @@ var _ = Describe("#SNI", func() {
 					Hosts:               wildcardHosts,
 				}
 
+				expectedDestinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+					UseClientProtocol: true,
+				}
 				expectedDestinationRule.Spec.TrafficPolicy.LoadBalancer = &istioapinetworkingv1beta1.LoadBalancerSettings{
 					LbPolicy: &istioapinetworkingv1beta1.LoadBalancerSettings_Simple{
 						Simple: istioapinetworkingv1beta1.LoadBalancerSettings_LEAST_REQUEST,

--- a/pkg/component/test/istiocomponent.go
+++ b/pkg/component/test/istiocomponent.go
@@ -19,6 +19,7 @@ func CmpOptsForDestinationRule() cmp.Option {
 		istioapinetworkingv1beta1.DestinationRule{},
 		istioapinetworkingv1beta1.TrafficPolicy{},
 		istioapinetworkingv1beta1.ConnectionPoolSettings{},
+		istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{},
 		istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{},
 		istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{},
 		istioapinetworkingv1beta1.LoadBalancerSettings{},

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -35,6 +35,9 @@ func DestinationRuleWithTLSTermination(destinationRule *istionetworkingv1beta1.D
 			CredentialName: caSecret,
 			Sni:            sniHost,
 		},
+		&istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+			UseClientProtocol: true,
+		},
 	)
 }
 
@@ -55,6 +58,7 @@ func DestinationRuleWithLocalityPreferenceAndTLS(destinationRule *istionetworkin
 			MinHealthPercent: 0,
 		},
 		tls,
+		nil,
 	)
 }
 
@@ -65,6 +69,7 @@ func destinationRuleWithTrafficPolicy(
 	loadbalancer *istioapinetworkingv1beta1.LoadBalancerSettings,
 	outlierDetection *istioapinetworkingv1beta1.OutlierDetection,
 	tls *istioapinetworkingv1beta1.ClientTLSSettings,
+	httpConnectionPool *istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings,
 ) func() error {
 	return func() error {
 		destinationRule.Labels = labels
@@ -80,6 +85,7 @@ func destinationRuleWithTrafficPolicy(
 							Interval: &durationpb.Duration{Seconds: 75},
 						},
 					},
+					Http: httpConnectionPool,
 				},
 				LoadBalancer:     loadbalancer,
 				OutlierDetection: outlierDetection,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane scalability
/kind bug

**What this PR does / why we need it**:
We found out, that Istio Ingress-Gateways use HTTP1.1 by default when forwarding requests to upstream services.
Thus, we had something like an "connection downgrade" for shoots where L7 load-balancing was active.
This might lead to many connections between Envoy and kube-apiservers which could even exceed our limit of 5000 connections. When this happened new client connections timed out.

This PR fixes the issue by setting `useClientProtocol` of destination rules for kube-apiserver to `true` when L7 load-balancing is used.
We can't enforce an connection upgrade to HTTP2, because then the streaming APIs (like `kubectl port-forward`) which are using websockets (see [this blog post](https://kubernetes.io/blog/2024/08/20/websockets-transition/)) won't work anymore.

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which made istio-ingressgateway forwarding requests via HTTP1.1 only to kube-apiserver when `IstioTLSTermination` feature gate is active has been fixed. Exhausted connection limits between istio-ingressgateway and kube-apiserver could be a consequence of this bug.
```
