### PR TITLE
Introduce `--use-bootstrap-etcd` flag for `gardenadm init`

### DIFF
--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -20,8 +20,9 @@ gardenadm init --config-dir /path/to/manifests
 ### Options
 
 ```
-  -d, --config-dir string   Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-  -h, --help                help for init
+  -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+  -h, --help                 help for init
+      --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This is useful for testing purposes to save time.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -260,13 +260,13 @@ func run(ctx context.Context, opts *Options) error {
 		reconcileBackupBucket = g.Add(flow.Task{
 			Name:         "Deploying BackupBucket for ETCD data",
 			Fn:           b.ReconcileBackupBucket,
-			SkipIf:       !allowBackup,
+			SkipIf:       !allowBackup || opts.UseBootstrapEtcd,
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
 		})
 		reconcileBackupEntry = g.Add(flow.Task{
 			Name:         "Deploying BackupEntry for ETCD data",
 			Fn:           b.ReconcileBackupEntry,
-			SkipIf:       !allowBackup,
+			SkipIf:       !allowBackup || opts.UseBootstrapEtcd,
 			Dependencies: flow.NewTaskIDs(reconcileBackupBucket),
 		})
 		deployControlPlane = g.Add(flow.Task{

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -287,11 +287,13 @@ func run(ctx context.Context, opts *Options) error {
 		deployEtcds = g.Add(flow.Task{
 			Name:         "Deploying main and events ETCDs",
 			Fn:           b.DeployEtcd,
+			SkipIf:       opts.UseBootstrapEtcd,
 			Dependencies: flow.NewTaskIDs(deployEtcdDruid, reconcileBackupEntry),
 		})
 		waitUntilEtcdsReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event ETCDs have been reconciled",
 			Fn:           b.WaitUntilEtcdsReconciled,
+			SkipIf:       opts.UseBootstrapEtcd,
 			Dependencies: flow.NewTaskIDs(deployEtcds),
 		})
 		deployControlPlaneDeployments = g.Add(flow.Task{
@@ -307,6 +309,7 @@ func run(ctx context.Context, opts *Options) error {
 		_ = g.Add(flow.Task{
 			Name:         "Finalizing ETCD bootstrap transition (cleanup bootstrap ETCD left-overs)",
 			Fn:           b.FinalizeEtcdBootstrapTransition,
+			SkipIf:       opts.UseBootstrapEtcd,
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneDeploymentsReady),
 		})
 		finalizeGardenerNodeAgentBootstrapping = g.Add(flow.Task{

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -14,6 +14,8 @@ import (
 type Options struct {
 	*cmd.Options
 	cmd.ManifestOptions
+
+	UseBootstrapEtcd bool
 }
 
 // ParseArgs parses the arguments to the options.
@@ -33,4 +35,5 @@ func (o *Options) Complete() error {
 
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
+	fs.BoolVar(&o.UseBootstrapEtcd, "use-bootstrap-etcd", false, "If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This is useful for testing purposes to save time.")
 }

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	*cmd.Options
 	cmd.ManifestOptions
 
+	// UseBootstrapEtcd indicates whether to use the bootstrap etcd instead of transitioning to etcd-druid.
 	UseBootstrapEtcd bool
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Currently, when bootstrapping a control plane node using `gardenadm init` it starts by deploying a bootstrap etcd, deploys `etcd-druid`, and finally transitions from the bootstrap etcd to the druid-managed etcd. Naturally, all of this takes a bit of time.
When using self-hosted shoot clusters in testing or experimentation scenarios it might not be necessary to use a druid-managed etcd after all. This speeds up the time that `gardenadm init` takes as the control plane could continue to use the bootstrap etcd.

This PR introduces a new flag for `gardenadm init` called `--use-bootstrap-etcd`. When enabled it does not perform the transition between the different etcd instances (However, `etcd-druid` is still deployed to the control plane of the self-hosted shoot cluster). 

**Which issue(s) this PR fixes**:

Part of: https://github.com/gardener/gardener/issues/2906
Implemented as a part of the Gardener hackathon topic _"Use Self-Hosted Shoot Cluster for Single-Node End-to-End Tests"_.

**Special notes for your reviewer**:

/cc @timebertt @rfranzke 

ℹ️ @Honigeintopf

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
