### PR TITLE
[GEP-34] Deploy `OTEL Collector` to `Garden` & `Seed` Clusters

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -389,6 +389,35 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								},
 							},
 						},
+						"attributes/vali": map[string]any{
+							"actions": []any{
+								map[string]any{
+									"key":            "nodename",
+									"from_attribute": "k8s.node.name",
+									"action":         "insert",
+								},
+								map[string]any{
+									"key":            "pod_name",
+									"from_attribute": "k8s.pod.name",
+									"action":         "insert",
+								},
+								map[string]any{
+									"key":            "container_name",
+									"from_attribute": "k8s.container.name",
+									"action":         "insert",
+								},
+								map[string]any{
+									"key":    "loki.resource.labels",
+									"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+									"action": "insert",
+								},
+								map[string]any{
+									"key":    "loki.format",
+									"value":  "raw",
+									"action": "insert",
+								},
+							},
+						},
 					},
 				},
 				Exporters: otelv1beta1.AnyConfig{
@@ -432,6 +461,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 							},
 							Processors: []string{
 								"resource/vali",
+								"attributes/vali",
 								"batch",
 							},
 						},

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -62,6 +62,10 @@ type Values struct {
 	ShootNodeLoggingEnabled bool
 	// IngressHost is the name for the ingress to access the OpenTelemetry Collector.
 	IngressHost string
+	// SecretNameServerCA is the name of the server CA secret.
+	SecretNameServerCA string
+	// PriorityClassName is the priority class name for the OpenTelemetry Collector pods.
+	PriorityClassName string
 	// ValiHost is the name for the ingress to access the Vali instance.
 	ValiHost string
 }
@@ -126,7 +130,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 			CertType:                    secrets.ServerCert,
 			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
 			SkipPublishingCACertificate: true,
-		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
+		}, secretsmanager.SignedByCA(o.values.SecretNameServerCA))
 		if err != nil {
 			return err
 		}
@@ -327,7 +331,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 			OpenTelemetryCommonFields: otelv1beta1.OpenTelemetryCommonFields{
 				Image:             o.values.Image,
 				Replicas:          ptr.To(o.values.Replicas),
-				PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
+				PriorityClassName: o.values.PriorityClassName,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -447,7 +447,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 										"pull": map[string]any{
 											"exporter": map[string]any{
 												"prometheus": map[string]any{
-													"host": "0.0.0.0",
+													"host": "[::]",
 													"port": metricsPort,
 												},
 											},
@@ -500,7 +500,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Name:  kubeRBACProxyName + "-vali",
 				Image: o.values.KubeRBACProxyImage,
 				Args: []string{
-					fmt.Sprintf("--insecure-listen-address=0.0.0.0:%d", collectorconstants.KubeRBACProxyValiPort),
+					fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyValiPort),
 					fmt.Sprintf("--upstream=http://logging:%d/", valiconstants.ValiPort),
 					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
 					"--logtostderr=true",
@@ -524,7 +524,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Name:  kubeRBACProxyName + "-otlp",
 				Image: o.values.KubeRBACProxyImage,
 				Args: []string{
-					fmt.Sprintf("--insecure-listen-address=0.0.0.0:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
+					fmt.Sprintf("--insecure-listen-address=[::]:%d", collectorconstants.KubeRBACProxyOTLPReceiverPort),
 					fmt.Sprintf("--upstream=http://127.0.0.1:%d/", collectorconstants.PushPort),
 					"--kubeconfig=" + gardenerutils.VolumeMountPathGenericKubeconfig + "/kubeconfig",
 					"--logtostderr=true",

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -389,6 +389,35 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									},
 								},
 							},
+							"attributes/vali": map[string]any{
+								"actions": []any{
+									map[string]any{
+										"key":            "nodename",
+										"from_attribute": "k8s.node.name",
+										"action":         "insert",
+									},
+									map[string]any{
+										"key":            "pod_name",
+										"from_attribute": "k8s.pod.name",
+										"action":         "insert",
+									},
+									map[string]any{
+										"key":            "container_name",
+										"from_attribute": "k8s.container.name",
+										"action":         "insert",
+									},
+									map[string]any{
+										"key":    "loki.resource.labels",
+										"value":  "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role",
+										"action": "insert",
+									},
+									map[string]any{
+										"key":    "loki.format",
+										"value":  "raw",
+										"action": "insert",
+									},
+								},
+							},
 						},
 					},
 					Exporters: otelv1beta1.AnyConfig{
@@ -430,7 +459,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 							"logs/vali": {
 								Exporters:  []string{"loki"},
 								Receivers:  []string{"otlp"},
-								Processors: []string{"resource/vali", "batch"},
+								Processors: []string{"resource/vali", "attributes/vali", "batch"},
 							},
 						},
 					},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -188,7 +188,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-vali",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--insecure-listen-address=0.0.0.0:8081",
+				"--insecure-listen-address=[::]:8081",
 				"--upstream=http://logging:3100/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
@@ -216,7 +216,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Name:  "rbac-proxy-otlp",
 			Image: kubeRBACProxyImage,
 			Args: []string{
-				"--insecure-listen-address=0.0.0.0:8080",
+				"--insecure-listen-address=[::]:8080",
 				"--upstream=http://127.0.0.1:4317/",
 				"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 				"--logtostderr=true",
@@ -443,7 +443,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 											"pull": map[string]any{
 												"exporter": map[string]any{
 													"prometheus": map[string]any{
-														"host": "0.0.0.0",
+														"host": "[::]",
 														// Field needs to be cast to `float64` due to an issue with serialization during tests.
 														// When fetching the object from the apiserver, since there's no type information regarding this field.
 														// the deserializer will interpret it as a `float64`. By setting the value to `float64` here, we ensure that

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -70,6 +70,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			ValiHost:                valiHost,
 			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
 			PriorityClassName:       "gardener-system-100",
+			ClusterType:             "shoot",
 		}
 
 		c         client.Client
@@ -326,6 +327,11 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				},
 			},
 			Spec: otelv1beta1.OpenTelemetryCollectorSpec{
+				Observability: otelv1beta1.ObservabilitySpec{
+					Metrics: otelv1beta1.MetricsConfigSpec{
+						DisablePrometheusAnnotations: true,
+					},
+				},
 				Mode:            "deployment",
 				UpgradeStrategy: "none",
 				OpenTelemetryCommonFields: otelv1beta1.OpenTelemetryCommonFields{

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -628,7 +628,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			// Verify that the component created the managed resource
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 		})
-
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/imagevector"
+	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
+	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// NewOpenTelemetryCollector instantiates a new `OpenTelemetryOperator` component.
+func NewOpenTelemetryCollector(
+	c client.Client,
+	gardenNamespaceName string,
+	priorityClassName string,
+	secretsManager secretsmanager.Interface,
+	secretNameServerCA string,
+) (
+	deployer collector.Interface,
+	err error,
+) {
+	collectorImage, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameOpentelemetryCollector)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeRBACProxyImage, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameKubeRbacProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	return collector.New(
+		c,
+		gardenNamespaceName,
+		collector.Values{
+			Image:                   collectorImage.String(),
+			KubeRBACProxyImage:      kubeRBACProxyImage.String(),
+			LokiEndpoint:            "http://" + valiconstants.ServiceName + ":" + strconv.Itoa(valiconstants.ValiPort) + valiconstants.PushEndpoint,
+			Replicas:                1,
+			ShootNodeLoggingEnabled: false,
+			IngressHost:             "",
+			SecretNameServerCA:      secretNameServerCA,
+			PriorityClassName:       priorityClassName,
+		},
+		secretsManager,
+	), nil
+}

--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -22,6 +23,7 @@ func NewOpenTelemetryCollector(
 	priorityClassName string,
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
+	clusterType component.ClusterType,
 ) (
 	deployer collector.Interface,
 	err error,
@@ -47,6 +49,7 @@ func NewOpenTelemetryCollector(
 			ShootNodeLoggingEnabled: false,
 			SecretNameServerCA:      secretNameServerCA,
 			PriorityClassName:       priorityClassName,
+			ClusterType:             clusterType,
 		},
 		secretsManager,
 	), nil

--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -45,7 +45,6 @@ func NewOpenTelemetryCollector(
 			LokiEndpoint:            "http://" + valiconstants.ServiceName + ":" + strconv.Itoa(valiconstants.ValiPort) + valiconstants.PushEndpoint,
 			Replicas:                1,
 			ShootNodeLoggingEnabled: false,
-			IngressHost:             "",
 			SecretNameServerCA:      secretNameServerCA,
 			PriorityClassName:       priorityClassName,
 		},

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -122,6 +122,7 @@ type components struct {
 	alertManager                  component.DeployWaiter
 	persesOperator                component.DeployWaiter
 	openTelemetryOperator         component.DeployWaiter
+	openTelemetryCollector        collector.Interface
 }
 
 func (r *Reconciler) instantiateComponents(
@@ -222,6 +223,10 @@ func (r *Reconciler) instantiateComponents(
 
 	// observability components
 	c.openTelemetryOperator, err = r.newOpenTelemetryOperator()
+	if err != nil {
+		return
+	}
+	c.openTelemetryCollector, err = r.newOpenTelemetryCollector(secretsManager)
 	if err != nil {
 		return
 	}
@@ -851,6 +856,16 @@ func (r *Reconciler) newOpenTelemetryOperator() (component.DeployWaiter, error) 
 		r.GardenNamespace,
 		gardenlethelper.IsLoggingEnabled(&r.Config),
 		v1beta1constants.PriorityClassNameSeedSystem600,
+	)
+}
+
+func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Interface) (collector.Interface, error) {
+	return sharedcomponent.NewOpenTelemetryCollector(
+		r.SeedClientSet.Client(),
+		r.GardenNamespace,
+		v1beta1constants.PriorityClassNameSeedSystem600,
+		secretsManager,
+		v1beta1constants.SecretNameCASeed,
 	)
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -866,6 +866,7 @@ func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Int
 		v1beta1constants.PriorityClassNameSeedSystem600,
 		secretsManager,
 		v1beta1constants.SecretNameCASeed,
+		component.ClusterTypeSeed,
 	)
 }
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -140,6 +140,10 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name: "Destroying aggregate Prometheus",
 			Fn:   c.aggregatePrometheus.Destroy,
 		})
+		destroyOpenTelemetryCollector = g.Add(flow.Task{
+			Name: "Destroying OpenTelemetry Collector",
+			Fn:   component.OpDestroyAndWait(c.openTelemetryCollector).Destroy,
+		})
 		destroyAlertManager = g.Add(flow.Task{
 			Name: "Destroying AlertManager",
 			Fn:   c.alertManager.Destroy,
@@ -202,9 +206,10 @@ func (r *Reconciler) runDeleteSeedFlow(
 			SkipIf: seedIsGarden,
 		})
 		destroyOpenTelemetryOperator = g.Add(flow.Task{
-			Name:   "Destroy OpenTelemetry Operator",
-			Fn:     component.OpDestroyAndWait(c.openTelemetryOperator).Destroy,
-			SkipIf: seedIsGarden,
+			Name:         "Destroy OpenTelemetry Operator",
+			Fn:           component.OpDestroyAndWait(c.openTelemetryOperator).Destroy,
+			Dependencies: flow.NewTaskIDs(destroyOpenTelemetryCollector),
+			SkipIf:       seedIsGarden,
 		})
 		destroyFluentBit = g.Add(flow.Task{
 			Name:   "Destroy Fluent Bit",
@@ -249,6 +254,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 			destroyClusterIdentity,
 			destroyCachePrometheus,
 			destroySeedPrometheus,
+			destroyOpenTelemetryCollector,
 			destroyAggregatePrometheus,
 			destroyAlertManager,
 			destroyNginxIngress,

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -426,6 +426,11 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
 			SkipIf:       seedIsGarden,
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying OpenTelemetry Collector",
+			Fn:           c.openTelemetryCollector.Deploy,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+		})
 		deployFluentOperator = g.Add(flow.Task{
 			Name:         "Deploying Fluent Operator",
 			Fn:           c.fluentOperator.Deploy,

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -150,6 +150,7 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
 			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane100,
 			ValiHost:                b.ComputeValiHost(),
+			ClusterType:             component.ClusterTypeShoot,
 		},
 		b.SecretsManager,
 	), nil

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -147,6 +147,8 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 			Replicas:                b.Shoot.GetReplicas(1),
 			ShootNodeLoggingEnabled: b.isShootNodeLoggingEnabled(),
 			IngressHost:             b.ComputeOpenTelemetryCollectorHost(),
+			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
+			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane100,
 			ValiHost:                b.ComputeValiHost(),
 		},
 		b.SecretsManager,

--- a/pkg/operator/client/scheme.go
+++ b/pkg/operator/client/scheme.go
@@ -6,6 +6,8 @@ package client
 
 import (
 	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
+	opentelemetryv1alpha1 "github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	opentelemetryv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -61,6 +63,8 @@ var (
 		monitoringv1beta1.AddToScheme,
 		monitoringv1alpha1.AddToScheme,
 		persesv1alpha1.AddToScheme,
+		opentelemetryv1alpha1.AddToScheme,
+		opentelemetryv1beta1.AddToScheme,
 		func(scheme *runtime.Scheme) error {
 			apiextensionsinstall.Install(scheme)
 			return nil

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1573,6 +1573,7 @@ func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Int
 		v1beta1constants.PriorityClassNameGardenSystem100,
 		secretsManager,
 		operatorv1alpha1.SecretNameCARuntime,
+		component.ClusterTypeSeed,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -76,6 +76,7 @@ import (
 	gardenprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/garden"
 	longtermprometheus "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/longterm"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
+	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
 	oteloperator "github.com/gardener/gardener/pkg/component/observability/opentelemetry/operator"
 	"github.com/gardener/gardener/pkg/component/observability/plutono"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
@@ -137,6 +138,7 @@ type components struct {
 	fluentOperatorCustomResources component.DeployWaiter
 	plutono                       plutono.Interface
 	vali                          component.Deployer
+	openTelemetryCollector        collector.Interface
 	prometheusOperator            component.DeployWaiter
 	openTelemetryOperator         component.DeployWaiter
 	alertManager                  alertmanager.Interface
@@ -313,6 +315,10 @@ func (r *Reconciler) instantiateComponents(
 		return
 	}
 	c.vali, err = r.newVali()
+	if err != nil {
+		return
+	}
+	c.openTelemetryCollector, err = r.newOpenTelemetryCollector(secretsManager)
 	if err != nil {
 		return
 	}
@@ -1558,6 +1564,15 @@ func (r *Reconciler) newOpenTelemetryOperator() (component.DeployWaiter, error) 
 		r.GardenNamespace,
 		true,
 		v1beta1constants.PriorityClassNameGardenSystem100,
+	)
+}
+
+func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Interface) (collector.Interface, error) {
+	return sharedcomponent.NewOpenTelemetryCollector(r.RuntimeClientSet.Client(),
+		r.GardenNamespace,
+		v1beta1constants.PriorityClassNameGardenSystem100,
+		secretsManager,
+		operatorv1alpha1.SecretNameCARuntime,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -106,6 +106,10 @@ func (r *Reconciler) delete(
 				return r.destroyGardenPrometheus(ctx, c.prometheusGarden)
 			},
 		})
+		destroyOpenTelemetryCollector = g.Add(flow.Task{
+			Name: "Destroying OpenTelemetry Collector",
+			Fn:   component.OpDestroyAndWait(c.openTelemetryCollector).Destroy,
+		})
 		destroyBlackboxExporter = g.Add(flow.Task{
 			Name: "Destroying blackbox-exporter",
 			Fn:   component.OpDestroyAndWait(c.blackboxExporter).Destroy,
@@ -321,7 +325,7 @@ func (r *Reconciler) delete(
 		destroyOpenTelemetryOperator = g.Add(flow.Task{
 			Name:         "Destroying OpenTelemetry Operator",
 			Fn:           component.OpDestroyAndWait(c.openTelemetryOperator).Destroy,
-			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+			Dependencies: flow.NewTaskIDs(destroyOpenTelemetryCollector, syncPointVirtualGardenControlPlaneDestroyed),
 		})
 		destroyFluentOperatorCustomResources = g.Add(flow.Task{
 			Name:         "Destroying fluent-operator custom resources",

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -575,7 +575,7 @@ func (r *Reconciler) reconcile(
 			Name: "Deploying prometheus-operator",
 			Fn:   c.prometheusOperator.Deploy,
 		})
-		_ = g.Add(flow.Task{
+		deployOpenTelemetryOperator = g.Add(flow.Task{
 			Name: "Deploying OpenTelemetry Operator",
 			Fn:   c.openTelemetryOperator.Deploy,
 		})
@@ -611,6 +611,11 @@ func (r *Reconciler) reconcile(
 				return r.deployLongTermPrometheus(ctx, secretsManager, c.prometheusLongTerm)
 			},
 			Dependencies: flow.NewTaskIDs(deployPrometheusGarden),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying OpenTelemetry Collector",
+			Fn:           c.openTelemetryCollector.Deploy,
+			Dependencies: flow.NewTaskIDs(deployOpenTelemetryOperator),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying blackbox-exporter",

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -222,6 +222,8 @@ build:
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_servicemonitors.yaml
             - pkg/component/observability/monitoring/prometheusoperator/templates/crd-monitoring.coreos.com_thanosrulers.yaml
             - pkg/component/observability/monitoring/utils
+            - pkg/component/observability/opentelemetry/collector
+            - pkg/component/observability/opentelemetry/collector/constants
             - pkg/component/observability/opentelemetry/operator
             - pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_instrumentations.yaml
             - pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opampbridges.yaml

--- a/test/e2e/operator/garden/garden.go
+++ b/test/e2e/operator/garden/garden.go
@@ -79,6 +79,7 @@ var gardenManagedResourceList = []string{
 	"extension-registration-networking-cilium",
 	"local-ext-shoot",
 	"opentelemetry-operator",
+	"opentelemetry-collector",
 }
 
 var istioManagedResourceList = []string{

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/logging/fluentoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/persesoperator"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheusoperator"
-	oteloperator "github.com/gardener/gardener/pkg/component/observability/opentelemetry/operator"
+	opentelemetryoperator "github.com/gardener/gardener/pkg/component/observability/opentelemetry/operator"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	seedcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/seed/seed"
@@ -644,7 +644,7 @@ var _ = Describe("Seed controller tests", func() {
 					// General CRDs are not deployed when seedIsGarden is true, as they are managed by the gardener-operator.
 					extensionCRD, err := extensionscrds.NewCRD(testClient, true, false)
 					Expect(err).NotTo(HaveOccurred())
-					openTelemetryCRD, err := oteloperator.NewCRDs(testClient)
+					openTelemetryCRD, err := opentelemetryoperator.NewCRDs(testClient)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(applier.ApplyManifest(ctx, managedResourceCRDReader, kubernetes.DefaultMergeFuncs)).To(Succeed())
@@ -702,6 +702,7 @@ var _ = Describe("Seed controller tests", func() {
 					"prometheus-aggregate",
 					"kube-state-metrics-seed",
 					"referenced-resources-" + seedName,
+					"opentelemetry-collector",
 				}
 
 				if !seedIsGarden {

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -488,6 +488,11 @@ spec:
 			"perses.perses.dev",
 			"persesdashboards.perses.dev",
 			"persesdatasources.perses.dev",
+			// opentelemetry-operator
+			"instrumentations.opentelemetry.io",
+			"opampbridges.opentelemetry.io",
+			"opentelemetrycollectors.opentelemetry.io",
+			"targetallocators.opentelemetry.io",
 		}
 
 		By("Verify that the custom resource definitions have been created")
@@ -582,6 +587,8 @@ spec:
 			"prometheus-operator",
 			"alertmanager-garden",
 			"perses-operator",
+			"opentelemetry-operator",
+			"opentelemetry-collector",
 		))
 
 		By("Verify that the virtual garden control plane components have been deployed")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR requires familiarity with [GEP-34](https://github.com/gardener/gardener/blob/master/docs/proposals/34-observability2.0-opentelemetry-operator-and-collectors.md) and GEP-35 (Still in progress).

After the work on the previous PRs, specifically:
- Adding `OpenTelemetry Operator` https://github.com/gardener/gardener/pull/12165
- Deploying `OpenTelemetry Collector` during `Shoot` reconciliation https://github.com/gardener/gardener/pull/12428

It was found that deploying an instance of `OpenTelemetry Collector` to the `garden` namespace of the `Garden` cluster, as well as the `garden` namespace of `Seed` clusters will be necessary for the further migration of `Vali` to `VictoriaLogs` on the same clusters.
This is due to a limitation that was found during the development of the `logging` plugin, where due to a collision of dependencies that `valitail` and `otlp` use, it is difficult to make them work simultaneously as outputs of `fluent-bit`.

To resolve this as easily and cleanly as possible, it was decided that `fluent-bit` will support only `otlp` as an exporter and the `OpenTelemetry Collector` instance will handle the necessary reformatting to both `VictoriaLogs` and `Vali` during [the migration period](in progress)

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
An instance of `OpenTelemetry Collector` is now deployed to the `garden` namespace of both `Garden` and `Seed` clusters.
```
