### PR TITLE
Deflake `controllermanager/cloudprofile` integration test

### DIFF
--- a/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apiserver/features"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/cloudprofile"
@@ -35,6 +36,7 @@ import (
 )
 
 func TestCloudProfile(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test Integration ControllerManager CloudProfile Suite")
 }

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
@@ -108,7 +108,7 @@ var _ = DescribeTableSubtree("CloudProfile controller tests", func(isCapabilitie
 			shoot.Spec.CloudProfileName = &cloudProfile.Name
 			Eventually(func() error {
 				return testClient.Create(ctx, shoot)
-			}).To(Succeed())
+			}).Should(Succeed())
 			log.Info("Created shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			By("Wait until manager has observed Shoot")

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
@@ -106,7 +106,9 @@ var _ = DescribeTableSubtree("CloudProfile controller tests", func(isCapabilitie
 		if shoot != nil {
 			By("Create Shoot")
 			shoot.Spec.CloudProfileName = &cloudProfile.Name
-			Expect(testClient.Create(ctx, shoot)).To(Succeed())
+			Eventually(func() error {
+				return testClient.Create(ctx, shoot)
+			}).To(Succeed())
 			log.Info("Created shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
 			By("Wait until manager has observed Shoot")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Sometimes, the integration test failed due to the unability to retrieve the referenced `CloudProfile`:
```console
 [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0x140007e1720>:         
      Internal error occurred: could not find referenced cloud profile: cloudprofile.core.gardener.cloud "cloudprofile-controller-test-f9mqh" not found        
      {                                              
          ErrStatus: {                               
              TypeMeta: {Kind: "", APIVersion: ""},  
              ListMeta: {                            
                  SelfLink: "",                      
                  ResourceVersion: "",               
                  Continue: "",                      
                  RemainingItemCount: nil,           
              },                                     
              Status: "Failure",                     
              Message: "Internal error occurred: could not find referenced cloud profile: cloudprofile.core.gardener.cloud \"cloudprofile-controller-test-f9mqh\" not found",                                       
              Reason: "InternalError",               
              Details: {                             
                  Name: "",                          
                  Group: "",                         
                  Kind: "",                          
                  UID: "",                           
                  Causes: [                          
                      {                              
                          Type: "",                  
                          Message: "could not find referenced cloud profile: cloudprofile.core.gardener.cloud \"cloudprofile-controller-test-f9mqh\" not found",                                                    
                          Field: "",                 
                      },                             
                  ],                                 
                  RetryAfterSeconds: 0,              
              },                                     
              Code: 500,                             
          },                                         
      }                                              
  In [JustBeforeEach] at: /Users/I543201/SAPDevelop/github.com/gardener/gardener/test/integration/controllermanager/cloudprofile/cloudprofile_test.go:112 @ 11/27/25 12:03:09.402     
```

This PR aims at fixing this by retrying the `Shoot` creation:
```
# from: 1m35s: 348 runs so far, 13 failures (3.74%), 48 active
# to:   2m15s: 528 runs so far,  0 failures,         48 active
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
