### PR TITLE
`CRDDeployer` improvement

### DIFF
--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -149,11 +149,7 @@ generate_group () {
     relevant_files+=("$(basename "$crd_out")")
 
     if $add_deletion_protection_label; then
-      if grep -q "clusters.extensions.gardener.cloud"  "$crd_out"; then
-        :
-      else
         sed -i '4 a\  labels:\n\    gardener.cloud/deletion-protected: "true"' "$crd_out"
-      fi
     fi
 
     if $add_keep_object_annotation; then

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -62,7 +62,7 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 
 			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd, func() error {
 				crd.Labels = desiredCRD.Labels
-				if c.deletionProtection && crd.Labels[gardenerutils.DeletionProtected] != "true" {
+				if c.deletionProtection {
 					metav1.SetMetaDataLabel(&crd.ObjectMeta, gardenerutils.DeletionProtected, "true")
 				}
 

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -62,13 +62,8 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 
 			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd, func() error {
 				crd.Labels = desiredCRD.Labels
-
-				if crd.Labels == nil {
-					crd.Labels = make(map[string]string)
-				}
-
 				if c.deletionProtection && crd.Labels[gardenerutils.DeletionProtected] != "true" {
-					crd.Labels[gardenerutils.DeletionProtected] = "true"
+					metav1.SetMetaDataLabel(&crd.ObjectMeta, gardenerutils.DeletionProtected, "true")
 				}
 
 				crd.Annotations = desiredCRD.Annotations

--- a/pkg/component/crddeployer/crd.go
+++ b/pkg/component/crddeployer/crd.go
@@ -60,15 +60,16 @@ func (c *crdDeployer) Deploy(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd, func() error {
-				crd.Labels = desiredCRD.Labels
-				if c.deletionProtection {
-					metav1.SetMetaDataLabel(&crd.ObjectMeta, gardenerutils.DeletionProtected, "true")
-				}
+			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, crd,
+				func() error {
+					crd.Labels = desiredCRD.Labels
+					if c.deletionProtection {
+						metav1.SetMetaDataLabel(&crd.ObjectMeta, gardenerutils.DeletionProtected, "true")
+					}
 
-				crd.Annotations = desiredCRD.Annotations
-
+					crd.Annotations = desiredCRD.Annotations
 					crd.Spec = desiredCRD.Spec
+
 					return nil
 				},
 				// Not sending an empty patch goes against the recommendation in the Kubernetes Clients in Gardener guide.

--- a/pkg/component/etcd/etcd/crd.go
+++ b/pkg/component/etcd/etcd/crd.go
@@ -22,15 +22,15 @@ import (
 
 // NewCRD can be used to deploy the CRD definitions for all CRDs defined by etcd-druid.
 func NewCRD(client client.Client, k8sVersion *semver.Version) (component.DeployWaiter, error) {
-	crdGetter, err := NewCRDGetter(k8sVersion)
+	crdYAMLs, err := druidcorecrds.GetAll(k8sVersion.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get etcd-druid CRDs for Kubernetes version %s: %w", k8sVersion, err)
 	}
-	crds, err := crdGetter.GetAllCRDsAsStringSlice()
-	if err != nil {
-		return nil, err
+	crdStrings := make([]string, 0, len(crdYAMLs))
+	for _, crdYAML := range crdYAMLs {
+		crdStrings = append(crdStrings, crdYAML)
 	}
-	return crddeployer.New(client, crds, true)
+	return crddeployer.New(client, crdStrings, true)
 }
 
 // CRDGetter provides methods to get CRDs defined in etcd-druid.

--- a/pkg/component/etcd/etcd/crd.go
+++ b/pkg/component/etcd/etcd/crd.go
@@ -6,6 +6,8 @@ package etcd
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	druidcorecrds "github.com/gardener/etcd-druid/api/core/v1alpha1/crds"
@@ -21,9 +23,5 @@ func NewCRD(client client.Client, k8sVersion *semver.Version) (component.DeployW
 	if err != nil {
 		return nil, fmt.Errorf("failed to get etcd-druid CRDs for Kubernetes version %s: %w", k8sVersion, err)
 	}
-	crdStrings := make([]string, 0, len(crdYAMLs))
-	for _, crdYAML := range crdYAMLs {
-		crdStrings = append(crdStrings, crdYAML)
-	}
-	return crddeployer.New(client, crdStrings, true)
+	return crddeployer.New(client, slices.Collect(maps.Values(crdYAMLs)), true)
 }

--- a/pkg/component/etcd/etcd/crd.go
+++ b/pkg/component/etcd/etcd/crd.go
@@ -9,15 +9,10 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	druidcorecrds "github.com/gardener/etcd-druid/api/core/v1alpha1/crds"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/crddeployer"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // NewCRD can be used to deploy the CRD definitions for all CRDs defined by etcd-druid.
@@ -31,76 +26,4 @@ func NewCRD(client client.Client, k8sVersion *semver.Version) (component.DeployW
 		crdStrings = append(crdStrings, crdYAML)
 	}
 	return crddeployer.New(client, crdStrings, true)
-}
-
-// CRDGetter provides methods to get CRDs defined in etcd-druid.
-type CRDGetter interface {
-	// GetAllCRDs returns a map of CRD names to CRD objects.
-	GetAllCRDs() map[string]*apiextensionsv1.CustomResourceDefinition
-	// GetCRD returns the CRD with the given name.
-	// An error is returned if no CRD is found with the given name.
-	GetCRD(name string) (*apiextensionsv1.CustomResourceDefinition, error)
-	// GetAllCRDsAsStringSlice returns all CRDs as Strings.
-	GetAllCRDsAsStringSlice() ([]string, error)
-}
-
-type crdGetterImpl struct {
-	crdResources map[string]*apiextensionsv1.CustomResourceDefinition
-	k8sVersion   *semver.Version
-}
-
-func (c *crdGetterImpl) GetAllCRDsAsStringSlice() ([]string, error) {
-	crds := c.GetAllCRDs()
-	crdStrings := make([]string, 0, len(crds))
-	for _, crd := range crds {
-		crdString, err := kubernetesutils.Serialize(crd, kubernetesscheme.Scheme)
-		if err != nil {
-			return nil, err
-		}
-		crdStrings = append(crdStrings, crdString)
-	}
-	return crdStrings, nil
-}
-
-var _ CRDGetter = (*crdGetterImpl)(nil)
-
-// NewCRDGetter creates a new CRDGetter.
-func NewCRDGetter(k8sVersion *semver.Version) (CRDGetter, error) {
-	crdResources, err := getEtcdCRDs(k8sVersion)
-	if err != nil {
-		return nil, err
-	}
-	return &crdGetterImpl{
-		crdResources: crdResources,
-		k8sVersion:   k8sVersion,
-	}, nil
-}
-
-func (c *crdGetterImpl) GetAllCRDs() map[string]*apiextensionsv1.CustomResourceDefinition {
-	return c.crdResources
-}
-
-func (c *crdGetterImpl) GetCRD(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
-	crdObj, ok := c.crdResources[name]
-	if !ok {
-		return nil, fmt.Errorf("CRD %s not found", name)
-	}
-	return crdObj, nil
-}
-
-func getEtcdCRDs(k8sVersion *semver.Version) (map[string]*apiextensionsv1.CustomResourceDefinition, error) {
-	crdYAMLs, err := druidcorecrds.GetAll(k8sVersion.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get etcd-druid CRDs for Kubernetes version %s: %w", k8sVersion, err)
-	}
-	var crdResources = make(map[string]*apiextensionsv1.CustomResourceDefinition, len(crdYAMLs))
-	for crdName, crdYAML := range crdYAMLs {
-		crdObj, err := kubernetesutils.DecodeCRD(crdYAML)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode etcd-druid CRD: %s: %w", crdName, err)
-		}
-		metav1.SetMetaDataLabel(&crdObj.ObjectMeta, gardenerutils.DeletionProtected, "true")
-		crdResources[crdName] = crdObj
-	}
-	return crdResources, nil
 }

--- a/pkg/component/etcd/etcd/crd_test.go
+++ b/pkg/component/etcd/etcd/crd_test.go
@@ -81,35 +81,6 @@ var _ = Describe("CRD", func() {
 			)
 		})
 	})
-
-	Describe("Getter", func() {
-		var (
-			crdGetter CRDGetter
-			err       error
-		)
-		crdGetter, err = NewCRDGetter(k8sVersion)
-		Expect(err).NotTo(HaveOccurred())
-
-		DescribeTable("Get CRD",
-			func(crdName string) {
-				crd, err := crdGetter.GetCRD(crdName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(crd).NotTo(BeNil())
-			},
-
-			Entry("Etcd", "etcds.druid.gardener.cloud"),
-			Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
-			Entry("EtcdOpsTask", "etcdopstasks.druid.gardener.cloud"),
-		)
-
-		Describe("Get all CRDs", func() {
-			allCRDs := crdGetter.GetAllCRDs()
-			Expect(allCRDs).To(HaveLen(3))
-			Expect(allCRDs).To(HaveKey("etcds.druid.gardener.cloud"))
-			Expect(allCRDs).To(HaveKey("etcdcopybackupstasks.druid.gardener.cloud"))
-			Expect(allCRDs).To(HaveKey("etcdopstasks.druid.gardener.cloud"))
-		})
-	})
 })
 
 func verifyDeployedCRD(ctx context.Context, crdName string, c client.Client) {

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
@@ -2,6 +2,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    gardener.cloud/deletion-protected: "true"
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
   name: clusters.extensions.gardener.cloud

--- a/test/integration/gardenlet/shoot/care/care_suite_test.go
+++ b/test/integration/gardenlet/shoot/care/care_suite_test.go
@@ -42,12 +42,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 	"github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
@@ -91,9 +91,11 @@ var _ = BeforeSuite(func() {
 	By("Fetch Etcd CRD")
 	k8sVersion, err := gardenerenvtest.GetK8SVersion()
 	Expect(err).NotTo(HaveOccurred())
-	etcdCRDGetter, err := etcd.NewCRDGetter(k8sVersion)
+	etcdCRDs, err := druidcorecrds.GetAll(k8sVersion.String())
 	Expect(err).NotTo(HaveOccurred())
-	etcdCRD, err := etcdCRDGetter.GetCRD(druidcorecrds.ResourceNameEtcd)
+	etcdCRDYAML, ok := etcdCRDs[druidcorecrds.ResourceNameEtcd]
+	Expect(ok).To(BeTrue())
+	etcdCRD, err := kubernetesutils.DecodeCRD(etcdCRDYAML)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Start test environment")

--- a/test/integration/operator/garden/care/care_suite_test.go
+++ b/test/integration/operator/garden/care/care_suite_test.go
@@ -33,12 +33,12 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/logger"
 	operatorconfigv1alpha1 "github.com/gardener/gardener/pkg/operator/apis/config/v1alpha1"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/operator/controller/garden/care"
 	"github.com/gardener/gardener/pkg/operator/features"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 )
@@ -75,9 +75,11 @@ var _ = BeforeSuite(func() {
 	By("Fetch Etcd CRD")
 	k8sVersion, err := gardenerenvtest.GetK8SVersion()
 	Expect(err).NotTo(HaveOccurred())
-	etcdCRDGetter, err := etcd.NewCRDGetter(k8sVersion)
+	etcdCRDs, err := druidcorecrds.GetAll(k8sVersion.String())
 	Expect(err).NotTo(HaveOccurred())
-	etcdCRD, err := etcdCRDGetter.GetCRD(druidcorecrds.ResourceNameEtcd)
+	etcdCRDYAML, ok := etcdCRDs[druidcorecrds.ResourceNameEtcd]
+	Expect(ok).To(BeTrue())
+	etcdCRD, err := kubernetesutils.DecodeCRD(etcdCRDYAML)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Start test environment")

--- a/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
+++ b/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "backupbuckets.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "backupentries.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "bastions.extensions.gardener.cloud"}},
+			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "clusters.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "containerruntimes.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "controlplanes.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "dnsrecords.extensions.gardener.cloud"}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR adopts the `CRDDeployer` to also add the `gardener.cloud/deletion-protected` label (when it is not already present), when the `deletionProtected` argument is passed to the deployer.

In addition to that, this PR removes the special handling in the `generate-crds.sh` script for the `Cluster`s `CRD`.
The deletion protection for the extension `CRD`s was introduced with #2066, but the Clusters `CRD` did not get it.
After speaking with @rfranzke and @shafeeqes, we decided to remove this special handling, because the `CRD` should not accidentally be deleted as well.

**Which issue(s) this PR fixes**:
Fixes #12969

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
