### PR TITLE
Remove outdated info from Kubernetes version upgrade guide

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -172,33 +172,6 @@ After the PR in `gardener/gardener` for the support of the new version has been 
 Provider extensions are using upstream `cloud-controller-manager` images.
 Make sure to adopt the new `cloud-controller-manager` release for the new Kubernetes minor version ([example PR](https://github.com/gardener/gardener-extension-provider-aws/pull/1055)).
 
-Some of the cloud providers are not using upstream `cloud-controller-manager` images for some of the supported Kubernetes versions.
-Instead, we build and maintain the images ourselves:
-
-- [cloud-provider-gcp](https://github.com/gardener/cloud-provider-gcp)
-
-Use the instructions below in case you need to maintain a release branch for such `cloud-controller-manager` image:
-
-<details>
-
-<summary>Expand the instructions!</summary>
-
-Until we switch to upstream images, you need to update the Kubernetes dependencies and release a new image.
-The required steps are as follows:
-
-- Checkout the `legacy-cloud-provider` branch of the respective repository
-- Bump the versions in the `Dockerfile` ([example commit](https://github.com/gardener/cloud-provider-gcp/commit/b7eb3f56b252aaf29adc78406672574b1bc17495)).
-- Update the `VERSION` to `vX.Y.Z-dev` where `Z` is the latest available Kubernetes patch version for the `vX.Y` minor version.
-- Update the `k8s.io/*` dependencies in the `go.mod` file to `vX.Y.Z` and run `go mod tidy` ([example commit](https://github.com/gardener/cloud-provider-gcp/commit/d41cc9f035bcc4893b40d90a4f617c4d436c5d62)).
-- Checkout a new `release-vX.Y` branch and release it ([example](https://github.com/gardener/cloud-provider-gcp/commits/release-v1.23))
-
-> As you are already on it, it is great if you also bump the `k8s.io/*` dependencies for the last three minor releases as well.
-In this case, you need to check out the `release-vX.{Y-{1,2,3}}` branches and only perform the last three steps ([example branch](https://github.com/gardener/cloud-provider-gcp/commits/release-v1.20), [example commit](https://github.com/gardener/cloud-provider-gcp/commit/372aa43fbacdeb76b3da9f6fad6cfd924d916227)).
-
-Now you need to update the new releases in the `imagevector/images.yaml` of the respective provider extension so that they are used (see this [example commit](https://github.com/gardener/gardener-extension-provider-aws/pull/942/commits/7e5c0d95ff95d65459d13ae7f79a030049322c71) for reference).
-
-</details>
-
 #### Maintaining Additional Images
 
 Provider extensions might also deploy additional images other than `cloud-controller-manager` that are specific for a given Kubernetes minor version.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

The provider-gcp extension does not use a custom built `cloud-controller-manager` anymore ([ref](https://github.com/gardener/gardener/blob/d8ce263975cbc9dfe67434c34f82adf823d78ec9/docs/development/new-kubernetes-version.md?plain=1#L175-L178))

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
