### PR TITLE
Fix gardener access component to not deploy shoot resource into garden cluster

### DIFF
--- a/pkg/component/gardener/access/access.go
+++ b/pkg/component/gardener/access/access.go
@@ -30,29 +30,25 @@ import (
 const ManagedResourceName = "shoot-core-gardeneraccess"
 
 // New creates a new instance of the deployer for GardenerAccess.
-// `withShootAccess` parameter defines whether to create ClusterRoleBindings for shoot access (adminkubeconfig and viewerkubeconfig).
 func New(
 	client client.Client,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	values Values,
-	withShootAccess bool,
 ) component.DeployWaiter {
 	return &gardener{
-		client:          client,
-		namespace:       namespace,
-		secretsManager:  secretsManager,
-		values:          values,
-		withShootAccess: withShootAccess,
+		client:         client,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		values:         values,
 	}
 }
 
 type gardener struct {
-	client          client.Client
-	namespace       string
-	secretsManager  secretsmanager.Interface
-	values          Values
-	withShootAccess bool
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	values         Values
 }
 
 // Values contains configurations for the component.
@@ -63,6 +59,8 @@ type Values struct {
 	ServerInCluster string
 	// ManagedResourceLabels are labels added to the ManagedResource.
 	ManagedResourceLabels map[string]string
+	// IsGardenCluster is specifying whether the component is deployed to a Garden cluster.
+	IsGardenCluster bool
 }
 
 type accessNameToServer struct {
@@ -162,7 +160,7 @@ func (g *gardener) computeResourcesData(serviceAccountNames ...string) (map[stri
 	}
 
 	resources := []client.Object{gardenerSystemClusterRoleBinding}
-	if g.withShootAccess {
+	if !g.values.IsGardenCluster {
 		resources = append(resources, adminClusterRoleBindings()...)
 		resources = append(resources, viewerClusterRoleBindings()...)
 	}

--- a/pkg/component/gardener/access/access_test.go
+++ b/pkg/component/gardener/access/access_test.go
@@ -164,14 +164,12 @@ var _ = Describe("Access", func() {
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
 
-		access = New(fakeClient, namespace, sm,
-			Values{
-				ServerOutOfCluster:    serverOutOfCluster,
-				ServerInCluster:       serverInCluster,
-				ManagedResourceLabels: map[string]string{"foo": "bar"},
-			},
-			true,
-		)
+		access = New(fakeClient, namespace, sm, Values{
+			ServerOutOfCluster:    serverOutOfCluster,
+			ServerInCluster:       serverInCluster,
+			ManagedResourceLabels: map[string]string{"foo": "bar"},
+			IsGardenCluster:       false,
+		})
 
 		expectedGardenerSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -327,14 +325,12 @@ users:
 		})
 
 		It("should not deploy shootAccess resource when configured so", func() {
-			access = New(fakeClient, namespace, sm,
-				Values{
-					ServerOutOfCluster:    serverOutOfCluster,
-					ServerInCluster:       serverInCluster,
-					ManagedResourceLabels: map[string]string{"foo": "bar"},
-				},
-				false,
-			)
+			access = New(fakeClient, namespace, sm, Values{
+				ServerOutOfCluster:    serverOutOfCluster,
+				ServerInCluster:       serverInCluster,
+				ManagedResourceLabels: map[string]string{"foo": "bar"},
+				IsGardenCluster:       true,
+			})
 			Expect(access.Deploy(ctx)).To(Succeed())
 
 			reconciledManagedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}

--- a/pkg/gardenlet/operation/botanist/gardeneraccess.go
+++ b/pkg/gardenlet/operation/botanist/gardeneraccess.go
@@ -19,7 +19,7 @@ func (b *Botanist) DefaultGardenerAccess() component.Deployer {
 		gardeneraccess.Values{
 			ServerInCluster:    b.Shoot.ComputeInClusterAPIServerAddress(false),
 			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
+			IsGardenCluster:    false,
 		},
-		true,
 	)
 }

--- a/pkg/gardenlet/operation/botanist/gardeneraccess.go
+++ b/pkg/gardenlet/operation/botanist/gardeneraccess.go
@@ -20,5 +20,6 @@ func (b *Botanist) DefaultGardenerAccess() component.Deployer {
 			ServerInCluster:    b.Shoot.ComputeInClusterAPIServerAddress(false),
 			ServerOutOfCluster: b.Shoot.ComputeOutOfClusterAPIServerAddress(true),
 		},
+		true,
 	)
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -989,6 +989,7 @@ func (r *Reconciler) newGardenerAccess(garden *operatorv1alpha1.Garden, secretsM
 			ServerOutOfCluster:    v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
 			ManagedResourceLabels: map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 		},
+		false,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -988,8 +988,8 @@ func (r *Reconciler) newGardenerAccess(garden *operatorv1alpha1.Garden, secretsM
 			ServerInCluster:       fmt.Sprintf("%s%s.%s.svc.cluster.local", namePrefix, v1beta1constants.DeploymentNameKubeAPIServer, r.GardenNamespace),
 			ServerOutOfCluster:    v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
 			ManagedResourceLabels: map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
+			IsGardenCluster:       true,
 		},
-		false,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
Fix gardener access component to not deploy shoot resource into garden cluster

Shoot's adminkubeconfig and viewerkubeconfig permissions are not needed in the Garden cluster

After https://github.com/gardener/gardener/pull/13270 gardeneraccess component deployed become responsible to deploy the RBACs for the shoot's Admin and Viewer Kubeoconfig permissions, but this deployer is used to manage resource also in the virtual garden cluster where shoot's admin/viewer kubeconfigs are not applicable, therefore the clusterrolebindings should not be present. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug where the Shoot relevant ClusterRoleBindings responsible for the `AdminKubeconfig` and `ViewerKubeconfig` permissions were deployed into the virtual Garden cluster has been fixed. 
```
