### PR TITLE
Enable `VPAInPlaceUpdates` feature gate for local `gardenlet` and `gardener-operator` setups

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -14,6 +14,7 @@ spec:
       DefaultSeccompProfile: true
       IstioTLSTermination: true
       OpenTelemetryCollector: true
+      VPAInPlaceUpdates: true
     controllers:
       shoot:
         reconcileInMaintenanceOnly: true

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -41,6 +41,7 @@ config:
     IstioTLSTermination: true
     OpenTelemetryCollector: true
     UseUnifiedHTTPProxyPort: true
+    VPAInPlaceUpdates: true
   logging:
     enabled: true
     vali:

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -1017,6 +1017,7 @@ deploy:
           nodeToleration.defaultUnreachableTolerationSeconds: "60"
           replicaCount: 2
           config.featureGates.IstioTLSTermination: true
+          config.featureGates.VPAInPlaceUpdates: true
         createNamespace: true
         wait: true
 profiles:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:

This PR enables the `VPAInPlaceUpdates` feature gate for `gardenlet` and `gardener-operator` local setups.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/12955

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `VPAInPlaceUpdates` feature gate is enabled in local setups for `gardenlet` and `gardener-operator`.
```
