### PR TITLE
Prevent GHA workflows from running into forks

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'gardener/gardener' }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -17,6 +18,7 @@ jobs:
       id-token: write
 
   component-descriptor:
+    if: ${{ github.repository == 'gardener/gardener' }}
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/heads/release-v')
+    if: ${{ github.repository == 'gardener/gardner' && startsWith(github.ref, 'refs/heads/release-v') }}
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: write
@@ -20,7 +20,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    if: startsWith(github.ref, 'refs/heads/release-v')
+    if: ${{ github.repository == 'gardener/gardner' && startsWith(github.ref, 'refs/heads/release-v') }}
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     needs:
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository == 'gardener/gardner' && startsWith(github.ref, 'refs/heads/release-v') }}
+    if: ${{ github.repository == 'gardener/gardener' && startsWith(github.ref, 'refs/heads/release-v') }}
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: write
@@ -20,7 +20,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    if: ${{ github.repository == 'gardener/gardner' && startsWith(github.ref, 'refs/heads/release-v') }}
+    if: ${{ github.repository == 'gardener/gardener' && startsWith(github.ref, 'refs/heads/release-v') }}
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     needs:
       - build


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Prevent GHA workflows from running into forks

The workflows are either way failing in forks, [example](https://github.com/vpnachev/gardener/actions/runs/19571198720), there is no need to waste compute resources. With this change, the workflows are just skipped in forks, [example](https://github.com/vpnachev/gardener/actions/runs/19572691278)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
