### PR TITLE
Allow update on old `Shoots`, `ManagedSeedSets` and `Garden` if invalid accepted issuers are unchanged

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -176,11 +176,11 @@ var (
 )
 
 type shootValidationOptions struct {
-	KubeAPIServerValidationOption
+	KubeAPIServerValidationOptions
 }
 
-// KubeAPIServerValidationOption are validation options for the KubeAPIServer fields.
-type KubeAPIServerValidationOption struct {
+// KubeAPIServerValidationOptions are validation options for the KubeAPIServer fields.
+type KubeAPIServerValidationOptions struct {
 	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
 	AllowInvalidAcceptedIssuers bool
 }
@@ -188,7 +188,7 @@ type KubeAPIServerValidationOption struct {
 // ValidateShoot validates a Shoot object.
 func ValidateShoot(shoot *core.Shoot) field.ErrorList {
 	opts := shootValidationOptions{
-		KubeAPIServerValidationOption: KubeAPIServerValidationOption{
+		KubeAPIServerValidationOptions: KubeAPIServerValidationOptions{
 			AllowInvalidAcceptedIssuers: false,
 		},
 	}
@@ -213,7 +213,7 @@ func ValidateShootWithOpts(shoot *core.Shoot, opts shootValidationOptions) field
 func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
 	opts := shootValidationOptions{
-		KubeAPIServerValidationOption: KubeAPIServerValidationOption{
+		KubeAPIServerValidationOptions: KubeAPIServerValidationOptions{
 			AllowInvalidAcceptedIssuers: oldShoot.Spec.Kubernetes.KubeAPIServer != nil && newShoot.Spec.Kubernetes.KubeAPIServer != nil &&
 				oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 				apiequality.Semantic.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -262,11 +262,11 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 }
 
 // ValidateShootTemplate validates a ShootTemplate.
-func ValidateShootTemplate(shootTemplate *core.ShootTemplate, opts KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplate(shootTemplate *core.ShootTemplate, opts KubeAPIServerValidationOptions, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	shootValidationOptions := shootValidationOptions{
-		KubeAPIServerValidationOption: opts,
+		KubeAPIServerValidationOptions: opts,
 	}
 
 	allErrs = append(allErrs, metav1validation.ValidateLabels(shootTemplate.Labels, fldPath.Child("metadata", "labels"))...)
@@ -1015,7 +1015,7 @@ func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking,
 	}
 
 	allErrs = append(allErrs, validateETCD(kubernetes.ETCD, fldPath.Child("etcd"))...)
-	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, opts.KubeAPIServerValidationOption, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
+	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, opts.KubeAPIServerValidationOptions, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
 	allErrs = append(allErrs, ValidateKubeControllerManager(kubernetes.KubeControllerManager, networking, kubernetes.Version, workerless, fldPath.Child("kubeControllerManager"))...)
 
 	if workerless {
@@ -1597,7 +1597,7 @@ func validateHibernationUpdate(new, old *core.Shoot) field.ErrorList {
 }
 
 // ValidateKubeAPIServer validates KubeAPIServerConfig.
-func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, opts KubeAPIServerValidationOption, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
+func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, opts KubeAPIServerValidationOptions, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if kubeAPIServer == nil {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -179,7 +179,7 @@ type shootValidationOptions struct {
 	KubeAPIServerValidationOption
 }
 
-// KubeAPIServerValidationOption is validation options for the KubeAPIServer fields.
+// KubeAPIServerValidationOption are validation options for the KubeAPIServer fields.
 type KubeAPIServerValidationOption struct {
 	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
 	AllowInvalidAcceptedIssuers bool

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -176,11 +176,11 @@ var (
 )
 
 type shootValidationOptions struct {
-	KubeAPIServerValidatonOption
+	KubeAPIServerValidationOption
 }
 
-// KubeAPIServerValidatonOption is validation options for the KubeAPIServer fields.
-type KubeAPIServerValidatonOption struct {
+// KubeAPIServerValidationOption is validation options for the KubeAPIServer fields.
+type KubeAPIServerValidationOption struct {
 	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
 	AllowInvalidAcceptedIssuers bool
 }
@@ -188,7 +188,7 @@ type KubeAPIServerValidatonOption struct {
 // ValidateShoot validates a Shoot object.
 func ValidateShoot(shoot *core.Shoot) field.ErrorList {
 	opts := shootValidationOptions{
-		KubeAPIServerValidatonOption: KubeAPIServerValidatonOption{
+		KubeAPIServerValidationOption: KubeAPIServerValidationOption{
 			AllowInvalidAcceptedIssuers: false,
 		},
 	}
@@ -213,7 +213,7 @@ func ValidateShootWithOpts(shoot *core.Shoot, opts shootValidationOptions) field
 func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
 	opts := shootValidationOptions{
-		KubeAPIServerValidatonOption: KubeAPIServerValidatonOption{
+		KubeAPIServerValidationOption: KubeAPIServerValidationOption{
 			AllowInvalidAcceptedIssuers: oldShoot.Spec.Kubernetes.KubeAPIServer != nil && newShoot.Spec.Kubernetes.KubeAPIServer != nil &&
 				oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 				apiequality.Semantic.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -262,11 +262,11 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 }
 
 // ValidateShootTemplate validates a ShootTemplate.
-func ValidateShootTemplate(shootTemplate *core.ShootTemplate, opts KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplate(shootTemplate *core.ShootTemplate, opts KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	shootValidationOptions := shootValidationOptions{
-		KubeAPIServerValidatonOption: opts,
+		KubeAPIServerValidationOption: opts,
 	}
 
 	allErrs = append(allErrs, metav1validation.ValidateLabels(shootTemplate.Labels, fldPath.Child("metadata", "labels"))...)
@@ -1015,7 +1015,7 @@ func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking,
 	}
 
 	allErrs = append(allErrs, validateETCD(kubernetes.ETCD, fldPath.Child("etcd"))...)
-	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, opts.KubeAPIServerValidatonOption, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
+	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, opts.KubeAPIServerValidationOption, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
 	allErrs = append(allErrs, ValidateKubeControllerManager(kubernetes.KubeControllerManager, networking, kubernetes.Version, workerless, fldPath.Child("kubeControllerManager"))...)
 
 	if workerless {
@@ -1597,7 +1597,7 @@ func validateHibernationUpdate(new, old *core.Shoot) field.ErrorList {
 }
 
 // ValidateKubeAPIServer validates KubeAPIServerConfig.
-func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, opts KubeAPIServerValidatonOption, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
+func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, opts KubeAPIServerValidationOption, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if kubeAPIServer == nil {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -175,14 +175,35 @@ var (
 	workerlessErrorMsg = "this field should not be set for workerless Shoot clusters"
 )
 
+type shootValidationOptions struct {
+	KubeAPIServerValidatonOption
+}
+
+// KubeAPIServerValidatonOption is validation options for the KubeAPIServer fields.
+type KubeAPIServerValidatonOption struct {
+	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
+	AllowInvalidAcceptedIssuers bool
+}
+
 // ValidateShoot validates a Shoot object.
 func ValidateShoot(shoot *core.Shoot) field.ErrorList {
+	opts := shootValidationOptions{
+		KubeAPIServerValidatonOption: KubeAPIServerValidatonOption{
+			AllowInvalidAcceptedIssuers: false,
+		},
+	}
+
+	return ValidateShootWithOpts(shoot, opts)
+}
+
+// ValidateShootWithOpts validates a Shoot object with the given options.
+func ValidateShootWithOpts(shoot *core.Shoot, opts shootValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&shoot.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, validateNameConsecutiveHyphens(shoot.Name, field.NewPath("metadata", "name"))...)
 	allErrs = append(allErrs, validateShootOperation(v1beta1helper.GetShootGardenerOperations(shoot.Annotations), v1beta1helper.GetShootMaintenanceOperations(shoot.Annotations), shoot, field.NewPath("metadata", "annotations"))...)
-	allErrs = append(allErrs, ValidateShootSpec(shoot.ObjectMeta, &shoot.Spec, field.NewPath("spec"), false)...)
+	allErrs = append(allErrs, ValidateShootSpec(shoot.ObjectMeta, &shoot.Spec, opts, field.NewPath("spec"), false)...)
 	allErrs = append(allErrs, ValidateShootHAConfig(shoot)...)
 
 	return allErrs
@@ -191,6 +212,13 @@ func ValidateShoot(shoot *core.Shoot) field.ErrorList {
 // ValidateShootUpdate validates a Shoot object before an update.
 func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
+	opts := shootValidationOptions{
+		KubeAPIServerValidatonOption: KubeAPIServerValidatonOption{
+			AllowInvalidAcceptedIssuers: oldShoot.Spec.Kubernetes.KubeAPIServer != nil && newShoot.Spec.Kubernetes.KubeAPIServer != nil &&
+				oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
+				apiequality.Semantic.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
+		},
+	}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShoot.ObjectMeta, &oldShoot.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, oldShoot.ObjectMeta, field.NewPath("metadata"))...)
@@ -223,7 +251,7 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	}
 
 	allErrs = append(allErrs, ValidateEncryptionConfigUpdate(newEncryptionConfig, oldEncryptionConfig, encryptedResources, etcdEncryptionKeyRotation, hibernationEnabled, field.NewPath("spec", "kubernetes", "kubeAPIServer", "encryptionConfig"))...)
-	allErrs = append(allErrs, ValidateShoot(newShoot)...)
+	allErrs = append(allErrs, ValidateShootWithOpts(newShoot, opts)...)
 	allErrs = append(allErrs, ValidateShootHAConfigUpdate(newShoot, oldShoot)...)
 	allErrs = append(allErrs, validateHibernationUpdate(newShoot, oldShoot)...)
 	allErrs = append(allErrs, ValidateForceDeletion(newShoot, oldShoot)...)
@@ -264,7 +292,7 @@ func ValidateShootObjectMetaUpdate(_, _ metav1.ObjectMeta, _ *field.Path) field.
 }
 
 // ValidateShootSpec validates the specification of a Shoot object.
-func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *field.Path, inTemplate bool) field.ErrorList {
+func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootValidationOptions, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	var (
 		allErrs       = field.ErrorList{}
 		workerless    = len(spec.Provider.Workers) == 0
@@ -277,7 +305,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
 	allErrs = append(allErrs, ValidateResources(spec.Resources, fldPath.Child("resources"), true)...)
-	allErrs = append(allErrs, validateKubernetes(spec.Kubernetes, spec.Networking, workerless, fldPath.Child("kubernetes"))...)
+	allErrs = append(allErrs, validateKubernetes(spec.Kubernetes, spec.Networking, opts, workerless, fldPath.Child("kubernetes"))...)
 	allErrs = append(allErrs, validateNetworking(spec.Networking, workerless, fldPath.Child("networking"))...)
 	allErrs = append(allErrs, validateMaintenance(spec.Maintenance, fldPath.Child("maintenance"), workerless)...)
 	allErrs = append(allErrs, validateMonitoring(spec.Monitoring, fldPath.Child("monitoring"))...)
@@ -974,7 +1002,7 @@ func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking, workerless bool, fldPath *field.Path) field.ErrorList {
+func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking, opts shootValidationOptions, workerless bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(kubernetes.Version) == 0 {
@@ -983,7 +1011,7 @@ func validateKubernetes(kubernetes core.Kubernetes, networking *core.Networking,
 	}
 
 	allErrs = append(allErrs, validateETCD(kubernetes.ETCD, fldPath.Child("etcd"))...)
-	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
+	allErrs = append(allErrs, ValidateKubeAPIServer(kubernetes.KubeAPIServer, kubernetes.Version, opts.KubeAPIServerValidatonOption, workerless, gardenerutils.DefaultGroupResourcesForEncryption(), fldPath.Child("kubeAPIServer"))...)
 	allErrs = append(allErrs, ValidateKubeControllerManager(kubernetes.KubeControllerManager, networking, kubernetes.Version, workerless, fldPath.Child("kubeControllerManager"))...)
 
 	if workerless {
@@ -1565,7 +1593,7 @@ func validateHibernationUpdate(new, old *core.Shoot) field.ErrorList {
 }
 
 // ValidateKubeAPIServer validates KubeAPIServerConfig.
-func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
+func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version string, opts KubeAPIServerValidatonOption, workerless bool, defaultEncryptedResources []schema.GroupResource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if kubeAPIServer == nil {
@@ -1691,7 +1719,7 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 		if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
 			allErrs = append(allErrs, ValidateOIDCIssuerURL(*kubeAPIServer.ServiceAccountConfig.Issuer, fldPath.Child("serviceAccountConfig", "issuer"))...)
 		}
-		if len(kubeAPIServer.ServiceAccountConfig.AcceptedIssuers) > 0 {
+		if len(kubeAPIServer.ServiceAccountConfig.AcceptedIssuers) > 0 && !opts.AllowInvalidAcceptedIssuers {
 			issuers := sets.New[string]()
 			if kubeAPIServer.ServiceAccountConfig.Issuer != nil {
 				issuers.Insert(*kubeAPIServer.ServiceAccountConfig.Issuer)

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -262,12 +262,16 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 }
 
 // ValidateShootTemplate validates a ShootTemplate.
-func ValidateShootTemplate(shootTemplate *core.ShootTemplate, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplate(shootTemplate *core.ShootTemplate, opts KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	shootValidationOptions := shootValidationOptions{
+		KubeAPIServerValidatonOption: opts,
+	}
 
 	allErrs = append(allErrs, metav1validation.ValidateLabels(shootTemplate.Labels, fldPath.Child("metadata", "labels"))...)
 	allErrs = append(allErrs, apivalidation.ValidateAnnotations(shootTemplate.Annotations, fldPath.Child("metadata", "annotations"))...)
-	allErrs = append(allErrs, ValidateShootSpec(shootTemplate.ObjectMeta, &shootTemplate.Spec, fldPath.Child("spec"), true)...)
+	allErrs = append(allErrs, ValidateShootSpec(shootTemplate.ObjectMeta, &shootTemplate.Spec, shootValidationOptions, fldPath.Child("spec"), true)...)
 
 	return allErrs
 }

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -71,7 +71,7 @@ func init() {
 // ValidateGarden contains functionality for performing extended validation of a Garden object which is not possible
 // with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
-	opts := gardencorevalidation.KubeAPIServerValidationOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
 	}
 
@@ -79,7 +79,7 @@ func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alph
 }
 
 // ValidateGardenWithOps validates a Garden object with the given options.
-func ValidateGardenWithOps(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension, opts gardencorevalidation.KubeAPIServerValidationOption) field.ErrorList {
+func ValidateGardenWithOps(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension, opts gardencorevalidation.KubeAPIServerValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateOperation(helper.GetGardenerOperations(garden.Annotations), garden, field.NewPath("metadata", "annotations"))...)
@@ -109,7 +109,7 @@ func validateResources(resources []gardencorev1beta1.NamedResourceReference, pat
 // is not possible with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGardenUpdate(oldGarden, newGarden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
 	allErrs := field.ErrorList{}
-	opts := gardencorevalidation.KubeAPIServerValidationOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
 			oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -328,7 +328,7 @@ func validateRuntimeClusterSettings(runtimeCluster operatorv1alpha1.RuntimeClust
 	return allErrs
 }
 
-func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
+func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, opts gardencorevalidation.KubeAPIServerValidationOptions, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateDomains(dns, virtualCluster.DNS.Domains, fldPath.Child("dns", "domains"))...)

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -71,7 +71,7 @@ func init() {
 // ValidateGarden contains functionality for performing extended validation of a Garden object which is not possible
 // with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
-	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOption{
 		AllowInvalidAcceptedIssuers: false,
 	}
 
@@ -79,7 +79,7 @@ func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alph
 }
 
 // ValidateGardenWithOps validates a Garden object with the given options.
-func ValidateGardenWithOps(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension, opts gardencorevalidation.KubeAPIServerValidatonOption) field.ErrorList {
+func ValidateGardenWithOps(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension, opts gardencorevalidation.KubeAPIServerValidationOption) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateOperation(helper.GetGardenerOperations(garden.Annotations), garden, field.NewPath("metadata", "annotations"))...)
@@ -109,7 +109,7 @@ func validateResources(resources []gardencorev1beta1.NamedResourceReference, pat
 // is not possible with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGardenUpdate(oldGarden, newGarden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
 	allErrs := field.ErrorList{}
-	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOption{
 		AllowInvalidAcceptedIssuers: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
 			oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -328,7 +328,7 @@ func validateRuntimeClusterSettings(runtimeCluster operatorv1alpha1.RuntimeClust
 	return allErrs
 }
 
-func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
+func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateDomains(dns, virtualCluster.DNS.Domains, fldPath.Child("dns", "domains"))...)

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -70,14 +71,23 @@ func init() {
 // ValidateGarden contains functionality for performing extended validation of a Garden object which is not possible
 // with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
+	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+		AllowInvalidAcceptedIssuers: false,
+	}
+
+	return ValidateGardenWithOps(garden, extensions, opts)
+}
+
+// ValidateGardenWithOps validates a Garden object with the given options.
+func ValidateGardenWithOps(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension, opts gardencorevalidation.KubeAPIServerValidatonOption) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateOperation(helper.GetGardenerOperations(garden.Annotations), garden, field.NewPath("metadata", "annotations"))...)
 	allErrs = append(allErrs, validateDNS(garden.Spec.DNS, field.NewPath("spec", "dns"))...)
 	allErrs = append(allErrs, validateExtensions(garden.Spec.Extensions, extensions, field.NewPath("spec", "extensions"))...)
 	allErrs = append(allErrs, validateRuntimeCluster(garden.Spec.DNS, garden.Spec.RuntimeCluster, helper.HighAvailabilityEnabled(garden), field.NewPath("spec", "runtimeCluster"))...)
-	allErrs = append(allErrs, validateVirtualCluster(garden.Spec.DNS, garden.Spec.VirtualCluster, garden.Spec.RuntimeCluster, field.NewPath("spec", "virtualCluster"))...)
 	allErrs = append(allErrs, validateResources(garden.Spec.Resources, field.NewPath("spec", "resources"))...)
+	allErrs = append(allErrs, validateVirtualCluster(garden.Spec.DNS, garden.Spec.VirtualCluster, garden.Spec.RuntimeCluster, opts, field.NewPath("spec", "virtualCluster"))...)
 
 	return allErrs
 }
@@ -99,10 +109,15 @@ func validateResources(resources []gardencorev1beta1.NamedResourceReference, pat
 // is not possible with standard CRD validation, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules.
 func ValidateGardenUpdate(oldGarden, newGarden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
 	allErrs := field.ErrorList{}
+	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+		AllowInvalidAcceptedIssuers: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
+			oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
+			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
+	}
 
 	allErrs = append(allErrs, validateRuntimeClusterUpdate(oldGarden, newGarden)...)
 	allErrs = append(allErrs, validateVirtualClusterUpdate(oldGarden, newGarden)...)
-	allErrs = append(allErrs, ValidateGarden(newGarden, extensions)...)
+	allErrs = append(allErrs, ValidateGardenWithOps(newGarden, extensions, opts)...)
 
 	return allErrs
 }
@@ -313,7 +328,7 @@ func validateRuntimeClusterSettings(runtimeCluster operatorv1alpha1.RuntimeClust
 	return allErrs
 }
 
-func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, fldPath *field.Path) field.ErrorList {
+func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster operatorv1alpha1.VirtualCluster, runtimeCluster operatorv1alpha1.RuntimeCluster, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateDomains(dns, virtualCluster.DNS.Domains, fldPath.Child("dns", "domains"))...)
@@ -340,7 +355,7 @@ func validateVirtualCluster(dns *operatorv1alpha1.DNSManagement, virtualCluster 
 				return allErrs
 			}
 
-			allErrs = append(allErrs, gardencorevalidation.ValidateKubeAPIServer(coreKubeAPIServerConfig, virtualCluster.Kubernetes.Version, true, gardenerutils.DefaultGroupResourcesForEncryption(), path)...)
+			allErrs = append(allErrs, gardencorevalidation.ValidateKubeAPIServer(coreKubeAPIServerConfig, virtualCluster.Kubernetes.Version, opts, true, gardenerutils.DefaultGroupResourcesForEncryption(), path)...)
 		}
 
 		// The API server domain of the virtual cluster which is derived from the primary (immutable) DNS name does not

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -27,7 +27,7 @@ import (
 
 // ValidateManagedSeedSet validates a ManagedSeedSet object.
 func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
-	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOption{
 		AllowInvalidAcceptedIssuers: false,
 	}
 
@@ -35,7 +35,7 @@ func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field
 }
 
 // ValidateManagedSeedSetWithOps validates ManagedSeedSet with given validation options.
-func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet, opts gardencorevalidation.KubeAPIServerValidatonOption) field.ErrorList {
+func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet, opts gardencorevalidation.KubeAPIServerValidationOption) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure namespace is garden
@@ -52,7 +52,7 @@ func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet
 // ValidateManagedSeedSetUpdate validates a ManagedSeedSet object before an update.
 func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	allErrs := field.ErrorList{}
-	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOption{
 		AllowInvalidAcceptedIssuers: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
 			oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -85,7 +85,7 @@ func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *se
 }
 
 // ValidateManagedSeedSetSpec validates the specification of a ManagedSeed object.
-func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
+func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure replicas is non-negative if specified
@@ -200,7 +200,7 @@ func ValidateManagedSeedTemplateForManagedSeedSet(template *seedmanagement.Manag
 }
 
 // ValidateShootTemplateForManagedSeedSet validates the given ShootTemplate.
-func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateTemplateLabels(&template.ObjectMeta, selector, fldPath.Child("metadata"))...)

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -27,7 +27,7 @@ import (
 
 // ValidateManagedSeedSet validates a ManagedSeedSet object.
 func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
-	opts := gardencorevalidation.KubeAPIServerValidationOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
 	}
 
@@ -35,7 +35,7 @@ func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field
 }
 
 // ValidateManagedSeedSetWithOps validates ManagedSeedSet with given validation options.
-func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet, opts gardencorevalidation.KubeAPIServerValidationOption) field.ErrorList {
+func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet, opts gardencorevalidation.KubeAPIServerValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure namespace is garden
@@ -52,7 +52,7 @@ func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet
 // ValidateManagedSeedSetUpdate validates a ManagedSeedSet object before an update.
 func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	allErrs := field.ErrorList{}
-	opts := gardencorevalidation.KubeAPIServerValidationOption{
+	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
 			oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
@@ -85,7 +85,7 @@ func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *se
 }
 
 // ValidateManagedSeedSetSpec validates the specification of a ManagedSeed object.
-func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
+func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, opts gardencorevalidation.KubeAPIServerValidationOptions, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure replicas is non-negative if specified
@@ -200,7 +200,7 @@ func ValidateManagedSeedTemplateForManagedSeedSet(template *seedmanagement.Manag
 }
 
 // ValidateShootTemplateForManagedSeedSet validates the given ShootTemplate.
-func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, opts gardencorevalidation.KubeAPIServerValidationOption, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, opts gardencorevalidation.KubeAPIServerValidationOptions, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateTemplateLabels(&template.ObjectMeta, selector, fldPath.Child("metadata"))...)

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -26,6 +27,15 @@ import (
 
 // ValidateManagedSeedSet validates a ManagedSeedSet object.
 func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
+	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+		AllowInvalidAcceptedIssuers: false,
+	}
+
+	return ValidateManagedSeedSetWithOps(ManagedSeedSet, opts)
+}
+
+// ValidateManagedSeedSetWithOps validates ManagedSeedSet with given validation options.
+func ValidateManagedSeedSetWithOps(ManagedSeedSet *seedmanagement.ManagedSeedSet, opts gardencorevalidation.KubeAPIServerValidatonOption) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure namespace is garden
@@ -34,7 +44,7 @@ func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&ManagedSeedSet.ObjectMeta, true, gardencorevalidation.ValidateName, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateManagedSeedSetSpec(&ManagedSeedSet.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSetSpec(&ManagedSeedSet.Spec, opts, field.NewPath("spec"))...)
 
 	return allErrs
 }
@@ -42,10 +52,15 @@ func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field
 // ValidateManagedSeedSetUpdate validates a ManagedSeedSet object before an update.
 func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	allErrs := field.ErrorList{}
+	opts := gardencorevalidation.KubeAPIServerValidatonOption{
+		AllowInvalidAcceptedIssuers: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
+			oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
+			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
+	}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newManagedSeedSet.ObjectMeta, &oldManagedSeedSet.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateManagedSeedSetSpecUpdate(&newManagedSeedSet.Spec, &oldManagedSeedSet.Spec, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateManagedSeedSet(newManagedSeedSet)...)
+	allErrs = append(allErrs, ValidateManagedSeedSetWithOps(newManagedSeedSet, opts)...)
 
 	return allErrs
 }
@@ -70,7 +85,7 @@ func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *se
 }
 
 // ValidateManagedSeedSetSpec validates the specification of a ManagedSeed object.
-func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, fldPath *field.Path) field.ErrorList {
+func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Ensure replicas is non-negative if specified
@@ -93,7 +108,7 @@ func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, fldPath
 
 	// Validate template and shootTemplate
 	allErrs = append(allErrs, ValidateManagedSeedTemplateForManagedSeedSet(&spec.Template, selector, fldPath.Child("template"))...)
-	allErrs = append(allErrs, ValidateShootTemplateForManagedSeedSet(&spec.ShootTemplate, selector, fldPath.Child("shootTemplate"))...)
+	allErrs = append(allErrs, ValidateShootTemplateForManagedSeedSet(&spec.ShootTemplate, selector, opts, fldPath.Child("shootTemplate"))...)
 
 	if spec.UpdateStrategy != nil {
 		allErrs = append(allErrs, validateUpdateStrategy(spec.UpdateStrategy, fldPath.Child("updateStrategy"))...)
@@ -185,12 +200,12 @@ func ValidateManagedSeedTemplateForManagedSeedSet(template *seedmanagement.Manag
 }
 
 // ValidateShootTemplateForManagedSeedSet validates the given ShootTemplate.
-func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, fldPath *field.Path) field.ErrorList {
+func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, opts gardencorevalidation.KubeAPIServerValidatonOption, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validateTemplateLabels(&template.ObjectMeta, selector, fldPath.Child("metadata"))...)
 	allErrs = append(allErrs, validateIfWorkerless(&template.Spec, fldPath.Child("spec"))...)
-	allErrs = append(allErrs, gardencorevalidation.ValidateShootTemplate(template, fldPath)...)
+	allErrs = append(allErrs, gardencorevalidation.ValidateShootTemplate(template, opts, fldPath)...)
 
 	return allErrs
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR allows updates on old `Shoots`, `ManagedSeedSets` and `Garden` if invalid accepted issuers are unchanged, which was restricted with https://github.com/gardener/gardener/pull/13325 PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @dimityrmirchev @dimitar-kostadinov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updates on old `Shoots`, `ManagedSeedSets`, and `Garden` are now allowed if invalid accepted issuers are unchanged.
```
