### PR TITLE
Reduce retention to latest 4 K8s minor versions only

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -8,7 +8,7 @@ This document describes the steps needed to perform in order to confidently add 
 - Ensure Gardener and extensions are updated to support the new Kubernetes version ([example](https://github.com/gardener/gardener/issues/11020))
 - Bump Golang dependencies for `k8s.io/*` and `sigs.k8s.io/controller-runtime` ([example](https://github.com/gardener/gardener/issues/11186)) [[ref](#bump-golang-dependencies-for-k8sio-and-sigsk8siocontroller-runtime)]
 - Prepare a short (~30-60 min) session for a special edition of Gardener's Review Meeting on new key features and changes in the release
-- Drop support for all but the greatest/latest 5 Kubernetes minor versions (the newly added plus four prior). Drop all lower/older versions and adapt accordingly ([example](https://github.com/gardener/gardener/pull/10664))
+- Drop support for all but the greatest/latest 4 Kubernetes minor versions (the newly added plus three prior). Drop all lower/older versions and adapt accordingly ([example](https://github.com/gardener/gardener/pull/10664))
 
 Version | Expected Release Date | Release Responsibles                                                                         |
 --------|-----------------------|----------------------------------------------------------------------------------------------|

--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -9,6 +9,7 @@ This document describes the steps needed to perform in order to confidently add 
 - Bump Golang dependencies for `k8s.io/*` and `sigs.k8s.io/controller-runtime` ([example](https://github.com/gardener/gardener/issues/11186)) [[ref](#bump-golang-dependencies-for-k8sio-and-sigsk8siocontroller-runtime)]
 - Prepare a short (~30-60 min) session for a special edition of Gardener's Review Meeting on new key features and changes in the release
 - Drop support for all but the greatest/latest 4 Kubernetes minor versions (the newly added plus three prior). Drop all lower/older versions and adapt accordingly ([example](https://github.com/gardener/gardener/pull/10664))
+  - Removing support is only possible if the Kubernetes version to be dropped has been supported for at least 14 months. See [Supported Kubernetes Versions](../usage/shoot-operations/supported_k8s_versions.md) for details.
 
 Version | Expected Release Date | Release Responsibles                                                                         |
 --------|-----------------------|----------------------------------------------------------------------------------------------|

--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -205,6 +205,9 @@ Typically, the following validations should be performed:
 If everything looks good, then go ahead and file the PR ([example PR](https://github.com/gardener/gardener-extension-provider-aws/pull/480)).
 Generally, it is again great if you add the PRs also to the umbrella issue so that they can be tracked more easily.
 
+Once the release is published that adds support for the new Kubernetes version, update the [Supported Kubernetes Versions](../usage/shoot-operations/supported_k8s_versions.md) table accordingly.
+We consider a new Kubernetes version supported by Gardener with the release of `gardener/gardener` and keep support for at least 14 months after the publish date of the release.
+
 ### Bump Golang dependencies for `k8s.io/*` and `sigs.k8s.io/controller-runtime`
 
 The versions of the upstream Go dependencies `k8s.io/*` and `sigs.k8s.io/controller-runtime` should be updated to the latest version that is compatible with the new Kubernetes version.

--- a/docs/development/remove-support-for-kubernetes-version.md
+++ b/docs/development/remove-support-for-kubernetes-version.md
@@ -11,6 +11,7 @@ This guide describes the typical steps to remove support for a Kubernetes versio
 ## Prerequisites
 
 - As mentioned in [Adding Support For a New Kubernetes Version](new-kubernetes-version.md) - adding support for a new Kubernetes version is a prerequisite for dropping support for versions older than 4 Kubernetes minor versions.
+- A Kubernetes version has to be supported for at least 14 months after its initial support date. Check the [Supported Kubernetes Versions](../usage/shoot-operations/supported_k8s_versions.md) page for details.
 
 ## Tasks
 

--- a/docs/development/remove-support-for-kubernetes-version.md
+++ b/docs/development/remove-support-for-kubernetes-version.md
@@ -10,7 +10,7 @@ This guide describes the typical steps to remove support for a Kubernetes versio
 
 ## Prerequisites
 
-- As mentioned in [Adding Support For a New Kubernetes Version](new-kubernetes-version.md) - adding support for a new Kubernetes version is a prerequisite for dropping support for versions older than 5 Kubernetes minor versions.
+- As mentioned in [Adding Support For a New Kubernetes Version](new-kubernetes-version.md) - adding support for a new Kubernetes version is a prerequisite for dropping support for versions older than 4 Kubernetes minor versions.
 
 ## Tasks
 

--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -6,7 +6,7 @@ title: Supported Kubernetes Versions
 
 Currently, Gardener supports the following Kubernetes versions:
 
-| Kubernetes version                                                         | Gardener version                                                         | Support added | Supported until |
+| Kubernetes version                                                         | Since Gardener version                                                   | Support added | Supported until |
 |----------------------------------------------------------------------------|--------------------------------------------------------------------------|---------------|-----------------|
 | [`v1.30`](https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/) | [`v1.95.0`](https://github.com/gardener/gardener/releases/tag/v1.95.0)   | `2024-05-16`  | `2025-07-16`    |
 | [`v1.31`](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/) | [`v1.106.0`](https://github.com/gardener/gardener/releases/tag/v1.106.0) | `2024-10-21`  | `2025-12-21`    |

--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -8,11 +8,11 @@ Currently, Gardener supports the following Kubernetes versions:
 
 ## Garden Clusters
 
-The minimum version of a garden cluster that can be used to run Gardener is **`1.30.x`**.
+The minimum version of a garden cluster that can be used to run Gardener is **`1.30.x`** up to **`1.34.x`**.
 
 ## Seed Clusters
 
-The minimum version of a seed cluster that can be connected to Gardener is **`1.30.x`**.
+The minimum version of a seed cluster that can be connected to Gardener is **`1.30.x`** up to **`1.34.x`**.
 
 ## Shoot Clusters
 

--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -6,6 +6,17 @@ title: Supported Kubernetes Versions
 
 Currently, Gardener supports the following Kubernetes versions:
 
+| Kubernetes version                                                         | Gardener version                                                         | Support added | Supported until |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------|---------------|-----------------|
+| [`v1.30`](https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/) | [`v1.95.0`](https://github.com/gardener/gardener/releases/tag/v1.95.0)   | `2024-05-16`  | `2025-07-16`    |
+| [`v1.31`](https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/) | [`v1.106.0`](https://github.com/gardener/gardener/releases/tag/v1.106.0) | `2024-10-21`  | `2025-12-21`    |
+| [`v1.32`](https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/) | [`v1.113.0`](https://github.com/gardener/gardener/releases/tag/v1.113.0) | `2025-02-24`  | `2026-04-24`    |
+| [`v1.33`](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/) | [`v1.122.0`](https://github.com/gardener/gardener/releases/tag/v1.122.0) | `2025-06-27`  | `2026-08-27`    |
+| [`v1.34`](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/) | [`v1.132.0`](https://github.com/gardener/gardener/releases/tag/v1.132.0) | `2025-11-13`  | `2027-01-13`    |
+
+> [!NOTE]  
+> Gardener supports Kubernetes versions for at least 14 months after their initial support date.
+
 ## Garden Clusters
 
 The minimum version of a garden cluster that can be used to run Gardener is **`1.30.x`** up to **`1.34.x`**.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area ops-productivity
/kind cleanup

**What this PR does / why we need it**:

This PR adapts our guide for supporting new Kubernetes versions, reducing the retention of supported Kubernetes versions to 4. Additionally, it adds a minimum lifetime of 14 months, which Gardener should support a Kubernetes version before dropping it again.

Quoting from: https://github.com/gardener/gardener/pull/12201
> Motivation: Older Kubernetes versions only receive security patches for approximately 14 months (about three minor versions). Being more aggressive in dropping outdated versions improves the security posture of Gardener and its adopters, simplifies vulnerability assessments, and reduces exposure to known issues.

Extended motivation:
https://github.com/gardener/gardener/pull/12201#issuecomment-2918926371

See also:
https://endoflife.date/kubernetes

**Which issue(s) this PR fixes**:

Follow-up to:
* https://github.com/gardener/gardener/pull/12201

**Special notes for your reviewer**:

cc @heldkat @dkistner @dguendisch @ccwienk @donistz @fheine @HeckEK @jordanjordanov @kon-angelo @rfranzke @vlerenc @timebertt @majst01 @Gerrit91 @schrodit @veith4f @berendt @franziska-schallhorn

fyi @ScheererJ @tobschli, as the current [Kubernetes release responsibles](https://github.com/gardener/gardener/blob/master/docs/development/new-kubernetes-version.md#kubernetes-release-responsible-plan)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Adapted the policy in the Kubernetes version support process to retain only the latest 4 minor versions, improving security by dropping older, unpatched versions. Additionally, a minimum period of 14 months has been added, during which Gardener will maintain support for any given Kubernetes version before removing it again.
```
