### PR TITLE
Add extension labels for seeds

### DIFF
--- a/pkg/utils/gardener/controllerregistration.go
+++ b/pkg/utils/gardener/controllerregistration.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -17,4 +18,37 @@ func extensionEnabledForCluster(clusterType gardencorev1beta1.ClusterType, resou
 	return resource.Kind == extensionsv1alpha1.ExtensionResource &&
 		!disabledExtensions.Has(resource.Type) &&
 		slices.Contains(resource.AutoEnable, clusterType)
+}
+
+func computeEnabledTypesForKindExtension(
+	clusterType gardencorev1beta1.ClusterType,
+	extensions []gardencorev1beta1.Extension,
+	controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList,
+	resourceFilter func(res gardencorev1beta1.ControllerResource) bool,
+) sets.Set[string] {
+	var (
+		enabledTypes  = sets.New[string]()
+		disabledTypes = sets.New[string]()
+	)
+
+	for _, extension := range extensions {
+		if ptr.Deref(extension.Disabled, false) {
+			disabledTypes.Insert(extension.Type)
+		} else {
+			enabledTypes.Insert(extension.Type)
+		}
+	}
+
+	for _, controllerRegistration := range controllerRegistrationList.Items {
+		for _, resource := range controllerRegistration.Spec.Resources {
+			if resourceFilter != nil && !resourceFilter(resource) {
+				continue
+			}
+			if extensionEnabledForCluster(clusterType, resource, disabledTypes) {
+				enabledTypes.Insert(resource.Type)
+			}
+		}
+	}
+
+	return enabledTypes
 }

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -103,6 +103,34 @@ func ComputeRequiredExtensionsForSeed(seed *gardencorev1beta1.Seed, controllerRe
 	return wantedKindTypeCombinations
 }
 
+// ComputeEnabledTypesForKindExtensionSeed computes the enabled extension types for a given Seed and ControllerRegistrationList.
+// It considers extensions explicitly enabled or disabled in the Seed specification and those automatically enabled
+// based on the ControllerRegistration resources.
+func ComputeEnabledTypesForKindExtensionSeed(seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList) sets.Set[string] {
+	var (
+		enabledTypes  = sets.New[string]()
+		disabledTypes = sets.New[string]()
+	)
+
+	for _, extension := range seed.Spec.Extensions {
+		if ptr.Deref(extension.Disabled, false) {
+			disabledTypes.Insert(extension.Type)
+		} else {
+			enabledTypes.Insert(extension.Type)
+		}
+	}
+
+	for _, controllerRegistration := range controllerRegistrationList.Items {
+		for _, resource := range controllerRegistration.Spec.Resources {
+			if extensionEnabledForCluster(gardencorev1beta1.ClusterTypeSeed, resource, disabledTypes) {
+				enabledTypes.Insert(resource.Type)
+			}
+		}
+	}
+
+	return enabledTypes
+}
+
 // ExtensionKindAndTypeForID returns the extension's type and kind based on the given ID.
 func ExtensionKindAndTypeForID(extensionID string) (extensionKind string, extensionType string, err error) {
 	split := strings.Split(extensionID, "/")

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -107,28 +107,12 @@ func ComputeRequiredExtensionsForSeed(seed *gardencorev1beta1.Seed, controllerRe
 // It considers extensions explicitly enabled or disabled in the Seed specification and those automatically enabled
 // based on the ControllerRegistration resources.
 func ComputeEnabledTypesForKindExtensionSeed(seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList) sets.Set[string] {
-	var (
-		enabledTypes  = sets.New[string]()
-		disabledTypes = sets.New[string]()
+	return computeEnabledTypesForKindExtension(
+		gardencorev1beta1.ClusterTypeSeed,
+		seed.Spec.Extensions,
+		controllerRegistrationList,
+		nil,
 	)
-
-	for _, extension := range seed.Spec.Extensions {
-		if ptr.Deref(extension.Disabled, false) {
-			disabledTypes.Insert(extension.Type)
-		} else {
-			enabledTypes.Insert(extension.Type)
-		}
-	}
-
-	for _, controllerRegistration := range controllerRegistrationList.Items {
-		for _, resource := range controllerRegistration.Spec.Resources {
-			if extensionEnabledForCluster(gardencorev1beta1.ClusterTypeSeed, resource, disabledTypes) {
-				enabledTypes.Insert(resource.Type)
-			}
-		}
-	}
-
-	return enabledTypes
 }
 
 // ExtensionKindAndTypeForID returns the extension's type and kind based on the given ID.

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -117,6 +117,303 @@ var _ = Describe("utils", func() {
 		})
 	})
 
+	Describe("#ComputeEnabledTypesForKindExtensionSeed", func() {
+		const (
+			extensionType1 = "extension1"
+			extensionType2 = "extension2"
+			extensionType3 = "extension3"
+			extensionType4 = "extension4"
+		)
+
+		var (
+			seed                       *gardencorev1beta1.Seed
+			controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList
+		)
+
+		BeforeEach(func() {
+			seed = &gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Provider: gardencorev1beta1.SeedProvider{Type: "local"},
+				},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{}
+		})
+
+		It("should return empty set when no extensions are configured", func() {
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(BeEmpty())
+		})
+
+		It("should return extensions explicitly enabled in seed spec", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1},
+				{Type: extensionType2},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+				extensionType2,
+			)))
+		})
+
+		It("should return auto-enabled extensions from controller registrations", func() {
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType1,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType2,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeShoot},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+			)))
+		})
+
+		It("should not return auto-enabled extensions that are explicitly disabled", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1, Disabled: ptr.To(true)},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType1,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType2,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType2,
+			)))
+		})
+
+		It("should combine explicitly enabled and auto-enabled extensions", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType2,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+				extensionType2,
+			)))
+		})
+
+		It("should exclude non-extension controller resources", func() {
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType1,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+								{
+									Kind:       extensionsv1alpha1.WorkerResource,
+									Type:       "some-worker",
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+			)))
+		})
+
+		It("should handle extensions with both seed and shoot cluster types", func() {
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType1,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed, gardencorev1beta1.ClusterTypeShoot},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+			)))
+		})
+
+		It("should handle multiple controller registrations with mixed settings", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1},
+				{Type: extensionType4, Disabled: ptr.To(true)},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType2,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType3,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeShoot},
+								},
+							},
+						},
+					},
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType4,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+				extensionType2,
+			)))
+		})
+
+		It("should handle disabled extensions that override auto-enabled ones", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1},
+				{Type: extensionType2, Disabled: ptr.To(false)},
+				{Type: extensionType3, Disabled: ptr.To(true)},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType2,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType3,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+								{
+									Kind:       extensionsv1alpha1.ExtensionResource,
+									Type:       extensionType4,
+									AutoEnable: []gardencorev1beta1.ClusterType{gardencorev1beta1.ClusterTypeSeed},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+				extensionType2,
+				extensionType4,
+			)))
+		})
+
+		It("should handle empty controller registration list", func() {
+			seed.Spec.Extensions = []gardencorev1beta1.Extension{
+				{Type: extensionType1},
+			}
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(Equal(sets.New(
+				extensionType1,
+			)))
+		})
+
+		It("should handle controller registrations without auto-enable", func() {
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind: extensionsv1alpha1.ExtensionResource,
+									Type: extensionType1,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(ComputeEnabledTypesForKindExtensionSeed(seed, controllerRegistrationList)).To(BeEmpty())
+		})
+	})
+
 	Describe("#ComputeRequiredExtensionsForSeed", func() {
 		var (
 			seed                       *gardencorev1beta1.Seed

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -295,7 +295,7 @@ func addMetaDataLabelsShoot(shoot *core.Shoot, controllerRegistrations []*garden
 		}),
 	}
 
-	for extensionType := range gardenerutils.ComputeEnabledTypesForKindExtension(v1beta1Shoot, controllerRegistrationList) {
+	for extensionType := range gardenerutils.ComputeEnabledTypesForKindExtensionShoot(v1beta1Shoot, controllerRegistrationList) {
 		metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionExtensionTypePrefix+extensionType, "true")
 	}
 

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -133,8 +133,15 @@ func (e *ExtensionLabels) Admit(_ context.Context, a admission.Attributes, _ adm
 			return apierrors.NewBadRequest("could not convert resource into Seed object")
 		}
 
+		controllerRegistrations, err := e.controllerRegistrationLister.List(labels.Everything())
+		if err != nil {
+			return apierrors.NewInternalError(err)
+		}
+
 		removeLabels(&seed.ObjectMeta)
-		addMetaDataLabelsSeed(seed)
+		if err := addMetaDataLabelsSeed(seed, controllerRegistrations); err != nil {
+			return fmt.Errorf("failed to add metadata labels to seed: %w", err)
+		}
 
 	case core.Kind("SecretBinding"):
 		secretBinding, ok := a.GetObject().(*core.SecretBinding)
@@ -233,7 +240,26 @@ func (e *ExtensionLabels) Admit(_ context.Context, a admission.Attributes, _ adm
 	return nil
 }
 
-func addMetaDataLabelsSeed(seed *core.Seed) {
+func addMetaDataLabelsSeed(seed *core.Seed, controllerRegistrations []*gardencorev1beta1.ControllerRegistration) error {
+	v1beta1Seed := &gardencorev1beta1.Seed{}
+	if err := kubernetes.GardenScheme.Convert(seed, v1beta1Seed, nil); err != nil {
+		return fmt.Errorf("could not convert Seed to v1beta1.Seed: %v", err)
+	}
+
+	controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{
+		Items: slices.Collect(func(yield func(gardencorev1beta1.ControllerRegistration) bool) {
+			for _, registration := range controllerRegistrations {
+				if !yield(*registration) {
+					return
+				}
+			}
+		}),
+	}
+
+	for extensionType := range gardenerutils.ComputeEnabledTypesForKindExtensionSeed(v1beta1Seed, controllerRegistrationList) {
+		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionExtensionTypePrefix+extensionType, "true")
+	}
+
 	metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+seed.Spec.Provider.Type, "true")
 	if seed.Spec.Backup != nil {
 		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+seed.Spec.Backup.Provider, "true")
@@ -242,6 +268,8 @@ func addMetaDataLabelsSeed(seed *core.Seed) {
 	if seed.Spec.DNS.Provider != nil {
 		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionDNSRecordTypePrefix+seed.Spec.DNS.Provider.Type, "true")
 	}
+
+	return nil
 }
 
 func addMetaDataLabelsSecretBinding(secretBinding *core.SecretBinding) {

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -673,6 +673,10 @@ var _ = Describe("Seed controller tests", func() {
 					return gardenerutils.RequiredExtensionsReady(ctx, testClient, seed.Name, gardenerutils.ComputeRequiredExtensionsForSeed(seed, controllerRegistrationList))
 				}).WithTimeout(time.Minute).Should(Succeed())
 
+				By("Verify seed has extension label")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(seed), seed)).To(Succeed())
+				Expect(seed.Labels).To(HaveKeyWithValue("extensions.extensions.gardener.cloud/"+providerName, "true"))
+
 				By("Verify that the seed system components have been deployed")
 				expectedManagedResources := []string{
 					"cluster-autoscaler",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Similar shoots, this PR changes the extension labels admission plugin to also label the seed when it configures `.spec.extensions` or if the extension is automatically enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @marwinski thanks for reporting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Seed clusters are now labelled with a specific extension label `extensions.extensions.gardener.cloud/<extension-type>: true` whenever such an extension is activated for the seed.
```
