### PR TITLE
feat: add permissions for `NamespacedCloudProfile`s to `gardener-dashboard`

### DIFF
--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -751,7 +751,7 @@ frontend:
 				},
 				{
 					APIGroups: []string{"core.gardener.cloud"},
-					Resources: []string{"quotas", "projects", "shoots", "controllerregistrations"},
+					Resources: []string{"quotas", "projects", "shoots", "controllerregistrations", "namespacedcloudprofiles"},
 					Verbs:     []string{"list", "watch"},
 				},
 				{

--- a/pkg/component/gardener/dashboard/rbac.go
+++ b/pkg/component/gardener/dashboard/rbac.go
@@ -42,7 +42,7 @@ func (g *gardenerDashboard) clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{gardencorev1beta1.GroupName},
-				Resources: []string{"quotas", "projects", "shoots", "controllerregistrations"},
+				Resources: []string{"quotas", "projects", "shoots", "controllerregistrations", "namespacedcloudprofiles"},
 				Verbs:     []string{"list", "watch"},
 			},
 			{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Add permissions to read and watch`NamespacedCloudProfile`s for the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Add permissions to read and watch `NamespacedCloudProfile`s for the dashboard.
```
