### PR TITLE
Switch to `raw` format for logs when sending to `Vali`

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -382,7 +382,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								},
 								map[string]any{
 									"key":    "loki.format",
-									"value":  "logfmt",
+									"value":  "raw",
 									"action": "insert",
 								},
 							},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -345,7 +345,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									},
 									map[string]any{
 										"key":    "loki.format",
-										"value":  "logfmt",
+										"value":  "raw",
 										"action": "insert",
 									},
 								},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
The log format for `Vali` needs to be raw so that `Plutono` can detect fields in the labels.
Previously, the collector would format the logs as `logfmt` but put all of the values in a `msg` field so Plutono would only detect it.

The raw format allows `Plutono` to detect fields without the detector interfering with changes.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue where `Plutono` would not detect all fields when the `OpenTelemetryCollector` feature gate is enabled is now fixed.
```
