### PR TITLE
[GEP-28] `gardenadm init`: Deploy/restore `Worker`

### DIFF
--- a/cmd/machine-controller-manager-provider-local/main.go
+++ b/cmd/machine-controller-manager-provider-local/main.go
@@ -23,11 +23,15 @@ import (
 	"k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/provider-local/machine-provider/local"
 )
 
 func main() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+
 	s := options.NewMCServer()
 	s.AddFlags(pflag.CommandLine)
 

--- a/docs/extensions/migration.md
+++ b/docs/extensions/migration.md
@@ -89,9 +89,13 @@ In such cases, the `Migrate` and `Restore` methods might need to be overridden a
 
 Note that the machine state is handled specially by `gardenlet` (i.e., all relevant objects in the `machine.sapcloud.io/v1alpha1` API are directly persisted by `gardenlet` and **NOT** by the generic actuators).
 In the past, they were persisted to the `Worker`'s `.status.state` field by the so-called "worker state reconciler", however, this reconciler was dropped and changed as part of [GEP-22](../proposals/22-improved-usage-of-shootstate-api.md#eliminating-the-worker-state-reconciler).
-Nowadays, `gardenlet` directly writes the state to the `ShootState` resource during the `Migrate` phase of a `Shoot` (without the detour of the `Worker`'s `.status.state` field).
-On restoration, unlike for other extension kinds, `gardenlet` no longer populates the machine state into the `Worker`'s `.status.state` field.
-Instead, the extension controller should read the machine state directly from the `ShootState` in the garden cluster (see [this document](garden-api-access.md) for information how to access the garden cluster) and use it to subsequently restore the relevant `machine.sapcloud.io/v1alpha1` resources.
+
+Gardener directly writes the machine state to the `ShootState` resource during the `Migrate` phase of a `Shoot` (without requiring the extension to popluate the `Worker.status.state` field).
+On restoration, Gardener copies the machine state back to the `Worker.status.state` field for the extension to pick it up and restore the relevant `machine.sapcloud.io/v1alpha1` resources.
+
+Previously, the extension controller would read the machine state directly from the `ShootState` in the garden cluster (see [this document](garden-api-access.md)) during the `restore` operation.
+However, for supporting self-hosted shoots with managed infrastructure [GEP-28](../proposals/28-self-hosted-shoot-clusters.md#managed-infrastructure), the extension controller must read the machine state from the `Worker.status.state` field instead of the `ShootState` resource from the garden cluster, as the garden cluster might not exist when running `gardenadm bootstrap`.
+
 This flow is implemented in the [generic `Worker` actuator](../../extensions/pkg/controller/worker/genericactuator/actuator_restore.go).
 As a result, Extension controllers using this generic actuator do not need to implement any custom logic.
 

--- a/docs/extensions/resources/worker.md
+++ b/docs/extensions/resources/worker.md
@@ -132,7 +132,10 @@ The `spec.pools[].clusterAutoscaler` field contains `cluster-autoscaler` setting
 
 The controller must only inject its provider-specific sidecar container into the `machine-controller-manager` `Deployment` managed by `gardenlet`.
 
-After that, it must compute the desired machine classes and the desired machine deployments.
+After that, it must compute the desired `MachineClasses` and the desired `MachineDeployments`.
+The object names are prefixed with the technical ID of the shoot.
+The worker extension needs to determine the technical ID by reading the `shoot.status.technicalID` field from the `Cluster` object in the seed cluster, as the `Worker` object's namespace might be different from the shoot's technical ID (i.e., in case of [self-hosted shoots](../../proposals/28-self-hosted-shoot-clusters.md#managed-infrastructure)).
+
 Typically, one class maps to one deployment, and one class/deployment is created per availability zone.
 Following this convention, the created resource would look like this:
 

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
@@ -84,7 +84,7 @@ func NewControlPlaneBootstrap(
 }
 
 func (c *controlPlaneBootstrap) Deploy(ctx context.Context) error {
-	oscKey, err := calculateKeyForValues(2, c.values.Values, c.values.Worker)
+	oscKey, err := calculateKeyForValues(LatestHashVersion(), c.values.Values, c.values.Worker)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
@@ -38,13 +38,13 @@ type controlPlaneBootstrap struct {
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
 
-	osc *extensionsv1alpha1.OperatingSystemConfig
+	osc Data
 }
 
 // ControlPlaneBootstrapValues contains the values used to create an OperatingSystemConfig resource for gardenadm bootstrap.
 type ControlPlaneBootstrapValues struct {
-	// Namespace is the namespace for the OperatingSystemConfig resource.
-	Namespace string
+	*Values
+
 	// Worker is the control plane worker pool.
 	Worker *gardencorev1beta1.Worker
 	// GardenadmImage is the gardenadm image reference that should be pulled.
@@ -69,10 +69,12 @@ func NewControlPlaneBootstrap(
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
 
-		osc: &extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{
-			Name:      "gardenadm-" + values.Worker.Name,
-			Namespace: values.Namespace,
-		}},
+		osc: Data{
+			Object: &extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardenadm-" + values.Worker.Name,
+				Namespace: values.Namespace,
+			}},
+		},
 	}
 }
 
@@ -87,19 +89,19 @@ func (c *controlPlaneBootstrap) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.osc, func() error {
-		metav1.SetMetaDataAnnotation(&c.osc.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-		metav1.SetMetaDataAnnotation(&c.osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.osc.Object, func() error {
+		metav1.SetMetaDataAnnotation(&c.osc.Object.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&c.osc.Object.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().Format(time.RFC3339Nano))
 
-		c.osc.Spec = extensionsv1alpha1.OperatingSystemConfigSpec{
+		c.osc.Object.Spec = extensionsv1alpha1.OperatingSystemConfigSpec{
 			Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			Units:   units,
 			Files:   files,
 		}
 
 		// TODO(timebertt): ensure Worker.Machine.Image is set in Shoot validation for `gardenadm bootstrap`
-		c.osc.Spec.Type = c.values.Worker.Machine.Image.Name
-		c.osc.Spec.ProviderConfig = c.values.Worker.Machine.Image.ProviderConfig
+		c.osc.Object.Spec.Type = c.values.Worker.Machine.Image.Name
+		c.osc.Object.Spec.ProviderConfig = c.values.Worker.Machine.Image.ProviderConfig
 
 		return nil
 	})
@@ -111,24 +113,25 @@ func (c *controlPlaneBootstrap) Wait(ctx context.Context) error {
 		ctx,
 		c.client,
 		c.log,
-		c.osc,
+		c.osc.Object,
 		extensionsv1alpha1.OperatingSystemConfigResource,
 		c.waitInterval,
 		c.waitSevereThreshold,
 		c.waitTimeout,
 		func() error {
-			if c.osc.Status.CloudConfig == nil {
+			if c.osc.Object.Status.CloudConfig == nil {
 				return fmt.Errorf("no cloud config information provided in status")
 			}
 
 			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Namespace: c.osc.Status.CloudConfig.SecretRef.Namespace,
-				Name:      c.osc.Status.CloudConfig.SecretRef.Name,
+				Namespace: c.osc.Object.Status.CloudConfig.SecretRef.Namespace,
+				Name:      c.osc.Object.Status.CloudConfig.SecretRef.Name,
 			}}
 			if err := c.client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 				return fmt.Errorf("failed getting cloud config secret %q: %w", client.ObjectKeyFromObject(secret), err)
 			}
 
+			c.osc.SecretName = ptr.To(c.osc.Object.Status.CloudConfig.SecretRef.Name)
 			return nil
 		},
 	)
@@ -137,9 +140,7 @@ func (c *controlPlaneBootstrap) Wait(ctx context.Context) error {
 func (c *controlPlaneBootstrap) WorkerPoolNameToOperatingSystemConfigsMap() map[string]*OperatingSystemConfigs {
 	return map[string]*OperatingSystemConfigs{
 		c.values.Worker.Name: {
-			Init: Data{
-				SecretName: ptr.To(c.osc.Status.CloudConfig.SecretRef.Name),
-			},
+			Init: c.osc,
 		},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -172,13 +173,13 @@ var _ = Describe("controlPlaneBootstrap", func() {
 		})
 
 		It("should return the correct result from the Deploy and Wait operations", func() {
-			Expect(deployer.WorkerPoolNameToOperatingSystemConfigsMap()).To(Equal(map[string]*OperatingSystemConfigs{
-				worker.Name: {
-					Init: Data{
-						SecretName: ptr.To(ccSecret.Name),
-					},
-				},
-			}))
+			Expect(deployer.WorkerPoolNameToOperatingSystemConfigsMap()).To(
+				HaveKeyWithValue(worker.Name, HaveField("Init", And(
+					HaveField("SecretName", ptr.To(ccSecret.Name)),
+					HaveField("IncludeSecretNameInWorkerPool", true),
+					HaveField("GardenerNodeAgentSecretName", "gardener-node-agent-control-plane-afd64c60da0e2d2d"),
+				))),
+			)
 		})
 	})
 })

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
@@ -126,6 +126,11 @@ var _ = Describe("controlPlaneBootstrap", func() {
 					HaveField("Content.Inline.Encoding", "b64"),
 					HaveField("Content.Inline.Data", Not(BeEmpty())),
 				),
+				And(
+					HaveField("Path", "/var/lib/gardener-node-agent/machine-name"),
+					HaveField("Content.Inline.Data", "<<MACHINE_NAME>>"),
+					HaveField("Content.TransmitUnencoded", HaveValue(BeTrue())),
+				),
 			))
 
 			Expect(actual.Spec.Type).To(Equal("type1"))

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
@@ -85,7 +85,10 @@ var _ = Describe("controlPlaneBootstrap", func() {
 		}
 
 		values = &ControlPlaneBootstrapValues{
-			Namespace:      namespace,
+			Values: &Values{
+				Namespace:         namespace,
+				KubernetesVersion: semver.MustParse("1.34.0"),
+			},
 			Worker:         worker,
 			GardenadmImage: "gardenadm-image",
 		}

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -101,6 +101,11 @@ chmod +x "/opt/bin/gardenadm"
 						},
 					},
 				},
+				And(
+					HaveField("Path", "/var/lib/gardener-node-agent/machine-name"),
+					HaveField("Content.Inline.Data", "<<MACHINE_NAME>>"),
+					HaveField("Content.TransmitUnencoded", HaveValue(BeTrue())),
+				),
 			))
 		})
 	})

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -332,6 +332,8 @@ type Values struct {
 	NodeAgentAuthorizerEnabled bool
 	// NodeAgentAuthorizerAuthorizeWithSelectors specifies if node-agent-authorizer should allow authorization to use field selectors.
 	NodeAgentAuthorizerAuthorizeWithSelectors *bool
+	// MachineNamespace is the namespace in the source cluster in which the Machine objects are stored.
+	MachineNamespace *string
 	// PodKubeAPIServerLoadBalancingWebhook specifies the settings of pod-kube-apiserver-load-balancing webhook.
 	PodKubeAPIServerLoadBalancingWebhook PodKubeAPIServerLoadBalancingWebhook
 	// VPAInPlaceUpdatesEnabled specifies if a vpa-in-place-pod-vertical-scaling webhook should be enabled.
@@ -616,7 +618,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			NodeAgentAuthorizer: resourcemanagerconfigv1alpha1.NodeAgentAuthorizerWebhookConfig{
 				Enabled:                r.values.NodeAgentAuthorizerEnabled,
 				AuthorizeWithSelectors: r.values.NodeAgentAuthorizerAuthorizeWithSelectors,
-				MachineNamespace:       r.values.WatchedNamespace,
+				MachineNamespace:       r.values.MachineNamespace,
 			},
 			SeccompProfile: resourcemanagerconfigv1alpha1.SeccompProfileWebhookConfig{
 				Enabled: r.values.DefaultSeccompProfileEnabled,
@@ -662,7 +664,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	if v := r.values.MaxConcurrentCSRApproverWorkers; v != nil {
 		config.Controllers.CSRApprover.Enabled = true
 		config.Controllers.CSRApprover.ConcurrentSyncs = v
-		config.Controllers.CSRApprover.MachineNamespace = r.values.WatchedNamespace
+		config.Controllers.CSRApprover.MachineNamespace = r.values.MachineNamespace
 	}
 
 	if v := r.values.MaxConcurrentTokenRequestorWorkers; v != nil {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -345,6 +345,7 @@ var _ = Describe("ResourceManager", func() {
 			ManagedResourceLabels:                     map[string]string{"foo": "bar"},
 			NodeAgentAuthorizerEnabled:                true,
 			NodeAgentAuthorizerAuthorizeWithSelectors: ptr.To(true),
+			MachineNamespace:                          ptr.To(watchedNamespace),
 			PodKubeAPIServerLoadBalancingWebhook: PodKubeAPIServerLoadBalancingWebhook{
 				Enabled: false,
 				Configs: []PodKubeAPIServerLoadBalancingWebhookConfig{
@@ -426,7 +427,7 @@ var _ = Describe("ResourceManager", func() {
 					CSRApprover: resourcemanagerconfigv1alpha1.CSRApproverControllerConfig{
 						Enabled:          !isWorkerless,
 						ConcurrentSyncs:  &maxConcurrentCSRApproverWorkers,
-						MachineNamespace: watchedNamespace,
+						MachineNamespace: cfg.MachineNamespace,
 					},
 					ManagedResource: resourcemanagerconfigv1alpha1.ManagedResourceControllerConfig{
 						ConcurrentSyncs: &concurrentSyncs,
@@ -466,7 +467,7 @@ var _ = Describe("ResourceManager", func() {
 					NodeAgentAuthorizer: resourcemanagerconfigv1alpha1.NodeAgentAuthorizerWebhookConfig{
 						Enabled:                true,
 						AuthorizeWithSelectors: ptr.To(true),
-						MachineNamespace:       watchedNamespace,
+						MachineNamespace:       cfg.MachineNamespace,
 					},
 				},
 			}

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -23,6 +23,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
@@ -297,6 +298,7 @@ func RestoreExtensionObjectState(
 			}
 		}
 	}
+
 	if shootState.Spec.Resources != nil {
 		list := v1beta1helper.ResourceDataList(shootState.Spec.Resources)
 		for _, resourceRef := range resourceRefs {
@@ -312,6 +314,68 @@ func RestoreExtensionObjectState(
 			}
 		}
 	}
+
+	if worker, ok := extensionObj.(*extensionsv1alpha1.Worker); ok {
+		if err := RestoreWorkerState(ctx, c, shootState, worker); err != nil {
+			return fmt.Errorf("failed restoring Worker state: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// RestoreWorkerState restores machine state from ShootState gardener data into the Worker.status.state field.
+// Historically, the ShootState object was fetched from the garden cluster by the extension's Worker controller.
+// However, when bootstrapping self-hosted shoots with managed infrastructure, the ShootState is not transported
+// via the garden cluster, but passed to `gardenadm init` as a manifest in the config directory.
+// Therefore, the extension's Worker controller cannot fetch the ShootState and we need to pass the machine state
+// via the Worker.status.state here.
+func RestoreWorkerState(ctx context.Context, c client.Client, shootState *gardencorev1beta1.ShootState, worker *extensionsv1alpha1.Worker) error {
+	// Read machine state from ShootState gardener data.
+	var state []byte
+	gardenerData := v1beta1helper.GardenerResourceDataList(shootState.Spec.Gardener)
+	if machineState := gardenerData.Get(v1beta1constants.DataTypeMachineState); machineState != nil && machineState.Type == v1beta1constants.DataTypeMachineState {
+		state = machineState.Data.Raw
+	}
+
+	if len(state) == 0 {
+		return nil
+	}
+
+	if worker.Status.State != nil && len(worker.Status.State.Raw) > 0 {
+		return fmt.Errorf("cannot restore machine state from gardener data in ShootState because ShootState already contains state of Worker. "+
+			"Ensure that the %s provider extension doesn't write Worker.status.state during the Migrate operation", worker.Spec.Type)
+	}
+
+	// Update namespaces in the machine state to the worker's namespace.
+	// This is necessary for `gardenadm bootstrap`, where the `Machines` are created in the shoot namespace in the
+	// bootstrap cluster, but restored in the kube-system namespace in the self-hosted shoot cluster.
+	machineState, err := shootstate.UnmarshalMachineState(state)
+	if err != nil {
+		return err
+	}
+
+	for _, machineDeploymentState := range machineState.MachineDeployments {
+		for i := range machineDeploymentState.Machines {
+			machineDeploymentState.Machines[i].Namespace = worker.Namespace
+		}
+		for i := range machineDeploymentState.MachineSets {
+			machineDeploymentState.MachineSets[i].Namespace = worker.Namespace
+		}
+	}
+
+	state, err = shootstate.MarshalMachineState(machineState)
+	if err != nil {
+		return err
+	}
+
+	// Patch the updated machine state into the Worker.status.state field.
+	patch := client.MergeFrom(worker.DeepCopy())
+	worker.Status.State = &runtime.RawExtension{Raw: state}
+	if err := c.Status().Patch(ctx, worker, patch); err != nil {
+		return fmt.Errorf("failed restoring worker state: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -270,9 +270,10 @@ func RestoreExtensionObjectState(
 	extensionObj extensionsv1alpha1.Object,
 	kind string,
 ) error {
-	if extensionObj.GetExtensionStatus().GetLastOperation() != nil {
-		// Extension controller has already started restoration/reconciliation of this extension object.
-		// Don't overwrite its status anymore to avoid conflicts and potential state loss.
+	if extensionObj.GetExtensionStatus().GetState() != nil {
+		// The extension object status contains state, so we either already restored it or the extension controller has
+		// already started restoration/reconciliation of this object.
+		// Don't overwrite status.state anymore to avoid conflicts and potential state loss.
 		// This can happen if `gardenadm init` is re-run with a `ShootState` manifest because it always sets the operation
 		// of the in-memory Shoot object to `Restore` which triggers restoration of all extension objects.
 		return nil

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -634,7 +634,7 @@ var _ = Describe("extensions", func() {
 				Expect(expected.Status.State).To(Equal(expectedState))
 			})
 
-			It("should not update the state if the extension controller has already picked up the object", func() {
+			It("should not overwrite the extension object's state if already present", func() {
 				defer test.WithVars(
 					&TimeNow, mockNow.Do,
 				)()
@@ -644,9 +644,6 @@ var _ = Describe("extensions", func() {
 
 				changedStatus := &runtime.RawExtension{
 					Raw: []byte(`{"data":"changed-value"}`),
-				}
-				expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-					State: gardencorev1beta1.LastOperationStateProcessing,
 				}
 				expected.Status.State = changedStatus
 				Expect(c.Status().Update(ctx, expected)).To(Succeed())

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -26,6 +27,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -657,6 +659,134 @@ var _ = Describe("extensions", func() {
 					extensionsv1alpha1.WorkerResource,
 				)).To(Succeed())
 				Expect(expected.Status.State).To(Equal(changedStatus))
+			})
+		})
+
+		Describe("#RestoreWorkerState", func() {
+			var (
+				machineState     *shootstate.MachineState
+				machineStateData []byte
+			)
+
+			BeforeEach(func() {
+				machineState = &shootstate.MachineState{
+					MachineDeployments: map[string]*shootstate.MachineDeploymentState{
+						"shoot--foo--bar-worker-z1": {
+							Replicas: 3,
+							MachineSets: []machinev1alpha1.MachineSet{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name:      "shoot--foo--bar-worker-z1-hash1",
+										Namespace: namespace,
+									},
+									Spec: machinev1alpha1.MachineSetSpec{
+										Replicas: 3,
+										MachineClass: machinev1alpha1.ClassSpec{
+											Name: "shoot--foo--bar-worker-z1-hash1",
+										},
+										Template: machinev1alpha1.MachineTemplateSpec{
+											Spec: machinev1alpha1.MachineSpec{
+												Class: machinev1alpha1.ClassSpec{
+													Name: "shoot--foo--bar-worker-z1-hash1",
+												},
+											},
+										},
+									},
+								},
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name:      "shoot--foo--bar-worker-z1-hash2",
+										Namespace: namespace,
+									},
+									Spec: machinev1alpha1.MachineSetSpec{
+										Replicas: 3,
+										MachineClass: machinev1alpha1.ClassSpec{
+											Name: "shoot--foo--bar-worker-z1-hash2",
+										},
+										Template: machinev1alpha1.MachineTemplateSpec{
+											Spec: machinev1alpha1.MachineSpec{
+												Class: machinev1alpha1.ClassSpec{
+													Name: "shoot--foo--bar-worker-z1-hash2",
+												},
+											},
+										},
+									},
+								},
+							},
+							Machines: []machinev1alpha1.Machine{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name:      "shoot--foo--bar-worker-z1-hash1-abcde",
+										Namespace: namespace,
+									},
+									Spec: machinev1alpha1.MachineSpec{
+										Class: machinev1alpha1.ClassSpec{
+											Name: "shoot--foo--bar-worker-z1-hash1-abcde",
+										},
+									},
+								},
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name:      "shoot--foo--bar-worker-z1-hash2-abcde",
+										Namespace: namespace,
+									},
+									Spec: machinev1alpha1.MachineSpec{
+										Class: machinev1alpha1.ClassSpec{
+											Name: "shoot--foo--bar-worker-z1-hash2-abcde",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				var err error
+				machineStateData, err = shootstate.MarshalMachineState(machineState)
+				Expect(err).NotTo(HaveOccurred())
+
+				shootState.Spec.Gardener = []gardencorev1beta1.GardenerResourceData{{
+					Name: "machine-state",
+					Type: "machine-state",
+					Data: runtime.RawExtension{
+						Raw: machineStateData,
+					},
+				}}
+			})
+
+			It("should fail if the worker object already has a state", func() {
+				expected.Status.State = &runtime.RawExtension{Raw: []byte(`{"data":"some-existing-value"}`)}
+
+				Expect(RestoreWorkerState(ctx, c, shootState, expected)).Error().To(MatchError(ContainSubstring("already contains state")))
+			})
+
+			It("should copy the machine-state to the worker status", func() {
+				Expect(c.Create(ctx, expected)).To(Succeed())
+
+				Expect(RestoreWorkerState(ctx, c, shootState, expected)).To(Succeed())
+
+				actual := &extensionsv1alpha1.Worker{}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
+				Expect(actual.Status.State.Raw).To(HaveValue(Equal(machineStateData)))
+			})
+
+			It("should update the namespace of the machine-state", func() {
+				expected.Namespace = "kube-system"
+				Expect(c.Create(ctx, expected)).To(Succeed())
+
+				Expect(RestoreWorkerState(ctx, c, shootState, expected)).To(Succeed())
+
+				actual := &extensionsv1alpha1.Worker{}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
+
+				machineState.MachineDeployments["shoot--foo--bar-worker-z1"].Machines[0].Namespace = expected.Namespace
+				machineState.MachineDeployments["shoot--foo--bar-worker-z1"].Machines[1].Namespace = expected.Namespace
+				machineState.MachineDeployments["shoot--foo--bar-worker-z1"].MachineSets[0].Namespace = expected.Namespace
+				machineState.MachineDeployments["shoot--foo--bar-worker-z1"].MachineSets[1].Namespace = expected.Namespace
+
+				actualMachineState, err := shootstate.UnmarshalMachineState(actual.Status.State.Raw)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actualMachineState).To(Equal(machineState))
 			})
 		})
 	})

--- a/pkg/gardenadm/botanist/nodeagent_test.go
+++ b/pkg/gardenadm/botanist/nodeagent_test.go
@@ -134,6 +134,14 @@ var _ = Describe("NodeAgent", func() {
 			Expect(bootstrapToken).NotTo(BeEmpty())
 		})
 
+		It("should skip writing the machine name if it already exists", func() {
+			Expect(fakeFS.WriteFile("/var/lib/gardener-node-agent/machine-name", []byte("existing-machine-name"), 0o600)).To(Succeed())
+
+			Expect(b.ActivateGardenerNodeAgent(ctx)).To(Succeed())
+
+			Expect(fakeFS.ReadFile("/var/lib/gardener-node-agent/machine-name")).To(Equal([]byte("existing-machine-name")))
+		})
+
 		It("should create the temporary cluster-admin binding for bootstrapping the node-agent", func() {
 			Expect(b.ActivateGardenerNodeAgent(ctx)).To(Succeed())
 

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -241,12 +241,17 @@ func (b *GardenadmBotanist) ControlPlaneBootstrapOperatingSystemConfig() (operat
 		return nil, fmt.Errorf("did not find the control plane worker pool of the shoot")
 	}
 
+	values, err := b.OperatingSystemConfigValues()
+	if err != nil {
+		return nil, fmt.Errorf("failed creating operating system config values: %w", err)
+	}
+
 	return operatingsystemconfig.NewControlPlaneBootstrap(
 		b.Logger,
 		b.SeedClientSet.Client(),
 		b.SecretsManager,
 		&operatingsystemconfig.ControlPlaneBootstrapValues{
-			Namespace:      b.Shoot.ControlPlaneNamespace,
+			Values:         values,
 			Worker:         worker,
 			GardenadmImage: image.String(),
 		},

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -443,7 +443,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 			Fn: flow.TaskFn(func(_ context.Context) error {
 				clientSet, err = b.CreateClientSet(ctx)
 				return err
-			}).RetryUntilTimeout(2*time.Second, time.Minute),
+			}).RetryUntilTimeout(2*time.Second, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(applyOperatingSystemConfig),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -62,6 +62,10 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		}
 	)
 
+	if b.Shoot.HasManagedInfrastructure() {
+		values.MachineNamespace = ptr.To(b.Shoot.ControlPlaneNamespace)
+	}
+
 	if b.Shoot.IsSelfHosted() {
 		values.KubernetesServiceHost = nil
 

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -73,16 +73,22 @@ var _ = Describe("ResourceManager", func() {
 			botanist.Shoot = &shootpkg.Shoot{
 				KubernetesVersion:     semver.MustParse("1.32.1"),
 				ExternalClusterDomain: ptr.To("foo.local.gardener.cloud"),
+				ControlPlaneNamespace: "shoot--foo--bar",
 			}
-			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					CredentialsBindingName: ptr.To("foo-credentials"),
+				},
+			})
 		})
 
 		It("should successfully create a resource-manager component", func() {
 			resourceManager, err := botanist.DefaultResourceManager()
 			Expect(resourceManager).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resourceManager.GetValues().PodTopologySpreadConstraintsEnabled).To(BeFalse())
 
+			Expect(resourceManager.GetValues().PodTopologySpreadConstraintsEnabled).To(BeFalse())
+			Expect(resourceManager.GetValues().MachineNamespace).To(HaveValue(Equal("shoot--foo--bar")))
 		})
 
 		It("should consider node toleration configuration", func() {
@@ -144,6 +150,44 @@ var _ = Describe("ResourceManager", func() {
 			Expect(resourceManager).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues().NodeAgentAuthorizerAuthorizeWithSelectors).To(PointTo(Equal(true)))
+		})
+
+		Context("self-hosted shoots", func() {
+			BeforeEach(func() {
+				shoot := botanist.Shoot.GetInfo()
+				shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{{
+					Name:         "control-plane",
+					ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+				}}
+				botanist.Shoot.SetInfo(shoot)
+				botanist.Shoot.ControlPlaneNamespace = "kube-system"
+			})
+
+			Context("managed infrastructure", func() {
+				It("should correctly configure the resource-manager component", func() {
+					resourceManager, err := botanist.DefaultResourceManager()
+					Expect(resourceManager).NotTo(BeNil())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(resourceManager.GetValues().MachineNamespace).To(HaveValue(Equal("kube-system")))
+				})
+			})
+
+			Context("unmanaged infrastructure", func() {
+				BeforeEach(func() {
+					shoot := botanist.Shoot.GetInfo()
+					shoot.Spec.CredentialsBindingName = nil
+					botanist.Shoot.SetInfo(shoot)
+				})
+
+				It("should correctly configure the resource-manager component", func() {
+					resourceManager, err := botanist.DefaultResourceManager()
+					Expect(resourceManager).NotTo(BeNil())
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(resourceManager.GetValues().MachineNamespace).To(BeNil())
+				})
+			})
 		})
 
 		When("VPAInPlaceUpdates feature gate is enabled", func() {

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -88,6 +88,12 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, worker *extensi
 }
 
 func (a *actuator) deleteNoLongerNeededMachines(ctx context.Context, log logr.Logger, namespace string) error {
+	if namespace == metav1.NamespaceSystem {
+		// In the self-hosted shoot scenario, we do not need to delete any machines since we will adapt the machine pods
+		// running in the kind cluster (i.e., outside the self-hosted shoot).
+		return nil
+	}
+
 	_, shootClient, err := util.NewClientForShoot(ctx, a.workerDelegate.seedClient, namespace, client.Options{}, extensionsconfigv1alpha1.RESTOptions{})
 	if err != nil {
 		return fmt.Errorf("failed creating client for shoot cluster: %w", err)

--- a/pkg/provider-local/controller/worker/helper.go
+++ b/pkg/provider-local/controller/worker/helper.go
@@ -44,5 +44,5 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 
 	patch := client.MergeFrom(w.worker.DeepCopy())
 	w.worker.Status.ProviderStatus = &runtime.RawExtension{Object: workerStatusV1alpha1}
-	return w.client.Status().Patch(ctx, w.worker, patch)
+	return w.runtimeClient.Status().Patch(ctx, w.worker, patch)
 }

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -108,7 +108,8 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		})
 
 		providerConfig := map[string]interface{}{
-			"image": image.Image,
+			"image":     image.Image,
+			"namespace": w.cluster.Shoot.Status.TechnicalID,
 		}
 
 		for _, ipFamily := range w.cluster.Shoot.Spec.Networking.IPFamilies {

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -89,7 +89,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 
 		var (
-			deploymentName = fmt.Sprintf("%s-%s", w.worker.Namespace, pool.Name)
+			deploymentName = fmt.Sprintf("%s-%s", w.cluster.Shoot.Status.TechnicalID, pool.Name)
 			className      = fmt.Sprintf("%s-%s", deploymentName, workerPoolHash)
 		)
 
@@ -117,7 +117,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				key = "ipPoolNameV6"
 			}
 
-			providerConfig[key] = infrastructure.IPPoolName(w.worker.Namespace, string(ipFamily))
+			providerConfig[key] = infrastructure.IPPoolName(w.cluster.Shoot.Status.TechnicalID, string(ipFamily))
 		}
 
 		providerConfigBytes, err := json.Marshal(providerConfig)
@@ -271,7 +271,7 @@ func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
 	// Overwrite only if Machine Image Version is not present to prevent overwriting the new version after an in-place update.
 
 	podList := &corev1.PodList{}
-	if err := w.providerClient.List(ctx, podList, client.InNamespace(w.worker.Namespace), client.MatchingLabels{
+	if err := w.providerClient.List(ctx, podList, client.InNamespace(w.cluster.Shoot.Status.TechnicalID), client.MatchingLabels{
 		"app":              "machine",
 		"machine-provider": "local",
 	}); err != nil {

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
@@ -39,13 +38,13 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 	}
 
 	for _, obj := range w.machineClassSecrets {
-		if err := w.client.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+		if err := w.runtimeClient.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 			return fmt.Errorf("failed to apply machine class secret %s: %w", obj.GetName(), err)
 		}
 	}
 
 	for _, obj := range w.machineClasses {
-		if err := w.client.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+		if err := w.runtimeClient.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 			return fmt.Errorf("failed to apply machine class %s: %w", obj.GetName(), err)
 		}
 	}
@@ -84,7 +83,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 		machineImages = appendMachineImage(machineImages, *image, w.cluster.CloudProfile.Spec.MachineCapabilities)
 
-		userData, err := worker.FetchUserData(ctx, w.client, w.worker.Namespace, pool)
+		userData, err := worker.FetchUserData(ctx, w.runtimeClient, w.worker.Namespace, pool)
 		if err != nil {
 			return err
 		}
@@ -254,11 +253,12 @@ func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
 	}
 
 	for _, obj := range []client.Object{role, roleBinding} {
-		if err := controllerutil.SetControllerReference(w.worker, obj, w.client.Scheme()); err != nil {
-			return fmt.Errorf("error setting controller reference on %T %s: %w", obj, obj.GetName(), err)
-		}
-
-		if err := w.client.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+		// We cannot set an ownerReference here, because the Role/RoleBinding might live in another cluster than the Worker.
+		// E.g., this is the case for `gardenadm bootstrap`, where the Worker lives in the self-hosted shoot cluster and the
+		// machine pods and thus also the Role/RoleBinding live in the bootstrap kind cluster.
+		// On the other hand, not setting an ownerReference is not a problem, because when the worker is deleted, the
+		// namespace will also be deleted, automatically cleaning up these objects as well.
+		if err := w.providerClient.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 			return fmt.Errorf("error applying %T %s: %w", obj, obj.GetName(), err)
 		}
 	}
@@ -271,7 +271,7 @@ func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
 	// Overwrite only if Machine Image Version is not present to prevent overwriting the new version after an in-place update.
 
 	podList := &corev1.PodList{}
-	if err := w.client.List(ctx, podList, client.InNamespace(w.worker.Namespace), client.MatchingLabels{
+	if err := w.providerClient.List(ctx, podList, client.InNamespace(w.worker.Namespace), client.MatchingLabels{
 		"app":              "machine",
 		"machine-provider": "local",
 	}); err != nil {

--- a/pkg/provider-local/machine-provider/api/v1alpha1/provider_spec.go
+++ b/pkg/provider-local/machine-provider/api/v1alpha1/provider_spec.go
@@ -15,6 +15,8 @@ const (
 type ProviderSpec struct {
 	// APIVersion determines the API version for the provider APIs.
 	APIVersion string `json:"apiVersion,omitempty"`
+	// Namespace is the namespace in which the machine pods should be created.
+	Namespace string `json:"namespace,omitempty"`
 	// Image is the container image to use for the node.
 	Image string `json:"image,omitempty"`
 	// IPPoolNameV4 is the name of the crd.projectcalico.org/v1.IPPool that should be used for machine pods for IPv4

--- a/pkg/provider-local/machine-provider/local/delete_machine.go
+++ b/pkg/provider-local/machine-provider/local/delete_machine.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/provider-local/local"
 	apiv1alpha1 "github.com/gardener/gardener/pkg/provider-local/machine-provider/api/v1alpha1"
 )
 
@@ -25,17 +26,16 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, apiv1alpha1.Provider))
 	}
 
+	providerClient, err := local.GetProviderClient(ctx, log, d.runtimeClient, *req.MachineClass.CredentialsSecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for infrastructure resources: %w", err)
+	}
+
 	klog.V(3).Infof("Machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
-	userDataSecret := userDataSecretForMachine(req.Machine, req.MachineClass)
-	if err := d.client.Delete(ctx, userDataSecret); client.IgnoreNotFound(err) != nil {
-		// Unknown leads to short retry in machine controller
-		return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting user data secret: %s", err.Error()))
-	}
-
 	pod := podForMachine(req.Machine, req.MachineClass)
-	if err := d.client.Delete(ctx, pod); err != nil {
+	if err := providerClient.Delete(ctx, pod); err != nil {
 		if !apierrors.IsNotFound(err) {
 			// Unknown leads to short retry in machine controller
 			return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting pod: %s", err.Error()))
@@ -50,7 +50,7 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 	defer cancel()
 
 	if err := wait.PollUntilContextCancel(timeoutCtx, 5*time.Second, false, func(ctx context.Context) (bool, error) {
-		if err := d.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+		if err := providerClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}

--- a/pkg/provider-local/machine-provider/local/delete_machine.go
+++ b/pkg/provider-local/machine-provider/local/delete_machine.go
@@ -34,7 +34,12 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 	klog.V(3).Infof("Machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
-	pod := podForMachine(req.Machine, req.MachineClass)
+	providerSpec, err := validateProviderSpecAndSecret(req.MachineClass, req.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	pod := podForMachine(req.Machine, req.MachineClass, providerSpec)
 	if err := providerClient.Delete(ctx, pod); err != nil {
 		if !apierrors.IsNotFound(err) {
 			// Unknown leads to short retry in machine controller

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -15,7 +15,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("machine-provider-local")
 
 const (
 	fieldOwner        = client.FieldOwner("machine-controller-manager-provider-local")
@@ -32,7 +35,7 @@ func NewDriver(client client.Client) driver.Driver {
 }
 
 type localDriver struct {
-	client client.Client
+	runtimeClient client.Client
 }
 
 // GenerateMachineClassForMigration is not implemented.

--- a/pkg/provider-local/machine-provider/local/driver.go
+++ b/pkg/provider-local/machine-provider/local/driver.go
@@ -16,6 +16,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	apiv1alpha1 "github.com/gardener/gardener/pkg/provider-local/machine-provider/api/v1alpha1"
 )
 
 var log = logf.Log.WithName("machine-provider-local")
@@ -48,7 +50,7 @@ func (*localDriver) InitializeMachine(context.Context, *driver.InitializeMachine
 	return nil, status.Error(codes.Unimplemented, "InitializeMachine is not yet implemented")
 }
 
-func serviceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Service {
+func serviceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass, providerSpec *apiv1alpha1.ProviderSpec) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -56,12 +58,12 @@ func serviceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName(machine.Name),
-			Namespace: getNamespaceForMachine(machine, machineClass),
+			Namespace: getNamespaceForMachine(machine, machineClass, providerSpec),
 		},
 	}
 }
 
-func podForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Pod {
+func podForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass, providerSpec *apiv1alpha1.ProviderSpec) *corev1.Pod {
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -69,12 +71,12 @@ func podForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alph
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName(machine.Name),
-			Namespace: getNamespaceForMachine(machine, machineClass),
+			Namespace: getNamespaceForMachine(machine, machineClass, providerSpec),
 		},
 	}
 }
 
-func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) *corev1.Secret {
+func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass, providerSpec *apiv1alpha1.ProviderSpec) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
@@ -82,7 +84,7 @@ func userDataSecretForMachine(machine *machinev1alpha1.Machine, machineClass *ma
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName(machine.Name) + "-userdata",
-			Namespace: getNamespaceForMachine(machine, machineClass),
+			Namespace: getNamespaceForMachine(machine, machineClass, providerSpec),
 		},
 	}
 }
@@ -95,9 +97,13 @@ func machineName(podName string) string {
 	return strings.TrimPrefix(podName, machinePrefix)
 }
 
-// TODO(scheererj): Remove the empty namespace mitigation after https://github.com/gardener/machine-controller-manager/pull/932 has been adopted
-func getNamespaceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass) string {
+func getNamespaceForMachine(machine *machinev1alpha1.Machine, machineClass *machinev1alpha1.MachineClass, providerSpec *apiv1alpha1.ProviderSpec) string {
+	if providerSpec.Namespace != "" {
+		return providerSpec.Namespace
+	}
+
 	// machine.Namespace may be empty due to machine controller manager omitting namespace
+	// TODO(scheererj): Remove the empty namespace mitigation after https://github.com/gardener/machine-controller-manager/pull/932 has been adopted
 	if machine.Namespace != "" {
 		return machine.Namespace
 	}

--- a/pkg/provider-local/machine-provider/local/get_machine_status.go
+++ b/pkg/provider-local/machine-provider/local/get_machine_status.go
@@ -32,7 +32,12 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	klog.V(3).Infof("Machine status request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine status request has been processed for %q", req.Machine.Name)
 
-	pod := podForMachine(req.Machine, req.MachineClass)
+	providerSpec, err := validateProviderSpecAndSecret(req.MachineClass, req.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	pod := podForMachine(req.Machine, req.MachineClass, providerSpec)
 	if err := providerClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, err.Error())

--- a/pkg/provider-local/machine-provider/local/get_machine_status.go
+++ b/pkg/provider-local/machine-provider/local/get_machine_status.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/provider-local/local"
 	apiv1alpha1 "github.com/gardener/gardener/pkg/provider-local/machine-provider/api/v1alpha1"
 )
 
@@ -23,11 +24,16 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, apiv1alpha1.Provider))
 	}
 
+	providerClient, err := local.GetProviderClient(ctx, log, d.runtimeClient, *req.MachineClass.CredentialsSecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for infrastructure resources: %w", err)
+	}
+
 	klog.V(3).Infof("Machine status request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine status request has been processed for %q", req.Machine.Name)
 
 	pod := podForMachine(req.Machine, req.MachineClass)
-	if err := d.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+	if err := providerClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}

--- a/pkg/provider-local/machine-provider/local/list_machines.go
+++ b/pkg/provider-local/machine-provider/local/list_machines.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/provider-local/local"
 	apiv1alpha1 "github.com/gardener/gardener/pkg/provider-local/machine-provider/api/v1alpha1"
 )
 
@@ -23,11 +24,16 @@ func (d *localDriver) ListMachines(ctx context.Context, req *driver.ListMachines
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, apiv1alpha1.Provider))
 	}
 
+	providerClient, err := local.GetProviderClient(ctx, log, d.runtimeClient, *req.MachineClass.CredentialsSecretRef)
+	if err != nil {
+		return nil, fmt.Errorf("could not create client for infrastructure resources: %w", err)
+	}
+
 	klog.V(3).Infof("Machine list request has been received for %q", req.MachineClass.Name)
 	defer klog.V(3).Infof("Machine list request has been processed for %q", req.MachineClass.Name)
 
 	podList := &corev1.PodList{}
-	if err := d.client.List(ctx, podList, client.InNamespace(req.MachineClass.Namespace), client.MatchingLabels{labelKeyProvider: apiv1alpha1.Provider}); err != nil {
+	if err := providerClient.List(ctx, podList, client.InNamespace(req.MachineClass.Namespace), client.MatchingLabels{labelKeyProvider: apiv1alpha1.Provider}); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/provider-local/machine-provider/local/list_machines.go
+++ b/pkg/provider-local/machine-provider/local/list_machines.go
@@ -32,8 +32,13 @@ func (d *localDriver) ListMachines(ctx context.Context, req *driver.ListMachines
 	klog.V(3).Infof("Machine list request has been received for %q", req.MachineClass.Name)
 	defer klog.V(3).Infof("Machine list request has been processed for %q", req.MachineClass.Name)
 
+	providerSpec, err := validateProviderSpecAndSecret(req.MachineClass, req.Secret)
+	if err != nil {
+		return nil, err
+	}
+
 	podList := &corev1.PodList{}
-	if err := providerClient.List(ctx, podList, client.InNamespace(req.MachineClass.Namespace), client.MatchingLabels{labelKeyProvider: apiv1alpha1.Provider}); err != nil {
+	if err := providerClient.List(ctx, podList, client.InNamespace(providerSpec.Namespace), client.MatchingLabels{labelKeyProvider: apiv1alpha1.Provider}); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/utils/gardener/shootstate/machines_test.go
+++ b/pkg/utils/gardener/shootstate/machines_test.go
@@ -5,36 +5,106 @@
 package shootstate_test
 
 import (
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
-var _ = Describe("Machines", func() {
-	Describe("#DecompressMachineState", func() {
-		It("should do nothing because state is empty", func() {
-			state, err := DecompressMachineState(nil)
+var _ = Describe("MachineState", func() {
+	Describe("MarshalMachineState and UnmarshalMachineState", Ordered, func() {
+		var (
+			machineState *MachineState
+			state        []byte
+		)
+
+		BeforeAll(func() {
+			machineState = &MachineState{
+				MachineDeployments: map[string]*MachineDeploymentState{
+					"shoot--foo--bar-worker-z1": {
+						Replicas: 3,
+						MachineSets: []machinev1alpha1.MachineSet{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "shoot--foo--bar-worker-z1-hash1",
+									Namespace: "shoot--foo--bar",
+								},
+								Spec: machinev1alpha1.MachineSetSpec{
+									Replicas: 3,
+									MachineClass: machinev1alpha1.ClassSpec{
+										Name: "shoot--foo--bar-worker-z1-hash1",
+									},
+									Template: machinev1alpha1.MachineTemplateSpec{
+										Spec: machinev1alpha1.MachineSpec{
+											Class: machinev1alpha1.ClassSpec{
+												Name: "shoot--foo--bar-worker-z1-hash1",
+											},
+										},
+									},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "shoot--foo--bar-worker-z1-hash2",
+									Namespace: "shoot--foo--bar",
+								},
+								Spec: machinev1alpha1.MachineSetSpec{
+									Replicas: 3,
+									MachineClass: machinev1alpha1.ClassSpec{
+										Name: "shoot--foo--bar-worker-z1-hash2",
+									},
+									Template: machinev1alpha1.MachineTemplateSpec{
+										Spec: machinev1alpha1.MachineSpec{
+											Class: machinev1alpha1.ClassSpec{
+												Name: "shoot--foo--bar-worker-z1-hash2",
+											},
+										},
+									},
+								},
+							},
+						},
+						Machines: []machinev1alpha1.Machine{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "shoot--foo--bar-worker-z1-hash1-abcde",
+									Namespace: "shoot--foo--bar",
+								},
+								Spec: machinev1alpha1.MachineSpec{
+									Class: machinev1alpha1.ClassSpec{
+										Name: "shoot--foo--bar-worker-z1-hash1-abcde",
+									},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "shoot--foo--bar-worker-z1-hash2-abcde",
+									Namespace: "shoot--foo--bar",
+								},
+								Spec: machinev1alpha1.MachineSpec{
+									Class: machinev1alpha1.ClassSpec{
+										Name: "shoot--foo--bar-worker-z1-hash2-abcde",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should marshal the MachineState", func() {
+			var err error
+			state, err = MarshalMachineState(machineState)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(state).To(BeNil())
 		})
 
-		It("should fail because the state cannot be unmarshalled", func() {
-			state, err := DecompressMachineState([]byte("{foo"))
-			Expect(err).To(MatchError(ContainSubstring("failed unmarshalling JSON to compressed machine state structure")))
-			Expect(state).To(BeNil())
-		})
-
-		It("should fail because the gzip reader cannot be created", func() {
-			state, err := DecompressMachineState([]byte(`{"state":"eW91LXNob3VsZC1ub3QtaGF2ZS1yZWFkLXRoaXM="}`))
-			Expect(err).To(MatchError(ContainSubstring("failed creating gzip reader for decompressing machine state data")))
-			Expect(state).To(BeNil())
-		})
-
-		It("should successfully decompress the data", func() {
-			state, err := DecompressMachineState([]byte(`{"state":"H4sIAAAAAAAAAyvJyCzWLc/MydHNSCxL1U3OzytOLSxNzUtOLQYA3w65lxsAAAA="}`))
+		It("should unmarshal the MachineState", func() {
+			machineStateAfter, err := UnmarshalMachineState(state)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(state).To(Equal([]byte("this-will-have-consequences")))
+			Expect(machineState).To(DeepEqual(machineStateAfter))
 		})
 	})
 })

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -132,14 +132,9 @@ func computeGardenerData(
 	}
 
 	if machineState != nil {
-		machineStateJSON, err := json.Marshal(machineState)
+		machineStateJSONCompressed, err := MarshalMachineState(machineState)
 		if err != nil {
-			return nil, fmt.Errorf("failed marshalling machine state to JSON: %w", err)
-		}
-
-		machineStateJSONCompressed, err := compressMachineState(machineStateJSON)
-		if err != nil {
-			return nil, fmt.Errorf("failed compressing machine state data: %w", err)
+			return nil, err
 		}
 
 		if machineStateJSONCompressed != nil {

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1234,9 +1234,55 @@ build:
         dependencies:
           paths:
             - cmd/machine-controller-manager-provider-local
+            - pkg/api
+            - pkg/apis/authentication
+            - pkg/apis/authentication/install
+            - pkg/apis/authentication/v1alpha1
+            - pkg/apis/core
+            - pkg/apis/core/install
+            - pkg/apis/core/v1
+            - pkg/apis/core/v1beta1
+            - pkg/apis/core/v1beta1/constants
+            - pkg/apis/core/v1beta1/helper
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/chartrenderer
+            - pkg/client/kubernetes
+            - pkg/client/kubernetes/cache
+            - pkg/gardenlet/apis/config/v1alpha1
+            - pkg/logger
+            - pkg/provider-local/local
             - pkg/provider-local/machine-provider/api/v1alpha1
             - pkg/provider-local/machine-provider/api/validation
             - pkg/provider-local/machine-provider/local
+            - pkg/resourcemanager/controller/garbagecollector/references
+            - pkg/utils
+            - pkg/utils/context
+            - pkg/utils/errors
+            - pkg/utils/flow
+            - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
+            - pkg/utils/retry
+            - pkg/utils/timewindow
+            - pkg/utils/validation/kubernetesversion
+            - pkg/utils/version
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -299,6 +299,7 @@ build:
             - pkg/utils/gardener/gardenlet
             - pkg/utils/gardener/operator
             - pkg/utils/gardener/secretsrotation
+            - pkg/utils/gardener/shootstate
             - pkg/utils/gardener/tokenrequest
             - pkg/utils/imagevector
             - pkg/utils/istio
@@ -1342,9 +1343,55 @@ build:
         dependencies:
           paths:
             - cmd/machine-controller-manager-provider-local
+            - pkg/api
+            - pkg/apis/authentication
+            - pkg/apis/authentication/install
+            - pkg/apis/authentication/v1alpha1
+            - pkg/apis/core
+            - pkg/apis/core/install
+            - pkg/apis/core/v1
+            - pkg/apis/core/v1beta1
+            - pkg/apis/core/v1beta1/constants
+            - pkg/apis/core/v1beta1/helper
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/chartrenderer
+            - pkg/client/kubernetes
+            - pkg/client/kubernetes/cache
+            - pkg/gardenlet/apis/config/v1alpha1
+            - pkg/logger
+            - pkg/provider-local/local
             - pkg/provider-local/machine-provider/api/v1alpha1
             - pkg/provider-local/machine-provider/api/validation
             - pkg/provider-local/machine-provider/local
+            - pkg/resourcemanager/controller/garbagecollector/references
+            - pkg/utils
+            - pkg/utils/context
+            - pkg/utils/errors
+            - pkg/utils/flow
+            - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
+            - pkg/utils/retry
+            - pkg/utils/timewindow
+            - pkg/utils/validation/kubernetesversion
+            - pkg/utils/version
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -840,9 +840,55 @@ build:
         dependencies:
           paths:
             - cmd/machine-controller-manager-provider-local
+            - pkg/api
+            - pkg/apis/authentication
+            - pkg/apis/authentication/install
+            - pkg/apis/authentication/v1alpha1
+            - pkg/apis/core
+            - pkg/apis/core/install
+            - pkg/apis/core/v1
+            - pkg/apis/core/v1beta1
+            - pkg/apis/core/v1beta1/constants
+            - pkg/apis/core/v1beta1/helper
+            - pkg/apis/extensions
+            - pkg/apis/extensions/v1alpha1
+            - pkg/apis/operations
+            - pkg/apis/operations/install
+            - pkg/apis/operations/v1alpha1
+            - pkg/apis/operator
+            - pkg/apis/operator/v1alpha1
+            - pkg/apis/resources
+            - pkg/apis/resources/v1alpha1
+            - pkg/apis/security
+            - pkg/apis/security/install
+            - pkg/apis/security/v1alpha1
+            - pkg/apis/seedmanagement
+            - pkg/apis/seedmanagement/encoding
+            - pkg/apis/seedmanagement/install
+            - pkg/apis/seedmanagement/v1alpha1
+            - pkg/apis/settings
+            - pkg/apis/settings/install
+            - pkg/apis/settings/v1alpha1
+            - pkg/chartrenderer
+            - pkg/client/kubernetes
+            - pkg/client/kubernetes/cache
+            - pkg/gardenlet/apis/config/v1alpha1
+            - pkg/logger
+            - pkg/provider-local/local
             - pkg/provider-local/machine-provider/api/v1alpha1
             - pkg/provider-local/machine-provider/api/validation
             - pkg/provider-local/machine-provider/local
+            - pkg/resourcemanager/controller/garbagecollector/references
+            - pkg/utils
+            - pkg/utils/context
+            - pkg/utils/errors
+            - pkg/utils/flow
+            - pkg/utils/kubernetes
+            - pkg/utils/kubernetes/health
+            - pkg/utils/retry
+            - pkg/utils/timewindow
+            - pkg/utils/validation/kubernetesversion
+            - pkg/utils/version
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -278,7 +278,10 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 
 		It("should deploy/restore the Worker in the shoot", func(ctx SpecContext) {
 			worker := &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: "kube-system"}}
-			Eventually(ctx, shootKomega.Object(worker)).Should(BeHealthy(health.CheckExtensionObject))
+			Eventually(ctx, shootKomega.Object(worker)).Should(And(
+				BeHealthy(health.CheckExtensionObject),
+				HaveField("Status.DefaultStatus.State", BeNil()), // ensure machine state is removed after restoration
+			))
 		}, SpecTimeout(time.Minute))
 
 		It("should adopt and keep the initial control plane machine", func(ctx SpecContext) {

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -313,7 +313,7 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 
 		It("should run successfully a second time (should be idempotent)", func(ctx SpecContext) {
 			RunAndWait(ctx, "bootstrap", "-d", "../../../dev-setup/gardenadm/resources/generated/managed-infra", "--bastion-ingress-cidr", "1.2.3.4/32")
-		}, SpecTimeout(2*time.Minute))
+		}, SpecTimeout(10*time.Minute))
 	})
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Similar to https://github.com/gardener/gardener/pull/13353 and https://github.com/gardener/gardener/pull/13385, this PR adds the deployment of the `Worker` resource within the shoot cluster. Its state from the bootstrap cluster is restored by `gardenadm init` from the `ShootState` compiled by `gardenadm bootstrap`.

The PR is comprised of several individual steps:
- Ensure the same worker pool hash in the bootstrap and the shoot cluster. This is required for mcm in the shoot cluster to adopt the machine/node provisioned by `gardeadm init`.
- Restore machine state without requiring garden cluster. There is no garden cluster where the worker extension can read the `ShootState` from. Instead, Gardener populates the state in `Worker.status.state`.
- Correctly configure the node-agent-authorizer to work with `Machine` objects and node-agent to request a certificate for the correct user.
- Add new tasks to the `gardenadm init` flow for deploying/restoring the worker.

Some steps are specific to provider-local:
- Worker controller and local machine provider use the kubeconfig from the `cloudprovider` secret for managing machine pods in the kind cluster instead of within the shoot cluster (similar to `Infrastructure` and `DNSRecord` controller).
- The local machine provider uses the `namespace` from the `MachineClass` provider spec instead of the `Machine` object's namespace for managing pods. The pods are located in the shoot namespace in the kind cluster, while the `Machine` objects are located in the `kube-system` namespace in the shoot.

One change is required in all provider extensions:
The `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.

- [x] https://github.com/gardener/gardener-extension-provider-alicloud/pull/853
- [x] https://github.com/gardener/gardener-extension-provider-aws/pull/1581
- [x] https://github.com/gardener/gardener-extension-provider-azure/pull/1378
- [x] https://github.com/gardener/gardener-extension-provider-gcp/pull/1239
- [x] https://github.com/gardener/gardener-extension-provider-openstack/pull/1211
- [x] https://github.com/stackitcloud/gardener-extension-provider-stackit/pull/531
- [x] https://github.com/metal-stack/gardener-extension-provider-metal/pull/483
- [x] https://github.com/ironcore-dev/gardener-extension-provider-ironcore/pull/831
- [x] https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/pull/265

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ @tobschli 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `Worker` extension no longer needs to fetch the machine state from the `ShootState` object in the garden cluster. Instead, Gardener populates the machine state directly in the `Worker.status.state` field on restoration of the shoot. Read the [docs](https://github.com/gardener/gardener/blob/v1.133.0/docs/extensions/migration.md#worker-state).
```
```breaking developer
To support self-hosted shoots with managed infrastructure, the `Worker` extension (controller/delegate) needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots. Read the [docs](https://github.com/gardener/gardener/blob/v1.133.0/docs/extensions/resources/worker.md).
```
