### PR TITLE
test/e2e/gardener/seed: Eliminate `BeforeTestSetup`

### DIFF
--- a/test/e2e/operation.go
+++ b/test/e2e/operation.go
@@ -5,6 +5,7 @@
 package e2e
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,11 +16,20 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
-// ItShouldEventuallyNotHaveOperationAnnotation checks if the given object does not have the gardener operation annotation set
+// EventuallyNotHaveOperationAnnotation checks if the given object does not have the gardener operation annotation set.
+func EventuallyNotHaveOperationAnnotation(ctx context.Context, komega komega.Komega, obj client.Object) {
+	GinkgoHelper()
+
+	Eventually(ctx, komega.Object(obj)).WithPolling(2 * time.Second).Should(
+		HaveField("ObjectMeta.Annotations", Not(HaveKey(v1beta1constants.GardenerOperation))))
+}
+
+// ItShouldEventuallyNotHaveOperationAnnotation checks if the given object does not have the gardener operation annotation set.
+//
+// Deprecated: Instead, use the `EventuallyNotHaveOperationAnnotation` function. For more details, see https://github.com/gardener/gardener/issues/13134.
 func ItShouldEventuallyNotHaveOperationAnnotation(komega komega.Komega, obj client.Object) {
 	GinkgoHelper()
 	It("Should not have operation annotation", func(ctx SpecContext) {
-		Eventually(ctx, komega.Object(obj)).WithPolling(2 * time.Second).Should(
-			HaveField("ObjectMeta.Annotations", Not(HaveKey(v1beta1constants.GardenerOperation))))
+		EventuallyNotHaveOperationAnnotation(ctx, komega, obj)
 	}, SpecTimeout(time.Minute))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/13134

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13134

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
