### PR TITLE
Add audit policy configmap validation for operator

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
@@ -54,5 +54,5 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 }
 
 func admitConfig(auditPolicyRaw string, _ []*gardencore.Shoot) (int32, error) {
-	return configvalidator.AdmitAudtPolicy(auditPolicyRaw)
+	return configvalidator.AdmitAuditPolicy(auditPolicyRaw)
 }

--- a/pkg/operator/webhook/validation/add.go
+++ b/pkg/operator/webhook/validation/add.go
@@ -9,6 +9,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operator/webhook/validation/auditpolicy"
 	"github.com/gardener/gardener/pkg/operator/webhook/validation/extension"
 	"github.com/gardener/gardener/pkg/operator/webhook/validation/garden"
 	"github.com/gardener/gardener/pkg/operator/webhook/validation/namespace"
@@ -28,6 +30,10 @@ func AddToManager(mgr manager.Manager) error {
 
 	if err := (&namespace.Handler{}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding %s webhook handler: %w", extension.HandlerName, err)
+	}
+
+	if err := auditpolicy.AddToManager(mgr, v1beta1constants.GardenNamespace); err != nil {
+		return fmt.Errorf("failed adding %s webhook handler: %w", auditpolicy.HandlerName, err)
 	}
 
 	return nil

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -48,12 +48,18 @@ func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, 
 		ConfigMapDataKey: "policy",
 
 		GetNamespace: func() string { return gardenNamespace },
-		GetConfigMapNameFromGarden: func(garden *operatorv1alpha1.Garden) string {
+		GetConfigMapNameFromGarden: func(garden *operatorv1alpha1.Garden) map[string]string {
+			configMapNames := map[string]string{}
 			if garden.Spec.VirtualCluster.Gardener.APIServer != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig != nil &&
 				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-				return garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+				configMapNames["gardener-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
 			}
-			return ""
+
+			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig != nil &&
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+			}
+			return configMapNames
 		},
 		AdmitGardenConfig: configvalidator.AdmitAudtPolicy,
 	}

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -5,15 +5,6 @@
 package auditpolicy
 
 import (
-	"fmt"
-	"net/http"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apiserver/pkg/apis/audit"
-	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	auditvalidation "k8s.io/apiserver/pkg/apis/audit/validation"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -46,15 +37,6 @@ func AddToManager(mgr manager.Manager, gardenNamespace string) error {
 	return nil
 }
 
-var decoder runtime.Decoder
-
-func init() {
-	scheme := runtime.NewScheme()
-	schemeBuilder := runtime.NewSchemeBuilder(auditv1.AddToScheme, audit.AddToScheme)
-	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
-	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
-}
-
 // NewHandler returns a handler that validates audit policy for Garden and referenced ConfigMaps
 func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, gardenNamespace string) admission.Handler {
 	return &configvalidator.Handler{
@@ -73,19 +55,6 @@ func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, 
 			}
 			return ""
 		},
-		AdmitGardenConfig: func(auditPolicyRaw string) (int32, error) {
-			obj, schemaVersion, err := decoder.Decode([]byte(auditPolicyRaw), nil, nil)
-			if err != nil {
-				return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided audit policy: %w", err)
-			}
-			policy, ok := obj.(*audit.Policy)
-			if !ok {
-				return http.StatusInternalServerError, fmt.Errorf("failed to cast to audit policy type: %v", schemaVersion)
-			}
-			if errList := auditvalidation.ValidatePolicy(policy); len(errList) != 0 {
-				return http.StatusUnprocessableEntity, fmt.Errorf("provided invalid audit policy: %v", errList)
-			}
-			return 0, nil
-		},
+		AdmitGardenConfig: configvalidator.AdmitAudtPolicy,
 	}
 }

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auditpolicy
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/apis/audit"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	auditvalidation "k8s.io/apiserver/pkg/apis/audit/validation"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/webhook/configvalidator"
+)
+
+const (
+	// HandlerName is the name of this admission webhook handler.
+	HandlerName = "auditpolicy_validator"
+	// WebhookPath is the HTTP handler path for this admission webhook handler.
+	WebhookPath = "/webhooks/audit-policies"
+)
+
+// AddToManager adds the webhook to the given manager.
+func AddToManager(mgr manager.Manager, gardenNamespace string) error {
+	webhook := &admission.Webhook{
+		Handler: NewHandler(
+			mgr.GetAPIReader(),
+			mgr.GetClient(),
+			admission.NewDecoder(mgr.GetScheme()),
+			gardenNamespace,
+		),
+		RecoverPanic: ptr.To(true),
+	}
+
+	mgr.GetWebhookServer().Register(WebhookPath, webhook)
+	return nil
+}
+
+var decoder runtime.Decoder
+
+func init() {
+	scheme := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(auditv1.AddToScheme, audit.AddToScheme)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+}
+
+// NewHandler returns a handler that validates audit policy for Garden and referenced ConfigMaps
+func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, gardenNamespace string) admission.Handler {
+	return &configvalidator.Handler{
+		APIReader: apiReader,
+		Client:    c,
+		Decoder:   decoderAdmission,
+
+		ConfigMapPurpose: "audit policy",
+		ConfigMapDataKey: "policy",
+
+		GetNamespace: func() string { return gardenNamespace },
+		GetConfigMapNameFromGarden: func(garden *operatorv1alpha1.Garden) string {
+			if garden.Spec.VirtualCluster.Gardener.APIServer != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig != nil &&
+				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+				return garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+			}
+			return ""
+		},
+		AdmitGardenConfig: func(auditPolicyRaw string) (int32, error) {
+			obj, schemaVersion, err := decoder.Decode([]byte(auditPolicyRaw), nil, nil)
+			if err != nil {
+				return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided audit policy: %w", err)
+			}
+			policy, ok := obj.(*audit.Policy)
+			if !ok {
+				return http.StatusInternalServerError, fmt.Errorf("failed to cast to audit policy type: %v", schemaVersion)
+			}
+			if errList := auditvalidation.ValidatePolicy(policy); len(errList) != 0 {
+				return http.StatusUnprocessableEntity, fmt.Errorf("provided invalid audit policy: %v", errList)
+			}
+			return 0, nil
+		},
+	}
+}

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -55,9 +55,9 @@ func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, 
 				configMapNames["gardener-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
 			}
 
-			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig != nil &&
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig != nil &&
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
 			}
 			return configMapNames
 		},

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -55,12 +55,12 @@ func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, 
 				configMapNames["gardener-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
 			}
 
-			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig != nil &&
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
+			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig != nil &&
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
 			}
 			return configMapNames
 		},
-		AdmitGardenConfig: configvalidator.AdmitAudtPolicy,
+		AdmitGardenConfig: configvalidator.AdmitAuditPolicy,
 	}
 }

--- a/pkg/operator/webhook/validation/auditpolicy/add.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add.go
@@ -48,16 +48,16 @@ func NewHandler(apiReader, c client.Reader, decoderAdmission admission.Decoder, 
 		ConfigMapDataKey: "policy",
 
 		GetNamespace: func() string { return gardenNamespace },
-		GetConfigMapNameFromGarden: func(garden *operatorv1alpha1.Garden) map[string]string {
-			configMapNames := map[string]string{}
+		GetConfigMapNamesFromGarden: func(garden *operatorv1alpha1.Garden) []string {
+			configMapNames := []string{}
 			if garden.Spec.VirtualCluster.Gardener.APIServer != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig != nil &&
 				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-				configMapNames["gardener-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+				configMapNames = append(configMapNames, garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name)
 			}
 
 			if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig != nil &&
 				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-				configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+				configMapNames = append(configMapNames, garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name)
 			}
 			return configMapNames
 		},

--- a/pkg/operator/webhook/validation/auditpolicy/add_test.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add_test.go
@@ -256,7 +256,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "referenced configMap is valid", "")
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "all referenced configMaps are valid", "")
 			})
 
 			It("referenced auditPolicy name was not changed (UPDATE)", func() {
@@ -277,7 +277,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "referenced configMap is valid", "")
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "all referenced configMaps are valid", "")
 			})
 
 			It("referenced auditPolicy name was changed (UPDATE)", func() {
@@ -290,7 +290,7 @@ rules:
 					*cm = returnedCm
 					return nil
 				})
-				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "referenced configMap is valid", "")
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "all referenced configMaps are valid", "")
 			})
 
 			It("referenced auditPolicy name was removed (UPDATE)", func() {

--- a/pkg/operator/webhook/validation/auditpolicy/add_test.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add_test.go
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auditpolicy_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	. "github.com/gardener/gardener/pkg/operator/webhook/validation/auditpolicy"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+)
+
+var _ = Describe("handler", func() {
+	var (
+		ctx = context.TODO()
+
+		request admission.Request
+		decoder admission.Decoder
+		handler admission.Handler
+
+		ctrl       *gomock.Controller
+		mockReader *mockclient.MockReader
+		fakeClient client.Client
+
+		statusCodeAllowed       int32 = http.StatusOK
+		statusCodeInvalid       int32 = http.StatusUnprocessableEntity
+		statusCodeInternalError int32 = http.StatusInternalServerError
+
+		testEncoder runtime.Encoder
+
+		cmName      = "fake-cm-name"
+		cmNameOther = "fake-cm-name-other"
+		gardenName  = "fake-garden"
+		gardenNs    = "garden"
+
+		cm     *corev1.ConfigMap
+		garden *operatorv1alpha1.Garden
+
+		validAuditPolicy = `
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: RequestResponse
+    resources:
+    - group: ""
+      resources: ["pods"]
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+`
+		anotherValidAuditPolicy = `
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: RequestResponse
+    resources:
+    - group: ""
+      resources: ["pods"]
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log"]
+`
+		missingKeyAuditPolicy = `
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: RequestResponse
+    resources:
+    - group: "
+      resources: ["pods"]
+`
+		invalidAuditPolicy = `
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  - level: FakeLevel
+    resources:
+    - group: ""
+      resources: ["pods"]
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+`
+
+		validAuditPolicyV1alpha1 = `
+---
+apiVersion: audit.k8s.io/v1alpha1
+kind: Policy
+rules:
+  - level: RequestResponse
+    resources:
+    - group: ""
+      resources: ["pods"]
+  - level: Metadata
+    resources:
+    - group: ""
+      resources: ["pods/log", "pods/status"]
+`
+	)
+
+	BeforeEach(func() {
+		testEncoder = &jsonserializer.Serializer{}
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockReader = mockclient.NewMockReader(ctrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
+
+		decoder = admission.NewDecoder(operatorclient.RuntimeScheme)
+
+		handler = NewHandler(mockReader, fakeClient, decoder, gardenNs)
+
+		request = admission.Request{}
+
+		garden = &operatorv1alpha1.Garden{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: operatorv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "Garden",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: gardenName,
+			},
+			Spec: operatorv1alpha1.GardenSpec{
+				VirtualCluster: operatorv1alpha1.VirtualCluster{
+					Gardener: operatorv1alpha1.Gardener{
+						APIServer: &operatorv1alpha1.GardenerAPIServerConfig{
+							AuditConfig: &gardencorev1beta1.AuditConfig{
+								AuditPolicy: &gardencorev1beta1.AuditPolicy{
+									ConfigMapRef: &corev1.ObjectReference{
+										Name: cmName,
+									},
+								},
+							},
+						},
+					},
+					Kubernetes: operatorv1alpha1.Kubernetes{
+						Version: "1.31.1",
+					},
+				},
+			},
+		}
+
+		cm = &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: gardenNs,
+			},
+			Data: map[string]string{
+				"policy": validAuditPolicy,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	test := func(op admissionv1.Operation, oldObj runtime.Object, obj runtime.Object, expectedAllowed bool, expectedStatusCode int32, expectedMsg string, expectedReason string) {
+		request.Operation = op
+
+		if oldObj != nil {
+			objData, err := runtime.Encode(testEncoder, oldObj)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			request.OldObject.Raw = objData
+		}
+
+		if obj != nil {
+			objData, err := runtime.Encode(testEncoder, obj)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+		}
+
+		response := handler.Handle(ctx, request)
+		ExpectWithOffset(1, response).To(Not(BeNil()))
+		ExpectWithOffset(1, response.Allowed).To(Equal(expectedAllowed))
+		ExpectWithOffset(1, response.Result.Code).To(Equal(expectedStatusCode))
+		if expectedMsg != "" {
+			ExpectWithOffset(1, response.Result.Message).To(ContainSubstring(expectedMsg))
+		}
+		if expectedReason != "" {
+			ExpectWithOffset(1, string(response.Result.Reason)).To(ContainSubstring(expectedReason))
+		}
+		ExpectWithOffset(1, response.Patches).To(BeEmpty())
+	}
+
+	Context("Gardens", func() {
+		BeforeEach(func() {
+			request.Kind = metav1.GroupVersionKind{Group: "operator.gardener.cloud", Version: "v1alpha1", Kind: "Garden"}
+		})
+
+		Context("Allow", func() {
+			It("has no APIServer config", func() {
+				garden.Spec.VirtualCluster.Gardener.APIServer = nil
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
+			})
+
+			It("has no AuditConfig", func() {
+				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig = nil
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
+			})
+
+			It("has no audit policy", func() {
+				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy = nil
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
+			})
+
+			It("has no audit policy cm Ref", func() {
+				garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef = nil
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
+			})
+
+			It("references a valid auditPolicy (CREATE)", func() {
+				returnedCm := corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+					Data:       map[string]string{"policy": validAuditPolicy},
+				}
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "referenced configMap is valid", "")
+			})
+
+			It("referenced auditPolicy name was not changed (UPDATE)", func() {
+				newGarden := garden.DeepCopy()
+				newGarden.Labels = map[string]string{"foo": "bar"}
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "garden spec was not changed", "")
+			})
+
+			It("auditPolicy name was added (UPDATE)", func() {
+				returnedCm := corev1.ConfigMap{
+					Data: map[string]string{"policy": validAuditPolicy},
+				}
+				apiServerConfig := garden.Spec.VirtualCluster.Gardener.APIServer.DeepCopy()
+				garden.Spec.VirtualCluster.Gardener.APIServer = nil
+				newGarden := garden.DeepCopy()
+				newGarden.Spec.VirtualCluster.Gardener.APIServer = apiServerConfig
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "referenced configMap is valid", "")
+			})
+
+			It("referenced auditPolicy name was changed (UPDATE)", func() {
+				returnedCm := corev1.ConfigMap{
+					Data: map[string]string{"policy": validAuditPolicy},
+				}
+				newGarden := garden.DeepCopy()
+				newGarden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmNameOther}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "referenced configMap is valid", "")
+			})
+
+			It("referenced auditPolicy name was removed (UPDATE)", func() {
+				newGarden := garden.DeepCopy()
+				newGarden.Spec.VirtualCluster.Gardener.APIServer = nil
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
+			})
+
+			It("should not validate auditPolicy if already marked for deletion (UPDATE)", func() {
+				now := metav1.Now()
+				garden.DeletionTimestamp = &now
+				newGarden := garden.DeepCopy()
+				newGarden.Labels = map[string]string{
+					"foo": "bar",
+				}
+				test(admissionv1.Update, garden, newGarden, true, statusCodeAllowed, "marked for deletion", "")
+			})
+		})
+
+		Context("Deny", func() {
+			It("references a configmap that does not exist", func() {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
+					return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cmName)
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInvalid, `referenced ConfigMap garden/fake-cm-name does not exist: configmaps "fake-cm-name" not found`, "")
+			})
+
+			It("fails getting cm", func() {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ *corev1.ConfigMap, _ ...client.GetOption) error {
+					return errors.New("fake")
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInternalError, "could not retrieve ConfigMap garden/fake-cm-name: fake", "")
+			})
+
+			It("references configmap without a policy key", func() {
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = corev1.ConfigMap{
+						Data: nil,
+					}
+					return nil
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInvalid, "error getting ConfigMap /: missing audit policy key in policy ConfigMap data", "")
+			})
+
+			It("references audit policy which breaks validation rules", func() {
+				returnedCm := corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+					Data:       map[string]string{"policy": invalidAuditPolicy},
+				}
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInvalid, "Unsupported value: \"FakeLevel\"", "")
+			})
+
+			It("references audit policy with invalid structure", func() {
+				returnedCm := corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+					Data:       map[string]string{"policy": missingKeyAuditPolicy},
+				}
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInvalid, "did not find expected key", "")
+			})
+
+			It("references a deprecated auditPolicy/v1alpha1", func() {
+				returnedCm := corev1.ConfigMap{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+					Data:       map[string]string{"policy": validAuditPolicyV1alpha1},
+				}
+				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmName}, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: gardenNs, Name: cmName}}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
+					*cm = returnedCm
+					return nil
+				})
+				test(admissionv1.Create, nil, garden, false, statusCodeInvalid, "no kind \"Policy\" is registered for version \"audit.k8s.io/v1alpha1\"", "")
+			})
+		})
+	})
+
+	Context("ConfigMaps", func() {
+		BeforeEach(func() {
+			request.Kind = metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+			request.Name = cmName
+			request.Namespace = gardenNs
+		})
+
+		Context("Update", func() {
+			Context("Allow", func() {
+				It("is not referenced by any garden", func() {
+					gardenNotReferencing := garden.DeepCopy()
+					gardenNotReferencing.Spec.VirtualCluster.Gardener.APIServer = nil
+					Expect(fakeClient.Create(ctx, gardenNotReferencing)).To(Succeed())
+
+					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "config map is not referenced by garden resource, nothing to validate", "")
+				})
+
+				It("did not change policy field", func() {
+					Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "audit policy did not change", "")
+				})
+
+				It("should allow if the auditPolicy is changed to something valid", func() {
+					Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = anotherValidAuditPolicy
+
+					test(admissionv1.Update, cm, newCm, true, statusCodeAllowed, "referenced audit policy is valid", "")
+				})
+			})
+
+			Context("Deny", func() {
+				BeforeEach(func() {
+					Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+				})
+
+				It("has no data key", func() {
+					newCm := cm.DeepCopy()
+					newCm.Data = nil
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "error getting audit policy from ConfigMap garden/fake-cm-name: missing audit policy key in policy ConfigMap data", "")
+				})
+
+				It("has empty policy", func() {
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = ""
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "error getting audit policy from ConfigMap garden/fake-cm-name: audit policy in policy key is empty", "")
+				})
+
+				It("holds audit policy which breaks validation rules", func() {
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = invalidAuditPolicy
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "Unsupported value: \"FakeLevel\"", "")
+				})
+
+				It("holds audit policy with invalid YAML structure", func() {
+					newCm := cm.DeepCopy()
+					newCm.Data["policy"] = missingKeyAuditPolicy
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "did not find expected key", "")
+				})
+			})
+		})
+	})
+})

--- a/pkg/operator/webhook/validation/auditpolicy/add_test.go
+++ b/pkg/operator/webhook/validation/auditpolicy/add_test.go
@@ -263,19 +263,19 @@ rules:
 
 			It("has no AuditConfig for KubeAPIServer", func() {
 				garden.Spec.VirtualCluster.Gardener.APIServer = nil
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig = nil
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig = nil
 				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
 			})
 
 			It("has no audit policy for KubeAPIServer", func() {
 				garden.Spec.VirtualCluster.Gardener.APIServer = nil
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy = nil
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy = nil
 				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
 			})
 
 			It("has no audit policy cm Ref for KubeAPIServer", func() {
 				garden.Spec.VirtualCluster.Gardener.APIServer = nil
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef = nil
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef = nil
 				test(admissionv1.Create, nil, garden, true, statusCodeAllowed, "no audit policy config map reference found in garden spec", "")
 			})
 
@@ -382,7 +382,7 @@ rules:
 					Data: map[string]string{"policy": validAuditPolicy},
 				}
 				newGarden := garden.DeepCopy()
-				newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
+				newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = cmNameOther
 				mockReader.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: gardenNs, Name: cmNameOther}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, cm *corev1.ConfigMap, _ ...client.GetOption) error {
 					*cm = returnedCm
 					return nil

--- a/pkg/operator/webhook/validation/auditpolicy/auditpolicy_suite_test.go
+++ b/pkg/operator/webhook/validation/auditpolicy/auditpolicy_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auditpolicy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Webhook Validation AuditPolicy Suite")
+}

--- a/pkg/operator/webhook/validation/auditpolicy/auditpolicy_suite_test.go
+++ b/pkg/operator/webhook/validation/auditpolicy/auditpolicy_suite_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNamespace(t *testing.T) {
+func TestAuditPolicy(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operator Webhook Validation AuditPolicy Suite")
 }

--- a/pkg/webhook/configvalidator/auditpolicy.go
+++ b/pkg/webhook/configvalidator/auditpolicy.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package configvalidator
+
+import (
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/apis/audit"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	auditvalidation "k8s.io/apiserver/pkg/apis/audit/validation"
+)
+
+var decoder runtime.Decoder
+
+func init() {
+	scheme := runtime.NewScheme()
+	schemeBuilder := runtime.NewSchemeBuilder(auditv1.AddToScheme, audit.AddToScheme)
+	utilruntime.Must(schemeBuilder.AddToScheme(scheme))
+	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+}
+
+// AdmitAudtPolicy validates the provided audit policy.
+func AdmitAudtPolicy(auditPolicyRaw string) (int32, error) {
+	obj, schemaVersion, err := decoder.Decode([]byte(auditPolicyRaw), nil, nil)
+	if err != nil {
+		return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided audit policy: %w", err)
+	}
+
+	auditPolicy, ok := obj.(*audit.Policy)
+	if !ok {
+		return http.StatusInternalServerError, fmt.Errorf("failed to cast to audit policy type: %v", schemaVersion)
+	}
+
+	if errList := auditvalidation.ValidatePolicy(auditPolicy); len(errList) != 0 {
+		return http.StatusUnprocessableEntity, fmt.Errorf("provided invalid audit policy: %v", errList)
+	}
+
+	return 0, nil
+}

--- a/pkg/webhook/configvalidator/auditpolicy.go
+++ b/pkg/webhook/configvalidator/auditpolicy.go
@@ -25,8 +25,8 @@ func init() {
 	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 }
 
-// AdmitAudtPolicy validates the provided audit policy.
-func AdmitAudtPolicy(auditPolicyRaw string) (int32, error) {
+// AdmitAuditPolicy validates the provided audit policy.
+func AdmitAuditPolicy(auditPolicyRaw string) (int32, error) {
 	obj, schemaVersion, err := decoder.Decode([]byte(auditPolicyRaw), nil, nil)
 	if err != nil {
 		return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided audit policy: %w", err)

--- a/pkg/webhook/configvalidator/auditpolicy_test.go
+++ b/pkg/webhook/configvalidator/auditpolicy_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package configvalidator_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/webhook/configvalidator"
+)
+
+var _ = Describe("AdmitAudtPolicy", func() {
+	Describe("valid audit policies", func() {
+		It("should accept a valid minimal audit policy", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(0)))
+		})
+
+		It("should accept a valid audit policy with multiple rules", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: None
+  users: ["system:kube-proxy"]
+  verbs: ["watch"]
+  resources:
+  - group: ""
+    resources: ["endpoints", "services", "services/status"]
+- level: None
+  users: ["system:unsecured"]
+  namespaces: ["kube-system"]
+  verbs: ["get"]
+  resources:
+  - group: ""
+    resources: ["configmaps"]
+- level: Metadata
+  resources:
+  - group: ""
+    resources: ["secrets", "configmaps"]
+- level: RequestResponse
+  resources:
+  - group: ""
+    resources: ["pods"]
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(0)))
+		})
+
+		It("should accept audit policy with omitStages", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+- level: Metadata
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(0)))
+		})
+
+		It("should accept audit policy with namespaces and objectRef", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: None
+  namespaces: ["kube-system", "kube-public"]
+- level: Metadata
+  objectRef:
+    resource: "pods"
+    namespace: "default"
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(0)))
+		})
+	})
+
+	Describe("invalid audit policies", func() {
+		It("should reject invalid YAML", func() {
+			auditPolicy := `
+invalid: yaml: content
+  - missing quotes
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+			Expect(err.Error()).To(ContainSubstring("failed to decode the provided audit policy"))
+		})
+
+		It("should reject empty content", func() {
+			auditPolicy := ""
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+			Expect(err.Error()).To(ContainSubstring("failed to decode the provided audit policy"))
+		})
+
+		It("should reject audit policy without apiVersion", func() {
+			auditPolicy := `
+kind: Policy
+rules:
+- level: Metadata
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+		})
+
+		It("should reject audit policy without kind", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+rules:
+- level: Metadata
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+		})
+
+		It("should reject audit policy with invalid level", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: InvalidLevel
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+			Expect(err.Error()).To(ContainSubstring("provided invalid audit policy"))
+		})
+
+		It("should reject audit policy with invalid omitStages", func() {
+			auditPolicy := `
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - InvalidStage
+rules:
+- level: Metadata
+`
+			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			Expect(err).To(HaveOccurred())
+			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
+			Expect(err.Error()).To(ContainSubstring("provided invalid audit policy"))
+		})
+	})
+})

--- a/pkg/webhook/configvalidator/auditpolicy_test.go
+++ b/pkg/webhook/configvalidator/auditpolicy_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/gardener/gardener/pkg/webhook/configvalidator"
 )
 
-var _ = Describe("AdmitAudtPolicy", func() {
+var _ = Describe("AdmitAuditPolicy", func() {
 	Describe("valid audit policies", func() {
 		It("should accept a valid minimal audit policy", func() {
 			auditPolicy := `
@@ -22,7 +22,7 @@ kind: Policy
 rules:
 - level: Metadata
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(0)))
 		})
@@ -54,7 +54,7 @@ rules:
   - group: ""
     resources: ["pods"]
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(0)))
 		})
@@ -68,7 +68,7 @@ omitStages:
 rules:
 - level: Metadata
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(0)))
 		})
@@ -85,7 +85,7 @@ rules:
     resource: "pods"
     namespace: "default"
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(0)))
 		})
@@ -97,7 +97,7 @@ rules:
 invalid: yaml: content
   - missing quotes
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 			Expect(err.Error()).To(ContainSubstring("failed to decode the provided audit policy"))
@@ -105,7 +105,7 @@ invalid: yaml: content
 
 		It("should reject empty content", func() {
 			auditPolicy := ""
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 			Expect(err.Error()).To(ContainSubstring("failed to decode the provided audit policy"))
@@ -117,7 +117,7 @@ kind: Policy
 rules:
 - level: Metadata
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 		})
@@ -128,7 +128,7 @@ apiVersion: audit.k8s.io/v1
 rules:
 - level: Metadata
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 		})
@@ -140,7 +140,7 @@ kind: Policy
 rules:
 - level: InvalidLevel
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 			Expect(err.Error()).To(ContainSubstring("provided invalid audit policy"))
@@ -155,7 +155,7 @@ omitStages:
 rules:
 - level: Metadata
 `
-			statusCode, err := AdmitAudtPolicy(auditPolicy)
+			statusCode, err := AdmitAuditPolicy(auditPolicy)
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(int32(http.StatusUnprocessableEntity)))
 			Expect(err.Error()).To(ContainSubstring("provided invalid audit policy"))

--- a/pkg/webhook/configvalidator/handler.go
+++ b/pkg/webhook/configvalidator/handler.go
@@ -52,7 +52,7 @@ func init() {
 		runtime.DisabledGroupVersioner, runtime.InternalGroupVersioner, operatorScheme.Name())
 }
 
-// Handler validates configuration part of ConfigMaps which are referenced in Shoot resources.
+// Handler validates configuration part of ConfigMaps which are referenced in Shoot or Garden resources.
 type Handler struct {
 	APIReader client.Reader
 	Client    client.Reader
@@ -69,7 +69,7 @@ type Handler struct {
 	AdmitGardenConfig          func(configRaw string) (int32, error)
 }
 
-// Handle validates configuration part of ConfigMaps which are referenced in Shoot resources.
+// Handle validates configuration part of ConfigMaps which are referenced in Shoot or Garden resources.
 func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	requestGK := schema.GroupKind{Group: req.Kind.Group, Kind: req.Kind.Kind}
 

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -115,16 +115,16 @@ var _ = Describe("Handler", func() {
 			GetNamespace: func() string {
 				return configMap.Namespace
 			},
-			GetConfigMapNameFromGarden: func(garden *operatorv1alpha1.Garden) map[string]string {
-				configMapNames := map[string]string{}
+			GetConfigMapNamesFromGarden: func(garden *operatorv1alpha1.Garden) []string {
+				configMapNames := []string{}
 				if garden.Spec.VirtualCluster.Gardener.APIServer != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig != nil &&
 					garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-					configMapNames["gardener-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+					configMapNames = append(configMapNames, garden.Spec.VirtualCluster.Gardener.APIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name)
 				}
 
 				if garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig != nil &&
 					garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-					configMapNames["virtual-garden-kube-apiserver-audit-policy"] = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name
+					configMapNames = append(configMapNames, garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name)
 				}
 				return configMapNames
 			},

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -24,6 +24,7 @@ build:
             - imagevector/containers.yaml
             - pkg/admissioncontroller/apis/config/v1alpha1
             - pkg/admissioncontroller/apis/config/v1alpha1/validation
+            - pkg/admissioncontroller/webhook/admission
             - pkg/api
             - pkg/api/extensions
             - pkg/api/indexer
@@ -276,6 +277,7 @@ build:
             - pkg/operator/webhook/defaulting/extension
             - pkg/operator/webhook/defaulting/garden
             - pkg/operator/webhook/validation
+            - pkg/operator/webhook/validation/auditpolicy
             - pkg/operator/webhook/validation/extension
             - pkg/operator/webhook/validation/garden
             - pkg/operator/webhook/validation/namespace
@@ -329,6 +331,7 @@ build:
             - pkg/utils/validation/kubernetesversion
             - pkg/utils/version
             - pkg/utils/workloadidentity
+            - pkg/webhook/configvalidator
             - plugin/pkg
             - VERSION
         ldflags:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging
/kind enhancement

**What this PR does / why we need it**:
This PR adds validation for the audit policy configmap for gardener API server referenced in the garden resource.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/12127

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Audit policy configmap for the gardener API server referenced in the garden resource is now validated.
```
