### PR TITLE
[Don't review this if you care about mental health] local setup: Ensure load balancer IPs are not within kind network

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - --ingress-max-concurrent-reconciles={{ .Values.controllers.ingress.concurrentSyncs }}
         - --service-max-concurrent-reconciles={{ .Values.controllers.service.concurrentSyncs }}
         - --service-host-ip={{ .Values.controllers.service.hostIP }}
+        - --service-virtual-garden-ip={{ .Values.controllers.service.virtualGardenIP }}
         - --service-zone-0-ip={{ .Values.controllers.service.zone0IP }}
         - --service-zone-1-ip={{ .Values.controllers.service.zone1IP }}
         - --service-zone-2-ip={{ .Values.controllers.service.zone2IP }}

--- a/charts/gardener/provider-local/templates/networkpolicy.yaml
+++ b/charts/gardener/provider-local/templates/networkpolicy.yaml
@@ -13,9 +13,15 @@ spec:
       networking.gardener.cloud/to-kind-network: allowed
   egress:
   - to:
+    # kind network CIDR
     - ipBlock:
-        cidr: 172.18.0.0/16
+        cidr: 172.18.0.0/24
     - ipBlock:
         cidr: fd00:10::/64
+    # range for "load balancer" IPs (manually added to loopback interface on host)
+    - ipBlock:
+        cidr: 172.18.255.0/24
+    - ipBlock:
+        cidr: ::/120
   policyTypes:
   - Egress

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -35,6 +35,7 @@ controllers:
   service:
     concurrentSyncs: 5
     hostIP: "172.18.255.1"
+    virtualGardenIP: "172.18.255.3"
     zone0IP: "172.18.255.10"
     zone1IP: "172.18.255.11"
     zone2IP: "172.18.255.12"

--- a/dev-setup/extensions/provider-local/overlays/operator-dual/patch-dual.yaml
+++ b/dev-setup/extensions/provider-local/overlays/operator-dual/patch-dual.yaml
@@ -9,6 +9,7 @@ spec:
         controllers:
           service:
             hostIP: "::1"
+            virtualGardenIP: "::3"
             zone0IP: "::10"
             zone1IP: "::11"
             zone2IP: "::12"

--- a/dev-setup/extensions/provider-local/overlays/operator-ipv6/patch-ipv6.yaml
+++ b/dev-setup/extensions/provider-local/overlays/operator-ipv6/patch-ipv6.yaml
@@ -9,6 +9,7 @@ spec:
         controllers:
           service:
             hostIP: "::1"
+            virtualGardenIP: "::3"
             zone0IP: "::10"
             zone1IP: "::11"
             zone2IP: "::12"

--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -18,7 +18,7 @@ spec:
         kind: nginx
     networking:
       nodes:
-      - 172.18.0.0/16
+      - 172.18.0.0/24
       pods:
       # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
       - 10.1.0.0/16

--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -74,7 +74,7 @@ spec:
           controller:
             kind: nginx
         networks:
-          nodes: 172.18.0.0/16
+          nodes: 172.18.0.0/24
           # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
           pods: 10.1.0.0/16
           services: 10.2.0.0/16

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -491,7 +491,7 @@ spec:
             kind: nginx
           domain: ingress.local.seed.local.gardener.cloud
         networks:
-          nodes: 172.18.0.0/16
+          nodes: 172.18.0.0/24
           pods: 10.1.0.0/16
           services: 10.2.0.0/16
           shootDefaults:

--- a/docs/deployment/deploy_gardenlet_via_operator.md
+++ b/docs/deployment/deploy_gardenlet_via_operator.md
@@ -92,7 +92,7 @@ spec:
             kind: nginx
           domain: ingress.local.seed.local.gardener.cloud
         networks:
-          nodes: 172.18.0.0/16
+          nodes: 172.18.0.0/24
           pods: 10.1.0.0/16
           services: 10.2.0.0/16
           shootDefaults:

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -146,8 +146,8 @@ This only happens for shoot namespaces (`gardener.cloud/role=shoot` label) to ma
 #### `Service`
 
 This controller reconciles `Services` of type `LoadBalancer` in the local `Seed` cluster.
-Since the local Kubernetes clusters used as Seed clusters typically don't support such services, this controller sets the `.status.ingress.loadBalancer.ip[0]` to the IP of the host.
-It makes important LoadBalancer Services (e.g. `istio-ingress/istio-ingressgateway` and `shoot--*--*/bastion-*`) available to the host by setting `spec.ports[].nodePort` to well-known ports that are mapped to `hostPorts` in the kind cluster configuration.
+Since the local Kubernetes clusters used as Seed clusters typically don't support such services, this controller sets the `.status.ingress.loadBalancer.ip[0]` to magic `172.18.255.*` IP addresses that are added to the loopback interface of the host machine running the kind cluster.
+It makes LoadBalancer Services (e.g. `istio-ingressgateway` and `shoot--*--*/bastion-*`) available to the host by setting `spec.ports[].nodePort` to well-known ports that are mapped to `hostPorts` in the kind cluster configuration.
 
 `istio-ingress/istio-ingressgateway` is set to be exposed on `nodePort` `30433` by this controller.
 The bastion services are exposed on `nodePort` `30022`.

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -103,7 +103,7 @@ config:
         controller:
           kind: nginx
       networks:
-        nodes: 172.18.0.0/16
+        nodes: 172.18.0.0/24
         # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
         pods: 10.1.0.0/16
         services: 10.2.0.0/16

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -47,7 +47,7 @@ spec:
       ipFamilies:
       - IPv4
       nodes:
-      - 172.18.0.0/16
+      - 172.18.0.0/24
       pods:
       # Subnet for automatic pod IP assignment (calico default IPPool) in the kind cluster.
       - 10.1.0.0/16

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -98,7 +98,7 @@ function install_previous_release() {
   popd >/dev/null
 }
 
-# TODO(timebertt): Remove this after v1.133 has been released.
+# TODO(timebertt): Remove this after v1.134 has been released.
 # See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13549/pull-gardener-e2e-kind-upgrade/1993723553601556480
 # and https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/13549/pull-gardener-e2e-kind-upgrade/1993723553601556480/artifacts/gardener-local/gardener-local-control-plane/pods/garden_gardenlet-6c9469b889-68grv_ecd815cd-f5fb-4f8a-93e5-f07b97809d95/gardenlet/6.log
 function migrate_kind_network_range() {

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -93,8 +93,16 @@ function kind_down() {
 function install_previous_release() {
   pushd $GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE >/dev/null
   copy_kubeconfig_from_kubeconfig_env_var
+  migrate_kind_network_range
   gardener_up
   popd >/dev/null
+}
+
+# TODO(timebertt): Remove this after v1.133 has been released.
+# See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13549/pull-gardener-e2e-kind-upgrade/1993723553601556480
+# and https://gcsweb.prow.gardener.cloud/gcs/gardener-prow/pr-logs/pull/gardener_gardener/13549/pull-gardener-e2e-kind-upgrade/1993723553601556480/artifacts/gardener-local/gardener-local-control-plane/pods/garden_gardenlet-6c9469b889-68grv_ecd815cd-f5fb-4f8a-93e5-f07b97809d95/gardenlet/6.log
+function migrate_kind_network_range() {
+  sed -i 's|172.18.0.0/16|172.18.0.0/24|g' dev-setup/garden/base/garden.yaml dev-setup/gardenlet/base/gardenlet.yaml example/gardener-local/gardenlet/values.yaml
 }
 
 function upgrade_to_next_release() {
@@ -182,12 +190,12 @@ function run_post_upgrade_test() {
   make "$test_command" GARDENER_PREVIOUS_RELEASE="$GARDENER_PREVIOUS_RELEASE" GARDENER_NEXT_RELEASE="$GARDENER_NEXT_RELEASE"
 }
 
-# TODO(rfranzke): Remove this after v1.122 has been released.
+# TODO(rfranzke): Remove this after legacy helm-based dev setup has been dropped.
 if [[ "$SHOOT_FAILURE_TOLERANCE_TYPE" == "zone" ]] || [[ "$SHOOT_FAILURE_TOLERANCE_TYPE" == "node" ]]; then
   echo "WARNING: The Gardener upgrade tests for the zone/node failure tolerance types are not executed in this release because the dev/e2e test setup is currently reworked."
   echo "See https://github.com/gardener/gardener/issues/11958 for more information."
   echo "Skipping the tests."
-  echo "After v1.122 has been released, this early exit can be removed again (TODO(rfranzke))."
+  echo "After the rework has been finished, this early exit can be removed again (TODO(rfranzke))."
   exit 0
 fi
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -85,7 +85,7 @@ setup_kind_network() {
     network="$(docker network inspect $existing_network_id | yq '.[]')"
     network_options="$(echo "$network" | yq '.EnableIPv6 + "," + .Options["com.docker.network.bridge.enable_ip_masquerade"]')"
     network_ipam="$(echo "$network" | yq '.IPAM.Config' -o=json -I=0 | sed -E 's/"IPRange":"",//g')"
-    expected_network_ipam='[{"Subnet":"172.18.0.0/16","Gateway":"172.18.0.1"},{"Subnet":"fd00:10::/64","Gateway":"fd00:10::1"}]'
+    expected_network_ipam='[{"Subnet":"172.18.0.0/24","Gateway":"172.18.0.1"},{"Subnet":"fd00:10::/64","Gateway":"fd00:10::1"}]'
 
     if [ "$network_options" = 'true,true' ] && [ "$network_ipam" = "$expected_network_ipam" ] ; then
       # kind network is already configured correctly, nothing to do
@@ -98,7 +98,7 @@ setup_kind_network() {
 
   # (re-)create kind network with expected settings
   docker network create kind --driver=bridge \
-    --subnet 172.18.0.0/16 --gateway 172.18.0.1 \
+    --subnet 172.18.0.0/24 --gateway 172.18.0.1 \
     --ipv6 --subnet fd00:10::/64 --gateway fd00:10::1 \
     --opt com.docker.network.bridge.enable_ip_masquerade=true
 }

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -382,7 +382,7 @@ EOF"
 done
 
 local_address_operator="172.18.255.3"
-if [[ "$IPFAMILY" == "ipv6" ]]; then
+if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
   local_address_operator="::3"
 fi
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -381,16 +381,21 @@ EOF"
   docker exec "$node" sh -c "systemctl enable gardener-local-kind-add-hosts.service"
 done
 
+local_address_operator="172.18.255.3"
+if [[ "$IPFAMILY" == "ipv6" ]]; then
+  local_address_operator="::3"
+fi
+
 # Inject garden.local.gardener.cloud into coredns config (after ready plugin, before kubernetes plugin)
 kubectl -n kube-system get configmap coredns -ojson | \
   yq '.data.Corefile' | \
   sed '0,/ready.*$/s//&'"\n\
     hosts {\n\
       $garden_cluster_ip garden.local.gardener.cloud\n\
-      $garden_cluster_ip gardener.virtual-garden.local.gardener.cloud\n\
-      $garden_cluster_ip api.virtual-garden.local.gardener.cloud\n\
-      $garden_cluster_ip dashboard.ingress.runtime-garden.local.gardener.cloud\n\
-      $garden_cluster_ip discovery.ingress.runtime-garden.local.gardener.cloud\n\
+      $local_address_operator gardener.virtual-garden.local.gardener.cloud\n\
+      $local_address_operator api.virtual-garden.local.gardener.cloud\n\
+      $local_address_operator dashboard.ingress.runtime-garden.local.gardener.cloud\n\
+      $local_address_operator discovery.ingress.runtime-garden.local.gardener.cloud\n\
       fallthrough\n\
     }\
 "'/' | \

--- a/pkg/controller/service/add.go
+++ b/pkg/controller/service/add.go
@@ -23,6 +23,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, predicates ...predicate.P
 	if r.HostIP == "" {
 		r.HostIP = "172.18.255.1"
 	}
+	if r.VirtualGardenIP == "" {
+		r.VirtualGardenIP = "172.18.255.3"
+	}
 	if r.BastionIP == "" {
 		r.BastionIP = "172.18.255.22"
 	}

--- a/pkg/provider-local/controller/service/add.go
+++ b/pkg/provider-local/controller/service/add.go
@@ -30,6 +30,8 @@ type AddOptions struct {
 	Controller controller.Options
 	// HostIP is the IP address of the host.
 	HostIP string
+	// VirtualGardenIP is the IP address of the virtual-garden istio ingress gateway.
+	VirtualGardenIP string
 	// Zone0IP is the IP address to be used for the zone 0 istio ingress gateway.
 	Zone0IP string
 	// Zone1IP is the IP address to be used for the zone 1 istio ingress gateway.
@@ -70,11 +72,12 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 	predicates = append(predicates, bastionPredicate)
 
 	return (&service.Reconciler{
-		HostIP:    opts.HostIP,
-		Zone0IP:   opts.Zone0IP,
-		Zone1IP:   opts.Zone1IP,
-		Zone2IP:   opts.Zone2IP,
-		BastionIP: opts.BastionIP,
+		HostIP:          opts.HostIP,
+		VirtualGardenIP: opts.VirtualGardenIP,
+		Zone0IP:         opts.Zone0IP,
+		Zone1IP:         opts.Zone1IP,
+		Zone2IP:         opts.Zone2IP,
+		BastionIP:       opts.BastionIP,
 	}).AddToManager(mgr, predicate.Or(predicates...))
 }
 

--- a/pkg/provider-local/controller/service/options.go
+++ b/pkg/provider-local/controller/service/options.go
@@ -16,6 +16,8 @@ type ControllerOptions struct {
 	MaxConcurrentReconciles int
 	// HostIP is the host ip.
 	HostIP string
+	// VirtualGardenIP is the IP address of the virtual-garden istio ingress gateway.
+	VirtualGardenIP string
 	// Zone0IP is the IP address to be used for the zone 0 istio ingress gateway.
 	Zone0IP string
 	// Zone1IP is the IP address to be used for the zone 1 istio ingress gateway.
@@ -32,6 +34,7 @@ type ControllerOptions struct {
 func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.MaxConcurrentReconciles, cmd.MaxConcurrentReconcilesFlag, c.MaxConcurrentReconciles, "The maximum number of concurrent reconciliations.")
 	fs.StringVar(&c.HostIP, "host-ip", c.HostIP, "Overwrite Host IP to use for kube-apiserver service LoadBalancer")
+	fs.StringVar(&c.VirtualGardenIP, "virtual-garden-ip", c.VirtualGardenIP, "Overwrite IP to use for istio ingress gateway service LoadBalancer for virtual garden")
 	fs.StringVar(&c.Zone0IP, "zone-0-ip", c.Zone0IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 0")
 	fs.StringVar(&c.Zone1IP, "zone-1-ip", c.Zone1IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 1")
 	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 2")
@@ -40,7 +43,7 @@ func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 // Complete implements Completer.Complete.
 func (c *ControllerOptions) Complete() error {
-	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP}
+	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.VirtualGardenIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP}
 	return nil
 }
 
@@ -55,6 +58,8 @@ type ControllerConfig struct {
 	MaxConcurrentReconciles int
 	// HostIP is the host ip.
 	HostIP string
+	// VirtualGardenIP is the IP address of the virtual-garden istio ingress gateway.
+	VirtualGardenIP string
 	// Zone0IP is the IP address to be used for the zone 0 istio ingress gateway.
 	Zone0IP string
 	// Zone1IP is the IP address to be used for the zone 1 istio ingress gateway.
@@ -69,6 +74,7 @@ type ControllerConfig struct {
 func (c *ControllerConfig) Apply(opts *AddOptions) {
 	opts.Controller.MaxConcurrentReconciles = c.MaxConcurrentReconciles
 	opts.HostIP = c.HostIP
+	opts.VirtualGardenIP = c.VirtualGardenIP
 	opts.Zone0IP = c.Zone0IP
 	opts.Zone1IP = c.Zone1IP
 	opts.Zone2IP = c.Zone2IP

--- a/pkg/provider-local/controller/service/options.go
+++ b/pkg/provider-local/controller/service/options.go
@@ -33,12 +33,12 @@ type ControllerOptions struct {
 // AddFlags implements Flagger.AddFlags.
 func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.MaxConcurrentReconciles, cmd.MaxConcurrentReconcilesFlag, c.MaxConcurrentReconciles, "The maximum number of concurrent reconciliations.")
-	fs.StringVar(&c.HostIP, "host-ip", c.HostIP, "Overwrite Host IP to use for kube-apiserver service LoadBalancer")
-	fs.StringVar(&c.VirtualGardenIP, "virtual-garden-ip", c.VirtualGardenIP, "Overwrite IP to use for istio ingress gateway service LoadBalancer for virtual garden")
-	fs.StringVar(&c.Zone0IP, "zone-0-ip", c.Zone0IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 0")
-	fs.StringVar(&c.Zone1IP, "zone-1-ip", c.Zone1IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 1")
-	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite IP to use for kube-apiserver service LoadBalancer in zone 2")
-	fs.StringVar(&c.BastionIP, "bastion-ip", c.BastionIP, "Overwrite Bastion IP to use for Bastion service LoadBalancer")
+	fs.StringVar(&c.HostIP, "host-ip", c.HostIP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed")
+	fs.StringVar(&c.VirtualGardenIP, "virtual-garden-ip", c.VirtualGardenIP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for virtual garden")
+	fs.StringVar(&c.Zone0IP, "zone-0-ip", c.Zone0IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 0")
+	fs.StringVar(&c.Zone1IP, "zone-1-ip", c.Zone1IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 1")
+	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 2")
+	fs.StringVar(&c.BastionIP, "bastion-ip", c.BastionIP, "Overwrite LoadBalancer IP to use for bastion service")
 }
 
 // Complete implements Completer.Complete.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:

Currently, the load balancer IPs (`172.18.255.*`) overlap with the kind network (`172.18.0.0/16`).
Hence, we needed some hacks/workaround for making the load balancer IPs accessible from within the kind cluster.
With this commit, we ensure disjoint ranges, so that traffic to load balancer IPs from withing the kind cluster are correctly routed.
This allows us to drop the hacks/workarounds (see the next commit).

Previously, we added the internal IPs of nodes to the `Service.status.loadBalancer.ips[]`.
With this, we exploited the kube-proxy shortcut for LoadBalancer IPs (it directly routes traffic to such IPs to the Services' clusterIP).
This was only necessary, because the load balancer IPs (`172.18.255.*`) overlapped with the kind docker network
and the traffic was not correctly routed to the load balancer IPs on the host machine's loopback interface.

With the previous commit, we correctly route traffic to the load balancer IPs (`172.18.255.*`) via the host machine.
Hence, we no longer need the shortcut added by kube-proxy.

This is a preparation for running gardener within a self-hosted shoot instead of a kind cluster.

Co-Authored-By @rfranzke at the [2025-11 Hackathon](https://gardener.cloud/community/hackathons/2025-11/)

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

/cc @ScheererJ 

The hacks/workarounds that are cleaned up by this PR were introduced in https://github.com/gardener/gardener/pull/9763.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
