### PR TITLE
Insecure communication for local registries

### DIFF
--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -25,7 +25,7 @@ import (
 const (
 	mediaTypeHelm = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
-	inKubernetesRegistry = "garden.local.gardener.cloud:5001"
+	inKubernetesRegistry = "local.gardener.cloud:"
 )
 
 type pullSecretNamespace struct{}

--- a/pkg/utils/oci/helmregistry_test.go
+++ b/pkg/utils/oci/helmregistry_test.go
@@ -193,6 +193,10 @@ var _ = Describe("buildRef", func() {
 			&gardencorev1.OCIRepository{Ref: ptr.To("garden.local.gardener.cloud:5001/foo:1.0.0")},
 			name.MustParseReference("garden.local.gardener.cloud:5001/foo:1.0.0", name.Insecure),
 		),
+		Entry("configure insecure in local setup when using registry.local.gardener.cloud",
+			&gardencorev1.OCIRepository{Ref: ptr.To("registry.local.gardener.cloud:5000/foo:1.0.0")},
+			name.MustParseReference("registry.local.gardener.cloud:5000/foo:1.0.0", name.Insecure),
+		),
 	)
 })
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/13551, the local registry will be no longer exposed under `garden.local.gardener.cloud:5001` but `registry.local.gardener.cloud:5000`.
In order to make the `e2e-upgrade` tests work, we have to make sure that already older Gardener versions talk to the new registry via HTTP instead of HTTPS. See https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13551/pull-gardener-e2e-kind-upgrade/1993796026556747776.

This PR must be merged and released before https://github.com/gardener/gardener/pull/13551 can be merged.

**Special notes for your reviewer**:
FYI @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
