### PR TITLE
Clean up unused consts

### DIFF
--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -719,18 +719,6 @@ const (
 	// By default we set this to 0 so that then BackupEntryController will trigger deletion immediately.
 	DefaultBackupEntryDeletionGracePeriodHours = 0
 
-	// DefaultDiscoveryDirName is the name of the default directory used for discovering Kubernetes APIs.
-	DefaultDiscoveryDirName = "gardenlet-discovery"
-
-	// DefaultDiscoveryCacheDirName is the name of the default directory used for the discovery cache.
-	DefaultDiscoveryCacheDirName = "cache"
-
-	// DefaultDiscoveryHTTPCacheDirName is the name of the default directory used for the discovery HTTP cache.
-	DefaultDiscoveryHTTPCacheDirName = "http-cache"
-
-	// DefaultDiscoveryTTL is the default ttl for the cached discovery client.
-	DefaultDiscoveryTTL = 10 * time.Second
-
 	// DefaultControllerConcurrentSyncs is a default value for concurrent syncs for controllers.
 	DefaultControllerConcurrentSyncs = 20
 

--- a/pkg/scheduler/apis/config/v1alpha1/types.go
+++ b/pkg/scheduler/apis/config/v1alpha1/types.go
@@ -5,8 +5,6 @@
 package v1alpha1
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 )
@@ -22,12 +20,6 @@ const (
 	SchedulerDefaultLockObjectNamespace = "garden"
 	// SchedulerDefaultLockObjectName is the default lock name for leader election.
 	SchedulerDefaultLockObjectName = "gardener-scheduler-leader-election"
-	// SchedulerDefaultConfigurationConfigMapNamespace is the namespace of the scheduler configuration config map
-	SchedulerDefaultConfigurationConfigMapNamespace = "garden"
-	// SchedulerDefaultConfigurationConfigMapName is the name of the scheduler configuration config map
-	SchedulerDefaultConfigurationConfigMapName = "gardener-scheduler-configmap"
-	// DefaultDiscoveryTTL is the default ttl for the cached discovery client.
-	DefaultDiscoveryTTL = 10 * time.Second
 
 	// LogLevelDebug is the debug log level, i.e. the most verbose.
 	LogLevelDebug = "debug"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Clean up some unused constants from the `github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1` and `github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1` pkgs.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
