### PR TITLE
Improve the check for the local registry

### DIFF
--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -25,7 +25,7 @@ import (
 const (
 	mediaTypeHelm = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
-	inKubernetesRegistry = "local.gardener.cloud:"
+	inKubernetesRegistry = "garden.local.gardener.cloud:5001"
 )
 
 type pullSecretNamespace struct{}
@@ -122,7 +122,10 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	}
 
 	// in the local setup we don't want to use TLS
-	if strings.Contains(ref, inKubernetesRegistry) {
+	//
+	// Allow "registry.local.gardener.cloud:5000" to make the e2e-upgrade tests work.
+	// With https://github.com/gardener/gardener/pull/13551 the local registry will be exposed under "registry.local.gardener.cloud:5000".
+	if strings.Contains(ref, inKubernetesRegistry) || strings.Contains(ref, "registry.local.gardener.cloud:5000") {
 		opts = append(opts, name.Insecure)
 	}
 

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -125,6 +125,9 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	//
 	// Allow "registry.local.gardener.cloud:5000" to make the e2e-upgrade tests work.
 	// With https://github.com/gardener/gardener/pull/13551 the local registry will be exposed under "registry.local.gardener.cloud:5000".
+	//
+	// TODO(ialidzhikov): Change the local registry to "registry.local.gardener.cloud:5000" after https://github.com/gardener/gardener/pull/13551 is merged.
+	// TODO(ialidzhikov): Remove the check for "garden.local.gardener.cloud:5001" after https://github.com/gardener/gardener/pull/13551 is released.
 	if strings.Contains(ref, inKubernetesRegistry) || strings.Contains(ref, "registry.local.gardener.cloud:5000") {
 		opts = append(opts, name.Insecure)
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The PR improves the check for the local registry so we always check for the full hostname and port.
I find it this approach (keeping full local registry host)  more intuitive and understandable than checking for the `local.gardener.cloud:` substring.

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/13557

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
