### PR TITLE
Fix flake in fluent operator CRD deployment test

### DIFF
--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -60,13 +60,17 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd, func() error {
-				crd.Labels = desiredCRD.Labels
-				crd.Annotations = desiredCRD.Annotations
+			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd,
+				func() error {
+					crd.Labels = desiredCRD.Labels
+					crd.Annotations = desiredCRD.Annotations
 
-				crd.Spec = desiredCRD.Spec
-				return nil
-			}, controllerutils.SkipEmptyPatch{})
+					crd.Spec = desiredCRD.Spec
+					return nil
+				},
+				// Not sending an empty patch goes against the recommendation in (https://github.com/gardener/gardener/blob/62ce73bd39cc2ff5ae8d711ce5d66f80cbbe2d00/docs/development/kubernetes-clients.md?plain=1#L352)
+				// However, skipping empty patches for CRDs is ok as we do not expect them to be handled by any mutating webhooks.
+				controllerutils.SkipEmptyPatch{})
 			return err
 		})
 	}

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -66,7 +66,7 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 
 				crd.Spec = desiredCRD.Spec
 				return nil
-			})
+			}, controllerutils.SkipEmptyPatch{})
 			return err
 		})
 	}

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -68,8 +68,15 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 					crd.Spec = desiredCRD.Spec
 					return nil
 				},
-				// Not sending an empty patch goes against the recommendation in (https://github.com/gardener/gardener/blob/62ce73bd39cc2ff5ae8d711ce5d66f80cbbe2d00/docs/development/kubernetes-clients.md?plain=1#L352)
-				// However, skipping empty patches for CRDs is ok as we do not expect them to be handled by any mutating webhooks.
+				// Not sending an empty patch goes against the recommendation in the Kubernetes Clients in Gardener guide.
+				// See https://github.com/gardener/gardener/blob/62ce73bd39cc2ff5ae8d711ce5d66f80cbbe2d00/docs/development/kubernetes-clients.md?plain=1#L352
+				//
+				// However, empty patches can be skipped here for the following reasons:
+				// - The fake client (`sigs.k8s.io/controller-runtime/pkg/client/fake`), used in unit tests, eats up a lot of CPU
+				//   when working with large resources during the handling of patch operations in the underlying `ObjectTracker` interface,
+				//   ref: https://github.com/kubernetes/client-go/blob/master/testing/fixture.go#L48-L80
+				// - Reduce the load on the kube-apiserver for CRDs that have already been deployed.
+				// - CRDs are not expected to be handled by any mutating webhooks.
 				controllerutils.SkipEmptyPatch{})
 			return err
 		})

--- a/pkg/component/observability/logging/fluentoperator/crds_test.go
+++ b/pkg/component/observability/logging/fluentoperator/crds_test.go
@@ -22,68 +22,68 @@ import (
 
 var _ = Describe("CRDs", func() {
 	var (
-		ctx         context.Context
-		c           client.Client
-		crdDeployer component.DeployWaiter
+		ctx          context.Context
+		c            client.Client
+		crdDeployer  component.DeployWaiter
+		expectedCRDs []string
 	)
 
 	BeforeEach(func() {
-		var err error
 		ctx = context.TODO()
 
 		s := runtime.NewScheme()
-		Expect(apiextensionsv1.AddToScheme(s)).NotTo(HaveOccurred())
+		Expect(apiextensionsv1.AddToScheme(s)).To(Succeed())
 
 		c = fake.NewClientBuilder().WithScheme(s).Build()
 
+		var err error
 		crdDeployer, err = fluentoperator.NewCRDs(c)
 		Expect(err).NotTo(HaveOccurred())
+
+		expectedCRDs = []string{
+			"clusterfilters.fluentbit.fluent.io",
+			"clusterfluentbitconfigs.fluentbit.fluent.io",
+			"clusterinputs.fluentbit.fluent.io",
+			"clusteroutputs.fluentbit.fluent.io",
+			"clusterparsers.fluentbit.fluent.io",
+			"fluentbits.fluentbit.fluent.io",
+			"collectors.fluentbit.fluent.io",
+			"fluentbitconfigs.fluentbit.fluent.io",
+			"filters.fluentbit.fluent.io",
+			"parsers.fluentbit.fluent.io",
+			"outputs.fluentbit.fluent.io",
+			"clustermultilineparsers.fluentbit.fluent.io",
+			"multilineparsers.fluentbit.fluent.io",
+		}
 	})
 
 	JustBeforeEach(func() {
-		Expect(crdDeployer.Deploy(ctx)).ToNot(HaveOccurred(), "fluent operator crds deploy succeeds")
+		Expect(crdDeployer.Deploy(ctx)).To(Succeed(), "fluent operator crds deploy succeeds")
 	})
 
-	DescribeTable("CRD is deployed",
-		func(crdName string) {
-			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).ToNot(HaveOccurred())
-		},
+	It("should deploy CRDs", func() {
+		for _, crdName := range expectedCRDs {
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed(), crdName+" should get created")
+		}
+	})
 
-		Entry("ClusterFilter", "clusterfilters.fluentbit.fluent.io"),
-		Entry("ClusterFluentBitConfig", "clusterfluentbitconfigs.fluentbit.fluent.io"),
-		Entry("ClusterInput", "clusterinputs.fluentbit.fluent.io"),
-		Entry("ClusterOutput", "clusteroutputs.fluentbit.fluent.io"),
-		Entry("ClusterParser", "clusterparsers.fluentbit.fluent.io"),
-		Entry("FluentBit", "fluentbits.fluentbit.fluent.io"),
-		Entry("Collector", "collectors.fluentbit.fluent.io"),
-		Entry("FluentBitConfig", "fluentbitconfigs.fluentbit.fluent.io"),
-		Entry("Filter", "filters.fluentbit.fluent.io"),
-		Entry("Parser", "parsers.fluentbit.fluent.io"),
-		Entry("Output", "outputs.fluentbit.fluent.io"),
-		Entry("ClusterMultilineParser", "clustermultilineparsers.fluentbit.fluent.io"),
-		Entry("MultilineParser", "multilineparsers.fluentbit.fluent.io"),
-	)
-
-	DescribeTable("should re-create CRD if it is deleted",
-		func(crdName string) {
-			Expect(c.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}})).ToNot(HaveOccurred())
+	It("should re-create CRDs if they are deleted", func() {
+		for _, crdName := range expectedCRDs {
+			Expect(c.Delete(ctx, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: crdName}})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
-			Expect(crdDeployer.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).ToNot(HaveOccurred())
-		},
+		}
 
-		Entry("ClusterFilter", "clusterfilters.fluentbit.fluent.io"),
-		Entry("ClusterFluentBitConfig", "clusterfluentbitconfigs.fluentbit.fluent.io"),
-		Entry("ClusterInput", "clusterinputs.fluentbit.fluent.io"),
-		Entry("ClusterOutput", "clusteroutputs.fluentbit.fluent.io"),
-		Entry("ClusterParser", "clusterparsers.fluentbit.fluent.io"),
-		Entry("FluentBit", "fluentbits.fluentbit.fluent.io"),
-		Entry("Collectors", "collectors.fluentbit.fluent.io"),
-		Entry("FluentBitConfig", "fluentbitconfigs.fluentbit.fluent.io"),
-		Entry("Filter", "filters.fluentbit.fluent.io"),
-		Entry("Parser", "parsers.fluentbit.fluent.io"),
-		Entry("Output", "outputs.fluentbit.fluent.io"),
-		Entry("ClusterMultilineParser", "clustermultilineparsers.fluentbit.fluent.io"),
-		Entry("MultilineParser", "multilineparsers.fluentbit.fluent.io"),
-	)
+		Expect(crdDeployer.Deploy(ctx)).ToNot(HaveOccurred())
+
+		for _, crdName := range expectedCRDs {
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed(), crdName+" should get recreated")
+		}
+	})
+
+	It("should destroy CRDs", func() {
+		Expect(crdDeployer.Destroy(ctx)).To(Succeed())
+		for _, crdName := range expectedCRDs {
+			Expect(c.Get(ctx, client.ObjectKey{Name: crdName}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError(), crdName+" should get deleted")
+		}
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing logging
/kind flake

**What this PR does / why we need it**:
This PR is an attempt to fix the flake reported in https://github.com/gardener/gardener/issues/13404 and https://github.com/gardener/gardener/issues/13072

After managing to reproduce the issue and profiling the test as described in https://github.com/gardener/gardener/issues/13072#issuecomment-3546057047, I've tried to optimise both the CRD deployer by skipping empty patch requests (ut should be safe to use the `controllerutils.SkipEmptyPatch{}` option when deploying CRDs), and optimising the test itself by making it not call the `Deploy` function of the crd deployer before checking whether each CRD has been successfully deployed.

Generally, it seems that the fake client's requests can eat up a lot of CPU time when working with large api resources such as  [`FluentBit`](https://github.com/gardener/gardener/blob/master/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_fluentbits.yaml), [`ClusterOutput`](https://github.com/gardener/gardener/blob/master/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_clusteroutputs.yaml) and [`Output`](https://github.com/gardener/gardener/blob/master/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_outputs.yaml)
In the end, this PR reduces the calls that are made via the fake client, which should hopefully let the test finish in time even if it CPU is taken by other processes.

When testing the canges locally, the `fluentoperator` test suite completes in 16 seconds when cpu is limited to only `0.05` cores. The timeout of the test is 2 minutes, so there is still a lot of headroom.

**Which issue(s) this PR fixes**:
Fix attempt for  https://github.com/gardener/gardener/issues/13404 and https://github.com/gardener/gardener/issues/13072

**Special notes for your reviewer**:
Once we are sure that the flake is fixed with this PR, I will open subsequent PRs to also adapt other tests that use the crd deployer in a similar fashion and write a short addition to our `testing.md` file explaining that we should be mindful when using the fake client.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
