### PR TITLE
docs: Update the supported Kubernetes versions for Shoots

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please find more information regarding the concepts and a detailed description o
 ## K8s Conformance Test Coverage <img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" alt="certified kubernetes logo" width="50" align="right"/>
 
 Gardener takes part in the [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/) to attest its compatibility with the K8s conformance testsuite.
-Currently, Gardener is certified for K8s versions up to v1.33, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=110:111).
+Currently, Gardener is certified for K8s versions up to v1.33, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=109:110).
 
 Continuous conformance test results of the latest stable Gardener release are uploaded regularly to the CNCF test grid:
 

--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -16,7 +16,7 @@ The minimum version of a seed cluster that can be connected to Gardener is **`1.
 
 ## Shoot Clusters
 
-Gardener itself is capable of spinning up clusters with Kubernetes versions **`1.29`** up to **`1.33`**.
+Gardener itself is capable of spinning up clusters with Kubernetes versions **`1.29`** up to **`1.34`**.
 However, the concrete versions that can be used for shoot clusters depend on the installed provider extension.
 Consequently, please consult the documentation of your provider extension to see which Kubernetes versions are supported for shoot clusters.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
A side finding while reviewing https://github.com/gardener/gardener/pull/13487.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/12883

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
