### PR TITLE
Move the validation of the Shoot `.spec.kubernetes.kubeAPIServer.oidcConfig` field from admission validator to the storage layer

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1049,10 +1049,6 @@ func validateKubernetesForWorkerlessShoot(kubernetes core.Kubernetes, fldPath *f
 	return allErrs
 }
 
-func fieldNilOrEmptyString(field *string) bool {
-	return field == nil || len(*field) == 0
-}
-
 func validateNetworking(networking *core.Networking, workerless bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -1584,22 +1580,16 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 	} else if oidc != nil {
 		oidcPath := fldPath.Child("oidcConfig")
 
-		if fieldNilOrEmptyString(oidc.ClientID) {
-			if oidc.ClientID != nil {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientID"), oidc.ClientID, "clientID cannot be empty when key is provided"))
-			}
-			if !fieldNilOrEmptyString(oidc.IssuerURL) {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("clientID"), oidc.ClientID, "clientID must be set when issuerURL is provided"))
-			}
+		if oidc.ClientID == nil {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("clientID"), "clientID must be set when oidcConfig is provided"))
+		} else if len(*oidc.ClientID) == 0 {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("clientID"), "clientID cannot be empty"))
 		}
 
-		if fieldNilOrEmptyString(oidc.IssuerURL) {
-			if oidc.IssuerURL != nil {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("issuerURL"), oidc.IssuerURL, "issuerURL cannot be empty when key is provided"))
-			}
-			if !fieldNilOrEmptyString(oidc.ClientID) {
-				allErrs = append(allErrs, field.Invalid(oidcPath.Child("issuerURL"), oidc.IssuerURL, "issuerURL must be set when clientID is provided"))
-			}
+		if oidc.IssuerURL == nil {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("issuerURL"), "issuerURL must be set when oidcConfig is provided"))
+		} else if len(*oidc.IssuerURL) == 0 {
+			allErrs = append(allErrs, field.Required(oidcPath.Child("issuerURL"), "issuerURL cannot be empty"))
 		} else {
 			allErrs = append(allErrs, ValidateOIDCIssuerURL(*oidc.IssuerURL, oidcPath.Child("issuerURL"))...)
 		}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2272,7 +2272,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Detail": Equal(detail),
 					}))
 				},
-					Entry("should add error if issuerURL is nil ", 1, nil, "issuerURL must be set when oidcConfig is provided"),
+					Entry("should add error if issuerURL is nil", 1, nil, "issuerURL must be set when oidcConfig is provided"),
 					Entry("should add error if issuerURL is empty string", 1, ptr.To(""), "issuerURL cannot be empty"),
 				)
 
@@ -2298,7 +2298,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))
 				},
 					Entry("should add error if clientID is nil", 1, nil, "clientID must be set when oidcConfig is provided"),
-					Entry("should add error if clientID is empty string ", 1, ptr.To(""), "clientID cannot be empty"),
+					Entry("should add error if clientID is empty string", 1, ptr.To(""), "clientID cannot be empty"),
 				)
 
 				It("should forbid setting clientAuthentication from kubernetes version 1.31", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2233,10 +2233,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					errorList := ValidateShoot(shoot)
 
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
+						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.issuerURL"),
 					})), PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
+						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.clientID"),
 					})), PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
@@ -2260,19 +2260,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				DescribeTable("should forbid issuerURL to be empty string or nil, if clientID exists ", func(errorListSize int, issuerURL *string) {
+				DescribeTable("should forbid issuerURL to be empty string or nil", func(errorListSize int, issuerURL *string, detail string) {
 					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientID = ptr.To("someClientID")
 					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL = issuerURL
 
 					errorList := ValidateShoot(shoot)
 					Expect(errorList).To(HaveLen(errorListSize))
 					Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.issuerURL"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.kubernetes.kubeAPIServer.oidcConfig.issuerURL"),
+						"Detail": Equal(detail),
 					}))
 				},
-					Entry("should add error if clientID is set but issuerURL is nil", 1, nil),
-					Entry("should add error if clientID is set but issuerURL is empty string", 2, ptr.To("")),
+					Entry("should add error if issuerURL is nil ", 1, nil, "issuerURL must be set when oidcConfig is provided"),
+					Entry("should add error if issuerURL is empty string", 1, ptr.To(""), "issuerURL cannot be empty"),
 				)
 
 				It("should not fail if both clientID and issuerURL are set", func() {
@@ -2284,19 +2285,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(errorList).To(BeEmpty())
 				})
 
-				DescribeTable("should forbid clientID to be empty string or nil, if issuerURL exists ", func(errorListSize int, clientID *string) {
-					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL = ptr.To("https://issuer.com")
+				DescribeTable("should forbid clientID to be empty string or nil", func(errorListSize int, clientID *string, detail string) {
 					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.ClientID = clientID
+					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig.IssuerURL = ptr.To("https://issuer.com")
 
 					errorList := ValidateShoot(shoot)
 					Expect(errorList).To(HaveLen(errorListSize))
 					Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.clientID"),
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.kubernetes.kubeAPIServer.oidcConfig.clientID"),
+						"Detail": Equal(detail),
 					}))
 				},
-					Entry("should add error if issuerURL is set but clientID is nil", 1, nil),
-					Entry("should add error if issuerURL is set but clientID is empty string ", 2, ptr.To("")),
+					Entry("should add error if clientID is nil", 1, nil, "clientID must be set when oidcConfig is provided"),
+					Entry("should add error if clientID is empty string ", 1, ptr.To(""), "clientID cannot be empty"),
 				)
 
 				It("should forbid setting clientAuthentication from kubernetes version 1.31", func() {

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -2518,7 +2518,14 @@ var _ = Describe("Validation Tests", func() {
 								IssuerURL:      ptr.To("https://example.com"),
 								ClientIDPublic: ptr.To("my-client-id"),
 							}}
-							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{OIDCConfig: &gardencorev1beta1.OIDCConfig{}}}
+							garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{
+								KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{
+									OIDCConfig: &gardencorev1beta1.OIDCConfig{
+										ClientID:  ptr.To("someClientID"),
+										IssuerURL: ptr.To("https://issuer.com"),
+									},
+								},
+							}
 
 							Expect(ValidateGarden(garden, extensions)).To(BeEmpty())
 						})

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -778,39 +778,6 @@ func (c *validationContext) validateAdmissionPlugins(a admission.Attributes, sec
 	return allErrs
 }
 
-// For backwards-compatibility, we want to validate the oidc config only for newly created Shoot clusters.
-// Performing the validation for all Shoots would prevent already existing Shoots with the wrong spec to be updated/deleted.
-// There is additional oidc config validation in the static API validation.
-func (c *validationContext) validateKubeAPIServerOIDCConfig(a admission.Attributes) field.ErrorList {
-	var (
-		allErrs field.ErrorList
-		path    = field.NewPath("spec", "kubernetes", "kubeAPIServer", "oidcConfig")
-	)
-
-	if a.GetOperation() != admission.Create {
-		return nil
-	}
-
-	if c.shoot.Spec.Kubernetes.KubeAPIServer == nil || c.shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig == nil {
-		return nil
-	}
-
-	oidc := c.shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig
-	if oidc.ClientID == nil {
-		allErrs = append(allErrs, field.Required(path.Child("clientID"), "clientID must be set when oidcConfig is provided"))
-	} else if len(*oidc.ClientID) == 0 {
-		allErrs = append(allErrs, field.Required(path.Child("clientID"), "clientID cannot be empty"))
-	}
-
-	if oidc.IssuerURL == nil {
-		allErrs = append(allErrs, field.Required(path.Child("issuerURL"), "issuerURL must be set when oidcConfig is provided"))
-	} else if len(*oidc.IssuerURL) == 0 {
-		allErrs = append(allErrs, field.Required(path.Child("issuerURL"), "issuerURL cannot be empty"))
-	}
-
-	return allErrs
-}
-
 func (c *validationContext) validateReferencedSecret(secretLister kubecorev1listers.SecretLister, secretName, namespace string, fldPath *field.Path) *field.Error {
 	var (
 		secret *corev1.Secret
@@ -907,7 +874,6 @@ func (c *validationContext) validateKubernetes(a admission.Attributes) field.Err
 	}
 
 	allErrs = append(allErrs, validateKubernetesVersionConstraints(a, c.cloudProfileSpec.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version, false, path.Child("version"))...)
-	allErrs = append(allErrs, c.validateKubeAPIServerOIDCConfig(a)...)
 
 	return allErrs
 }

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2140,55 +2140,6 @@ var _ = Describe("validator", func() {
 			})
 		})
 
-		Context("oidc config check", func() {
-			BeforeEach(func() {
-				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{}
-			})
-
-			DescribeTable("validate oidc config on shoot create", func(clientID, issuerURL *string, errorMatcher types.GomegaMatcher) {
-				shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = &core.OIDCConfig{
-					ClientID:  clientID,
-					IssuerURL: issuerURL,
-				}
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
-
-				Expect(err).To(errorMatcher)
-			},
-				Entry("should allow when oidcConfig is valid", ptr.To("someClientID"), ptr.To("https://issuer.com"), BeNil()),
-				Entry("should forbid when oidcConfig clientID is nil", nil, ptr.To("https://issuer.com"), BeForbiddenError()),
-				Entry("should forbid when oidcConfig clientID is empty string", ptr.To(""), ptr.To("https://issuer.com"), BeForbiddenError()),
-				Entry("should forbid when oidcConfig issuerURL is nil", ptr.To("someClientID"), nil, BeForbiddenError()),
-				Entry("should forbid when oidcConfig issuerURL is empty string", ptr.To("someClientID"), ptr.To(""), BeForbiddenError()),
-			)
-
-			DescribeTable("do not validate oidc config when operation is not create", func(admissionOperation admission.Operation, operationOptions runtime.Object) {
-				oldShoot := shoot.DeepCopy()
-				shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = &core.OIDCConfig{}
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admissionOperation, operationOptions, false, nil)
-				err := admissionHandler.Validate(ctx, attrs, nil)
-
-				Expect(err).ToNot(HaveOccurred())
-			},
-				Entry("should allow invalid oidcConfig on shoot update", admission.Update, &metav1.UpdateOptions{}),
-				Entry("should allow invalid oidcConfig on shoot delete", admission.Delete, &metav1.DeleteOptions{}),
-			)
-		})
-
 		Context("networking settings checks", func() {
 			var (
 				oldShoot *core.Shoot

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1072,6 +1072,8 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 							ExtraConfig: map[string]string{"foo": "bar"},
 							Secret:      ptr.To("foo-secret"),
 						},
+						ClientID:  ptr.To("client-id"),
+						IssuerURL: ptr.To("https://foo.bar"),
 					},
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind technical-debt

**What this PR does / why we need it**:

Moves the validation introduced with https://github.com/gardener/gardener/pull/10461 to the static API validation in the storage layer as per [Validation Guidelines](https://github.com/gardener/gardener/blob/master/docs/development/validation-guidelines.md).

The changes from https://github.com/gardener/gardener/pull/10252 have been re-implemented in this PR.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Shoot `.spec.kubernetes.kubeAPIServer.oidcConfig` field is now validated only in the storage layer. Previously, the required `.spec.kubernetes.kubeAPIServer.{oidcConfig,issuerURL}` fields were validated in the [`ShootValidator`](https://github.com/gardener/gardener/blob/v1.133.0/docs/concepts/apiserver-admission-plugins.md#shootvalidator) admission plugin due to backwards-compatibility reasons.
```
