### PR TITLE
[GEP-26] Promote ShootCredentialsBinding feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -21,8 +21,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | Feature                                  | Default | Stage   | Since   | Until   |
 |------------------------------------------|---------|---------|---------|---------|
 | DefaultSeccompProfile                    | `false` | `Alpha` | `1.54`  |         |
-| ShootCredentialsBinding                  | `false` | `Alpha` | `1.98`  | `1.106` |
-| ShootCredentialsBinding                  | `true`  | `Beta`  | `1.107` |         |
 | NewWorkerPoolHash                        | `false` | `Alpha` | `1.98`  | `1.125` |
 | NewWorkerPoolHash                        | `true`  | `Beta`  | `1.126` |         |
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
@@ -206,6 +204,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | CredentialsRotationWithoutWorkersRollout     | `true`  | `Beta`       | `1.121` | `1.126` |
 | CredentialsRotationWithoutWorkersRollout     | `true`  | `GA`         | `1.127` | `1.128` |
 | CredentialsRotationWithoutWorkersRollout     |         | `Removed`    | `1.129` |         |
+| ShootCredentialsBinding                      | `false` | `Alpha`      | `1.98`  | `1.106` |
+| ShootCredentialsBinding                      | `true`  | `Beta`       | `1.107` | `1.132` |
+| ShootCredentialsBinding                      | `true`  | `GA`         | `1.133` |         |
 
 ## Using a Feature
 

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/core/shoot"
@@ -31,7 +30,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -62,10 +60,6 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	newShoot.Status = core.ShootStatus{}
 
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
-
-	if !utilfeature.DefaultFeatureGate.Enabled(features.ShootCredentialsBinding) {
-		newShoot.Spec.CredentialsBindingName = nil
-	}
 }
 
 func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
@@ -87,10 +81,6 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	}
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
-
-	if oldShoot.Spec.CredentialsBindingName == nil && !utilfeature.DefaultFeatureGate.Enabled(features.ShootCredentialsBinding) {
-		newShoot.Spec.CredentialsBindingName = nil
-	}
 
 	// Ensure that encrypted resources are synced from `.status.encryptedResources` to `status.credentials.encryptionAtRest.resources`.
 	SyncEncryptedResourcesStatus(newShoot)

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/apiserver/registry/core/shoot"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Strategy", func() {
@@ -126,24 +124,6 @@ var _ = Describe("Strategy", func() {
 					Name: "bar",
 				}))
 			})
-
-			It("should remove CredentialsBindingName field if ShootCredentialsBinding feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, false))
-
-				shoot.Spec.CredentialsBindingName = ptr.To("binding")
-				strategy.PrepareForCreate(ctx, shoot)
-
-				Expect(shoot.Spec.CredentialsBindingName).To(BeNil())
-			})
-
-			It("should not remove CredentialsBindingName field if ShootCredentialsBinding feature gate is enabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, true))
-
-				shoot.Spec.CredentialsBindingName = ptr.To("binding")
-				strategy.PrepareForCreate(ctx, shoot)
-
-				Expect(shoot.Spec.CredentialsBindingName).To(Equal(ptr.To("binding")))
-			})
 		})
 	})
 
@@ -212,35 +192,6 @@ var _ = Describe("Strategy", func() {
 					Kind: "NamespacedCloudProfile",
 					Name: "bar",
 				}))
-			})
-
-			It("should remove CredentialsBindingName field if ShootCredentialsBinding feature gate is disabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, false))
-
-				newShoot.Spec.CredentialsBindingName = ptr.To("binding")
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Spec.CredentialsBindingName).To(BeNil())
-			})
-
-			It("should not remove CredentialsBindingName field if ShootCredentialsBinding feature gate is enabled", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, true))
-
-				newShoot.Spec.CredentialsBindingName = ptr.To("binding")
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Spec.CredentialsBindingName).To(Equal(ptr.To("binding")))
-			})
-
-			It("should not remove CredentialsBindingName field if ShootCredentialsBinding feature gate is disabled but the CredentialsBindingName field is present in the old Shoot", func() {
-				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, false))
-
-				bindingName := ptr.To("binding")
-				oldShoot.Spec.CredentialsBindingName = bindingName
-				newShoot.Spec.CredentialsBindingName = bindingName
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Spec.CredentialsBindingName).To(Equal(ptr.To("binding")))
 			})
 
 			It("should not mutate shoots being deleted (cloud profile sync)", func() {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -26,6 +26,7 @@ const (
 	// owner: @vpnachev @dimityrmirchev
 	// alpha: v1.98.0
 	// beta: v1.107.0
+	// GA: v1.133.0
 	ShootCredentialsBinding featuregate.Feature = "ShootCredentialsBinding"
 
 	// NewWorkerPoolHash enables a new calculation method for the worker pool hash. The new
@@ -113,7 +114,7 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:         {Default: false, PreRelease: featuregate.Alpha},
-	ShootCredentialsBinding:       {Default: true, PreRelease: featuregate.Beta},
+	ShootCredentialsBinding:       {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	NewWorkerPoolHash:             {Default: true, PreRelease: featuregate.Beta},
 	InPlaceNodeUpdates:            {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:           {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
+++ b/test/integration/controllermanager/credentialsbinding/credentialsbinding_test.go
@@ -14,9 +14,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -32,7 +30,6 @@ var _ = Describe("CredentialsBinding controller test", func() {
 	)
 
 	BeforeEach(func() {
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.ShootCredentialsBinding, true))
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testID + "-" + utils.ComputeSHA256Hex([]byte(testNamespace.Name + CurrentSpecReport().LeafNodeLocation.String()))[:8],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality security
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `ShootCredentialsBinding` feature gate of `gardenlet` is promoted to GA and is unconditionally enabled.
```
