### PR TITLE
Add nftables support to kube-proxy

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -272,7 +272,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
-  #   mode: IPVS
+  #   mode: IPVS # {IPTables,NFTables,IPVS}
   #   enabled: true
   # kubelet:
   #   cpuCFSQuota: true

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -1013,6 +1013,8 @@ type ProxyMode string
 const (
 	// ProxyModeIPTables uses iptables as proxy implementation.
 	ProxyModeIPTables ProxyMode = "IPTables"
+	// ProxyModeNFTables uses nftables as proxy implementation.
+	ProxyModeNFTables ProxyMode = "NFTables"
 	// ProxyModeIPVS uses ipvs as proxy implementation.
 	ProxyModeIPVS ProxyMode = "IPVS"
 )

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1324,6 +1324,8 @@ type ProxyMode string
 const (
 	// ProxyModeIPTables uses iptables as proxy implementation.
 	ProxyModeIPTables ProxyMode = "IPTables"
+	// ProxyModeNFTables uses nftables as proxy implementation.
+	ProxyModeNFTables ProxyMode = "NFTables"
 	// ProxyModeIPVS uses ipvs as proxy implementation.
 	ProxyModeIPVS ProxyMode = "IPVS"
 )

--- a/pkg/component/kubernetes/proxy/proxy.go
+++ b/pkg/component/kubernetes/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
@@ -90,8 +91,8 @@ type kubeProxy struct {
 
 // Values is a set of configuration values for the kube-proxy component.
 type Values struct {
-	// IPVSEnabled states whether IPVS is enabled.
-	IPVSEnabled bool
+	// ProxyMode defines the kernel module used for the proxy, can be one of ipvs, iptables or nftables.
+	ProxyMode gardencore.ProxyMode
 	// FeatureGates is the set of feature gates.
 	FeatureGates map[string]bool
 	// ImageAlpine is the alpine container image.

--- a/pkg/gardenlet/operation/botanist/kubeproxy.go
+++ b/pkg/gardenlet/operation/botanist/kubeproxy.go
@@ -15,6 +15,7 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	kubeproxy "github.com/gardener/gardener/pkg/component/kubernetes/proxy"
@@ -39,7 +40,7 @@ func (b *Botanist) DefaultKubeProxy() (kubeproxy.Interface, error) {
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		kubeproxy.Values{
-			IPVSEnabled:  b.Shoot.IPVSEnabled(),
+			ProxyMode:    core.ProxyMode(b.Shoot.ProxyMode()),
 			FeatureGates: featureGates,
 			ImageAlpine:  imageAlpine.String(),
 			VPAEnabled:   b.Shoot.WantsVerticalPodAutoscaler,

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -68,7 +68,7 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	for _, ip := range b.Shoot.Networks.CoreDNS {
 		coreDNS = append(coreDNS, ip.String())
 	}
-	if b.Shoot.IPVSEnabled() {
+	if b.Shoot.ProxyMode() == gardencorev1beta1.ProxyModeIPVS {
 		clusterDNS = coreDNS
 	} else {
 		dnsServers = coreDNS

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -148,7 +148,7 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 		clusterDNSAddresses = clusterDNSAddresses[:1]
 	}
 
-	if b.Shoot.NodeLocalDNSEnabled && b.Shoot.IPVSEnabled() {
+	if b.Shoot.NodeLocalDNSEnabled && b.Shoot.ProxyMode() == gardencorev1beta1.ProxyModeIPVS {
 		// If IPVS is enabled then instruct the kubelet to create pods resolving DNS to the `nodelocaldns` network
 		// interface link-local ip address. For more information checkout the usage documentation under
 		// https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/.

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -507,12 +507,13 @@ func (s *Shoot) ComputeOutOfClusterAPIServerAddress(preferInternalClusterDomain 
 	return v1beta1helper.GetAPIServerDomain(*s.ExternalClusterDomain)
 }
 
-// IPVSEnabled returns true if IPVS is enabled for the shoot.
-func (s *Shoot) IPVSEnabled() bool {
+// ProxyMode returns the kube-proxy mode config for the shoot.
+func (s *Shoot) ProxyMode() gardencorev1beta1.ProxyMode {
 	shoot := s.GetInfo()
-	return shoot.Spec.Kubernetes.KubeProxy != nil &&
-		shoot.Spec.Kubernetes.KubeProxy.Mode != nil &&
-		*shoot.Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS
+	if shoot.Spec.Kubernetes.KubeProxy != nil && shoot.Spec.Kubernetes.KubeProxy.Mode != nil {
+		return *shoot.Spec.Kubernetes.KubeProxy.Mode
+	}
+	return gardencorev1beta1.ProxyModeIPTables
 }
 
 // IsShootControlPlaneLoggingEnabled return true if the Shoot controlplane logging is enabled

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -162,15 +162,15 @@ var _ = Describe("shoot", func() {
 			)
 		})
 
-		Describe("#IPVSEnabled", func() {
+		Describe("#ProxyMode", func() {
 			It("should return false when KubeProxy is null", func() {
 				shoot.GetInfo().Spec.Kubernetes.KubeProxy = nil
-				Expect(shoot.IPVSEnabled()).To(BeFalse())
+				Expect(shoot.ProxyMode()).To(Equal(gardencorev1beta1.ProxyModeIPTables))
 			})
 
 			It("should return false when KubeProxy.Mode is null", func() {
 				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{}
-				Expect(shoot.IPVSEnabled()).To(BeFalse())
+				Expect(shoot.ProxyMode()).To(Equal(gardencorev1beta1.ProxyModeIPTables))
 			})
 
 			It("should return false when KubeProxy.Mode is not IPVS", func() {
@@ -178,7 +178,7 @@ var _ = Describe("shoot", func() {
 				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
 					Mode: &mode,
 				}
-				Expect(shoot.IPVSEnabled()).To(BeFalse())
+				Expect(shoot.ProxyMode()).To(Equal(gardencorev1beta1.ProxyModeIPTables))
 			})
 
 			It("should return true when KubeProxy.Mode is IPVS", func() {
@@ -186,7 +186,7 @@ var _ = Describe("shoot", func() {
 				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
 					Mode: &mode,
 				}
-				Expect(shoot.IPVSEnabled()).To(BeTrue())
+				Expect(shoot.ProxyMode()).To(Equal(gardencorev1beta1.ProxyModeIPVS))
 			})
 		})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
NFtables is added as a additional option to kube-proxy mode.

**Which issue(s) this PR fixes**:
Fixes #11686

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now specify `nftables` as proxy mode implementation of `kube-proxy` in the `Shoot` spec like so if your Kubernetes version is `>= 1.31`: `.spec.kubernetes.kubeProxy.mode=NFTables`, please consult https://kubernetes.io/blog/2025/02/28/nftables-kube-proxy/ for all glory details.
```
