### PR TITLE
Enhance validation for `operator.gardener.cloud/v1alpha1.Extension`

### DIFF
--- a/pkg/apis/operator/v1alpha1/validation/extension.go
+++ b/pkg/apis/operator/v1alpha1/validation/extension.go
@@ -68,6 +68,10 @@ func validateAdmissionDeployment(deployment *operatorv1alpha1.AdmissionDeploymen
 		return allErrs
 	}
 
+	if deployment.RuntimeCluster == nil && deployment.VirtualCluster == nil {
+		return append(allErrs, field.Required(fldPath, "at least one of runtimeCluster or virtualCluster must be specified"))
+	}
+
 	if deployment.RuntimeCluster != nil {
 		allErrs = append(allErrs, validateHelmDeployment(deployment.RuntimeCluster.Helm, fldPath.Child("runtimeCluster", "helm"))...)
 	}

--- a/pkg/apis/operator/v1alpha1/validation/extension_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/extension_test.go
@@ -18,288 +18,50 @@ import (
 )
 
 var _ = Describe("Validation Tests", func() {
-	Describe("#ValidateExtension", func() {
-		var extension *operatorv1alpha1.Extension
+	var extension *operatorv1alpha1.Extension
 
-		BeforeEach(func() {
-			extension = &operatorv1alpha1.Extension{
-				Spec: operatorv1alpha1.ExtensionSpec{
-					Deployment: &operatorv1alpha1.Deployment{
-						ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
-							DeploymentSpec: operatorv1alpha1.DeploymentSpec{
-								Helm: &operatorv1alpha1.ExtensionHelm{
-									OCIRepository: &gardencorev1.OCIRepository{
-										Ref: ptr.To("example.com/chart:v1.0.0"),
-									},
+	BeforeEach(func() {
+		extension = &operatorv1alpha1.Extension{
+			Spec: operatorv1alpha1.ExtensionSpec{
+				Deployment: &operatorv1alpha1.Deployment{
+					ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+						DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+							Helm: &operatorv1alpha1.ExtensionHelm{
+								OCIRepository: &gardencorev1.OCIRepository{
+									Ref: ptr.To("example.com/chart:v1.0.0"),
 								},
 							},
 						},
 					},
-					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: "Extension", Type: "type-a"},
-					},
 				},
-			}
-		})
+				Resources: []gardencorev1beta1.ControllerResource{
+					{Kind: "Extension", Type: "type-a"},
+				},
+			},
+		}
+	})
 
-		It("should return no errors for basic extension", func() {
-			Expect(ValidateExtension(extension)).To(BeEmpty())
-		})
-
-		It("should return an error when deployment is nil", func() {
-			extension.Spec.Deployment = nil
-
-			Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.deployment"),
-			}))))
-		})
-
-		It("should return an error when neither extension nor admission deployment is specified", func() {
-			extension.Spec.Deployment.ExtensionDeployment = nil
-			extension.Spec.Deployment.AdmissionDeployment = nil
-
-			Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.deployment"),
-			}))))
-		})
-
-		Context("Extension Deployment", func() {
-			It("should return no errors when extension deployment is nil", func() {
-				extension.Spec.Deployment.ExtensionDeployment = nil
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{
-								Ref: ptr.To("example.com/admission:v1.0.0"),
-							},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-
-			It("should return an error when extension deployment has no helm config", func() {
-				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.extension.helm"),
-				}))))
-			})
-
-			It("should return an error when admission runtime deployment has no helm config", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{},
-				}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.admission.runtimeCluster.helm"),
-				}))))
-			})
-
-			It("should return an error when admission virtual deployment has no helm config", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					VirtualCluster: &operatorv1alpha1.DeploymentSpec{},
-				}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.admission.virtualCluster.helm"),
-				}))))
-			})
-
-			It("should return an error when extension deployment helm has invalid OCI repository", func() {
-				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
-					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.extension.helm.ociRepository"),
-				}))))
-			})
-
-			It("should return no errors when extension deployment helm has valid OCI repository with ref", func() {
-				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
-					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{
-								Ref: ptr.To("example.com/chart:v1.0.0"),
-							},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-
-			It("should return no errors when extension deployment helm has valid OCI repository with repository and tag", func() {
-				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
-					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{
-								Repository: ptr.To("example.com/chart"),
-								Tag:        ptr.To("v1.0.0"),
-							},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-		})
-
-		Context("Admission Deployment", func() {
-			It("should return no errors when admission deployment is nil", func() {
-				extension.Spec.Deployment.AdmissionDeployment = nil
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-
-			It("should return an error when runtime or virtual cluster deployment is nil", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.admission"),
-				}))))
-			})
-
-			It("should return an error when admission runtime cluster has invalid OCI repository", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
-				}))))
-			})
-
-			It("should return no errors when admission runtime cluster has valid OCI repository", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{
-								Ref: ptr.To("example.com/admission:v1.0.0"),
-							},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-
-			It("should return an error when admission virtual cluster has invalid OCI repository", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
-				}))))
-			})
-
-			It("should return no errors when admission virtual cluster has valid OCI repository", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{
-								Repository: ptr.To("example.com/admission"),
-								Digest:     ptr.To("sha256:abc123"),
-							},
-						},
-					},
-				}
-
-				Expect(ValidateExtension(extension)).To(BeEmpty())
-			})
-
-			It("should return errors when both runtime and virtual clusters have invalid OCI repositories", func() {
-				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
-					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{},
-						},
-					},
-					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
-						Helm: &operatorv1alpha1.ExtensionHelm{
-							OCIRepository: &gardencorev1.OCIRepository{},
-						},
-					},
-				}
-
-				errs := ValidateExtension(extension)
-				Expect(errs).To(HaveLen(2))
-				Expect(errs).To(ContainElements(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
-					})),
-				))
-			})
-		})
+	Describe("#ValidateExtension", func() {
+		validateExtensionTests(
+			func() field.ErrorList {
+				return ValidateExtension(extension)
+			},
+			func() *operatorv1alpha1.Extension {
+				return extension
+			},
+		)
 	})
 
 	Describe("#ValidateExtensionUpdate", func() {
-		var extension *operatorv1alpha1.Extension
-
-		BeforeEach(func() {
-			extension = &operatorv1alpha1.Extension{
-				Spec: operatorv1alpha1.ExtensionSpec{
-					Deployment: &operatorv1alpha1.Deployment{},
-				},
-			}
-		})
-
-		It("should return no errors for basic extension", func() {
-			newExtension := extension.DeepCopy()
-			newExtension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
-				DeploymentSpec: operatorv1alpha1.DeploymentSpec{
-					Helm: &operatorv1alpha1.ExtensionHelm{
-						OCIRepository: &gardencorev1.OCIRepository{
-							Ref: ptr.To("example.com/chart:v1.0.0"),
-						},
-					},
-				},
-			}
-
-			newExtension.Spec.Resources = []gardencorev1beta1.ControllerResource{
-				{Kind: "Extension", Type: "type-a"},
-			}
-
-			Expect(ValidateExtensionUpdate(extension, newExtension)).To(BeEmpty())
-		})
-
-		It("should return an error when extension is nil", func() {
-			extension.Spec.Deployment = nil
-
-			Expect(ValidateExtensionUpdate(extension, extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.deployment"),
-			}))))
-		})
+		// Check basic extension validation is executed during update as well
+		validateExtensionTests(
+			func() field.ErrorList {
+				return ValidateExtensionUpdate(extension, extension)
+			},
+			func() *operatorv1alpha1.Extension {
+				return extension
+			},
+		)
 
 		Context("Extension Deployment", func() {
 			It("should return an error when extension deployment helm has invalid OCI repository", func() {
@@ -379,3 +141,224 @@ var _ = Describe("Validation Tests", func() {
 		})
 	})
 })
+
+func validateExtensionTests(test func() field.ErrorList, extension func() *operatorv1alpha1.Extension) {
+	It("should return no errors for basic extension", func() {
+		Expect(test()).To(BeEmpty())
+	})
+
+	It("should return an error when deployment is nil", func() {
+		extension().Spec.Deployment = nil
+
+		Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":  Equal(field.ErrorTypeRequired),
+			"Field": Equal("spec.deployment"),
+		}))))
+	})
+
+	It("should return an error when neither extension nor admission deployment is specified", func() {
+		extension().Spec.Deployment.ExtensionDeployment = nil
+		extension().Spec.Deployment.AdmissionDeployment = nil
+
+		Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":  Equal(field.ErrorTypeRequired),
+			"Field": Equal("spec.deployment"),
+		}))))
+	})
+
+	Context("Extension Deployment", func() {
+		It("should return no errors when extension deployment is nil", func() {
+			extension().Spec.Deployment.ExtensionDeployment = nil
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Ref: ptr.To("example.com/admission:v1.0.0"),
+						},
+					},
+				},
+			}
+
+			Expect(test()).To(BeEmpty())
+		})
+
+		It("should return an error when extension deployment has no helm config", func() {
+			extension().Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.extension.helm"),
+			}))))
+		})
+
+		It("should return an error when admission runtime deployment has no helm config", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				RuntimeCluster: &operatorv1alpha1.DeploymentSpec{},
+			}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.admission.runtimeCluster.helm"),
+			}))))
+		})
+
+		It("should return an error when admission virtual deployment has no helm config", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				VirtualCluster: &operatorv1alpha1.DeploymentSpec{},
+			}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.admission.virtualCluster.helm"),
+			}))))
+		})
+
+		It("should return an error when extension deployment helm has invalid OCI repository", func() {
+			extension().Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+				DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{},
+					},
+				},
+			}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.extension.helm.ociRepository"),
+			}))))
+		})
+
+		It("should return no errors when extension deployment helm has valid OCI repository with ref", func() {
+			extension().Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+				DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Ref: ptr.To("example.com/chart:v1.0.0"),
+						},
+					},
+				},
+			}
+
+			Expect(test()).To(BeEmpty())
+		})
+
+		It("should return no errors when extension deployment helm has valid OCI repository with repository and tag", func() {
+			extension().Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+				DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Repository: ptr.To("example.com/chart"),
+							Tag:        ptr.To("v1.0.0"),
+						},
+					},
+				},
+			}
+
+			Expect(test()).To(BeEmpty())
+		})
+	})
+
+	Context("Admission Deployment", func() {
+		It("should return no errors when admission deployment is nil", func() {
+			extension().Spec.Deployment.AdmissionDeployment = nil
+
+			Expect(test()).To(BeEmpty())
+		})
+
+		It("should return an error when runtime or virtual cluster deployment is nil", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.admission"),
+			}))))
+		})
+
+		It("should return an error when admission runtime cluster has invalid OCI repository", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{},
+					},
+				},
+			}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
+			}))))
+		})
+
+		It("should return no errors when admission runtime cluster has valid OCI repository", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Ref: ptr.To("example.com/admission:v1.0.0"),
+						},
+					},
+				},
+			}
+
+			Expect(test()).To(BeEmpty())
+		})
+
+		It("should return an error when admission virtual cluster has invalid OCI repository", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{},
+					},
+				},
+			}
+
+			Expect(test()).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
+			}))))
+		})
+
+		It("should return no errors when admission virtual cluster has valid OCI repository", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Repository: ptr.To("example.com/admission"),
+							Digest:     ptr.To("sha256:abc123"),
+						},
+					},
+				},
+			}
+
+			Expect(test()).To(BeEmpty())
+		})
+
+		It("should return errors when both runtime and virtual clusters have invalid OCI repositories", func() {
+			extension().Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+				RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{},
+					},
+				},
+				VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{},
+					},
+				},
+			}
+
+			errs := test()
+			Expect(errs).To(HaveLen(2))
+			Expect(errs).To(ContainElements(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
+				})),
+			))
+		})
+	})
+}

--- a/pkg/apis/operator/v1alpha1/validation/extension_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/extension_test.go
@@ -12,16 +12,297 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
 var _ = Describe("Validation Tests", func() {
-	Describe("#ValidateExtensionUpdate", func() {
-		var (
-			extension *operatorv1alpha1.Extension
+	Describe("#ValidateExtension", func() {
+		var extension *operatorv1alpha1.Extension
 
-			test = func(oldPrimary, newPrimary *bool, matcher gomegatypes.GomegaMatcher) {
+		BeforeEach(func() {
+			extension = &operatorv1alpha1.Extension{
+				Spec: operatorv1alpha1.ExtensionSpec{
+					Deployment: &operatorv1alpha1.Deployment{
+						ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+							DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+								Helm: &operatorv1alpha1.ExtensionHelm{
+									OCIRepository: &gardencorev1.OCIRepository{
+										Ref: ptr.To("example.com/chart:v1.0.0"),
+									},
+								},
+							},
+						},
+					},
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "Extension", Type: "type-a"},
+					},
+				},
+			}
+		})
+
+		It("should return no errors for basic extension", func() {
+			Expect(ValidateExtension(extension)).To(BeEmpty())
+		})
+
+		It("should return an error when deployment is nil", func() {
+			extension.Spec.Deployment = nil
+
+			Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment"),
+			}))))
+		})
+
+		It("should return an error when neither extension nor admission deployment is specified", func() {
+			extension.Spec.Deployment.ExtensionDeployment = nil
+			extension.Spec.Deployment.AdmissionDeployment = nil
+
+			Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment"),
+			}))))
+		})
+
+		Context("Extension Deployment", func() {
+			It("should return no errors when extension deployment is nil", func() {
+				extension.Spec.Deployment.ExtensionDeployment = nil
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{}
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+
+			It("should return an error when extension deployment has no helm config", func() {
+				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.extension.helm"),
+				}))))
+			})
+
+			It("should return an error when admission runtime deployment has no helm config", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{},
+				}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.runtimeCluster.helm"),
+				}))))
+			})
+
+			It("should return an error when admission virtual deployment has no helm config", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					VirtualCluster: &operatorv1alpha1.DeploymentSpec{},
+				}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.virtualCluster.helm"),
+				}))))
+			})
+
+			It("should return an error when extension deployment helm has invalid OCI repository", func() {
+				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.extension.helm.ociRepository"),
+				}))))
+			})
+
+			It("should return no errors when extension deployment helm has valid OCI repository with ref", func() {
+				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{
+								Ref: ptr.To("example.com/chart:v1.0.0"),
+							},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+
+			It("should return no errors when extension deployment helm has valid OCI repository with repository and tag", func() {
+				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{
+								Repository: ptr.To("example.com/chart"),
+								Tag:        ptr.To("v1.0.0"),
+							},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+		})
+
+		Context("Admission Deployment", func() {
+			It("should return no errors when admission deployment is nil", func() {
+				extension.Spec.Deployment.AdmissionDeployment = nil
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+
+			It("should return an error when admission runtime cluster has invalid OCI repository", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
+				}))))
+			})
+
+			It("should return no errors when admission runtime cluster has valid OCI repository", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{
+								Ref: ptr.To("example.com/admission:v1.0.0"),
+							},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+
+			It("should return an error when admission virtual cluster has invalid OCI repository", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
+				}))))
+			})
+
+			It("should return no errors when admission virtual cluster has valid OCI repository", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{
+								Repository: ptr.To("example.com/admission"),
+								Digest:     ptr.To("sha256:abc123"),
+							},
+						},
+					},
+				}
+
+				Expect(ValidateExtension(extension)).To(BeEmpty())
+			})
+
+			It("should return errors when both runtime and virtual clusters have invalid OCI repositories", func() {
+				extension.Spec.Deployment.AdmissionDeployment = &operatorv1alpha1.AdmissionDeploymentSpec{
+					RuntimeCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+					VirtualCluster: &operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+				}
+
+				errs := ValidateExtension(extension)
+				Expect(errs).To(HaveLen(2))
+				Expect(errs).To(ContainElements(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.deployment.admission.runtimeCluster.helm.ociRepository"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.deployment.admission.virtualCluster.helm.ociRepository"),
+					})),
+				))
+			})
+		})
+	})
+
+	Describe("#ValidateExtensionUpdate", func() {
+		var extension *operatorv1alpha1.Extension
+
+		BeforeEach(func() {
+			extension = &operatorv1alpha1.Extension{
+				Spec: operatorv1alpha1.ExtensionSpec{
+					Deployment: &operatorv1alpha1.Deployment{},
+				},
+			}
+		})
+
+		It("should return no errors for basic extension", func() {
+			newExtension := extension.DeepCopy()
+			newExtension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+				DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+					Helm: &operatorv1alpha1.ExtensionHelm{
+						OCIRepository: &gardencorev1.OCIRepository{
+							Ref: ptr.To("example.com/chart:v1.0.0"),
+						},
+					},
+				},
+			}
+
+			newExtension.Spec.Resources = []gardencorev1beta1.ControllerResource{
+				{Kind: "Extension", Type: "type-a"},
+			}
+
+			Expect(ValidateExtensionUpdate(extension, newExtension)).To(BeEmpty())
+		})
+
+		It("should return an error when extension is nil", func() {
+			extension.Spec.Deployment = nil
+
+			Expect(ValidateExtensionUpdate(extension, extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.deployment"),
+			}))))
+		})
+
+		Context("Extension Deployment", func() {
+			It("should return an error when extension deployment helm has invalid OCI repository", func() {
+				extension.Spec.Deployment.ExtensionDeployment = &operatorv1alpha1.ExtensionDeploymentSpec{
+					DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+						Helm: &operatorv1alpha1.ExtensionHelm{
+							OCIRepository: &gardencorev1.OCIRepository{},
+						},
+					},
+				}
+
+				Expect(ValidateExtensionUpdate(extension, extension)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.deployment.extension.helm.ociRepository"),
+				}))))
+			})
+		})
+
+		Context("Resources", func() {
+			test := func(oldPrimary, newPrimary *bool, matcher gomegatypes.GomegaMatcher) {
 				GinkgoHelper()
 
 				newExtension := extension.DeepCopy()
@@ -30,45 +311,54 @@ var _ = Describe("Validation Tests", func() {
 
 				Expect(ValidateExtensionUpdate(extension, newExtension)).To(matcher)
 			}
-		)
 
-		BeforeEach(func() {
-			extension = &operatorv1alpha1.Extension{
-				Spec: operatorv1alpha1.ExtensionSpec{
-					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: "kind-a", Type: "type-a"},
+			BeforeEach(func() {
+				extension.Spec = operatorv1alpha1.ExtensionSpec{
+					Deployment: &operatorv1alpha1.Deployment{
+						ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+							DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+								Helm: &operatorv1alpha1.ExtensionHelm{
+									OCIRepository: &gardencorev1.OCIRepository{
+										Ref: ptr.To("example.com/chart:v1.0.0"),
+									},
+								},
+							},
+						},
 					},
-				},
-			}
-		})
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "Extension", Type: "type-a"},
+					},
+				}
+			})
 
-		It("should return no errors when field is unchanged", func() {
-			test(ptr.To(true), ptr.To(true), BeEmpty())
-		})
+			It("should return no errors when field is unchanged", func() {
+				test(ptr.To(true), ptr.To(true), BeEmpty())
+			})
 
-		It("should return no errors when field is set from nil to true", func() {
-			test(nil, ptr.To(true), BeEmpty())
-		})
+			It("should return no errors when field is set from nil to true", func() {
+				test(nil, ptr.To(true), BeEmpty())
+			})
 
-		It("should return an error because the primary field is changed to false", func() {
-			test(ptr.To(true), ptr.To(false), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.resources[0].primary"),
-			}))))
-		})
+			It("should return an error because the primary field is changed to false", func() {
+				test(ptr.To(true), ptr.To(false), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.resources[0].primary"),
+				}))))
+			})
 
-		It("should return an error because the primary field is changed to nil", func() {
-			test(ptr.To(false), nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.resources[0].primary"),
-			}))))
-		})
+			It("should return an error because the primary field is changed to nil", func() {
+				test(ptr.To(false), nil, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.resources[0].primary"),
+				}))))
+			})
 
-		It("should return an error because the primary field is changed to true", func() {
-			test(ptr.To(false), ptr.To(true), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.resources[0].primary"),
-			}))))
+			It("should return an error because the primary field is changed to true", func() {
+				test(ptr.To(false), ptr.To(true), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.resources[0].primary"),
+				}))))
+			})
 		})
 	})
 })

--- a/pkg/operator/webhook/validation/extension/handler_test.go
+++ b/pkg/operator/webhook/validation/extension/handler_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	. "github.com/gardener/gardener/pkg/operator/webhook/validation/extension"
@@ -35,6 +36,18 @@ var _ = Describe("Handler", func() {
 		}
 		extension = &operatorv1alpha1.Extension{
 			Spec: operatorv1alpha1.ExtensionSpec{
+				Deployment: &operatorv1alpha1.Deployment{
+					ExtensionDeployment: &operatorv1alpha1.ExtensionDeploymentSpec{
+						DeploymentSpec: operatorv1alpha1.DeploymentSpec{
+							Helm: &operatorv1alpha1.ExtensionHelm{
+								OCIRepository: &gardencorev1.OCIRepository{
+									Repository: ptr.To("example.com/repo"),
+									Tag:        ptr.To("v0.0.0"),
+								},
+							},
+						},
+					},
+				},
 				Resources: resources,
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR introduces several field validations for the `Extension` resource (group `operator.gardener.cloud`):
- At least an extension or admission deployment must be specified
- Ensures Helm configuration is available
- Checks the OCI Repository configuration

Previously, extensions with such a misconfiguration were already considered invalid, but error messages only appeared later in the deployment flow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Thanks for the feedback @benedikt-haug

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Several fields and configurations of `operator.gardener.cloud/v1alpha1.Extension` resources are now validated:
- At least an extension or admission deployment must be specified (`spec.deployment.{extension,admission}`)
- A Helm deployment configuration must be in place (`spec.deployment.extension.helm` or `spec.deployment.admission.{runtimeCluster,virtualCluster}.helm`)
- A valid OCI repository configuration is required (`helm.ociRepository`)

Please check your `Extension` resources and rectify them accordingly, before upgrading to this version.
```
