### PR TITLE
Mention migration to CredentialsBinding in K8s upgrade to 1.34 guide

### DIFF
--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -12,6 +12,7 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 ## Upgrading to Kubernetes `v1.34`
 
 - The `Shoot`'s `.spec.cloudProfileName` field is forbidden. `Shoot` owners must migrate their `CloudProfile` reference to the new `spec.cloudProfile.name` field.
+- The `Shoot`'s `.spec.secretBindingName` field is forbidden. `Shoot` owners must migrate their `SecretBinding` references to `CredentialsBinding` and use the new `.spec.credentialsBindingName` field. For more information, see the [SecretBinding to CredentialsBinding migration guide](../shoot-operations/secretbinding-to-credentialsbinding-migration.md).
 - The `Shoot`'s operation annotations `rotate-etcd-encryption-key-(start|complete)` are forbidden. `Shoot` owners must use the `rotate-etcd-encryption-key` operation annotation instead, which performs a complete etcd encryption key rotation. `Shoot` clusters with an ongoing etcd encryption key rotation that is currently in the `Prepared` phase will move forward to the `Completing` phase.
 
 ## Upgrading to Kubernetes `v1.33`


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
I missed to update this document with https://github.com/gardener/gardener/pull/12804.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
