### PR TITLE
Add seed dashboard url to seed related alerts

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -52,9 +52,7 @@ type Interface interface {
 	// SetNamespaceUID sets the namespace UID.
 	SetNamespaceUID(name types.UID)
 	// SetAdditionalAlertRelabelConfigs sets the additional alert relabel configs.
-	SetAdditionalAlertRelabelConfigs([]*monitoringv1.RelabelConfig)
-	// GetAdditionalAlertRelabelConfigs get the additional alert relabel configs.
-	GetAdditionalAlertRelabelConfigs() []*monitoringv1.RelabelConfig
+	SetAdditionalAlertRelabelConfigs([]monitoringv1.RelabelConfig)
 }
 
 // Values contains configuration values for the prometheus resources.
@@ -343,24 +341,8 @@ func (p *prometheus) name() string {
 	return "prometheus-" + p.values.Name
 }
 
-func (p *prometheus) SetAdditionalAlertRelabelConfigs(configs []*monitoringv1.RelabelConfig) {
-	vals := make([]monitoringv1.RelabelConfig, len(configs))
-	for i, cfg := range configs {
-		vals[i] = *cfg
-	}
-	p.values.AdditionalAlertRelabelConfigs = vals
-}
-
-func (p *prometheus) GetAdditionalAlertRelabelConfigs() []*monitoringv1.RelabelConfig {
-	vals := p.values.AdditionalAlertRelabelConfigs
-	out := make([]*monitoringv1.RelabelConfig, len(vals))
-
-	for i := range vals {
-		cfg := vals[i]
-		out[i] = &cfg
-	}
-
-	return out
+func (p *prometheus) SetAdditionalAlertRelabelConfigs(configs []monitoringv1.RelabelConfig) {
+	p.values.AdditionalAlertRelabelConfigs = configs
 }
 
 func (p *prometheus) addCentralConfigsToRegistry(registry *managedresources.Registry) error {

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -51,6 +51,10 @@ type Interface interface {
 	SetCentralScrapeConfigs([]*monitoringv1alpha1.ScrapeConfig)
 	// SetNamespaceUID sets the namespace UID.
 	SetNamespaceUID(name types.UID)
+	// SetAdditionalAlertRelabelConfigs sets the additional alert relabel configs.
+	SetAdditionalAlertRelabelConfigs([]*monitoringv1.RelabelConfig)
+	// GetAdditionalAlertRelabelConfigs get the additional alert relabel configs.
+	GetAdditionalAlertRelabelConfigs() []*monitoringv1.RelabelConfig
 }
 
 // Values contains configuration values for the prometheus resources.
@@ -337,6 +341,26 @@ func (p *prometheus) SetNamespaceUID(uid types.UID) {
 
 func (p *prometheus) name() string {
 	return "prometheus-" + p.values.Name
+}
+
+func (p *prometheus) SetAdditionalAlertRelabelConfigs(configs []*monitoringv1.RelabelConfig) {
+	vals := make([]monitoringv1.RelabelConfig, len(configs))
+	for i, cfg := range configs {
+		vals[i] = *cfg
+	}
+	p.values.AdditionalAlertRelabelConfigs = vals
+}
+
+func (p *prometheus) GetAdditionalAlertRelabelConfigs() []*monitoringv1.RelabelConfig {
+	vals := p.values.AdditionalAlertRelabelConfigs
+	out := make([]*monitoringv1.RelabelConfig, len(vals))
+
+	for i := range vals {
+		cfg := vals[i]
+		out[i] = &cfg
+	}
+
+	return out
 }
 
 func (p *prometheus) addCentralConfigsToRegistry(registry *managedresources.Registry) error {

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -1013,40 +1013,6 @@ tls_config:
 							TargetLabel:  "shoot_dashboard_url",
 						}}
 					})
-
-					It("should successfully append the additional alert relabel config", func() {
-						prometheusRule.Namespace = namespace
-						metav1.SetMetaDataLabel(&prometheusRule.ObjectMeta, "prometheus", name)
-						metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", name)
-						metav1.SetMetaDataLabel(&serviceMonitor.ObjectMeta, "prometheus", name)
-						metav1.SetMetaDataLabel(&podMonitor.ObjectMeta, "prometheus", name)
-
-						prometheus := prometheusFor([]alertmanager{{name: alertmanagerName}}, false)
-						prometheus.Spec.Alerting.Alertmanagers[0].AlertRelabelConfigs = append(
-							prometheus.Spec.Alerting.Alertmanagers[0].AlertRelabelConfigs,
-							monitoringv1.RelabelConfig{
-								SourceLabels: []monitoringv1.LabelName{"project", "name"},
-								Regex:        "(.+);(.+)",
-								Action:       "replace",
-								Replacement:  ptr.To("https://dashboard.ingress.gardener.cloud/namespace/garden-$1/shoots/$2"),
-								TargetLabel:  "shoot_dashboard_url",
-							},
-						)
-
-						Expect(managedResource).To(contain(
-							serviceAccount,
-							service,
-							clusterRoleBinding,
-							prometheus,
-							vpa,
-							prometheusRule,
-							scrapeConfig,
-							serviceMonitor,
-							podMonitor,
-							secretAdditionalScrapeConfigs,
-							additionalConfigMap,
-						))
-					})
 				})
 			})
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1425,22 +1425,6 @@ func (r *Reconciler) newPrometheusGarden(log logr.Logger, garden *operatorv1alph
 			ServiceMonitors:         gardenprometheus.CentralServiceMonitors(),
 		},
 		Alerting: &prometheus.AlertingValues{Alertmanagers: []*prometheus.Alertmanager{{Name: "alertmanager-garden"}}},
-		AdditionalAlertRelabelConfigs: []monitoringv1.RelabelConfig{
-			{
-				SourceLabels: []monitoringv1.LabelName{"project", "name"},
-				Regex:        "(.+);(.+)",
-				Action:       "replace",
-				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden-$1/shoots/$2"),
-				TargetLabel:  "shoot_dashboard_url",
-			},
-			{
-				SourceLabels: []monitoringv1.LabelName{"project", "name"},
-				Regex:        "garden;(.+)",
-				Action:       "replace",
-				Replacement:  ptr.To("https://dashboard." + ingressDomain + "/namespace/garden/shoots/$1"),
-				TargetLabel:  "shoot_dashboard_url",
-			},
-		},
 		Ingress: &prometheus.IngressValues{
 			Host:                   "prometheus-garden." + ingressDomain,
 			SecretsManager:         secretsManager,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1096,9 +1096,9 @@ func (r *Reconciler) deployGardenPrometheus(ctx context.Context, log logr.Logger
 		},
 		{
 			SourceLabels: []monitoringv1.LabelName{"project", "name"},
-			Regex:        ";" + strings.Join(managedSeedNames, "|"),
+			Regex:        ";(" + strings.Join(managedSeedNames, "|") + ")",
 			Action:       "replace",
-			Replacement:  ptr.To("https://dashboard." + primaryIngressDomain + "/namespace/garden/shoots/$2"),
+			Replacement:  ptr.To("https://dashboard." + primaryIngressDomain + "/namespace/garden/shoots/$1"),
 			TargetLabel:  "dashboard_url",
 		},
 	}

--- a/test/integration/operator/garden/garden/garden_suite_test.go
+++ b/test/integration/operator/garden/garden/garden_suite_test.go
@@ -65,6 +65,7 @@ var _ = BeforeSuite(func() {
 				filepath.Join("..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_extensions.yaml"),
 				filepath.Join("testdata", "crd-seeds.yaml"),
 				filepath.Join("testdata", "crd-gardenlets.yaml"),
+				filepath.Join("testdata", "crd-managedseeds.yaml"),
 			},
 		},
 		ErrorIfCRDPathMissing: true,

--- a/test/integration/operator/garden/garden/testdata/crd-managedseeds.yaml
+++ b/test/integration/operator/garden/garden/testdata/crd-managedseeds.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedseeds.seedmanagement.gardener.cloud
+spec:
+  scope: Namespaced
+  names:
+    kind: ManagedSeed
+    listKind: ManagedSeedList
+    plural: managedseeds
+    singular: managedseed
+  group: seedmanagement.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
To the critical alerts about the shoot cluster are including the label shoot_dashboard_url, but the alerts of the seeds don't have this label, adding this label to seed failing alert for better convenience.

**Which issue(s) this PR fixes**:
n.a.

**Special notes for your reviewer**:

Previous [PR](https://github.com/gardener/gardener/pull/12999) has been closed  due to pending long time. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A link to the `Seed`-specific dashboard has been added to the annotations of `Seed`-related alerts. This allows operators to quickly navigate from an alert to the relevant monitoring dashboard for faster troubleshooting.
```
