### PR TITLE
Update monitoring stack docs about developing dashboards to suggest UTC as default timezone

### DIFF
--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -199,7 +199,7 @@ The following parameters should be added to all dashboards to ensure a homogeneo
 Dashboards have to:
 
 * contain a title which refers to the component name(s)
-* contain a timezone statement which should be the browser time
+* contain a timezone statement which should be UTC
 * contain tags which express where the component is running (`seed` or `shoot`) and to which category the component belong (see dashboard structure)
 * contain a version statement with a value of 1
 * be immutable


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/4229 adapted all dashboards to use UTC as timezone. 
The example in the docs also suggests UTC: https://github.com/gardener/gardener/blob/e6495795de49801b86ce40b9d91a4cb3473be133/docs/development/monitoring-stack.md#L212

However, the statement few lines above still suggests `browser` time to be used.
This PR fixes this - the statement now also suggest UTC.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/4229

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
