### PR TITLE
Add resources to Garden API

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -144,6 +144,39 @@ spec:
                   - type
                   type: object
                 type: array
+              resources:
+                description: Resources holds a list of named resource references that
+                  can be referred to in extension configs by their names.
+                items:
+                  description: NamedResourceReference is a named reference to a resource.
+                  properties:
+                    name:
+                      description: Name of the resource reference.
+                      type: string
+                    resourceRef:
+                      description: ResourceRef is a reference to a resource.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the API version of the referent
+                          type: string
+                        kind:
+                          description: 'kind is the kind of the referent; More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'name is the name of the referent; More info:
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  - resourceRef
+                  type: object
+                type: array
               runtimeCluster:
                 description: RuntimeCluster contains configuration for the runtime
                   cluster.

--- a/docs/api-reference/operator.md
+++ b/docs/api-reference/operator.md
@@ -1570,6 +1570,18 @@ VirtualCluster
 <p>VirtualCluster contains configuration for the virtual cluster.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+[]github.com/gardener/gardener/pkg/apis/core/v1beta1.NamedResourceReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources holds a list of named resource references that can be referred to in extension configs by their names.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1699,6 +1711,18 @@ VirtualCluster
 </td>
 <td>
 <p>VirtualCluster contains configuration for the virtual cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+[]github.com/gardener/gardener/pkg/apis/core/v1beta1.NamedResourceReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources holds a list of named resource references that can be referred to in extension configs by their names.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/extensions/referenced-resources.md
+++ b/docs/extensions/referenced-resources.md
@@ -1,6 +1,6 @@
 # Referenced Resources
 
-`Shoot`s and `Seed`s can include a list of resources (usually secrets) that can be referenced by name in the extension `providerConfig` and other Shoot sections, for example:
+`Shoot`s, `Seed`s and `Garden`s can include a list of resources (usually secrets) that can be referenced by name in the extension `providerConfig` and other Shoot sections, for example:
 
 ```yaml
 kind: Shoot
@@ -26,7 +26,7 @@ spec:
       name: my-foobar-secret
 ```
 
-Gardener expects these referenced resources to be located in the project namespace (e.g., `garden-dev`) for `Shoot`s and in the `garden` namespace for `Seed`s.
+Gardener expects these referenced resources to be located in the project namespace (e.g., `garden-dev`) for `Shoot`s and in the `garden` namespace for `Seed`s and `Garden`s.
 `Seed` resources are copied to the `garden` namespace in the seed cluster, while `Shoot` resources are copied to the control-plane namespace in the shoot cluster.
 To avoid conflicts with other resources in the shoot, all resources in the seed are prefixed with a static value.
 

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -144,6 +144,39 @@ spec:
                   - type
                   type: object
                 type: array
+              resources:
+                description: Resources holds a list of named resource references that
+                  can be referred to in extension configs by their names.
+                items:
+                  description: NamedResourceReference is a named reference to a resource.
+                  properties:
+                    name:
+                      description: Name of the resource reference.
+                      type: string
+                    resourceRef:
+                      description: ResourceRef is a reference to a resource.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the API version of the referent
+                          type: string
+                        kind:
+                          description: 'kind is the kind of the referent; More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'name is the name of the referent; More info:
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  - resourceRef
+                  type: object
+                type: array
               runtimeCluster:
                 description: RuntimeCluster contains configuration for the runtime
                   cluster.

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -315,3 +315,10 @@ spec:
     networking:
       services:
       - 100.64.0.0/13
+# List resources referenced by providerConfig and other sections
+# resources:
+# - name: foobar-secret
+#   resourceRef:
+#     apiVersion: v1
+#     kind: Secret
+#     name: my-foobar-secret

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -251,7 +251,7 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 	}
 
 	allErrs = append(allErrs, validateExtensions(seedSpec.Extensions, fldPath.Child("extensions"))...)
-	allErrs = append(allErrs, validateResources(seedSpec.Resources, fldPath.Child("resources"))...)
+	allErrs = append(allErrs, ValidateResources(seedSpec.Resources, fldPath.Child("resources"))...)
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -251,7 +251,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Purpose, workerless, fldPath.Child("addons"))...)
 	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
-	allErrs = append(allErrs, validateResources(spec.Resources, fldPath.Child("resources"))...)
+	allErrs = append(allErrs, ValidateResources(spec.Resources, fldPath.Child("resources"))...)
 	allErrs = append(allErrs, validateKubernetes(spec.Kubernetes, spec.Networking, workerless, fldPath.Child("kubernetes"))...)
 	allErrs = append(allErrs, validateNetworking(spec.Networking, workerless, fldPath.Child("networking"))...)
 	allErrs = append(allErrs, validateMaintenance(spec.Maintenance, fldPath.Child("maintenance"), workerless)...)

--- a/pkg/apis/core/validation/shootstate.go
+++ b/pkg/apis/core/validation/shootstate.go
@@ -56,7 +56,7 @@ func ValidateShootStateSpec(shootStateSpec *core.ShootStateSpec, fldPath *field.
 		if extension.Purpose != nil && len(*extension.Purpose) == 0 {
 			allErrs = append(allErrs, field.Invalid(purposePath, extension.Purpose, "extension resource purpose cannot be empty"))
 		}
-		allErrs = append(allErrs, validateResources(extension.Resources, fldPath.Child("resources"))...)
+		allErrs = append(allErrs, ValidateResources(extension.Resources, fldPath.Child("resources"))...)
 	}
 
 	for i, resource := range shootStateSpec.Resources {

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -532,7 +532,8 @@ func validateExtensions(extensions []core.Extension, fldPath *field.Path) field.
 	return allErrs
 }
 
-func validateResources(resources []core.NamedResourceReference, fldPath *field.Path) field.ErrorList {
+// ValidateResources validates the given list of NamedResourceReference for valid values and combinations.
+func ValidateResources(resources []core.NamedResourceReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	names := sets.Set[string]{}
 	for i, resource := range resources {

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -64,6 +64,9 @@ type GardenSpec struct {
 	RuntimeCluster RuntimeCluster `json:"runtimeCluster"`
 	// VirtualCluster contains configuration for the virtual cluster.
 	VirtualCluster VirtualCluster `json:"virtualCluster"`
+	// Resources holds a list of named resource references that can be referred to in extension configs by their names.
+	// +optional
+	Resources []gardencorev1beta1.NamedResourceReference `json:"resources,omitempty"`
 }
 
 // DNSManagement contains specifications of DNS providers.

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -72,8 +72,22 @@ func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alph
 	allErrs = append(allErrs, validateExtensions(garden.Spec.Extensions, extensions, field.NewPath("spec", "extensions"))...)
 	allErrs = append(allErrs, validateRuntimeCluster(garden.Spec.DNS, garden.Spec.RuntimeCluster, helper.HighAvailabilityEnabled(garden), field.NewPath("spec", "runtimeCluster"))...)
 	allErrs = append(allErrs, validateVirtualCluster(garden.Spec.DNS, garden.Spec.VirtualCluster, garden.Spec.RuntimeCluster, field.NewPath("spec", "virtualCluster"))...)
+	allErrs = append(allErrs, validateResources(garden.Spec.Resources, field.NewPath("spec", "resources"))...)
 
 	return allErrs
+}
+
+func validateResources(resources []gardencorev1beta1.NamedResourceReference, path *field.Path) field.ErrorList {
+	coreResources := make([]gardencore.NamedResourceReference, 0, len(resources))
+	for i, res := range resources {
+		coreResource := &gardencore.NamedResourceReference{}
+		if err := gardenCoreScheme.Convert(&res, coreResource, nil); err != nil {
+			return field.ErrorList{field.InternalError(path.Index(i), err)}
+		}
+		coreResources = append(coreResources, *coreResource)
+	}
+
+	return gardencorevalidation.ValidateResources(coreResources, path)
 }
 
 // ValidateGardenUpdate contains functionality for performing extended validation of a Garden object under update which

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -2531,6 +2532,42 @@ var _ = Describe("Validation Tests", func() {
 						Expect(ValidateGarden(garden, extensions)).To(BeEmpty())
 					})
 				})
+			})
+		})
+
+		Context("resources", func() {
+			BeforeEach(func() {
+				garden.Spec.Resources = []gardencorev1beta1.NamedResourceReference{
+					{
+						Name: "test",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "Secret",
+							Name:       "test-secret",
+							APIVersion: "v1",
+						},
+					},
+				}
+			})
+
+			It("should not complain for valid resource names", func() {
+				Expect(ValidateGarden(garden, extensions)).To(BeEmpty())
+			})
+
+			It("should complain about duplicate resource names", func() {
+				garden.Spec.Resources = append(garden.Spec.Resources, gardencorev1beta1.NamedResourceReference{
+					Name: garden.Spec.Resources[0].Name,
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "ConfigMap",
+						Name:       "some-other-name",
+						APIVersion: "v1",
+					},
+				})
+
+				Expect(ValidateGarden(garden, extensions)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeDuplicate),
+						"Field": Equal("spec.resources[1].name"),
+					}))))
 			})
 		})
 	})

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -864,6 +864,11 @@ func (in *GardenSpec) DeepCopyInto(out *GardenSpec) {
 	}
 	in.RuntimeCluster.DeepCopyInto(&out.RuntimeCluster)
 	in.VirtualCluster.DeepCopyInto(&out.VirtualCluster)
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = make([]v1beta1.NamedResourceReference, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/operator/controller/garden/reference/add_test.go
+++ b/pkg/operator/controller/garden/reference/add_test.go
@@ -7,6 +7,7 @@ package reference_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -140,6 +141,21 @@ var _ = Describe("Add", func() {
 		It("should return true because the gardener-apiserver admission plugin secret fields changed", func() {
 			oldShoot := garden.DeepCopy()
 			garden.Spec.VirtualCluster.Gardener.APIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{{KubeconfigSecretName: ptr.To("foo")}}
+			Expect(Predicate(oldShoot, garden)).To(BeTrue())
+		})
+
+		It("should return true because the resource references changed", func() {
+			oldShoot := garden.DeepCopy()
+			garden.Spec.Resources = []gardencorev1beta1.NamedResourceReference{
+				{
+					Name: "foo",
+					ResourceRef: autoscalingv1.CrossVersionObjectReference{
+						APIVersion: "v1",
+						Kind:       "Secret",
+						Name:       "bar",
+					},
+				},
+			}
 			Expect(Predicate(oldShoot, garden)).To(BeTrue())
 		})
 	})

--- a/test/integration/operator/garden/reference/reference_test.go
+++ b/test/integration/operator/garden/reference/reference_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Garden Reference controller tests", func() {
 						},
 					},
 					{
-						Name: "secret-resource",
+						Name: "configmap-resource",
 						ResourceRef: autoscalingv1.CrossVersionObjectReference{
 							Kind:       "ConfigMap",
 							APIVersion: "v1",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Similar to shoot and seed resources, this PR introduces a new field `spec.resources` to the Garden API for configuring resources that extensions can reference. This enhancement provides consistent resource handling across all cluster types.

**Which issue(s) this PR fixes**:
Fixes #13227

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new field `spec.resources` was added to the Garden API. The field can be used by extensions to reference `Secret`s and `ConfigMap`s. See [this documentation](https://github.com/gardener/gardener/blob/master/docs/extensions/referenced-resources.md) for more details.
```
