### PR TITLE
feat(plutono): Add new dashboard for `VPA Updater`

### DIFF
--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -360,7 +360,7 @@ func (v *vpa) reconcileUpdaterServiceMonitor(serviceMonitor *monitoringv1.Servic
 		}},
 	}
 
-	if v.values.ClusterType == component.ClusterTypeShoot {
+	if v.values.ClusterType == component.ClusterTypeShoot && !v.values.IsManagedSeed {
 		serviceMonitor.Spec.Endpoints[0].MetricRelabelConfigs = []monitoringv1.RelabelConfig{
 			{
 				SourceLabels: []monitoringv1.LabelName{"vpa_namespace"},

--- a/pkg/component/autoscaling/vpa/updater.go
+++ b/pkg/component/autoscaling/vpa/updater.go
@@ -359,4 +359,14 @@ func (v *vpa) reconcileUpdaterServiceMonitor(serviceMonitor *monitoringv1.Servic
 			},
 		}},
 	}
+
+	if v.values.ClusterType == component.ClusterTypeShoot {
+		serviceMonitor.Spec.Endpoints[0].MetricRelabelConfigs = []monitoringv1.RelabelConfig{
+			{
+				SourceLabels: []monitoringv1.LabelName{"vpa_namespace"},
+				Regex:        "(kube-system|)",
+				Action:       "keep",
+			},
+		}
+	}
 }

--- a/pkg/component/autoscaling/vpa/vpa.go
+++ b/pkg/component/autoscaling/vpa/vpa.go
@@ -91,6 +91,8 @@ type Values struct {
 	ClusterType component.ClusterType
 	// IsGardenCluster specifies if the VPA is being deployed in a cluster registered as a Garden.
 	IsGardenCluster bool
+	// IsManagedSeed specifies if the VPA is being deployed in a Managed Seed clusters.
+	IsManagedSeed bool
 	// SecretNameServerCA is the name of the server CA secret.
 	SecretNameServerCA string
 	// RuntimeKubernetesVersion is the Kubernetes version of the runtime cluster.

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -2060,7 +2060,7 @@ var _ = Describe("VPA", func() {
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should not have merics relabel config keeping only `vpa_namespace=kube-system` metrics", func() {
+					It("should take all metrics", func() {
 						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, true)
 						serviceMonitorExpected.ResourceVersion = "1"
 

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -562,6 +562,13 @@ var _ = Describe("VPA", func() {
 			case clusterType == component.ClusterTypeShoot:
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-updater"
+				obj.Spec.Endpoints[0].MetricRelabelConfigs = []monitoringv1.RelabelConfig{
+					{
+						SourceLabels: []monitoringv1.LabelName{"vpa_namespace"},
+						Regex:        "(kube-system|)",
+						Action:       "keep",
+					},
+				}
 			}
 
 			return obj

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -78,7 +78,7 @@ var _ = Describe("VPA", func() {
 		vpa       component.DeployWaiter
 		consistOf func(...client.Object) types.GomegaMatcher
 		contain   func(...client.Object) types.GomegaMatcher
-		vpaFor    func(component.ClusterType, bool, map[string]bool) component.DeployWaiter
+		vpaFor    func(component.ClusterType, bool, bool, map[string]bool) component.DeployWaiter
 
 		imageAdmissionController = "some-image:for-admission-controller"
 		imageRecommender         = "some-image:for-recommender"
@@ -129,7 +129,7 @@ var _ = Describe("VPA", func() {
 		podDisruptionBudgetUpdater       *policyv1.PodDisruptionBudget
 		vpaUpdater                       *vpaautoscalingv1.VerticalPodAutoscaler
 		serviceUpdaterFor                func(component.ClusterType, bool) *corev1.Service
-		serviceMonitorUpdaterFor         func(clusterType component.ClusterType, isGardenCluster bool) *monitoringv1.ServiceMonitor
+		serviceMonitorUpdaterFor         func(clusterType component.ClusterType, isGardenCluster bool, isManagedSeed bool) *monitoringv1.ServiceMonitor
 
 		serviceAccountRecommender                    *corev1.ServiceAccount
 		clusterRoleRecommenderMetricsReader          *rbacv1.ClusterRole
@@ -190,10 +190,11 @@ var _ = Describe("VPA", func() {
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
 
-		vpaFor = func(clusterType component.ClusterType, isGardenCluster bool, featureGates map[string]bool) component.DeployWaiter {
+		vpaFor = func(clusterType component.ClusterType, isGardenCluster bool, isManagedSeed bool, featureGates map[string]bool) component.DeployWaiter {
 			vpa = New(c, namespace, sm, Values{
 				ClusterType:              clusterType,
 				IsGardenCluster:          isGardenCluster,
+				IsManagedSeed:            isManagedSeed,
 				SecretNameServerCA:       secretNameCA,
 				RuntimeKubernetesVersion: runtimeKubernetesVersion,
 				AdmissionController:      valuesAdmissionController,
@@ -523,7 +524,7 @@ var _ = Describe("VPA", func() {
 
 			return obj
 		}
-		serviceMonitorUpdaterFor = func(clusterType component.ClusterType, isGardenCluster bool) *monitoringv1.ServiceMonitor {
+		serviceMonitorUpdaterFor = func(clusterType component.ClusterType, isGardenCluster bool, isManagedSeed bool) *monitoringv1.ServiceMonitor {
 			obj := &monitoringv1.ServiceMonitor{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -562,12 +563,14 @@ var _ = Describe("VPA", func() {
 			case clusterType == component.ClusterTypeShoot:
 				obj.Labels = map[string]string{"prometheus": "shoot"}
 				obj.Name = "shoot-vpa-updater"
-				obj.Spec.Endpoints[0].MetricRelabelConfigs = []monitoringv1.RelabelConfig{
-					{
-						SourceLabels: []monitoringv1.LabelName{"vpa_namespace"},
-						Regex:        "(kube-system|)",
-						Action:       "keep",
-					},
+				if !isManagedSeed {
+					obj.Spec.Endpoints[0].MetricRelabelConfigs = []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"vpa_namespace"},
+							Regex:        "(kube-system|)",
+							Action:       "keep",
+						},
+					}
 				}
 			}
 
@@ -1570,14 +1573,14 @@ var _ = Describe("VPA", func() {
 	Describe("#Deploy", func() {
 		Context("cluster type seed", func() {
 			BeforeEach(func() {
-				vpa = vpaFor(component.ClusterTypeSeed, false, nil)
+				vpa = vpaFor(component.ClusterTypeSeed, false, false, nil)
 				managedResourceName = "vpa"
 			})
 
 			Context("when deploying Services", func() {
 				Context("in a garden cluster", func() {
 					BeforeEach(func() {
-						vpa = vpaFor(component.ClusterTypeSeed, true, nil)
+						vpa = vpaFor(component.ClusterTypeSeed, true, false, nil)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -1611,7 +1614,7 @@ var _ = Describe("VPA", func() {
 			Context("when deploying ServiceMonitors", func() {
 				Context("in a garden cluster", func() {
 					BeforeEach(func() {
-						vpa = vpaFor(component.ClusterTypeSeed, true, nil)
+						vpa = vpaFor(component.ClusterTypeSeed, true, false, nil)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -1626,7 +1629,7 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-updater ServiceMonitor with `prometheus=garden`", func() {
-						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, true)
+						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, true, false)
 						Expect(managedResource).To(contain(serviceMonitorUpdater))
 					})
 				})
@@ -1647,7 +1650,7 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-updater ServiceMonitor with `prometheus=seed`", func() {
-						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, false)
+						serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeSeed, false, false)
 						Expect(managedResource).To(contain(serviceMonitorUpdater))
 					})
 				})
@@ -1711,7 +1714,7 @@ var _ = Describe("VPA", func() {
 					deploymentUpdater,
 					vpaUpdater,
 					serviceUpdaterFor(component.ClusterTypeSeed, false),
-					serviceMonitorUpdaterFor(component.ClusterTypeSeed, false),
+					serviceMonitorUpdaterFor(component.ClusterTypeSeed, false, false),
 				}
 
 				By("Verify vpa-recommender resources")
@@ -1894,7 +1897,7 @@ var _ = Describe("VPA", func() {
 
 		Context("cluster type shoot", func() {
 			BeforeEach(func() {
-				vpa = vpaFor(component.ClusterTypeShoot, false, nil)
+				vpa = vpaFor(component.ClusterTypeShoot, false, false, nil)
 				managedResourceName = "shoot-core-vpa"
 			})
 
@@ -1912,7 +1915,7 @@ var _ = Describe("VPA", func() {
 
 				Context("without entries", func() {
 					BeforeEach(func() {
-						vpa = vpaFor(component.ClusterTypeShoot, false, nil)
+						vpa = vpaFor(component.ClusterTypeShoot, false, false, nil)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -1946,7 +1949,7 @@ var _ = Describe("VPA", func() {
 						featureGates := map[string]bool{
 							"Foo": true,
 						}
-						vpa = vpaFor(component.ClusterTypeShoot, false, featureGates)
+						vpa = vpaFor(component.ClusterTypeShoot, false, false, featureGates)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -1979,7 +1982,7 @@ var _ = Describe("VPA", func() {
 			Context("when deploying ServiceMonitors", func() {
 				Context("in a garden cluster", func() {
 					BeforeEach(func() {
-						vpa = vpaFor(component.ClusterTypeShoot, true, nil)
+						vpa = vpaFor(component.ClusterTypeShoot, true, false, nil)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -2004,7 +2007,7 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-updater ServiceMonitor with `prometheus=shoot`", func() {
-						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, true)
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, true, false)
 						serviceMonitorExpected.ResourceVersion = "1"
 
 						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
@@ -2016,7 +2019,7 @@ var _ = Describe("VPA", func() {
 
 				Context("when not deployed in a garden cluster", func() {
 					BeforeEach(func() {
-						vpa = vpaFor(component.ClusterTypeShoot, false, nil)
+						vpa = vpaFor(component.ClusterTypeShoot, false, false, nil)
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
@@ -2041,7 +2044,41 @@ var _ = Describe("VPA", func() {
 					})
 
 					It("should label vpa-updater ServiceMonitor with `prometheus=shoot`", func() {
-						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false)
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, false)
+						serviceMonitorExpected.ResourceVersion = "1"
+
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-updater"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
+					})
+				})
+
+				Context("in a managed seed cluster", func() {
+					BeforeEach(func() {
+						vpa = vpaFor(component.ClusterTypeShoot, false, true, nil)
+						Expect(vpa.Deploy(ctx)).To(Succeed())
+					})
+
+					It("should not have merics relabel config keeping only `vpa_namespace=kube-system` metrics", func() {
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, true)
+						serviceMonitorExpected.ResourceVersion = "1"
+
+						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
+						Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-updater"}, serviceMonitorActual)).To(Succeed())
+
+						Expect(serviceMonitorActual).To(Equal(serviceMonitorExpected))
+					})
+				})
+
+				Context("when not deployed in a managed seed cluster", func() {
+					BeforeEach(func() {
+						vpa = vpaFor(component.ClusterTypeShoot, false, false, nil)
+						Expect(vpa.Deploy(ctx)).To(Succeed())
+					})
+
+					It("should have merics relabel config keeping only `vpa_namespace=kube-system` metrics", func() {
+						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, false)
 						serviceMonitorExpected.ResourceVersion = "1"
 
 						serviceMonitorActual := &monitoringv1.ServiceMonitor{}
@@ -2117,7 +2154,7 @@ var _ = Describe("VPA", func() {
 
 				serviceMonitor := &monitoringv1.ServiceMonitor{}
 				Expect(c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "shoot-vpa-updater"}, serviceMonitor)).To(Succeed())
-				serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false)
+				serviceMonitorUpdater := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, false)
 				serviceMonitorUpdater.ResourceVersion = "1"
 				Expect(serviceMonitor).To(Equal(serviceMonitorUpdater))
 

--- a/pkg/component/autoscaling/vpa/vpa_test.go
+++ b/pkg/component/autoscaling/vpa/vpa_test.go
@@ -2077,7 +2077,7 @@ var _ = Describe("VPA", func() {
 						Expect(vpa.Deploy(ctx)).To(Succeed())
 					})
 
-					It("should have merics relabel config keeping only `vpa_namespace=kube-system` metrics", func() {
+					It("should only keep metrics without `vpa_namespace` label or labeled with `vpa_namespace=kube-system`", func() {
 						serviceMonitorExpected := serviceMonitorUpdaterFor(component.ClusterTypeShoot, false, false)
 						serviceMonitorExpected.ResourceVersion = "1"
 

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1,0 +1,995 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1763385805135,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Scale",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 17,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{update_mode}}",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Controlled Pods",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:509",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:510",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "displayLabels": [],
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "pluginVersion": "7.5.40",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "interval": "",
+          "legendFormat": "{{update_mode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Current update mode distribution by Pods",
+      "type": "piechart"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_in_place_updatable_pods_total{pod=\"$pod\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Pending in-place update",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\", update_mode=\"InPlaceOrRecreate\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pods pending in-place update",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:401",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_vpas_with_in_place_updatable_pods_total{pod=\"$pod\"})",
+          "interval": "",
+          "legendFormat": "Matching in-place update criteria",
+          "refId": "Matching criteria"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(floor(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=\"$pod\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Successfully in-place updated",
+          "refId": "Successfully updater"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VPAs with Pods matching in-place update criteria",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:778",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:779",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 19,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_evictable_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Pending eviction with '{{update_mode}}' mode",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\", update_mode!=\"InPlaceOrRecreate\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pods pending eviction",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:401",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:402",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(vpa_updater_vpas_with_evictable_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "interval": "",
+          "legendFormat": "Matching eviction with '{{update_mode}}' mode",
+          "refId": "Matching criteria"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(floor(increase(vpa_updater_vpas_with_evicted_pods_total{pod=\"$pod\"}[$__rate_interval]))) by (update_mode)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Successfully evicted with '{{update_mode}}' mode",
+          "refId": "Successfully evicted"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VPAs with Pods matching eviction criteria",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:778",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:779",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Pod in-place resource updates witin \"$namespace\" namespace",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "successs/{{vpa_name}}",
+          "refId": "Succeeded Pod updates by VPA"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failure/{{vpa_name}}",
+          "refId": "Failed Pod updates by VPA"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total successful updates",
+          "refId": "Total number of successful Pod updates across all VPAs"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total failed updates",
+          "refId": "Total number of failed Pod updates across all VPAs"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pod in-place updates by VPA",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Pod evictions within \"$namespace\" namespace",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "successs/{{vpa_name}}",
+          "refId": "Succeeded Pod evictions by VPA"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "failure/{{vpa_name}}",
+          "refId": "Failed Pod evictions by VPA"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total successful updates",
+          "refId": "Total number of successful Pod evictions across all VPAs"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Total failed updates",
+          "refId": "Total number of failed Pod evictions across all VPAs"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Pod evictions by VPA",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "Autoscaling"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "datasource": null,
+        "definition": "label_values(vpa_updater_controlled_pods_total{},pod)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(vpa_updater_controlled_pods_total{},pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "datasource": null,
+        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/.*vpa_namespace=\"([^\"]+)\".*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "VPA Updater",
+  "uid": "vpa-updater",
+  "version": 9
+}

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -12,10 +12,10 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1764857281400,
+  "iteration": 1764935817718,
   "links": [],
   "panels": [
     {
@@ -85,7 +85,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=~\"$pod\"}) by (update_mode)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{update_mode}}",
@@ -93,7 +93,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"})",
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=~\"$pod\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -198,7 +198,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=~\"$pod\"}) by (update_mode)",
           "interval": "",
           "legendFormat": "{{update_mode}}",
           "refId": "A"
@@ -258,7 +258,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_in_place_updatable_pods_total{pod=\"$pod\"})",
+          "expr": "sum(vpa_updater_in_place_updatable_pods_total{pod=~\"$pod\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Pending in-place update",
@@ -266,7 +266,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\", update_mode=\"InPlaceOrRecreate\"})",
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=~\"$pod\", update_mode=\"InPlaceOrRecreate\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -366,14 +366,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_vpas_with_in_place_updatable_pods_total{pod=\"$pod\"})",
+          "expr": "sum(vpa_updater_vpas_with_in_place_updatable_pods_total{pod=~\"$pod\"})",
           "interval": "",
           "legendFormat": "Matching in-place update criteria",
           "refId": "Matching criteria"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=\"$pod\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=~\"$pod\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully in-place updated",
@@ -475,7 +475,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_evictable_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "expr": "sum(vpa_updater_evictable_pods_total{pod=~\"$pod\"}) by (update_mode)",
           "hide": false,
           "interval": "",
           "legendFormat": "Pending eviction with '{{update_mode}}' mode",
@@ -483,7 +483,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_controlled_pods_total{pod=\"$pod\", update_mode!=\"InPlaceOrRecreate\"})",
+          "expr": "sum(vpa_updater_controlled_pods_total{pod=~\"$pod\", update_mode!=\"InPlaceOrRecreate\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -584,14 +584,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(vpa_updater_vpas_with_evictable_pods_total{pod=\"$pod\"}) by (update_mode)",
+          "expr": "sum(vpa_updater_vpas_with_evictable_pods_total{pod=~\"$pod\"}) by (update_mode)",
           "interval": "",
           "legendFormat": "Matching eviction with '{{update_mode}}' mode",
           "refId": "Matching criteria"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_vpas_with_evicted_pods_total{pod=\"$pod\"}[$__rate_interval]))) by (update_mode)",
+          "expr": "sum(ceil(increase(vpa_updater_vpas_with_evicted_pods_total{pod=~\"$pod\"}[$__rate_interval]))) by (update_mode)",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully evicted with '{{update_mode}}' mode",
@@ -706,7 +706,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -714,7 +714,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -815,7 +815,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -823,7 +823,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -938,7 +938,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -946,7 +946,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1047,7 +1047,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -1055,7 +1055,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1140,7 +1140,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "pod",
-        "multi": false,
+        "multi": true,
         "name": "pod",
         "options": [],
         "query": {
@@ -1160,7 +1160,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=\"$pod\"})",
+        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\"} or vpa_updater_evicted_pods_total{pod=~\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\"})",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1170,7 +1170,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=\"$pod\"})",
+          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\"} or vpa_updater_evicted_pods_total{pod=~\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\"})",
           "refId": "prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1070,7 +1070,6 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Failed Pod evictions by VPA",
-
       "description": "Initial data points are set to 0, because the VPA Updater component does not emit default counter values. This behaviour causes the increase() function to perform its calculation with a single sample, resulting in 0. For more details, see https://github.com/kubernetes/autoscaler/issues/9058.",
       "tooltip": {
         "shared": true,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -726,6 +726,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Successful Pod in-place updates by VPA",
+      "description": "Initial data points are set to 0, because the VPA Updater component does not emit default counter values. This behaviour causes the increase() function to perform its calculation with a single sample, resulting in 0. For more details, see https://github.com/kubernetes/autoscaler/issues/9058.",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -835,6 +836,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Failed Pod in-place updates by VPA",
+      "description": "Initial data points are set to 0, because the VPA Updater component does not emit default counter values. This behaviour causes the increase() function to perform its calculation with a single sample, resulting in 0. For more details, see https://github.com/kubernetes/autoscaler/issues/9058.",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -958,6 +960,7 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Successful Pod evictions by VPA",
+      "description": "Initial data points are set to 0, because the VPA Updater component does not emit default counter values. This behaviour causes the increase() function to perform its calculation with a single sample, resulting in 0. For more details, see https://github.com/kubernetes/autoscaler/issues/9058.",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1067,6 +1070,8 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Failed Pod evictions by VPA",
+
+      "description": "Initial data points are set to 0, because the VPA Updater component does not emit default counter values. This behaviour causes the increase() function to perform its calculation with a single sample, resulting in 0. For more details, see https://github.com/kubernetes/autoscaler/issues/9058.",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1763385805135,
+  "iteration": 1763396492868,
   "links": [],
   "panels": [
     {
@@ -37,7 +37,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -145,7 +145,7 @@
       }
     },
     {
-      "datasource": null,
+      "datasource": "${datasource}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -212,7 +212,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -322,7 +322,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {},
@@ -429,7 +429,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {
@@ -539,7 +539,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {},
@@ -661,7 +661,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {},
@@ -709,31 +709,124 @@
           "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
           "hide": false,
           "interval": "",
-          "legendFormat": "successs/{{vpa_name}}",
+          "legendFormat": "{{vpa_name}}",
           "refId": "Succeeded Pod updates by VPA"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "failure/{{vpa_name}}",
-          "refId": "Failed Pod updates by VPA"
         },
         {
           "exemplar": true,
           "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
-          "legendFormat": "Total successful updates",
+          "legendFormat": "Total",
           "refId": "Total number of successful Pod updates across all VPAs"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Successful Pod in-place updates by VPA",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${datasource}",
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{vpa_name}}",
+          "refId": "Failed Pod updates by VPA"
         },
         {
           "exemplar": true,
           "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
-          "legendFormat": "Total failed updates",
+          "legendFormat": "Total",
           "refId": "Total number of failed Pod updates across all VPAs"
         }
       ],
@@ -741,7 +834,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Pod in-place updates by VPA",
+      "title": "Failed Pod in-place updates by VPA",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -788,7 +881,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 22,
       "panels": [],
@@ -800,7 +893,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "${datasource}",
       "decimals": 0,
       "fieldConfig": {
         "defaults": {},
@@ -812,7 +905,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 24,
@@ -848,31 +941,124 @@
           "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
           "hide": false,
           "interval": "",
-          "legendFormat": "successs/{{vpa_name}}",
+          "legendFormat": "{{vpa_name}}",
           "refId": "Succeeded Pod evictions by VPA"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "failure/{{vpa_name}}",
-          "refId": "Failed Pod evictions by VPA"
         },
         {
           "exemplar": true,
           "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
-          "legendFormat": "Total successful updates",
+          "legendFormat": "Total",
           "refId": "Total number of successful Pod evictions across all VPAs"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Successful Pod evictions by VPA",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:65",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:66",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${datasource}",
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{vpa_name}}",
+          "refId": "Failed Pod evictions by VPA"
         },
         {
           "exemplar": true,
           "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
-          "legendFormat": "Total failed updates",
+          "legendFormat": "Total",
           "refId": "Total number of failed Pod evictions across all VPAs"
         }
       ],
@@ -880,7 +1066,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Pod evictions by VPA",
+      "title": "Failed Pod evictions by VPA",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -930,20 +1116,36 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
-        "datasource": null,
-        "definition": "label_values(vpa_updater_controlled_pods_total{},pod)",
         "description": null,
         "error": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "datasource": "${datasource}",
+        "definition": "label_values(vpa_updater_controlled_pods_total{},pod)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "pod",
+        "multi": false,
         "name": "pod",
         "options": [],
         "query": {
           "query": "label_values(vpa_updater_controlled_pods_total{},pod)",
-          "refId": "StandardVariableQuery"
+          "refId": "prometheus-pod-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
@@ -957,7 +1159,7 @@
       },
       {
         "allValue": null,
-        "datasource": null,
+        "datasource": "${datasource}",
         "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
         "description": null,
         "error": null,
@@ -969,7 +1171,7 @@
         "options": [],
         "query": {
           "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
-          "refId": "StandardVariableQuery"
+          "refId": "prometheus-namespace-Variable-Query"
         },
         "refresh": 1,
         "regex": "/.*vpa_namespace=\"([^\"]+)\".*/",
@@ -984,12 +1186,12 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "VPA Updater",
   "uid": "vpa-updater",
-  "version": 9
+  "version": 17
 }

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1186,12 +1186,28 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "30s",
+      "1m",
+      "5m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "10d"
+    ]
+  },
   "timezone": "utc",
   "title": "VPA Updater",
   "uid": "vpa-updater",
-  "version": 17
+  "version": 1
 }

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -653,7 +653,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Pod in-place resource updates witin \"$namespace\" namespace",
+      "title": "Pod in-place resource updates within \"$namespace\" namespace",
       "type": "row"
     },
     {

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -653,7 +653,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Pod in-place resource updates within \"$namespace\" namespace",
+      "title": "Pod in-place resource updates within \"$vpa_namespace\" namespace",
       "type": "row"
     },
     {
@@ -706,7 +706,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -714,7 +714,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -815,7 +815,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -823,7 +823,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -885,7 +885,7 @@
       },
       "id": 22,
       "panels": [],
-      "title": "Pod evictions within \"$namespace\" namespace",
+      "title": "Pod evictions within \"$vpa_namespace\" namespace",
       "type": "row"
     },
     {
@@ -938,7 +938,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -946,7 +946,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1047,7 +1047,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -1055,7 +1055,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1165,9 +1165,9 @@
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": "namespace",
+        "label": "VPA object namespace",
         "multi": true,
-        "name": "namespace",
+        "name": "vpa_namespace",
         "options": [],
         "query": {
           "query": "{__name__=~\"vpa_updater_.+\", pod=~\"$pod\", vpa_namespace!=\"\"}",

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1134,7 +1134,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "label_values(vpa_updater_controlled_pods_total{},pod)",
+        "definition": "label_values(vpa_updater_controlled_pods_total,pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1144,7 +1144,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(vpa_updater_controlled_pods_total{},pod)",
+          "query": "label_values(vpa_updater_controlled_pods_total,pod)",
           "refId": "prometheus-pod-Variable-Query"
         },
         "refresh": 1,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -373,7 +373,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(floor(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=\"$pod\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=\"$pod\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully in-place updated",
@@ -591,7 +591,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(floor(increase(vpa_updater_vpas_with_evicted_pods_total{pod=\"$pod\"}[$__rate_interval]))) by (update_mode)",
+          "expr": "sum(ceil(increase(vpa_updater_vpas_with_evicted_pods_total{pod=\"$pod\"}[$__rate_interval]))) by (update_mode)",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully evicted with '{{update_mode}}' mode",

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -368,8 +368,8 @@
           "exemplar": true,
           "expr": "sum(vpa_updater_vpas_with_in_place_updatable_pods_total{pod=~\"$pod\"})",
           "interval": "",
-          "legendFormat": "Matching in-place update criteria",
-          "refId": "Matching criteria"
+          "legendFormat": "In-place updatable",
+          "refId": "In-place updatable"
         },
         {
           "exemplar": true,
@@ -377,14 +377,14 @@
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully in-place updated",
-          "refId": "Successfully updater"
+          "refId": "Successfully updated"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "VPAs with Pods matching in-place update criteria",
+      "title": "VPAs with in-place updatable Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -586,8 +586,8 @@
           "exemplar": true,
           "expr": "sum(vpa_updater_vpas_with_evictable_pods_total{pod=~\"$pod\"}) by (update_mode)",
           "interval": "",
-          "legendFormat": "Matching eviction with '{{update_mode}}' mode",
-          "refId": "Matching criteria"
+          "legendFormat": "Evictable with '{{update_mode}}' update mode",
+          "refId": "Evictable"
         },
         {
           "exemplar": true,
@@ -602,7 +602,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "VPAs with Pods matching eviction criteria",
+      "title": "VPAs with evictable Pods",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1160,7 +1160,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
+        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=\"$pod\"})",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1170,7 +1170,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or failed_in_place_update_attempts_total{pod=\"$pod\"} or failed_eviction_attempts_total{pod=\"$pod\"})",
+          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=\"$pod\"} or vpa_updater_evicted_pods_total{pod=\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=\"$pod\"})",
           "refId": "prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -12,10 +12,10 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1763396492868,
+  "iteration": 1764857281400,
   "links": [],
   "panels": [
     {
@@ -73,7 +73,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -247,7 +247,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -355,7 +355,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -464,7 +464,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -573,7 +573,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -695,7 +695,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -706,15 +706,15 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{vpa_name}}",
+          "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
           "refId": "Succeeded Pod updates by VPA"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -804,7 +804,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -815,15 +815,15 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{vpa_name}}",
+          "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
           "refId": "Failed Pod updates by VPA"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -927,7 +927,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -938,15 +938,15 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{vpa_name}}",
+          "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
           "refId": "Succeeded Pod evictions by VPA"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1036,7 +1036,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.43",
+      "pluginVersion": "7.5.44",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1047,15 +1047,15 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval]))) by (vpa_name)",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{vpa_name}}",
+          "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
           "refId": "Failed Pod evictions by VPA"
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=\"$namespace\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=\"$pod\", vpa_namespace=~\"$namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1166,7 +1166,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "namespace",
-        "multi": false,
+        "multi": true,
         "name": "namespace",
         "options": [],
         "query": {

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1160,7 +1160,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "query_result(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\"} or vpa_updater_evicted_pods_total{pod=~\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\"})",
+        "definition": "{__name__=~\"vpa_updater_.+\", pod=~\"$pod\", vpa_namespace!=\"\"}",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1170,7 +1170,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "query_result(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\"} or vpa_updater_evicted_pods_total{pod=~\"$pod\"} or vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\"} or vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\"})",
+          "query": "{__name__=~\"vpa_updater_.+\", pod=~\"$pod\", vpa_namespace!=\"\"}",
           "refId": "prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -685,7 +685,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,
@@ -794,7 +794,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,
@@ -917,7 +917,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,
@@ -1026,7 +1026,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -373,7 +373,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=~\"$pod\"}[$__rate_interval])))",
+          "expr": "sum(floor(increase(vpa_updater_vpas_with_in_place_updated_pods_total{pod=~\"$pod\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully in-place updated",
@@ -591,7 +591,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_vpas_with_evicted_pods_total{pod=~\"$pod\"}[$__rate_interval]))) by (update_mode)",
+          "expr": "sum(floor(increase(vpa_updater_vpas_with_evicted_pods_total{pod=~\"$pod\"}[$__rate_interval]))) by (update_mode)",
           "hide": false,
           "interval": "",
           "legendFormat": "Successfully evicted with '{{update_mode}}' mode",
@@ -706,7 +706,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(floor(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -714,7 +714,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
+          "expr": "sum(floor(increase(vpa_updater_in_place_updated_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -815,7 +815,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(floor(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -823,7 +823,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
+          "expr": "sum(floor(increase(vpa_updater_failed_in_place_update_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -938,7 +938,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(floor(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -946,7 +946,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
+          "expr": "sum(floor(increase(vpa_updater_evicted_pods_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",
@@ -1047,7 +1047,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
+          "expr": "sum(floor(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval]))) by (vpa_name,vpa_namespace)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{vpa_namespace}}/{{vpa_name}}",
@@ -1055,7 +1055,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(ceil(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
+          "expr": "sum(floor(increase(vpa_updater_failed_eviction_attempts_total{pod=~\"$pod\", vpa_namespace=~\"$vpa_namespace\"}[$__rate_interval])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total",

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -754,7 +754,7 @@ status:
 				})
 
 				It("should successfully deploy all resources", func() {
-					checkDeployedResources("plutono-dashboards", 38)
+					checkDeployedResources("plutono-dashboards", 39)
 				})
 			})
 

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -701,7 +701,7 @@ status:
 					})
 
 					It("should successfully deploy all resources", func() {
-						checkDeployedResources("plutono-dashboards-garden", 31)
+						checkDeployedResources("plutono-dashboards-garden", 32)
 					})
 				})
 

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -685,7 +685,7 @@ status:
 					})
 
 					It("should successfully deploy all resources", func() {
-						checkDeployedResources("plutono-dashboards", 27)
+						checkDeployedResources("plutono-dashboards", 28)
 					})
 				})
 			})

--- a/pkg/gardenlet/operation/botanist/vpa.go
+++ b/pkg/gardenlet/operation/botanist/vpa.go
@@ -51,7 +51,7 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 			Replicas:          ptr.To(b.Shoot.GetReplicas(1)),
 		}
 		featureGates  map[string]bool
-		isManagedSeed = b.Operation.ManagedSeed != nil
+		isManagedSeed = b.ManagedSeed != nil
 	)
 
 	if vpaConfig := b.Shoot.GetInfo().Spec.Kubernetes.VerticalPodAutoscaler; vpaConfig != nil {

--- a/pkg/gardenlet/operation/botanist/vpa.go
+++ b/pkg/gardenlet/operation/botanist/vpa.go
@@ -50,7 +50,8 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 			PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane200,
 			Replicas:          ptr.To(b.Shoot.GetReplicas(1)),
 		}
-		featureGates map[string]bool
+		featureGates  map[string]bool
+		isManagedSeed = b.Operation.ManagedSeed != nil
 	)
 
 	if vpaConfig := b.Shoot.GetInfo().Spec.Kubernetes.VerticalPodAutoscaler; vpaConfig != nil {
@@ -84,6 +85,7 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (vpa.Interface, error) {
 		b.SecretsManager,
 		vpa.Values{
 			ClusterType:              component.ClusterTypeShoot,
+			IsManagedSeed:            isManagedSeed,
 			SecretNameServerCA:       v1beta1constants.SecretNameCACluster,
 			RuntimeKubernetesVersion: b.Seed.KubernetesVersion,
 			AdmissionController:      valuesAdmissionController,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR introduces a new `VPA Updater` dashboard for `Plutono` instances running within `Shoot`, `Seed` and `Garden` clusters. WIth this enhancement `vpa-updater` operations will be easily monitored across namespaces and `VerticalPodAutoscaler` resources.

The new dashboard is split into three sections:

<img width="1660" height="182" alt="Screenshot 2026-01-08 at 15 03 05" src="https://github.com/user-attachments/assets/8fcddf19-4a3e-4cb2-9208-b63710e021c4" />

covering a broader _scale_ statistics of the managed resources, as well as both resource updates mechanism, via `in-place` resource updates or Pod `evictions`:

- __Scale__: Overall view of the performed operations and managed VPA resources
  
  <img width="1508" height="1039" alt="scale" src="https://github.com/user-attachments/assets/cec828b6-2548-49a3-ae4a-489815dc6f5a" />

- __Pod in-place resource updates__: _Success_/_failure_ charts of Pod _in-place_ resources updates by `VerticalPodAutoscaler` resource

  <img width="1652" height="654" alt="Screenshot 2026-01-08 at 15 01 56" src="https://github.com/user-attachments/assets/645f85be-4b6e-4c4a-b9d3-62604daa8b6d" />

- __Pod evictions__: _Success_/_failure_ charts of Pod evictions by `VerticalPodAutoscaler` resource

  <img width="1648" height="649" alt="Screenshot 2026-01-08 at 15 02 34" src="https://github.com/user-attachments/assets/558d3688-f635-4fa7-bbb5-846c2d8a199b" />

The new `VPA Updater` dashboard completes the `Autoscaling` suite as the only `VPA` component that was missing an operational dashboard was the `updater`.

#### Additional features

The following additional features are introduced as part of the general dashboard.

##### Dashboard

- Ability to _multi-select_ `vpa-updater` instance(s) which allows monitoring more than one active replicas.
- Ability to _multi-select_ `namespace` label which allows narrowing down monitoring to particular namespace or monitoring the entire cluster.
  - Legend(s) display the entries in the format `namespace/vpa-resource` for ease of navigation.

##### Prometheus Scrape Configuration

To limit the monitored entities to the Gardener out-of-box components within the `Shoot` data plane, this PR introduces an additional filtration in the `vpa-updater` _ServiceMonitor_ that keeps only workload related metrics related to the `kube-system` namespace.

*Note*: `ManagedSeed` clusters are notable exemption, where the above mentioned filtration does not apply.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/12955

<!--
**Special notes for your reviewer**:
-->

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add new `Plutono` dashboard for monitoring `VPA Updater` operations across `Shoot`, `Seed` and `Garden` clusters.
```
