### PR TITLE
Revert "Reapply server block imports (#13375)"

### DIFF
--- a/docs/usage/networking/custom-dns-config.md
+++ b/docs/usage/networking/custom-dns-config.md
@@ -102,9 +102,9 @@ This should bring the cluster DNS back to functioning state.
 
 ## Node Local DNS
 
-Starting with Gardener v1.132, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. The server configuration is read by a sidecar container and a new configuration file with the correct bind statement and port mappings is generated and imported into NodeLocalDNS pods. Prior to Gardener v1.132, custom DNS configurations might not function as expected with NodeLocalDNS.
-With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.132.
-If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.131 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
+Starting with Gardener v1.128, custom DNS configurations are fully supported in NodeLocalDNS. In this version, the `coredns-custom` `ConfigMap` is mounted into the NodeLocalDNS pod, allowing custom override and server configurations to be imported into the DNS server. Prior to Gardener v1.128, custom DNS configurations might not function as expected with NodeLocalDNS.
+With NodeLocalDNS, ordinary DNS queries targeting upstream DNS servers (i.e., non-Kubernetes domains) are sent directly to the upstream DNS server, bypassing CoreDNS. Therefore, configurations for non-Kubernetes entities, such as the `istio.server` block in the [custom DNS configuration](custom-dns-config.md) example, may not have any effect when NodeLocalDNS is enabled on landscapes with Gardener prior to v1.128.
+If you require custom DNS configurations for non-Kubernetes domains, you need to disable forwarding to upstream DNS with Gardener v1.127 and below. This can be done by setting the `disableForwardToUpstreamDNS` option in the Shoot resource to `true`:
 ```yaml
 ...
 spec:

--- a/docs/usage/networking/node-local-dns.md
+++ b/docs/usage/networking/node-local-dns.md
@@ -48,5 +48,5 @@ For more information about `node-local-dns`, please refer to the [KEP](https://g
 
 ## Known Issues
 
-Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.132.
+Custom DNS configuration may not work as expected in conjunction with `NodeLocalDNS` prior to gardener v1.128.
 Please refer to [Custom DNS Configuration](custom-dns-config.md#node-local-dns).

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -25,8 +25,6 @@ const (
 	ContainerImageNameConfigmapReloader = "configmap-reloader"
 	// ContainerImageNameCoredns is a constant for an image in the image vector with name 'coredns'.
 	ContainerImageNameCoredns = "coredns"
-	// ContainerImageNameCorednsConfigAdapter is a constant for an image in the image vector with name 'coredns-config-adapter'.
-	ContainerImageNameCorednsConfigAdapter = "coredns-config-adapter"
 	// ContainerImageNameCortex is a constant for an image in the image vector with name 'cortex'.
 	ContainerImageNameCortex = "cortex"
 	// ContainerImageNameDependencyWatchdog is a constant for an image in the image vector with name 'dependency-watchdog'.

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -494,23 +494,6 @@ images:
         value:
           - type: 'githubTeam'
             teamname: 'gardener/gardener-core-networking-maintainers'
-  - name: coredns-config-adapter
-    sourceRepository: github.com/gardener/coredns-config-adapter
-    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/coredns-config-adapter
-    tag: "v0.4.0"
-    labels:
-      - name: 'gardener.cloud/cve-categorisation'
-        value:
-          network_exposure: 'private'
-          authentication_enforced: false
-          user_interaction: 'end-user'
-          confidentiality_requirement: 'low'
-          integrity_requirement: 'high'
-          availability_requirement: 'high'
-      - name: 'cloud.gardener.cnudie/responsibles'
-        value:
-          - type: 'githubTeam'
-            teamname: 'gardener/gardener-core-networking-maintainers'
   - name: node-problem-detector
     sourceRepository: github.com/kubernetes/node-problem-detector
     repository: registry.k8s.io/node-problem-detector/node-problem-detector

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -55,9 +55,6 @@ const (
 	containerName = "coredns"
 	serviceName   = "kube-dns" // this is due to legacy reasons
 
-	// CustomConfigMapName is the name of the custom CoreDNS ConfigMap.
-	CustomConfigMapName = "coredns-custom"
-
 	portNameMetrics = "metrics"
 	portMetrics     = 9153
 
@@ -322,7 +319,7 @@ import custom/*.server
 
 		configMapCustom = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        CustomConfigMapName,
+				Name:        "coredns-custom",
 				Namespace:   metav1.NamespaceSystem,
 				Annotations: map[string]string{resourcesv1alpha1.Ignore: "true"},
 			},

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -64,8 +64,6 @@ const (
 	metricsPortName      = "metrics"
 	errorMetricsPortName = "errormetrics"
 
-	sideCarName = "coredns-config-adapter"
-
 	domain            = gardencorev1beta1.DefaultDomain
 	serviceName       = "kube-dns-upstream"
 	livenessProbePort = 8099
@@ -76,14 +74,13 @@ const (
 
 	daemonSetPollInterval = 5 * time.Second
 
-	volumeMountNameCleanUp         = "cleanup-script"
-	volumeMountPathCleanUp         = "/scripts"
-	volumeMountNameXtablesLock     = "xtables-lock"
-	volumeMountPathXtablesLock     = "/run/xtables.lock"
-	volumeMountPathCustomConfig    = "/etc/custom"
-	volumeMountNameCustomConfig    = "custom-config-volume"
-	volumeMountNameGeneratedConfig = "generated-config"
-	volumeMountPathGeneratedConfig = "/etc/generated-config"
+	volumeMountNameCleanUp      = "cleanup-script"
+	volumeMountPathCleanUp      = "/scripts"
+	volumeMountNameXtablesLock  = "xtables-lock"
+	volumeMountPathXtablesLock  = "/run/xtables.lock"
+	volumeMountPathCustomConfig = "/etc/custom"
+	volumeMountNameCustomConfig = "custom-config-volume"
+	customConfigMapName         = "coredns-custom"
 )
 
 var (
@@ -106,8 +103,6 @@ type Values struct {
 	Image string
 	// AlpineImage is the container image used for the cleanup DaemonSet.
 	AlpineImage string
-	// CorednsConfigAdapterImage is the container image used for the coredns config adapter sidecar.
-	CorednsConfigAdapterImage string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
 	// Config is the node local configuration for the shoot spec

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -31,7 +31,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	. "github.com/gardener/gardener/pkg/component/networking/nodelocaldns"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
@@ -351,7 +350,6 @@ data:
         cache 30
         reload
         }
-    import generated-config/custom-server-block.server
 immutable: true
 kind: ConfigMap
 metadata:
@@ -453,41 +451,6 @@ status:
 										Type: corev1.SeccompProfileTypeRuntimeDefault,
 									},
 								},
-								InitContainers: []corev1.Container{
-									{
-										Name:  "coredns-config-adapter",
-										Image: values.CorednsConfigAdapterImage,
-										Resources: corev1.ResourceRequirements{
-											Requests: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("5m"),
-												corev1.ResourceMemory: resource.MustParse("10Mi"),
-											},
-										},
-										SecurityContext: &corev1.SecurityContext{
-											AllowPrivilegeEscalation: ptr.To(false),
-											RunAsNonRoot:             ptr.To(true),
-											RunAsUser:                ptr.To[int64](65532),
-											RunAsGroup:               ptr.To[int64](65532),
-										},
-										Args: []string{
-											"-inputDir=/etc/custom",
-											"-outputDir=/etc/generated-config",
-											"-bind=bind " + bindIP(values),
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "custom-config-volume",
-												MountPath: "/etc/custom",
-												ReadOnly:  true,
-											},
-											{
-												MountPath: "/etc/generated-config",
-												Name:      "generated-config",
-											},
-										},
-										RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
-									},
-								},
 								Containers: []corev1.Container{
 									{
 										Name:  "node-cache",
@@ -569,10 +532,6 @@ status:
 												MountPath: "/etc/custom",
 												ReadOnly:  true,
 											},
-											{
-												MountPath: "/etc/generated-config",
-												Name:      "generated-config",
-											},
 										},
 									},
 								},
@@ -618,17 +577,11 @@ status:
 										VolumeSource: corev1.VolumeSource{
 											ConfigMap: &corev1.ConfigMapVolumeSource{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: coredns.CustomConfigMapName,
+													Name: "coredns-custom",
 												},
 												DefaultMode: ptr.To[int32](420),
 												Optional:    ptr.To(true),
 											},
-										},
-									},
-									{
-										Name: "generated-config",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{},
 										},
 									},
 								},
@@ -648,8 +601,6 @@ spec:
     containerPolicies:
     - containerName: '*'
       controlledValues: RequestsOnly
-    - containerName: coredns-config-adapter
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
@@ -769,7 +720,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-import generated-config/custom-server-block.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]
@@ -1044,7 +994,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-import generated-config/custom-server-block.server
 `,
 					}
 					configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -101,7 +100,6 @@ ip6.arpa:53 {
     cache 30
     reload
     }
-import generated-config/custom-server-block.server
 `,
 			},
 		}
@@ -210,41 +208,6 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 							v1beta1constants.LabelNodeLocalDNS: "true",
 							v1beta1constants.LabelWorkerPool:   worker.Name,
 						},
-						InitContainers: []corev1.Container{
-							{
-								Name:  sideCarName,
-								Image: n.values.CorednsConfigAdapterImage,
-								Resources: corev1.ResourceRequirements{
-									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("5m"),
-										corev1.ResourceMemory: resource.MustParse("10Mi"),
-									},
-								},
-								SecurityContext: &corev1.SecurityContext{
-									AllowPrivilegeEscalation: ptr.To(false),
-									RunAsNonRoot:             ptr.To(true),
-									RunAsUser:                ptr.To[int64](65532),
-									RunAsGroup:               ptr.To[int64](65532),
-								},
-								Args: []string{
-									"-inputDir=" + volumeMountPathCustomConfig,
-									"-outputDir=" + volumeMountPathGeneratedConfig,
-									"-bind=bind " + n.bindIP(),
-								},
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      volumeMountNameCustomConfig,
-										MountPath: volumeMountPathCustomConfig,
-										ReadOnly:  true,
-									},
-									{
-										MountPath: volumeMountPathGeneratedConfig,
-										Name:      volumeMountNameGeneratedConfig,
-									},
-								},
-								RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
-							},
-						},
 						Containers: []corev1.Container{
 							{
 								Name:  containerName,
@@ -326,10 +289,6 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 										MountPath: volumeMountPathCustomConfig,
 										ReadOnly:  true,
 									},
-									{
-										MountPath: volumeMountPathGeneratedConfig,
-										Name:      volumeMountNameGeneratedConfig,
-									},
 								},
 							},
 						},
@@ -375,17 +334,11 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 								VolumeSource: corev1.VolumeSource{
 									ConfigMap: &corev1.ConfigMapVolumeSource{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: coredns.CustomConfigMapName,
+											Name: customConfigMapName,
 										},
 										DefaultMode: ptr.To[int32](420),
 										Optional:    ptr.To(true),
 									},
-								},
-							},
-							{
-								Name: volumeMountNameGeneratedConfig,
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{},
 								},
 							},
 						},
@@ -413,16 +366,10 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 						UpdateMode: &vpaUpdateMode,
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-							{
-								ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
-								ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-							},
-							{
-								ContainerName: sideCarName,
-								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-							},
-						},
+						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
+							ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						}},
 					},
 				},
 			}

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -35,23 +35,17 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 		return nil, err
 	}
 
-	imageCorednsConfigAdapter, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameCorednsConfigAdapter)
-	if err != nil {
-		return nil, err
-	}
-
 	return nodelocaldns.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		nodelocaldns.Values{
-			Image:                     image.String(),
-			AlpineImage:               imageAlpine.String(),
-			CorednsConfigAdapterImage: imageCorednsConfigAdapter.String(),
-			VPAEnabled:                b.Shoot.WantsVerticalPodAutoscaler,
-			Config:                    v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
-			Workers:                   b.Shoot.GetInfo().Spec.Provider.Workers,
-			KubeProxyConfig:           b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
-			Log:                       b.Logger,
+			Image:           image.String(),
+			AlpineImage:     imageAlpine.String(),
+			VPAEnabled:      b.Shoot.WantsVerticalPodAutoscaler,
+			Config:          v1beta1helper.GetNodeLocalDNS(b.Shoot.GetInfo().Spec.SystemComponents),
+			Workers:         b.Shoot.GetInfo().Spec.Provider.Workers,
+			KubeProxyConfig: b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
+			Log:             b.Logger,
 		},
 	), nil
 }

--- a/pkg/provider-local/controller/dnsrecord/actuator.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator.go
@@ -21,7 +21,6 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
@@ -98,7 +97,7 @@ func (a *Actuator) Restore(ctx context.Context, log logr.Logger, dnsRecord *exte
 }
 
 func patchCoreDNSConfigMap(ctx context.Context, providerClient client.Client, mutate func(configMap *corev1.ConfigMap) error) error {
-	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: coredns.CustomConfigMapName, Namespace: "gardener-extension-provider-local-coredns"}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "coredns-custom", Namespace: "gardener-extension-provider-local-coredns"}}
 	_, err := controllerutil.CreateOrPatch(ctx, providerClient, configMap, func() error {
 		return mutate(configMap)
 	})

--- a/pkg/provider-local/controller/dnsrecord/actuator_test.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/provider-local/controller/dnsrecord"
 )
@@ -117,14 +116,14 @@ var _ = Describe("Actuator", func() {
 			}
 			emptyConfigMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      coredns.CustomConfigMapName,
+					Name:      "coredns-custom",
 					Namespace: extensionNamespace.Name,
 				},
 				Data: map[string]string{"test": "data"},
 			}
 			configMapWithRule = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      coredns.CustomConfigMapName,
+					Name:      "coredns-custom",
 					Namespace: extensionNamespace.Name,
 				},
 				Data: map[string]string{

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1137,8 +1137,6 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
-            - pkg/component/networking/coredns
-            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1148,8 +1148,6 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
-            - pkg/component/networking/coredns
-            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -740,8 +740,6 @@ build:
             - pkg/component/kubernetes/proxy
             - pkg/component/kubernetes/proxy/resources/cleanup.sh
             - pkg/component/kubernetes/proxy/resources/conntrack-fix.sh
-            - pkg/component/networking/coredns
-            - pkg/component/networking/coredns/constants
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machineclasses.yaml
             - pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml


### PR DESCRIPTION
This reverts commit 615272edec336264ba884d80594b23d40b6540e9.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
After using [init sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/ ) a new feature from kubernetes we have seen issues, where webhooks with too old clients strip the `restartPolicy: Always` field form the pod spec. This leads to problems where the init container is not getting ready and thus the main container not getting started. To give some time to adapt those interfering webhooks this PR will be reverted.

**Which issue(s) this PR fixes**:
Reverts https://github.com/gardener/gardener/pull/13375

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The feature for supporting custom server blocks in node-local-dns is now reverted.
```
