### PR TITLE
test/e2e/gardener/project: Eliminate `BeforeTestSetup`

### DIFF
--- a/test/e2e/gardener/project/project_roles.go
+++ b/test/e2e/gardener/project/project_roles.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	. "github.com/gardener/gardener/test/e2e"
 	. "github.com/gardener/gardener/test/e2e/gardener"
 )
 
@@ -34,7 +33,7 @@ var _ = Describe("Project Tests", Ordered, Label("Project", "default"), func() {
 		extensionClusterRole *rbacv1.ClusterRole
 	)
 
-	BeforeTestSetup(func() {
+	BeforeAll(func() {
 		projectName := "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:5]
 
 		project := &gardencorev1beta1.Project{
@@ -47,9 +46,7 @@ var _ = Describe("Project Tests", Ordered, Label("Project", "default"), func() {
 		}
 
 		s = NewTestContext().ForProject(project)
-	})
 
-	BeforeAll(func() {
 		DeferCleanup(func(ctx SpecContext) {
 			Eventually(func(g Gomega) {
 				if testEndpoint != nil {
@@ -66,8 +63,13 @@ var _ = Describe("Project Tests", Ordered, Label("Project", "default"), func() {
 		}, NodeTimeout(time.Minute))
 	})
 
-	ItShouldCreateProject(s)
-	ItShouldWaitForProjectToBeReconciledAndReady(s)
+	It("Create Project", func(ctx SpecContext) {
+		CreateProject(ctx, s)
+	}, SpecTimeout(time.Minute))
+
+	It("Wait for Project to be reconciled", func(ctx SpecContext) {
+		WaitForProjectToBeReconciledAndReady(ctx, s)
+	}, SpecTimeout(5*time.Minute))
 
 	It("Initialize test user", func(ctx SpecContext) {
 		testUserName = s.Project.Name
@@ -142,6 +144,11 @@ var _ = Describe("Project Tests", Ordered, Label("Project", "default"), func() {
 		}).Should(Succeed())
 	}, SpecTimeout(time.Minute))
 
-	ItShouldDeleteProject(s)
-	ItShouldWaitForProjectToBeDeleted(s)
+	It("Delete Project", func(ctx SpecContext) {
+		DeleteProject(ctx, s)
+	}, SpecTimeout(time.Minute))
+
+	It("Wait for Project to be deleted", func(ctx SpecContext) {
+		WaitForProjectToBeDeleted(ctx, s)
+	}, SpecTimeout(5*time.Minute))
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/13134

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13134

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
