### PR TITLE
Adapt Scheme field in Prometheus-related resources to prometheus-operator v0.87.0

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -452,7 +452,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			Endpoints: []monitoringv1.Endpoint{
 				{
 					Port:   portNameClient,
-					Scheme: "https",
+					Scheme: ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
 						// This is needed because the etcd's certificates are not are generated for a specific pod IP.
 						InsecureSkipVerify: ptr.To(true),
@@ -483,7 +483,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				{
 					Port:   portNameBackupRestore,
-					Scheme: "https",
+					Scheme: ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
 						// This is needed because the etcd's certificates are not are generated for a specific pod IP.
 						InsecureSkipVerify: ptr.To(true),

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -476,7 +476,7 @@ var _ = Describe("Etcd", func() {
 					Endpoints: []monitoringv1.Endpoint{
 						{
 							Port:   "client",
-							Scheme: "https",
+							Scheme: ptr.To(monitoringv1.SchemeHTTPS),
 							TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: ptr.To(true),
 								Cert: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
@@ -506,7 +506,7 @@ var _ = Describe("Etcd", func() {
 						},
 						{
 							Port:   "backuprestore",
-							Scheme: "https",
+							Scheme: ptr.To(monitoringv1.SchemeHTTPS),
 							TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: ptr.To(true),
 								Cert: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -645,7 +645,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				}},
 				Endpoints: []monitoringv1.Endpoint{{
 					TargetPort: ptr.To(intstr.FromInt32(8443)),
-					Scheme:     "https",
+					Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-garden"},

--- a/pkg/component/gardener/apiserver/servicemonitor.go
+++ b/pkg/component/gardener/apiserver/servicemonitor.go
@@ -23,7 +23,7 @@ func (g *gardenerAPIServer) serviceMonitor() *monitoringv1.ServiceMonitor {
 			Selector: metav1.LabelSelector{MatchLabels: GetLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
 				TargetPort: ptr.To(intstr.FromInt32(port)),
-				Scheme:     "https",
+				Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: garden.AccessSecretName},

--- a/pkg/component/gardener/dashboard/terminal/servicemonitor.go
+++ b/pkg/component/gardener/dashboard/terminal/servicemonitor.go
@@ -21,7 +21,7 @@ func (t *terminal) serviceMonitor() *monitoringv1.ServiceMonitor {
 			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
 				Port:      portNameMetrics,
-				Scheme:    "https",
+				Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-garden"},

--- a/pkg/component/gardener/dashboard/terminal/terminal_test.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal_test.go
@@ -394,7 +394,7 @@ server:
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "terminal-controller-manager"}},
 				Endpoints: []monitoringv1.Endpoint{{
 					Port:      "metrics",
-					Scheme:    "https",
+					Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-garden"},

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -499,7 +499,7 @@ var _ = Describe("KubeAPIServer", func() {
 						}},
 						Endpoints: []monitoringv1.Endpoint{{
 							TargetPort: ptr.To(intstr.FromInt32(443)),
-							Scheme:     "https",
+							Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 							TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-" + prometheusName},

--- a/pkg/component/kubernetes/apiserver/servicemonitor.go
+++ b/pkg/component/kubernetes/apiserver/servicemonitor.go
@@ -31,7 +31,7 @@ func (k *kubeAPIServer) reconcileServiceMonitor(ctx context.Context, serviceMoni
 			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
 				TargetPort: ptr.To(intstr.FromInt32(kubeapiserverconstants.Port)),
-				Scheme:     "https",
+				Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:  &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: k.prometheusAccessSecretName()},

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -519,7 +519,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
 				Port:      portNameMetrics,
-				Scheme:    "https",
+				Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: k.prometheusAccessSecretName()},

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -236,7 +236,7 @@ var _ = Describe("KubeControllerManager", func() {
 					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "kubernetes", "role": "controller-manager"}},
 					Endpoints: []monitoringv1.Endpoint{{
 						Port:      "metrics",
-						Scheme:    "https",
+						Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 						TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-" + prometheusName},

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -125,7 +125,7 @@ var _ = Describe("KubeProxy", func() {
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/kubernetes/scheduler/scheduler.go
+++ b/pkg/component/kubernetes/scheduler/scheduler.go
@@ -447,7 +447,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 			Endpoints: []monitoringv1.Endpoint{{
 				Port:      portNameMetrics,
-				Scheme:    "https",
+				Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: shoot.AccessSecretName},

--- a/pkg/component/kubernetes/scheduler/scheduler_test.go
+++ b/pkg/component/kubernetes/scheduler/scheduler_test.go
@@ -426,7 +426,7 @@ var _ = Describe("KubeScheduler", func() {
 				}},
 				Endpoints: []monitoringv1.Endpoint{{
 					Port:      "metrics",
-					Scheme:    "https",
+					Scheme:    ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig: &monitoringv1.TLSConfig{SafeTLSConfig: monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -96,7 +96,7 @@ var _ = Describe("APIServerProxy", func() {
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -585,7 +585,7 @@ status: {}
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -81,7 +81,7 @@ var _ = Describe("NodeLocalDNS", func() {
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
@@ -156,7 +156,7 @@ var _ = Describe("NodeLocalDNS", func() {
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster/scrapeconfig.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster/scrapeconfig.go
@@ -26,7 +26,7 @@ func ScrapeConfig(namespace string) []*monitoringv1alpha1.ScrapeConfig {
 		ObjectMeta: monitoringutils.ConfigObjectMeta("blackbox-exporter-k8s-service-check", namespace, shootprometheus.Label),
 		Spec: monitoringv1alpha1.ScrapeConfigSpec{
 			HonorLabels: ptr.To(false),
-			Scheme:      ptr.To("HTTPS"),
+			Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 			Params: map[string][]string{
 				"module": {moduleName},
 				"target": {"https://kubernetes.default.svc.cluster.local/healthz"},

--- a/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster/scrapeconfig_test.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/shoot/cluster/scrapeconfig_test.go
@@ -30,7 +30,7 @@ var _ = Describe("ScrapeConfig", func() {
 					},
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
 						HonorLabels: ptr.To(false),
-						Scheme:      ptr.To("HTTPS"),
+						Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 						Params: map[string][]string{
 							"module": {"http_kubernetes_service"},
 							"target": {"https://kubernetes.default.svc.cluster.local/healthz"},

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -56,7 +56,7 @@ var _ = Describe("NodeExporter", func() {
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
 				HonorLabels: ptr.To(false),
-				Scheme:      ptr.To("HTTPS"),
+				Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 				TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs.go
@@ -104,7 +104,7 @@ func newScrapeConfigForFederation(federation federationConfig) *monitoringv1alph
 	}
 
 	if federation.isIngress {
-		config.Spec.Scheme = ptr.To("HTTPS")
+		config.Spec.Scheme = ptr.To(monitoringv1.SchemeHTTPS)
 		config.Spec.TLSConfig = &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}
 		config.Spec.BasicAuth = &monitoringv1.BasicAuth{
 			Username: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: federation.secret.Name}, Key: secretsutils.DataKeyUserName},

--- a/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/scrapeconfigs_test.go
@@ -141,7 +141,7 @@ metric_relabel_configs:
 							HonorLabels:     ptr.To(true),
 							HonorTimestamps: ptr.To(false),
 							MetricsPath:     ptr.To("/federate"),
-							Scheme:          ptr.To("HTTPS"),
+							Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
 							Params: map[string][]string{
 								"match[]": {
 									`{__name__=~"seed:(.+):count"}`,

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -492,7 +492,7 @@ honor_labels: true`
 				Labels:    map[string]string{"foo": "bar"},
 			},
 			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				Scheme: ptr.To("baz"),
+				Scheme: ptr.To(monitoringv1.SchemeHTTPS),
 			},
 		}
 		additionalConfigMap = &corev1.ConfigMap{

--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
@@ -67,7 +67,7 @@ func CentralPodMonitors() []*monitoringv1.PodMonitor {
 				// 	{Key: "prometheus.io/port", Operator: metav1.LabelSelectorOpExists},
 				// }},
 				PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
-					Scheme:     "https",
+					Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 					HTTPConfig: monitoringv1.HTTPConfig{TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 					RelabelConfigs: []monitoringv1.RelabelConfig{
 						// TODO: These annotations should actually be labels so that PodMonitorSpec.Selector can be used

--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
@@ -62,7 +62,7 @@ var _ = Describe("PodMonitors", func() {
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
-							Scheme:     "https",
+							Scheme:     ptr.To(monitoringv1.SchemeHTTPS),
 							HTTPConfig: monitoringv1.HTTPConfig{TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)}},
 							RelabelConfigs: []monitoringv1.RelabelConfig{
 								{

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -199,7 +199,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 				Spec: monitoringv1alpha1.ScrapeConfigSpec{
 					HonorLabels:     ptr.To(false),
 					HonorTimestamps: ptr.To(false),
-					Scheme:          ptr.To("HTTPS"),
+					Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
 						Key:                  resourcesv1alpha1.DataKeyToken,
@@ -319,7 +319,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 				},
 				Spec: monitoringv1alpha1.ScrapeConfigSpec{
 					HonorLabels: ptr.To(false),
-					Scheme:      ptr.To("HTTPS"),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
 						Key:                  resourcesv1alpha1.DataKeyToken,
@@ -402,7 +402,7 @@ func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bo
 				},
 				Spec: monitoringv1alpha1.ScrapeConfigSpec{
 					HonorLabels: ptr.To(false),
-					Scheme:      ptr.To("HTTPS"),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
 						Key:                  resourcesv1alpha1.DataKeyToken,

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -180,7 +180,7 @@ var _ = Describe("ScrapeConfigs", func() {
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
 						HonorLabels:     ptr.To(false),
 						HonorTimestamps: ptr.To(false),
-						Scheme:          ptr.To("HTTPS"),
+						Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
 						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 							Key:                  "token",
@@ -286,7 +286,7 @@ var _ = Describe("ScrapeConfigs", func() {
 					},
 					Spec: monitoringv1alpha1.ScrapeConfigSpec{
 						HonorLabels: ptr.To(false),
-						Scheme:      ptr.To("HTTPS"),
+						Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 							Key:                  "token",
@@ -380,7 +380,7 @@ var _ = Describe("ScrapeConfigs", func() {
 						},
 						Spec: monitoringv1alpha1.ScrapeConfigSpec{
 							HonorLabels: ptr.To(false),
-							Scheme:      ptr.To("HTTPS"),
+							Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 								Key:                  "token",

--- a/pkg/component/observability/monitoring/prometheus/shoot/utils.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/utils.go
@@ -62,7 +62,7 @@ func ClusterComponentScrapeConfigSpec(jobName string, sdConfig KubernetesService
 
 	return monitoringv1alpha1.ScrapeConfigSpec{
 		HonorLabels: ptr.To(false),
-		Scheme:      ptr.To("HTTPS"),
+		Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 		// This is needed because we do not fetch the correct cluster CA bundle right now
 		TLSConfig: &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 		Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{

--- a/pkg/component/observability/monitoring/prometheus/shoot/utils_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/utils_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Utils", func() {
 					metric1, metric2,
 				)).To(Equal(monitoringv1alpha1.ScrapeConfigSpec{
 					HonorLabels: ptr.To(false),
-					Scheme:      ptr.To("HTTPS"),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
@@ -127,7 +127,7 @@ var _ = Describe("Utils", func() {
 					metric1, metric2,
 				)).To(Equal(monitoringv1alpha1.ScrapeConfigSpec{
 					HonorLabels: ptr.To(false),
-					Scheme:      ptr.To("HTTPS"),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
 					TLSConfig:   &monitoringv1.SafeTLSConfig{InsecureSkipVerify: ptr.To(true)},
 					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This fixes the prometheus-operator upgrade to v0.87.0:

- https://github.com/gardener/gardener/pull/13512

by adapting the `Scheme` field in Prometheus-related resources to new type.

**Special notes for your reviewer**:

/cc @istvanballok @marc1404 

**Release note**:

```other operator
NONE
```
