### PR TITLE
[GEP-28] Add `topology.kubernetes.io/region` to nodes of the self hosted shoots with `Unmanaged infrastructure` 

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -156,7 +156,7 @@ type OriginalValues struct {
 	PrimaryIPFamily gardencorev1beta1.IPFamily
 	// KubeProxyConfig is the configuration for kube-proxy.
 	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
-	// Region is a name of a region specificed in the shoot spec.
+	// Region is the name of the region specified in the Shoot spec.
 	Region string
 }
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -156,6 +156,8 @@ type OriginalValues struct {
 	PrimaryIPFamily gardencorev1beta1.IPFamily
 	// KubeProxyConfig is the configuration for kube-proxy.
 	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
+	// Region is a name of a region specificed in the shoot spec.
+	Region string
 }
 
 // New creates a new instance of Interface.
@@ -776,6 +778,7 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		taints:                                  taints,
 		caRotationLastInitiationTime:            caRotationLastInitiationTime,
 		serviceAccountKeyRotationLastInitiationTime: serviceAccountKeyRotationLastInitiationTime,
+		region: o.values.Region,
 	}, nil
 }
 
@@ -847,6 +850,7 @@ type deployer struct {
 	taints                                      []corev1.Taint
 	caRotationLastInitiationTime                *metav1.Time
 	serviceAccountKeyRotationLastInitiationTime *metav1.Time
+	region                                      string
 }
 
 // exposed for testing
@@ -871,7 +875,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		ClusterDomain:                           d.clusterDomain,
 		CRIName:                                 d.criName,
 		Images:                                  d.images,
-		NodeLabels:                              gardenerutils.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled, d.key),
+		NodeLabels:                              gardenerutils.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled, d.key, d.region),
 		NodeMonitorGracePeriod:                  d.nodeMonitorGracePeriod,
 		KubeletCABundle:                         d.kubeletCABundle,
 		KubeletConfigParameters:                 d.kubeletConfigParameters,

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -157,7 +157,7 @@ type OriginalValues struct {
 	// KubeProxyConfig is the configuration for kube-proxy.
 	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
 	// Region is the name of the region specified in the Shoot spec.
-	Region string
+	Region *string
 }
 
 // New creates a new instance of Interface.
@@ -850,7 +850,7 @@ type deployer struct {
 	taints                                      []corev1.Taint
 	caRotationLastInitiationTime                *metav1.Time
 	serviceAccountKeyRotationLastInitiationTime *metav1.Time
-	region                                      string
+	region                                      *string
 }
 
 // exposed for testing
@@ -875,7 +875,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		ClusterDomain:                           d.clusterDomain,
 		CRIName:                                 d.criName,
 		Images:                                  d.images,
-		NodeLabels:                              gardenerutils.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled, d.key, d.region),
+		NodeLabels:                              gardenerutils.NodeLabelsForWorkerPool(d.worker, d.nodeLocalDNSEnabled, d.key, ptr.Deref(d.region, "")),
 		NodeMonitorGracePeriod:                  d.nodeMonitorGracePeriod,
 		KubeletCABundle:                         d.kubeletCABundle,
 		KubeletConfigParameters:                 d.kubeletConfigParameters,

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -242,7 +242,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       ptr.Deref(workerPool.MaxSurge, intstr.FromInt32(0)),
 			MaxUnavailable: ptr.Deref(workerPool.MaxUnavailable, intstr.FromInt32(0)),
 			Annotations:    workerPool.Annotations,
-			// worker is not created for unmanaged shoots for all other cases ccm will always be there to put topology labels on the nodes for the region
+			// The worker is not created for unmanaged shoots; for all other cases, CCM will always be there to put topology labels on the nodes for the region.
 			Labels:      gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled, gardenerNodeAgentSecretName, ""),
 			Taints:      workerPool.Taints,
 			MachineType: workerPool.Machine.Type,

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -242,9 +242,10 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       ptr.Deref(workerPool.MaxSurge, intstr.FromInt32(0)),
 			MaxUnavailable: ptr.Deref(workerPool.MaxUnavailable, intstr.FromInt32(0)),
 			Annotations:    workerPool.Annotations,
-			Labels:         gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled, gardenerNodeAgentSecretName),
-			Taints:         workerPool.Taints,
-			MachineType:    workerPool.Machine.Type,
+			// worker is not created for unmanaged shoots for all other cases ccm will always be there to put topology labels on the nodes for the region
+			Labels:      gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled, gardenerNodeAgentSecretName, ""),
+			Taints:      workerPool.Taints,
+			MachineType: workerPool.Machine.Type,
 			MachineImage: extensionsv1alpha1.MachineImage{
 				Name:    workerPool.Machine.Image.Name,
 				Version: *workerPool.Machine.Image.Version,

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -242,7 +242,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			MaxSurge:       ptr.Deref(workerPool.MaxSurge, intstr.FromInt32(0)),
 			MaxUnavailable: ptr.Deref(workerPool.MaxUnavailable, intstr.FromInt32(0)),
 			Annotations:    workerPool.Annotations,
-			// The worker is not created for unmanaged shoots; for all other cases, CCM will always be there to put topology labels on the nodes for the region.
+			// The worker is not created for unmanaged self-hosted shoots; for all other cases, CCM should always be there to put topology labels on the nodes for the region.
 			Labels:      gardenerutils.NodeLabelsForWorkerPool(workerPool, w.values.NodeLocalDNSEnabled, gardenerNodeAgentSecretName, ""),
 			Taints:      workerPool.Taints,
 			MachineType: workerPool.Machine.Type,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -79,6 +79,11 @@ func (b *Botanist) OperatingSystemConfigValues() (*operatingsystemconfig.Values,
 		openTelemetryCollectorLogShipperEnabled, openTelemetryIngressHost = true, b.ComputeOpenTelemetryCollectorHost()
 	}
 
+	region := ""
+	if !b.Shoot.HasManagedInfrastructure() {
+		region = b.Shoot.GetInfo().Spec.Region
+	}
+
 	return &operatingsystemconfig.Values{
 		Namespace:         b.Shoot.ControlPlaneNamespace,
 		KubernetesVersion: b.Shoot.KubernetesVersion,
@@ -98,6 +103,7 @@ func (b *Botanist) OperatingSystemConfigValues() (*operatingsystemconfig.Values,
 			NodeMonitorGracePeriod:                  *b.Shoot.GetInfo().Spec.Kubernetes.KubeControllerManager.NodeMonitorGracePeriod,
 			PrimaryIPFamily:                         b.Shoot.GetInfo().Spec.Networking.IPFamilies[0],
 			KubeProxyConfig:                         b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
+			Region:                                  region,
 		},
 	}, nil
 }

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/version"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -79,9 +80,9 @@ func (b *Botanist) OperatingSystemConfigValues() (*operatingsystemconfig.Values,
 		openTelemetryCollectorLogShipperEnabled, openTelemetryIngressHost = true, b.ComputeOpenTelemetryCollectorHost()
 	}
 
-	region := ""
+	var region *string
 	if !b.Shoot.HasManagedInfrastructure() {
-		region = b.Shoot.GetInfo().Spec.Region
+		region = ptr.To(b.Shoot.GetInfo().Spec.Region)
 	}
 
 	return &operatingsystemconfig.Values{

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -164,7 +164,7 @@ func GetShootNameFromOwnerReferences(objectMeta metav1.Object) string {
 }
 
 // NodeLabelsForWorkerPool returns a combined map of all user-specified and gardener-managed node labels.
-func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEnabled bool, gardenerNodeAgentSecretName string) map[string]string {
+func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEnabled bool, gardenerNodeAgentSecretName, region string) map[string]string {
 	// copy worker pool labels map
 	labels := utils.MergeStringMaps(workerPool.Labels)
 	if labels == nil {
@@ -193,6 +193,10 @@ func NodeLabelsForWorkerPool(workerPool gardencorev1beta1.Worker, nodeLocalDNSEn
 				labels[key] = "true"
 			}
 		}
+	}
+
+	if region != "" {
+		labels[corev1.LabelTopologyRegion] = region
 	}
 
 	return labels

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Shoot", func() {
 		})
 
 		It("should maintain the common labels", func() {
-			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key")).To(And(
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "test")).To(And(
 				HaveKeyWithValue("node.kubernetes.io/role", "node"),
 				HaveKeyWithValue("kubernetes.io/arch", "arm64"),
 				HaveKeyWithValue("networking.gardener.cloud/node-local-dns-enabled", "false"),
@@ -298,6 +298,7 @@ var _ = Describe("Shoot", func() {
 				HaveKeyWithValue("worker.gardener.cloud/pool", "worker"),
 				HaveKeyWithValue("worker.garden.sapcloud.io/group", "worker"),
 				HaveKeyWithValue("worker.gardener.cloud/gardener-node-agent-secret-name", "osc-key"),
+				HaveKeyWithValue("topology.kubernetes.io/region", "test"),
 			))
 		})
 
@@ -306,7 +307,7 @@ var _ = Describe("Shoot", func() {
 				"test": "foo",
 				"bar":  "baz",
 			}
-			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key")).To(And(
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "")).To(And(
 				HaveKeyWithValue("test", "foo"),
 				HaveKeyWithValue("bar", "baz"),
 			))
@@ -314,16 +315,16 @@ var _ = Describe("Shoot", func() {
 
 		It("should not add system components label if they are not allowed", func() {
 			workerPool.SystemComponents.Allow = false
-			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key")).NotTo(
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "")).NotTo(
 				HaveKey("worker.gardener.cloud/system-components"),
 			)
 		})
 
 		It("should correctly handle the node-local-dns label", func() {
-			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key")).To(
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "")).To(
 				HaveKeyWithValue("networking.gardener.cloud/node-local-dns-enabled", "false"),
 			)
-			Expect(NodeLabelsForWorkerPool(workerPool, true, "osc-key")).To(
+			Expect(NodeLabelsForWorkerPool(workerPool, true, "osc-key", "")).To(
 				HaveKeyWithValue("networking.gardener.cloud/node-local-dns-enabled", "true"),
 			)
 		})
@@ -340,11 +341,17 @@ var _ = Describe("Shoot", func() {
 					},
 				},
 			}
-			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key")).To(And(
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "")).To(And(
 				HaveKeyWithValue("worker.gardener.cloud/cri-name", "containerd"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/gvisor", "true"),
 				HaveKeyWithValue("containerruntime.worker.gardener.cloud/kata", "true"),
 			))
+		})
+
+		It("should not add region label if it's an empty string", func() {
+			Expect(NodeLabelsForWorkerPool(workerPool, false, "osc-key", "")).NotTo(
+				HaveKey("topology.kubernetes.io/region"),
+			)
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
With this PR all the nodes of self-hosted shoots with Unmanaged infrastructure will have the`topology.kubernetes.io/region` label on it. Region value is decided from what is specified in shoot's specs.
Same thing can't be done for the zone topology label, as there is one common OSC per worker group and whatever node labels are specified in the OSC same is applied to all the nodes of that worker group.
A different PR will be opened for zone label, where zones are added manually at the end of the OSC reconciliation so that there can be different zone labels for different nodes of the same worker pool.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
