### PR TITLE
Remove `VGOPATH` and `hack/vgopath-setup.sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,10 @@ check-plutono-dashboards:
 	@hack/check-plutono-dashboards.sh
 
 .PHONY: check
-check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK) $(YQ) $(VGOPATH) $(TYPOS) logcheck-symlinks
+check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK) $(YQ) $(TYPOS) logcheck-symlinks
 	@sed ./.golangci.yaml.in -e "s#<<LOGCHECK_PLUGIN_PATH>>#$(TOOLS_BIN_DIR)#g" > ./.golangci.yaml
 	@hack/check.sh --golangci-lint-config=./.golangci.yaml ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
-	@VGOPATH=$(VGOPATH) hack/check-imports.sh ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
+	@hack/check-imports.sh ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
 
 	@echo "> Check $(LOGCHECK_DIR)"
 	@cd $(LOGCHECK_DIR); $(abspath $(GOLANGCI_LINT)) run -c $(REPO_ROOT)/.golangci.yaml --timeout 10m ./...
@@ -182,7 +182,7 @@ check: $(GO_ADD_LICENSE) $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(
 logcheck-symlinks:
 	@LOGCHECK_DIR=$(LOGCHECK_DIR) ./hack/generate-logcheck-symlinks.sh
 
-tools-for-generate: $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YQ) $(VGOPATH)
+tools-for-generate: $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YQ)
 
 define GENERATE_HELP_INFO
 # Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"]
@@ -212,7 +212,7 @@ generate:
 else
 generate: tools-for-generate
 	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n"
-	@REPO_ROOT=$(REPO_ROOT) VGOPATH=$(VGOPATH) LOGCHECK_DIR=$(LOGCHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegen-groups "$(CODEGEN_GROUPS)" --manifests-dirs "$(MANIFESTS_DIRS)" --mode "$(MODE)"
+	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegen-groups "$(CODEGEN_GROUPS)" --manifests-dirs "$(MANIFESTS_DIRS)" --mode "$(MODE)"
 	$(MAKE) format
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ logcheck-symlinks:
 	@LOGCHECK_DIR=$(LOGCHECK_DIR) ./hack/generate-logcheck-symlinks.sh
 
 tools-for-generate: $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(HELM) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC) $(PROTOC_GEN_GOGO) $(YQ)
+	@go mod download
 
 define GENERATE_HELP_INFO
 # Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"]

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -144,16 +144,14 @@ The Gardener repository and all the above-mentioned tools (git, golang, kubectl,
 
 # Get the Sources
 
-Clone the repository from GitHub into your `$GOPATH`.
+Clone the repository from GitHub.
 
 ```bash
-mkdir -p $(go env GOPATH)/src/github.com/gardener
-cd $(go env GOPATH)/src/github.com/gardener
+mkdir -p /path/to/src/github.com/gardener
+cd /path/to/src/github.com/gardener
 git clone git@github.com:gardener/gardener.git
 cd gardener
 ```
-
-> Note: Gardener is using Go modules and cloning the repository into `$GOPATH` is not a hard requirement. However it is still recommended to clone into `$GOPATH` because `k8s.io/code-generator` does not work yet outside of `$GOPATH` - [kubernetes/kubernetes#86753](https://github.com/kubernetes/kubernetes/issues/86753).
 
 # Start the Gardener
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -147,8 +147,6 @@ The Gardener repository and all the above-mentioned tools (git, golang, kubectl,
 Clone the repository from GitHub.
 
 ```bash
-mkdir -p /path/to/src/github.com/gardener
-cd /path/to/src/github.com/gardener
 git clone git@github.com:gardener/gardener.git
 cd gardener
 ```

--- a/example/seed-crds/10-crd-fluentbit.fluent.io_collectors.yaml
+++ b/example/seed-crds/10-crd-fluentbit.fluent.io_collectors.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1252,13 +1252,15 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                          will be set by the persistentvolume controller if it exists.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -1418,11 +1420,13 @@ spec:
                         description: |-
                           currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                           When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                          This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                         type: string
                       modifyVolumeStatus:
                         description: |-
                           ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                           When this is unset, there is no ModifyVolume operation being attempted.
+                          This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                         properties:
                           status:
                             description: "status is the status of the ControllerModifyVolume
@@ -1514,7 +1518,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -2545,13 +2549,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -2733,10 +2739,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -2815,7 +2823,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -3235,111 +3243,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -3474,6 +3377,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/example/seed-crds/10-crd-fluentbit.fluent.io_fluentbits.yaml
+++ b/example/seed-crds/10-crd-fluentbit.fluent.io_fluentbits.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1183,9 +1183,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -1241,43 +1239,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -1430,9 +1391,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -1488,43 +1448,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -1587,8 +1510,8 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
@@ -1615,9 +1538,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Optional text to prepend to the name of each
+                              environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -2288,7 +2210,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -2342,10 +2264,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -2357,59 +2279,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -3838,13 +3707,15 @@ spec:
                                   volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                   If specified, the CSI driver will create or update the volume with the attributes defined
                                   in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                  it can be changed after the claim is created. An empty string or nil value indicates that no
-                                  VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                  this field can be reset to its previous value (including nil) to cancel the modification.
+                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                  will be set by the persistentvolume controller if it exists.
                                   If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                   set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                   exists.
                                   More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                 type: string
                               volumeMode:
                                 description: |-
@@ -4025,10 +3896,12 @@ spec:
                     description: |-
                       glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                       Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                     properties:
                       endpoints:
-                        description: endpoints is the endpoint name that details Glusterfs
-                          topology.
+                        description: |-
+                          endpoints is the endpoint name that details Glusterfs topology.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                         type: string
                       path:
                         description: |-
@@ -4107,7 +3980,7 @@ spec:
                     description: |-
                       iscsi represents an ISCSI Disk resource that is attached to a
                       kubelet's host machine and then exposed to the pod.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                     properties:
                       chapAuthDiscovery:
                         description: chapAuthDiscovery defines whether support iSCSI
@@ -4519,111 +4392,6 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
-                            podCertificate:
-                              description: |-
-                                Projects an auto-rotating credential bundle (private key and certificate
-                                chain) that the pod can use either as a TLS client or server.
-
-                                Kubelet generates a private key and uses it to send a
-                                PodCertificateRequest to the named signer.  Once the signer approves the
-                                request and issues a certificate chain, Kubelet writes the key and
-                                certificate chain to the pod filesystem.  The pod does not start until
-                                certificates have been issued for each podCertificate projected volume
-                                source in its spec.
-
-                                Kubelet will begin trying to rotate the certificate at the time indicated
-                                by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                timestamp.
-
-                                Kubelet can write a single file, indicated by the credentialBundlePath
-                                field, or separate files, indicated by the keyPath and
-                                certificateChainPath fields.
-
-                                The credential bundle is a single file in PEM format.  The first PEM
-                                entry is the private key (in PKCS#8 format), and the remaining PEM
-                                entries are the certificate chain issued by the signer (typically,
-                                signers will return their certificate chain in leaf-to-root order).
-
-                                Prefer using the credential bundle format, since your application code
-                                can read it atomically.  If you use keyPath and certificateChainPath,
-                                your application must make two separate file reads. If these coincide
-                                with a certificate rotation, it is possible that the private key and leaf
-                                certificate you read may not correspond to each other.  Your application
-                                will need to check for this condition, and re-read until they are
-                                consistent.
-
-                                The named signer controls chooses the format of the certificate it
-                                issues; consult the signer implementation's documentation to learn how to
-                                use the certificates it issues.
-                              properties:
-                                certificateChainPath:
-                                  description: |-
-                                    Write the certificate chain at this path in the projected volume.
-
-                                    Most applications should use credentialBundlePath.  When using keyPath
-                                    and certificateChainPath, your application needs to check that the key
-                                    and leaf certificate are consistent, because it is possible to read the
-                                    files mid-rotation.
-                                  type: string
-                                credentialBundlePath:
-                                  description: |-
-                                    Write the credential bundle at this path in the projected volume.
-
-                                    The credential bundle is a single file that contains multiple PEM blocks.
-                                    The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                    key.
-
-                                    The remaining blocks are CERTIFICATE blocks, containing the issued
-                                    certificate chain from the signer (leaf and any intermediates).
-
-                                    Using credentialBundlePath lets your Pod's application code make a single
-                                    atomic read that retrieves a consistent key and certificate chain.  If you
-                                    project them to separate files, your application code will need to
-                                    additionally check that the leaf certificate was issued to the key.
-                                  type: string
-                                keyPath:
-                                  description: |-
-                                    Write the key at this path in the projected volume.
-
-                                    Most applications should use credentialBundlePath.  When using keyPath
-                                    and certificateChainPath, your application needs to check that the key
-                                    and leaf certificate are consistent, because it is possible to read the
-                                    files mid-rotation.
-                                  type: string
-                                keyType:
-                                  description: |-
-                                    The type of keypair Kubelet will generate for the pod.
-
-                                    Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                    "ECDSAP521", and "ED25519".
-                                  type: string
-                                maxExpirationSeconds:
-                                  description: |-
-                                    maxExpirationSeconds is the maximum lifetime permitted for the
-                                    certificate.
-
-                                    Kubelet copies this value verbatim into the PodCertificateRequests it
-                                    generates for this projection.
-
-                                    If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                    will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                    value is 7862400 (91 days).
-
-                                    The signer implementation is then free to issue a certificate with any
-                                    lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                    seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                    `kubernetes.io` signers will never issue certificates with a lifetime
-                                    longer than 24 hours.
-                                  format: int32
-                                  type: integer
-                                signerName:
-                                  description: Kubelet's generated CSRs will be addressed
-                                    to this signer.
-                                  type: string
-                              required:
-                              - keyType
-                              - signerName
-                              type: object
                             secret:
                               description: secret information about the secret data
                                 to project
@@ -4758,6 +4526,7 @@ spec:
                     description: |-
                       rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                       Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                      More info: https://examples.k8s.io/volumes/rbd/README.md
                     properties:
                       fsType:
                         description: |-
@@ -5250,7 +5019,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -6286,13 +6055,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -6474,10 +6245,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -6556,7 +6329,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -6976,111 +6749,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -7215,6 +6883,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/example/seed-crds/10-crd-machine.sapcloud.io_machinedeployments.yaml
+++ b/example/seed-crds/10-crd-machine.sapcloud.io_machinedeployments.yaml
@@ -397,8 +397,9 @@ spec:
                                         to a node.
                                       type: string
                                     timeAdded:
-                                      description: TimeAdded represents the time at
-                                        which the taint was added.
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
                                       format: date-time
                                       type: string
                                     value:

--- a/example/seed-crds/10-crd-machine.sapcloud.io_machines.yaml
+++ b/example/seed-crds/10-crd-machine.sapcloud.io_machines.yaml
@@ -194,8 +194,9 @@ spec:
                                 a node.
                               type: string
                             timeAdded:
-                              description: TimeAdded represents the time at which
-                                the taint was added.
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
                               format: date-time
                               type: string
                             value:

--- a/example/seed-crds/10-crd-machine.sapcloud.io_machinesets.yaml
+++ b/example/seed-crds/10-crd-machine.sapcloud.io_machinesets.yaml
@@ -279,8 +279,9 @@ spec:
                                         to a node.
                                       type: string
                                     timeAdded:
-                                      description: TimeAdded represents the time at
-                                        which the taint was added.
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
                                       format: date-time
                                       type: string
                                     value:

--- a/example/seed-crds/10-crd-perses.dev_perses.yaml
+++ b/example/seed-crds/10-crd-perses.dev_perses.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/google/go-containerregistry v0.20.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ironcore-dev/vgopath v0.1.5
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ionos-cloud/sdk-go/v6 v6.3.0 h1:/lTieTH9Mo/CWm3cTlFLnK10jgxjUGkAqRffGqvPteY=
 github.com/ionos-cloud/sdk-go/v6 v6.3.0/go.mod h1:SXrO9OGyWjd2rZhAhEpdYN6VUAODzzqRdqA9BCviQtI=
-github.com/ironcore-dev/vgopath v0.1.5 h1:+I46zEFfbmNIGIGylqedT2bMXw8V7yVP16GJkG64gAw=
-github.com/ironcore-dev/vgopath v0.1.5/go.mod h1:qbSUA7Eg0SO97OYfkG0DH+DxaPrH6XCiAQHqqs9R63Q=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=

--- a/hack/check-imports.sh
+++ b/hack/check-imports.sh
@@ -21,9 +21,6 @@ echo "> Check Imports"
 
 this_module=$(go list -m)
 
-# setup virtual GOPATH
-source $(dirname $0)/vgopath-setup.sh
-
 packages=()
 for p in "$@"; do
   packages+=("$this_module/${p#./}")

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -126,7 +126,7 @@ generate_group () {
     package_path="${package_path};${package_path}beta2;"
     generate="controller-gen crd"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate &> "$generator_output" ||:
-    grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'exit status 1' -e 'usage' "$generator_output" && { echo "Failed to generate CRD YAMLs."; exit 1; }
+    grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'usage' "$generator_output" && { echo "Failed to generate CRD YAMLs."; exit 1; }
   elif [[ "$group" == "perses.dev_v1alpha1" ]]; then
     generate="controller-gen crd:ignoreUnexportedFields=true"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -32,11 +32,6 @@ add_keep_object_annotation=false
 crd_options=""
 declare -A custom_packages=()
 
-# setup virtual GOPATH
-source $(dirname $0)/vgopath-setup.sh
-
-export GO111MODULE=off
-
 get_group_package () {
   if [[ -v custom_packages["$1"] ]]; then
     echo "${custom_packages["$1"]}"
@@ -131,7 +126,7 @@ generate_group () {
     package_path="${package_path};${package_path}beta2;"
     generate="controller-gen crd"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate &> "$generator_output" ||:
-    grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'usage' "$generator_output" && { echo "Failed to generate CRD YAMLs."; exit 1; }
+    grep -v -e 'map keys must be strings, not int' -e 'not all generators ran successfully' -e 'exit status 1' -e 'usage' "$generator_output" && { echo "Failed to generate CRD YAMLs."; exit 1; }
   elif [[ "$group" == "perses.dev_v1alpha1" ]]; then
     generate="controller-gen crd:ignoreUnexportedFields=true"$crd_options" paths="$package_path" output:crd:dir="$output_dir_temp" output:stdout"
     $generate

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -10,7 +10,6 @@ package tools
 
 import (
 	_ "github.com/ahmetb/gen-crd-api-reference-docs"
-	_ "github.com/ironcore-dev/vgopath"
 	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "go.uber.org/mock/mockgen"
 	_ "golang.org/x/tools/cmd/goimports"

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -264,5 +264,6 @@ $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
 	curl -L -o $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(SYSTEM_NAME)_$(SYSTEM_ARCH)
 	chmod +x $(YQ)
 
+# TODO(LucaBernstein): Remove VGOPATH in a future release.
 $(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))
 	go build -o $(VGOPATH) github.com/ironcore-dev/vgopath

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -264,6 +264,6 @@ $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
 	curl -L -o $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(SYSTEM_NAME)_$(SYSTEM_ARCH)
 	chmod +x $(YQ)
 
-# TODO(LucaBernstein): Remove VGOPATH in a future release.
+# TODO(LucaBernstein): Remove VGOPATH after gardener/gardener@v1.142 has been released.
 $(VGOPATH): $(call tool_version_file,$(VGOPATH),$(VGOPATH_VERSION))
 	go build -o $(VGOPATH) github.com/ironcore-dev/vgopath

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -34,9 +34,6 @@ AVAILABLE_CODEGEN_OPTIONS=(
   "nodeagent_groups"
 )
 
-# setup virtual GOPATH
-source $(dirname $0)/vgopath-setup.sh
-
 CODE_GEN_DIR=$(go list -m -f '{{.Dir}}' k8s.io/code-generator)
 source "${CODE_GEN_DIR}/kube_codegen.sh"
 

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -37,7 +37,7 @@ APIMACHINERY_PKGS=(
   -k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 )
 
-# For go-to-protobuf I need a path with `github.com/gardener/gardener` as it expects a structure like in the former GOPATH.
+# For go-to-protobuf, a path ending with `github.com/gardener/gardener` is expected, similar to the former GOPATH structure.
 TMP_DIR=$(mktemp -d)
 trap "rm -rf ${TMP_DIR}" EXIT
 mkdir -p "${TMP_DIR}/github.com/gardener/"

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -8,13 +8,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# setup virtual GOPATH
-source $(dirname $0)/vgopath-setup.sh
-
-# We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
-# see https://github.com/kubernetes/code-generator/issues/100.
-export GO111MODULE=off
-
 CURRENT_DIR="$(dirname $0)"
 PROJECT_ROOT="${CURRENT_DIR}"/..
 if [ "${PROJECT_ROOT#/}" == "${PROJECT_ROOT}" ]; then
@@ -44,14 +37,22 @@ APIMACHINERY_PKGS=(
   -k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 )
 
+# For go-to-protobuf I need a path with `github.com/gardener/gardener` as it expects a structure like in the former GOPATH.
+TMP_DIR=$(mktemp -d)
+trap "rm -rf ${TMP_DIR}" EXIT
+mkdir -p "${TMP_DIR}/github.com/gardener/"
+ln -s "${PROJECT_ROOT}" "${TMP_DIR}/github.com/gardener/gardener"
+
 # requires the 'proto' tag to build (will remove when ready)
 # searches for the protoc-gen-gogo extension in the output directory
 # satisfies import of github.com/gogo/protobuf/gogoproto/gogo.proto and the
 # core Google protobuf types
 go-to-protobuf \
   --go-header-file=${PROJECT_ROOT}/hack/LICENSE_BOILERPLATE.txt \
-  --output-dir="${GOPATH}/src" \
-  --proto-import="${GOPATH}/src/k8s.io/kubernetes/staging/src" \
-  --proto-import="${GOPATH}/src/k8s.io/kubernetes/vendor" \
+  --output-dir="${TMP_DIR}" \
+  --proto-import="github.com/gogo/protobuf/gogoproto=$(go list -f '{{ .Dir }}' github.com/gogo/protobuf/gogoproto)" \
+  --proto-import="k8s.io/api=$(go list -f '{{ .Dir }}' k8s.io/api)" \
+  --proto-import="k8s.io/apimachinery=$(go list -f '{{ .Dir }}' k8s.io/apimachinery)" \
+  --proto-import="k8s.io/apiextensions-apiserver=$(go list -f '{{ .Dir }}' k8s.io/apiextensions-apiserver)" \
   --packages="$(IFS=, ; echo "${PACKAGES[*]}")" \
   --apimachinery-packages=$(IFS=, ; echo "${APIMACHINERY_PKGS[*]}")

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -38,6 +38,9 @@ APIMACHINERY_PKGS=(
 )
 
 # For go-to-protobuf, a path ending with `github.com/gardener/gardener` is expected, similar to the former GOPATH structure.
+#
+# TODO(ialidzhikov): Check if it is possible to run go-to-probuf without GOPATH structure.
+# If it is upstream issue with the go-to-protobuf generator that it still requires GOPATH, report it to Kubernetes.
 TMP_DIR=$(mktemp -d)
 trap "rm -rf ${TMP_DIR}" EXIT
 mkdir -p "${TMP_DIR}/github.com/gardener/"

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+echo
+echo "DEPRECATED: hack/vgopath-setup.sh is deprecated and will be removed in a future release."
+echo "Please remove your usage of hack/vgopath-setup.sh from the gardener/gardener repository."
+echo
+
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Ensure that the GOPATH/{bin,pkg} directory exists. This seems to be not always

--- a/hack/vgopath-setup.sh
+++ b/hack/vgopath-setup.sh
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+
+# TODO(LucaBernstein): Remove this script after gardener/gardener@v1.142 has been released.
 echo
-echo "DEPRECATED: hack/vgopath-setup.sh is deprecated and will be removed in a future release."
+echo "DEPRECATED: hack/vgopath-setup.sh is deprecated and will be removed after gardener/gardener@v1.142 has been released."
 echo "Please remove your usage of hack/vgopath-setup.sh from the gardener/gardener repository."
 echo
 

--- a/pkg/component/gardener/dashboard/terminal/assets/crd-dashboard.gardener.cloud_terminals.yaml
+++ b/pkg/component/gardener/dashboard/terminal/assets/crd-dashboard.gardener.cloud_terminals.yaml
@@ -172,7 +172,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This field depends on the
+                                  This is an alpha field and requires enabling the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.

--- a/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
+++ b/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinedeployments.yaml
@@ -399,8 +399,9 @@ spec:
                                         to a node.
                                       type: string
                                     timeAdded:
-                                      description: TimeAdded represents the time at
-                                        which the taint was added.
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
                                       format: date-time
                                       type: string
                                     value:

--- a/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
+++ b/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machines.yaml
@@ -196,8 +196,9 @@ spec:
                                 a node.
                               type: string
                             timeAdded:
-                              description: TimeAdded represents the time at which
-                                the taint was added.
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
                               format: date-time
                               type: string
                             value:

--- a/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
+++ b/pkg/component/nodemanagement/machinecontrollermanager/templates/crd-machine.sapcloud.io_machinesets.yaml
@@ -281,8 +281,9 @@ spec:
                                         to a node.
                                       type: string
                                     timeAdded:
-                                      description: TimeAdded represents the time at
-                                        which the taint was added.
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
                                       format: date-time
                                       type: string
                                     value:

--- a/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_collectors.yaml
+++ b/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_collectors.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1252,13 +1252,15 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string or nil value indicates that no
-                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                          will be set by the persistentvolume controller if it exists.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -1418,11 +1420,13 @@ spec:
                         description: |-
                           currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                           When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                          This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                         type: string
                       modifyVolumeStatus:
                         description: |-
                           ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                           When this is unset, there is no ModifyVolume operation being attempted.
+                          This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                         properties:
                           status:
                             description: "status is the status of the ControllerModifyVolume
@@ -1514,7 +1518,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -2545,13 +2549,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -2733,10 +2739,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -2815,7 +2823,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -3235,111 +3243,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -3474,6 +3377,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_fluentbits.yaml
+++ b/pkg/component/observability/logging/fluentoperator/assets/crd-fluentbit.fluent.io_fluentbits.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1183,9 +1183,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -1241,43 +1239,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -1430,9 +1391,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -1488,43 +1448,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -1587,8 +1510,8 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
@@ -1615,9 +1538,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Optional text to prepend to the name of each
+                              environment variable. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -2288,7 +2210,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -2342,10 +2264,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -2357,59 +2279,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -3838,13 +3707,15 @@ spec:
                                   volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                   If specified, the CSI driver will create or update the volume with the attributes defined
                                   in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                  it can be changed after the claim is created. An empty string or nil value indicates that no
-                                  VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                  this field can be reset to its previous value (including nil) to cancel the modification.
+                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                  will be set by the persistentvolume controller if it exists.
                                   If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                   set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                   exists.
                                   More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                 type: string
                               volumeMode:
                                 description: |-
@@ -4025,10 +3896,12 @@ spec:
                     description: |-
                       glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                       Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
                     properties:
                       endpoints:
-                        description: endpoints is the endpoint name that details Glusterfs
-                          topology.
+                        description: |-
+                          endpoints is the endpoint name that details Glusterfs topology.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                         type: string
                       path:
                         description: |-
@@ -4107,7 +3980,7 @@ spec:
                     description: |-
                       iscsi represents an ISCSI Disk resource that is attached to a
                       kubelet's host machine and then exposed to the pod.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                      More info: https://examples.k8s.io/volumes/iscsi/README.md
                     properties:
                       chapAuthDiscovery:
                         description: chapAuthDiscovery defines whether support iSCSI
@@ -4519,111 +4392,6 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
-                            podCertificate:
-                              description: |-
-                                Projects an auto-rotating credential bundle (private key and certificate
-                                chain) that the pod can use either as a TLS client or server.
-
-                                Kubelet generates a private key and uses it to send a
-                                PodCertificateRequest to the named signer.  Once the signer approves the
-                                request and issues a certificate chain, Kubelet writes the key and
-                                certificate chain to the pod filesystem.  The pod does not start until
-                                certificates have been issued for each podCertificate projected volume
-                                source in its spec.
-
-                                Kubelet will begin trying to rotate the certificate at the time indicated
-                                by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                timestamp.
-
-                                Kubelet can write a single file, indicated by the credentialBundlePath
-                                field, or separate files, indicated by the keyPath and
-                                certificateChainPath fields.
-
-                                The credential bundle is a single file in PEM format.  The first PEM
-                                entry is the private key (in PKCS#8 format), and the remaining PEM
-                                entries are the certificate chain issued by the signer (typically,
-                                signers will return their certificate chain in leaf-to-root order).
-
-                                Prefer using the credential bundle format, since your application code
-                                can read it atomically.  If you use keyPath and certificateChainPath,
-                                your application must make two separate file reads. If these coincide
-                                with a certificate rotation, it is possible that the private key and leaf
-                                certificate you read may not correspond to each other.  Your application
-                                will need to check for this condition, and re-read until they are
-                                consistent.
-
-                                The named signer controls chooses the format of the certificate it
-                                issues; consult the signer implementation's documentation to learn how to
-                                use the certificates it issues.
-                              properties:
-                                certificateChainPath:
-                                  description: |-
-                                    Write the certificate chain at this path in the projected volume.
-
-                                    Most applications should use credentialBundlePath.  When using keyPath
-                                    and certificateChainPath, your application needs to check that the key
-                                    and leaf certificate are consistent, because it is possible to read the
-                                    files mid-rotation.
-                                  type: string
-                                credentialBundlePath:
-                                  description: |-
-                                    Write the credential bundle at this path in the projected volume.
-
-                                    The credential bundle is a single file that contains multiple PEM blocks.
-                                    The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                    key.
-
-                                    The remaining blocks are CERTIFICATE blocks, containing the issued
-                                    certificate chain from the signer (leaf and any intermediates).
-
-                                    Using credentialBundlePath lets your Pod's application code make a single
-                                    atomic read that retrieves a consistent key and certificate chain.  If you
-                                    project them to separate files, your application code will need to
-                                    additionally check that the leaf certificate was issued to the key.
-                                  type: string
-                                keyPath:
-                                  description: |-
-                                    Write the key at this path in the projected volume.
-
-                                    Most applications should use credentialBundlePath.  When using keyPath
-                                    and certificateChainPath, your application needs to check that the key
-                                    and leaf certificate are consistent, because it is possible to read the
-                                    files mid-rotation.
-                                  type: string
-                                keyType:
-                                  description: |-
-                                    The type of keypair Kubelet will generate for the pod.
-
-                                    Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                    "ECDSAP521", and "ED25519".
-                                  type: string
-                                maxExpirationSeconds:
-                                  description: |-
-                                    maxExpirationSeconds is the maximum lifetime permitted for the
-                                    certificate.
-
-                                    Kubelet copies this value verbatim into the PodCertificateRequests it
-                                    generates for this projection.
-
-                                    If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                    will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                    value is 7862400 (91 days).
-
-                                    The signer implementation is then free to issue a certificate with any
-                                    lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                    seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                    `kubernetes.io` signers will never issue certificates with a lifetime
-                                    longer than 24 hours.
-                                  format: int32
-                                  type: integer
-                                signerName:
-                                  description: Kubelet's generated CSRs will be addressed
-                                    to this signer.
-                                  type: string
-                              required:
-                              - keyType
-                              - signerName
-                              type: object
                             secret:
                               description: secret information about the secret data
                                 to project
@@ -4758,6 +4526,7 @@ spec:
                     description: |-
                       rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                       Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                      More info: https://examples.k8s.io/volumes/rbd/README.md
                     properties:
                       fsType:
                         description: |-
@@ -5250,7 +5019,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -6286,13 +6055,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -6474,10 +6245,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -6556,7 +6329,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -6976,111 +6749,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -7215,6 +6883,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/pkg/component/observability/monitoring/persesoperator/templates/crd-perses.dev_perses.yaml
+++ b/pkg/component/observability/monitoring/persesoperator/templates/crd-perses.dev_perses.yaml
@@ -610,8 +610,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_instrumentations.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_instrumentations.yaml
@@ -69,9 +69,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -127,43 +126,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -235,9 +197,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -293,43 +254,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -397,7 +321,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -644,13 +568,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -701,9 +627,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -759,43 +684,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -863,7 +751,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1106,13 +994,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -1148,9 +1038,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -1206,43 +1094,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -1358,9 +1209,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -1416,43 +1266,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -1520,7 +1333,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1763,13 +1576,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -1814,9 +1629,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -1872,43 +1686,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -1996,7 +1773,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -2239,13 +2016,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -2284,9 +2063,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -2342,43 +2120,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -2450,9 +2191,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -2508,43 +2248,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -2612,7 +2315,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -2855,13 +2558,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -2900,9 +2605,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -2958,43 +2662,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -3062,7 +2729,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -3305,13 +2972,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-
@@ -3368,9 +3037,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -3426,43 +3094,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -3530,7 +3161,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -3773,13 +3404,15 @@ spec:
                               volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                               If specified, the CSI driver will create or update the volume with the attributes defined
                               in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                              it can be changed after the claim is created. An empty string or nil value indicates that no
-                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                              this field can be reset to its previous value (including nil) to cancel the modification.
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                               exists.
                               More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                             type: string
                           volumeMode:
                             description: |-

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opampbridges.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opampbridges.yaml
@@ -334,6 +334,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -348,6 +349,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -513,6 +515,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -527,6 +530,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -619,8 +623,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -689,6 +693,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -703,6 +708,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -868,6 +874,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -882,6 +889,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -999,9 +1007,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -1057,43 +1063,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -1154,7 +1123,6 @@ spec:
                   the OpAMPBridge Pods.
                 items:
                   description: EnvFromSource represents the source of a set of ConfigMaps
-                    or Secrets
                   properties:
                     configMapRef:
                       description: The ConfigMap to select from
@@ -1174,9 +1142,8 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
-                      description: |-
-                        Optional text to prepend to the name of each environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
                       type: string
                     secretRef:
                       description: The Secret to select from
@@ -1610,7 +1577,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -2023,6 +1990,7 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -2033,6 +2001,7 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -2821,13 +2790,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -3009,10 +2980,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -3066,7 +3039,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:
@@ -3091,7 +3064,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -3511,111 +3484,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -3750,6 +3618,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opentelemetrycollectors.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_opentelemetrycollectors.yaml
@@ -118,9 +118,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -176,43 +175,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -275,14 +237,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps or Secrets
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -303,9 +265,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -568,12 +529,6 @@ spec:
                               - port
                               type: object
                           type: object
-                        stopSignal:
-                          description: |-
-                            StopSignal defines which signal will be sent to a container when it is being stopped.
-                            If not specified, the default is defined by the container runtime in use.
-                            StopSignal can only be set for Pods with a non-empty .spec.os.name
-                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -976,7 +931,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -1030,10 +985,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -1045,59 +1000,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -1880,6 +1782,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1894,6 +1797,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2059,6 +1963,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2073,6 +1978,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2165,8 +2071,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2235,6 +2141,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2249,6 +2156,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2414,6 +2322,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2428,6 +2337,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2534,9 +2444,7 @@ spec:
                           policies:
                             description: |-
                               policies is a list of potential scaling polices which can be used during scaling.
-                              If not set, use the default values:
-                              - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
-                              - For scale down: allow all pods to be removed in a 15s window.
+                              At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -2579,24 +2487,6 @@ spec:
                               - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                             format: int32
                             type: integer
-                          tolerance:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              tolerance is the tolerance on the ratio between the current and desired
-                              metric value under which no updates are made to the desired number of
-                              replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
-                              set, the default cluster-wide tolerance is applied (by default 10%).
-
-                              For example, if autoscaling is configured with a memory consumption target of 100Mi,
-                              and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
-                              triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
-
-                              This is an alpha field and requires enabling the HPAConfigurableTolerance
-                              feature gate.
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
                         type: object
                       scaleUp:
                         description: |-
@@ -2609,9 +2499,7 @@ spec:
                           policies:
                             description: |-
                               policies is a list of potential scaling polices which can be used during scaling.
-                              If not set, use the default values:
-                              - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
-                              - For scale down: allow all pods to be removed in a 15s window.
+                              At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                             items:
                               description: HPAScalingPolicy is a single policy which
                                 must hold true for a specified past interval.
@@ -2654,24 +2542,6 @@ spec:
                               - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                             format: int32
                             type: integer
-                          tolerance:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              tolerance is the tolerance on the ratio between the current and desired
-                              metric value under which no updates are made to the desired number of
-                              replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
-                              set, the default cluster-wide tolerance is applied (by default 10%).
-
-                              For example, if autoscaling is configured with a memory consumption target of 100Mi,
-                              and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
-                              triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
-
-                              This is an alpha field and requires enabling the HPAConfigurableTolerance
-                              feature gate.
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
                         type: object
                     type: object
                   maxReplicas:
@@ -2946,7 +2816,7 @@ spec:
                           pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
                           on that node is marked deleted. If the old pod becomes unavailable for any
                           reason (Ready transitions to false, is evicted, or is drained) an updated
-                          pod is immediately created on that node without considering surge limits.
+                          pod is immediatedly created on that node without considering surge limits.
                           Allowing surge implies the possibility that the resources consumed by the
                           daemonset on any given node can double if the readiness check fails, and
                           so resource intensive daemonsets should take into account that they may
@@ -3038,9 +2908,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -3096,43 +2964,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -3193,7 +3024,6 @@ spec:
                   the generated pods.
                 items:
                   description: EnvFromSource represents the source of a set of ConfigMaps
-                    or Secrets
                   properties:
                     configMapRef:
                       description: The ConfigMap to select from
@@ -3213,9 +3043,8 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
-                      description: |-
-                        Optional text to prepend to the name of each environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
                       type: string
                     secretRef:
                       description: The Secret to select from
@@ -3378,9 +3207,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -3436,43 +3264,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -3535,14 +3326,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps or Secrets
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -3563,9 +3354,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -3828,12 +3618,6 @@ spec:
                               - port
                               type: object
                           type: object
-                        stopSignal:
-                          description: |-
-                            StopSignal defines which signal will be sent to a container when it is being stopped.
-                            If not specified, the default is defined by the container runtime in use.
-                            StopSignal can only be set for Pods with a non-empty .spec.os.name
-                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -4236,7 +4020,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -4290,10 +4074,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -4305,59 +4089,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -5090,12 +4821,6 @@ spec:
                         - port
                         type: object
                     type: object
-                  stopSignal:
-                    description: |-
-                      StopSignal defines which signal will be sent to a container when it is being stopped.
-                      If not specified, the default is defined by the container runtime in use.
-                      StopSignal can only be set for Pods with a non-empty .spec.os.name
-                    type: string
                 type: object
               livenessProbe:
                 description: |-
@@ -5712,7 +5437,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -6325,6 +6050,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -6339,6 +6065,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -6505,6 +6232,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -6519,6 +6247,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -6612,8 +6341,8 @@ spec:
                               most preferred is the one with the greatest sum of weights, i.e.
                               for each node that meets all of the scheduling requirements (resource
                               request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and subtracting
-                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
@@ -6683,6 +6412,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -6697,6 +6427,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -6863,6 +6594,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -6877,6 +6609,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -6997,9 +6730,8 @@ spec:
                         in a Container.
                       properties:
                         name:
-                          description: |-
-                            Name of the environment variable.
-                            May consist of any printable ASCII characters except '='.
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
                         value:
                           description: |-
@@ -7055,43 +6787,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fileKeyRef:
-                              description: |-
-                                FileKeyRef selects a key of the env file.
-                                Requires the EnvFiles feature gate to be enabled.
-                              properties:
-                                key:
-                                  description: |-
-                                    The key within the env file. An invalid key will prevent the pod from starting.
-                                    The keys defined within a source may consist of any printable ASCII characters except '='.
-                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                  type: string
-                                optional:
-                                  default: false
-                                  description: |-
-                                    Specify whether the file or its key must be defined. If the file or key
-                                    does not exist, then the env var is not published.
-                                    If optional is set to true and the specified key does not exist,
-                                    the environment variable will not be set in the Pod's containers.
-
-                                    If optional is set to false and the specified key does not exist,
-                                    an error will be returned during Pod creation.
-                                  type: boolean
-                                path:
-                                  description: |-
-                                    The path within the volume from which to select the file.
-                                    Must be relative and may not contain the '..' path or start with '..'.
-                                  type: string
-                                volumeName:
-                                  description: The name of the volume mount containing
-                                    the env file.
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -7704,7 +7399,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This field depends on the
+                          This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -8122,6 +7817,7 @@ spec:
                             - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                             If this value is nil, the behavior is equivalent to the Honor policy.
+                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         nodeTaintsPolicy:
                           description: |-
@@ -8132,6 +7828,7 @@ spec:
                             - Ignore: node taints are ignored. All nodes are included.
 
                             If this value is nil, the behavior is equivalent to the Ignore policy.
+                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         topologyKey:
                           description: |-
@@ -8348,6 +8045,7 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -8358,6 +8056,7 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -8619,13 +8318,15 @@ spec:
                             volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                             If specified, the CSI driver will create or update the volume with the attributes defined
                             in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                            it can be changed after the claim is created. An empty string or nil value indicates that no
-                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                            this field can be reset to its previous value (including nil) to cancel the modification.
+                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                            will be set by the persistentvolume controller if it exists.
                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                             exists.
                             More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                           type: string
                         volumeMode:
                           description: |-
@@ -8788,11 +8489,13 @@ spec:
                           description: |-
                             currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
                             When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                            This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                           type: string
                         modifyVolumeStatus:
                           description: |-
                             ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
                             When this is unset, there is no ModifyVolume operation being attempted.
+                            This is a beta field and requires enabling VolumeAttributesClass feature (off by default).
                           properties:
                             status:
                               description: "status is the status of the ControllerModifyVolume
@@ -9563,13 +9266,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -9751,10 +9456,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -9808,7 +9515,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:
@@ -9833,7 +9540,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -10253,111 +9960,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -10492,6 +10094,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-

--- a/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_targetallocators.yaml
+++ b/pkg/component/observability/opentelemetry/operator/assets/crd-opentelemetry.io_targetallocators.yaml
@@ -103,9 +103,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -161,43 +160,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -260,14 +222,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps or Secrets
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -288,9 +250,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -553,12 +514,6 @@ spec:
                               - port
                               type: object
                           type: object
-                        stopSignal:
-                          description: |-
-                            StopSignal defines which signal will be sent to a container when it is being stopped.
-                            If not specified, the default is defined by the container runtime in use.
-                            StopSignal can only be set for Pods with a non-empty .spec.os.name
-                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -961,7 +916,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -1015,10 +970,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -1030,59 +985,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -1865,6 +1767,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1879,6 +1782,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2044,6 +1948,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2058,6 +1963,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2150,8 +2056,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and subtracting
-                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2220,6 +2126,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2234,6 +2141,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2399,6 +2307,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                 Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2413,6 +2322,7 @@ spec:
                                 pod labels will be ignored. The default value is empty.
                                 The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                 Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                               items:
                                 type: string
                               type: array
@@ -2528,9 +2438,7 @@ spec:
                     a Container.
                   properties:
                     name:
-                      description: |-
-                        Name of the environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
                       type: string
                     value:
                       description: |-
@@ -2586,43 +2494,6 @@ spec:
                               type: string
                           required:
                           - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fileKeyRef:
-                          description: |-
-                            FileKeyRef selects a key of the env file.
-                            Requires the EnvFiles feature gate to be enabled.
-                          properties:
-                            key:
-                              description: |-
-                                The key within the env file. An invalid key will prevent the pod from starting.
-                                The keys defined within a source may consist of any printable ASCII characters except '='.
-                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                              type: string
-                            optional:
-                              default: false
-                              description: |-
-                                Specify whether the file or its key must be defined. If the file or key
-                                does not exist, then the env var is not published.
-                                If optional is set to true and the specified key does not exist,
-                                the environment variable will not be set in the Pod's containers.
-
-                                If optional is set to false and the specified key does not exist,
-                                an error will be returned during Pod creation.
-                              type: boolean
-                            path:
-                              description: |-
-                                The path within the volume from which to select the file.
-                                Must be relative and may not contain the '..' path or start with '..'.
-                              type: string
-                            volumeName:
-                              description: The name of the volume mount containing
-                                the env file.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -2683,7 +2554,6 @@ spec:
                   the generated pods.
                 items:
                   description: EnvFromSource represents the source of a set of ConfigMaps
-                    or Secrets
                   properties:
                     configMapRef:
                       description: The ConfigMap to select from
@@ -2703,9 +2573,8 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
-                      description: |-
-                        Optional text to prepend to the name of each environment variable.
-                        May consist of any printable ASCII characters except '='.
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
                       type: string
                     secretRef:
                       description: The Secret to select from
@@ -2801,9 +2670,8 @@ spec:
                           in a Container.
                         properties:
                           name:
-                            description: |-
-                              Name of the environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
                             type: string
                           value:
                             description: |-
@@ -2859,43 +2727,6 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              fileKeyRef:
-                                description: |-
-                                  FileKeyRef selects a key of the env file.
-                                  Requires the EnvFiles feature gate to be enabled.
-                                properties:
-                                  key:
-                                    description: |-
-                                      The key within the env file. An invalid key will prevent the pod from starting.
-                                      The keys defined within a source may consist of any printable ASCII characters except '='.
-                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
-                                    type: string
-                                  optional:
-                                    default: false
-                                    description: |-
-                                      Specify whether the file or its key must be defined. If the file or key
-                                      does not exist, then the env var is not published.
-                                      If optional is set to true and the specified key does not exist,
-                                      the environment variable will not be set in the Pod's containers.
-
-                                      If optional is set to false and the specified key does not exist,
-                                      an error will be returned during Pod creation.
-                                    type: boolean
-                                  path:
-                                    description: |-
-                                      The path within the volume from which to select the file.
-                                      Must be relative and may not contain the '..' path or start with '..'.
-                                    type: string
-                                  volumeName:
-                                    description: The name of the volume mount containing
-                                      the env file.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -2958,14 +2789,14 @@ spec:
                     envFrom:
                       description: |-
                         List of sources to populate environment variables in the container.
-                        The keys defined within a source may consist of any printable ASCII characters except '='.
-                        When a key exists in multiple
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
                         sources, the value associated with the last source will take precedence.
                         Values defined by an Env with a duplicate key will take precedence.
                         Cannot be updated.
                       items:
                         description: EnvFromSource represents the source of a set
-                          of ConfigMaps or Secrets
+                          of ConfigMaps
                         properties:
                           configMapRef:
                             description: The ConfigMap to select from
@@ -2986,9 +2817,8 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: |-
-                              Optional text to prepend to the name of each environment variable.
-                              May consist of any printable ASCII characters except '='.
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -3251,12 +3081,6 @@ spec:
                               - port
                               type: object
                           type: object
-                        stopSignal:
-                          description: |-
-                            StopSignal defines which signal will be sent to a container when it is being stopped.
-                            If not specified, the default is defined by the container runtime in use.
-                            StopSignal can only be set for Pods with a non-empty .spec.os.name
-                          type: string
                       type: object
                     livenessProbe:
                       description: |-
@@ -3659,7 +3483,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This field depends on the
+                            This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -3713,10 +3537,10 @@ spec:
                     restartPolicy:
                       description: |-
                         RestartPolicy defines the restart behavior of individual containers in a pod.
-                        This overrides the pod-level restart policy. When this field is not specified,
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
                         the restart behavior is defined by the Pod's restart policy and the container type.
-                        Additionally, setting the RestartPolicy as "Always" for the init container will
-                        have the following effect:
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
                         this init container will be continually restarted on
                         exit until all regular containers have terminated. Once all regular
                         containers have completed, all init containers with restartPolicy "Always"
@@ -3728,59 +3552,6 @@ spec:
                         init container is started, or after any startupProbe has successfully
                         completed.
                       type: string
-                    restartPolicyRules:
-                      description: |-
-                        Represents a list of rules to be checked to determine if the
-                        container should be restarted on exit. The rules are evaluated in
-                        order. Once a rule matches a container exit condition, the remaining
-                        rules are ignored. If no rule matches the container exit condition,
-                        the Container-level restart policy determines the whether the container
-                        is restarted or not. Constraints on the rules:
-                        - At most 20 rules are allowed.
-                        - Rules can have the same action.
-                        - Identical rules are not forbidden in validations.
-                        When rules are specified, container MUST set RestartPolicy explicitly
-                        even it if matches the Pod's RestartPolicy.
-                      items:
-                        description: ContainerRestartRule describes how a container
-                          exit is handled.
-                        properties:
-                          action:
-                            description: |-
-                              Specifies the action taken on a container exit if the requirements
-                              are satisfied. The only possible value is "Restart" to restart the
-                              container.
-                            type: string
-                          exitCodes:
-                            description: Represents the exit codes to check on container
-                              exits.
-                            properties:
-                              operator:
-                                description: |-
-                                  Represents the relationship between the container exit code(s) and the
-                                  specified values. Possible values are:
-                                  - In: the requirement is satisfied if the container exit code is in the
-                                    set of specified values.
-                                  - NotIn: the requirement is satisfied if the container exit code is
-                                    not in the set of specified values.
-                                type: string
-                              values:
-                                description: |-
-                                  Specifies the set of values to check for container exit codes.
-                                  At most 255 elements are allowed.
-                                items:
-                                  format: int32
-                                  type: integer
-                                type: array
-                                x-kubernetes-list-type: set
-                            required:
-                            - operator
-                            type: object
-                        required:
-                        - action
-                        type: object
-                      type: array
-                      x-kubernetes-list-type: atomic
                     securityContext:
                       description: |-
                         SecurityContext defines the security options the container should be run with.
@@ -4513,12 +4284,6 @@ spec:
                         - port
                         type: object
                     type: object
-                  stopSignal:
-                    description: |-
-                      StopSignal defines which signal will be sent to a container when it is being stopped.
-                      If not specified, the default is defined by the container runtime in use.
-                      StopSignal can only be set for Pods with a non-empty .spec.os.name
-                    type: string
                 type: object
               managementState:
                 default: managed
@@ -5221,7 +4986,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This field depends on the
+                      This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -5665,6 +5430,7 @@ spec:
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                         If this value is nil, the behavior is equivalent to the Honor policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     nodeTaintsPolicy:
                       description: |-
@@ -5675,6 +5441,7 @@ spec:
                         - Ignore: node taints are ignored. All nodes are included.
 
                         If this value is nil, the behavior is equivalent to the Ignore policy.
+                        This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
                     topologyKey:
                       description: |-
@@ -6462,13 +6229,15 @@ spec:
                                     volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                                     If specified, the CSI driver will create or update the volume with the attributes defined
                                     in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string or nil value indicates that no
-                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
-                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
                                     If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                     set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                     exists.
                                     More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                   type: string
                                 volumeMode:
                                   description: |-
@@ -6650,10 +6419,12 @@ spec:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
                         Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: endpoints is the endpoint name that details
-                            Glusterfs topology.
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
                           description: |-
@@ -6707,7 +6478,7 @@ spec:
                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                         The volume will be mounted read-only (ro) and non-executable files (noexec).
-                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                       properties:
                         pullPolicy:
@@ -6732,7 +6503,7 @@ spec:
                       description: |-
                         iscsi represents an ISCSI Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
                           description: chapAuthDiscovery defines whether support iSCSI
@@ -7152,111 +6923,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                 type: object
-                              podCertificate:
-                                description: |-
-                                  Projects an auto-rotating credential bundle (private key and certificate
-                                  chain) that the pod can use either as a TLS client or server.
-
-                                  Kubelet generates a private key and uses it to send a
-                                  PodCertificateRequest to the named signer.  Once the signer approves the
-                                  request and issues a certificate chain, Kubelet writes the key and
-                                  certificate chain to the pod filesystem.  The pod does not start until
-                                  certificates have been issued for each podCertificate projected volume
-                                  source in its spec.
-
-                                  Kubelet will begin trying to rotate the certificate at the time indicated
-                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
-                                  timestamp.
-
-                                  Kubelet can write a single file, indicated by the credentialBundlePath
-                                  field, or separate files, indicated by the keyPath and
-                                  certificateChainPath fields.
-
-                                  The credential bundle is a single file in PEM format.  The first PEM
-                                  entry is the private key (in PKCS#8 format), and the remaining PEM
-                                  entries are the certificate chain issued by the signer (typically,
-                                  signers will return their certificate chain in leaf-to-root order).
-
-                                  Prefer using the credential bundle format, since your application code
-                                  can read it atomically.  If you use keyPath and certificateChainPath,
-                                  your application must make two separate file reads. If these coincide
-                                  with a certificate rotation, it is possible that the private key and leaf
-                                  certificate you read may not correspond to each other.  Your application
-                                  will need to check for this condition, and re-read until they are
-                                  consistent.
-
-                                  The named signer controls chooses the format of the certificate it
-                                  issues; consult the signer implementation's documentation to learn how to
-                                  use the certificates it issues.
-                                properties:
-                                  certificateChainPath:
-                                    description: |-
-                                      Write the certificate chain at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  credentialBundlePath:
-                                    description: |-
-                                      Write the credential bundle at this path in the projected volume.
-
-                                      The credential bundle is a single file that contains multiple PEM blocks.
-                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
-                                      key.
-
-                                      The remaining blocks are CERTIFICATE blocks, containing the issued
-                                      certificate chain from the signer (leaf and any intermediates).
-
-                                      Using credentialBundlePath lets your Pod's application code make a single
-                                      atomic read that retrieves a consistent key and certificate chain.  If you
-                                      project them to separate files, your application code will need to
-                                      additionally check that the leaf certificate was issued to the key.
-                                    type: string
-                                  keyPath:
-                                    description: |-
-                                      Write the key at this path in the projected volume.
-
-                                      Most applications should use credentialBundlePath.  When using keyPath
-                                      and certificateChainPath, your application needs to check that the key
-                                      and leaf certificate are consistent, because it is possible to read the
-                                      files mid-rotation.
-                                    type: string
-                                  keyType:
-                                    description: |-
-                                      The type of keypair Kubelet will generate for the pod.
-
-                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
-                                      "ECDSAP521", and "ED25519".
-                                    type: string
-                                  maxExpirationSeconds:
-                                    description: |-
-                                      maxExpirationSeconds is the maximum lifetime permitted for the
-                                      certificate.
-
-                                      Kubelet copies this value verbatim into the PodCertificateRequests it
-                                      generates for this projection.
-
-                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
-                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
-                                      value is 7862400 (91 days).
-
-                                      The signer implementation is then free to issue a certificate with any
-                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
-                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
-                                      `kubernetes.io` signers will never issue certificates with a lifetime
-                                      longer than 24 hours.
-                                    format: int32
-                                    type: integer
-                                  signerName:
-                                    description: Kubelet's generated CSRs will be
-                                      addressed to this signer.
-                                    type: string
-                                required:
-                                - keyType
-                                - signerName
-                                type: object
                               secret:
                                 description: secret information about the secret data
                                   to project
@@ -7391,6 +7057,7 @@ spec:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
                         Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
                           description: |-


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity open-source ipcei
/kind cleanup technical-debt

**What this PR does / why we need it**:
Remove the usage of `VGOPATH`. This also fixes the k8s version used when generating CRDs of dependencies.

Main change comes with how `go-to-protobuf` needs to be called, as it still expects a `GOPATH` layout.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Authored together with @maboehm at the Gardener Hackathon in November 2025.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The usages of `VGOPATH` have been removed.
```

```noteworthy developer
The script `hack/vgopath-setup.sh` and `hack/tools.mk` entry for `$(VGOPATH)` are deprecated and will be removed after `gardener/gardener@v1.142` has been released. It is recommended that consumers stop using them from the `gardener/gardener` repository.
```