### PR TITLE
Add deprecation notice for `SecretBinding`s

### DIFF
--- a/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
+++ b/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
@@ -8,7 +8,9 @@ With the introduction of the [`CredentialsBinding`](../../api-reference/security
 While `SecretBinding`s can only reference `Secret`s, `CredentialsBinding`s can also reference `WorkloadIdentity`s which provide an alternative authentication method.
 `WorkloadIdentity`s do not directly contain credentials but are rather a representation of the workload that is going to access the user's account.
 
-As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and have been deprecated as of [Kubernetes `v1.34`](../shoot/shoot_kubernetes_versions.md#upgrading-to-kubernetes-v134).
+As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and will be deprecated in the future.
+Shoots that use Kubernetes version `1.34` or later are forbidden to reference `SecretBinding`s.
+Please see the [upgrade to Kubernetes 1.34 specific requirements](../shoot/shoot_kubernetes_versions.md#upgrading-to-kubernetes-v134).
 This incurs the need for migration from `SecretBinding` to `CredentialsBinding` resources.
 
 > [!NOTE]

--- a/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
+++ b/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
@@ -8,7 +8,7 @@ With the introduction of the [`CredentialsBinding`](../../api-reference/security
 While `SecretBinding`s can only reference `Secret`s, `CredentialsBinding`s can also reference `WorkloadIdentity`s which provide an alternative authentication method.
 `WorkloadIdentity`s do not directly contain credentials but are rather a representation of the workload that is going to access the user's account.
 
-As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and will be deprecated in the future.
+As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and have been deprecated.
 Shoots that use Kubernetes version `1.34` or later are forbidden to reference `SecretBinding`s.
 Please see the [upgrade to Kubernetes 1.34 specific requirements](../shoot/shoot_kubernetes_versions.md#upgrading-to-kubernetes-v134).
 This incurs the need for migration from `SecretBinding` to `CredentialsBinding` resources.

--- a/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
+++ b/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md
@@ -8,7 +8,7 @@ With the introduction of the [`CredentialsBinding`](../../api-reference/security
 While `SecretBinding`s can only reference `Secret`s, `CredentialsBinding`s can also reference `WorkloadIdentity`s which provide an alternative authentication method.
 `WorkloadIdentity`s do not directly contain credentials but are rather a representation of the workload that is going to access the user's account.
 
-As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and will be deprecated in the future.
+As `CredentialsBinding`s cover the functionality of `SecretBinding`s, the latter are considered legacy and have been deprecated as of [Kubernetes `v1.34`](../shoot/shoot_kubernetes_versions.md#upgrading-to-kubernetes-v134).
 This incurs the need for migration from `SecretBinding` to `CredentialsBinding` resources.
 
 > [!NOTE]


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds a deprecation notice for `SecretBinding`, replaced by `CredentialsBinding` in Kubernetes v1.34.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
