### PR TITLE
[GEP-26] Promote DoNotCopyBackupCredentials feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,8 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | InPlaceNodeUpdates                       | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination                      | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities                 | `false` | `Alpha` | `1.117` |         |
-| DoNotCopyBackupCredentials               | `false` | `Alpha` | `1.121` | `1.122` |
-| DoNotCopyBackupCredentials               | `true`  | `Beta`  | `1.123` |         |
 | OpenTelemetryCollector                   | `false` | `Alpha` | `1.124` |         |
 | UseUnifiedHTTPProxyPort                  | `false` | `Alpha` | `1.130` |         |
 | VPAInPlaceUpdates                        | `false` | `Alpha` | `1.133` |         |
@@ -207,6 +205,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCredentialsBinding                      | `false` | `Alpha`      | `1.98`  | `1.106` |
 | ShootCredentialsBinding                      | `true`  | `Beta`       | `1.107` | `1.132` |
 | ShootCredentialsBinding                      | `true`  | `GA`         | `1.133` |         |
+| DoNotCopyBackupCredentials                   | `false` | `Alpha`      | `1.121` | `1.122` |
+| DoNotCopyBackupCredentials                   | `true`  | `Beta`       | `1.123` | `1.133` |
+| DoNotCopyBackupCredentials                   | `true`  | `GA`         | `1.134` |         |
 
 ## Using a Feature
 

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -446,14 +446,12 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	}
 
 	// Get backup secret
-	backupSecret, originalErr := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
-
-	if client.IgnoreNotFound(originalErr) != nil {
-		return originalErr
-	}
-
-	if apierrors.IsNotFound(originalErr) {
-		return fmt.Errorf("the configured backup secret does not exist and shoot infrastructure credentials will not be reused: %w", originalErr)
+	backupSecret, err := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("the configured backup secret does not exist: %w", err)
+		}
+		return err
 	}
 
 	const (

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -6,7 +6,6 @@ package gardenletdeployer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -17,14 +16,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -35,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/utils"
@@ -451,13 +447,6 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 		return nil
 	}
 
-	// If backup is specified and DoNotCopyBackupCredentials feature gate is disabled,
-	// create or update the backup secret if it doesn't exist or is owned by the object.
-	var (
-		checksum     string
-		allowCopying = !utilfeature.DefaultFeatureGate.Enabled(features.DoNotCopyBackupCredentials)
-	)
-
 	// Get backup secret
 	backupSecret, originalErr := kubernetesutils.GetSecretByObjectReference(ctx, a.GardenClient, spec.Backup.CredentialsRef)
 
@@ -465,12 +454,8 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 		return originalErr
 	}
 
-	if apierrors.IsNotFound(originalErr) && !allowCopying {
-		return fmt.Errorf("the configured backup secret does not exist, however the feature gate DoNotCopyBackupCredentials is enabled and shoot infrastructure credentials will not be reused: %w", originalErr)
-	}
-
-	if originalErr == nil {
-		checksum = utils.ComputeSecretChecksum(backupSecret.Data)[:8]
+	if apierrors.IsNotFound(originalErr) {
+		return fmt.Errorf("the configured backup secret does not exist and shoot infrastructure credentials will not be reused: %w", originalErr)
 	}
 
 	const (
@@ -478,44 +463,9 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 		secretStatusLabelValue = "previously-managed"
 	)
 
-	// Create or update backup secret if it doesn't exist, or is owned by the object, or was previously managed by this controller
-	if allowCopying && (apierrors.IsNotFound(originalErr) || metav1.IsControlledBy(backupSecret, obj) || backupSecret.Labels[secretStatusLabelKey] == secretStatusLabelValue) {
-		gvk, err := apiutil.GVKForObject(obj, a.GardenClient.Scheme())
-		if err != nil {
-			return fmt.Errorf("could not get GroupVersionKind from object %v: %w", obj, err)
-		}
-
-		infrastructureSecret, err := a.GetInfrastructureSecret(ctx)
-		if err != nil {
-			return err
-		}
-
-		// If there is no infrastructure Secret, e.g. WorkloadIdentity is used instead
-		// we skip the copying as it is not supported.
-		if infrastructureSecret != nil {
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Namespace: spec.Backup.CredentialsRef.Namespace, Name: spec.Backup.CredentialsRef.Name},
-			}
-
-			if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.GardenClient, secret, func() error {
-				secret.OwnerReferences = []metav1.OwnerReference{
-					*metav1.NewControllerRef(obj, gvk),
-				}
-				secret.Type = corev1.SecretTypeOpaque
-				secret.Data = infrastructureSecret.Data
-				delete(secret.Labels, secretStatusLabelKey)
-				return nil
-			}); err != nil {
-				return err
-			}
-
-			checksum = utils.ComputeSecretChecksum(secret.Data)[:8]
-		} else if apierrors.IsNotFound(originalErr) {
-			return errors.New("backup is configured to reference a credential, but there is no infrastructure credential to copy")
-		}
-	} else if !allowCopying && metav1.IsControlledBy(backupSecret, obj) {
-		// backup secret was copied at an earlier stage
-		// remove the ownerReference as the controller is no longer responsible for it
+	// If backup secret was copied at an earlier stage, remove the ownerReference as the controller is no longer responsible for it
+	// TODO(dimityrmirchev): Remove this logic when the DoNotCopyBackupCredentials feature gate is removed
+	if metav1.IsControlledBy(backupSecret, obj) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: spec.Backup.CredentialsRef.Namespace, Name: spec.Backup.CredentialsRef.Name},
 		}
@@ -539,7 +489,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 		gardenletDeployment = &seedmanagementv1alpha1.GardenletDeployment{}
 	}
 	gardenletDeployment.PodAnnotations = utils.MergeStringMaps(gardenletDeployment.PodAnnotations, map[string]string{
-		"checksum/seed-backup-secret": spec.Backup.CredentialsRef.Name + "-" + checksum,
+		"checksum/seed-backup-secret": spec.Backup.CredentialsRef.Name + "-" + utils.ComputeSecretChecksum(backupSecret.Data)[:8],
 	})
 
 	return nil

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -460,7 +460,7 @@ func (a *Actuator) reconcileSeedSecrets(ctx context.Context, obj client.Object, 
 	)
 
 	// If backup secret was copied at an earlier stage, remove the ownerReference as the controller is no longer responsible for it
-	// TODO(dimityrmirchev): Remove this logic when the DoNotCopyBackupCredentials feature gate is removed
+	// TODO(dimityrmirchev): Remove this logic when the DoNotCopyBackupCredentials feature gate is removed, i.e. after v1.134 has been released.
 	if metav1.IsControlledBy(backupSecret, obj) {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Namespace: spec.Backup.CredentialsRef.Namespace, Name: spec.Backup.CredentialsRef.Name},

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -60,12 +60,10 @@ type Interface interface {
 
 // Actuator is a concrete implementation of Interface.
 type Actuator struct {
-	GardenConfig            *rest.Config
-	GardenClient            client.Client
-	GetTargetClientFunc     func(ctx context.Context) (kubernetes.Interface, error)
-	CheckIfVPAAlreadyExists func(ctx context.Context) (bool, error)
-	// GetInfrastructureSecret will return the infrastructure secret or nil if other kind of credentials are used instead.
-	GetInfrastructureSecret  func(ctx context.Context) (*corev1.Secret, error) // TODO(dimityrmirchev): Deprecate and eventually remove this function.
+	GardenConfig             *rest.Config
+	GardenClient             client.Client
+	GetTargetClientFunc      func(ctx context.Context) (kubernetes.Interface, error)
+	CheckIfVPAAlreadyExists  func(ctx context.Context) (bool, error)
 	GetTargetDomain          func() string
 	ApplyGardenletChart      func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]interface{}) error
 	DeleteGardenletChart     func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]interface{}) error

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -31,11 +31,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockgardenletdepoyer "github.com/gardener/gardener/pkg/controller/gardenletdeployer/mock"
-	"github.com/gardener/gardener/pkg/features"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockrecord "github.com/gardener/gardener/third_party/mock/client-go/tools/record"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
@@ -67,9 +65,7 @@ var _ = Describe("Interface", func() {
 
 		ctx context.Context
 
-		managedSeed   *seedmanagementv1alpha1.ManagedSeed
-		secretBinding *gardencorev1beta1.SecretBinding
-		secret        *corev1.Secret
+		managedSeed *seedmanagementv1alpha1.ManagedSeed
 
 		seedTemplate *gardencorev1beta1.SeedTemplate
 		gardenlet    seedmanagementv1alpha1.GardenletConfig
@@ -98,8 +94,6 @@ var _ = Describe("Interface", func() {
 		shootClientSet.EXPECT().Client().Return(shootClient).AnyTimes()
 		shootClientSet.EXPECT().ChartApplier().Return(shootChartApplier).AnyTimes()
 
-		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.DoNotCopyBackupCredentials, false))
-
 		log = logr.Discard()
 		actuator = &Actuator{
 			GardenConfig: &rest.Config{},
@@ -118,7 +112,7 @@ var _ = Describe("Interface", func() {
 			},
 			GetInfrastructureSecret: func(ctx context.Context) (*corev1.Secret, error) {
 				shootSecretBinding := &gardencorev1beta1.SecretBinding{}
-				if err := gardenClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretBindingName}, shootSecretBinding); err != nil {
+				if err := gardenClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "test-secret-binding"}, shootSecretBinding); err != nil {
 					return nil, err
 				}
 				return kubernetesutils.GetSecretByReference(ctx, gardenClient, &shootSecretBinding.SecretRef)
@@ -149,25 +143,6 @@ var _ = Describe("Interface", func() {
 				Shoot: &seedmanagementv1alpha1.Shoot{
 					Name: name,
 				},
-			},
-		}
-		secretBinding = &gardencorev1beta1.SecretBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretBindingName,
-				Namespace: namespace,
-			},
-			SecretRef: corev1.SecretReference{
-				Name:      secretName,
-				Namespace: namespace,
-			},
-		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: namespace,
-			},
-			Data: map[string][]byte{
-				"foo": []byte("bar"),
 			},
 		}
 
@@ -233,7 +208,9 @@ var _ = Describe("Interface", func() {
 					*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 				},
 			},
-			Data: secret.Data,
+			Data: map[string][]byte{
+				"backupKey": []byte("backupValue"),
+			},
 			Type: corev1.SecretTypeOpaque,
 		}
 		seed = &gardencorev1beta1.Seed{
@@ -307,31 +284,26 @@ var _ = Describe("Interface", func() {
 		}
 
 		expectCreateSeedSecrets = func() {
+			// Backup secret should already exist (no longer copied from infrastructure secret)
+			// First Get: check if backup secret exists
 			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, _ *corev1.Secret, _ ...client.GetOption) error {
-					return apierrors.NewNotFound(corev1.Resource("secret"), backupSecretName)
-				},
-			)
-			// Get shoot secret
-			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretBindingName}, gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, sb *gardencorev1beta1.SecretBinding, _ ...client.GetOption) error {
-					*sb = *secretBinding
-					return nil
-				},
-			)
-			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-					*s = *secret
+					*s = *backupSecret
 					return nil
 				},
 			)
-			// Create backup secret
-			gardenClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
-					Expect(s).To(Equal(backupSecret))
+			// Second Get: patch operation to remove owner reference
+			gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
+					*s = *backupSecret
 					return nil
 				},
 			)
+			// Patch to remove owner reference and add label
+			gardenClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
+				Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"labels":{"secret.backup.gardener.cloud/status":"previously-managed"},"ownerReferences":null}}`))
+				return nil
+			})
 		}
 
 		expectDeleteSeedSecrets = func() {
@@ -574,57 +546,51 @@ var _ = Describe("Interface", func() {
 				))
 			})
 
-			When("DoNotCopyBackupCredentials feature gate is enabled", func() {
-				BeforeEach(func() {
-					DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.DoNotCopyBackupCredentials, true))
+			It("should return error when backup secret does not exist", func() {
+				expectCheckSeedSpec()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring gardenlet namespace in target cluster")
+				expectCreateGardenNamespace()
+				recorder.EXPECT().Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
+
+				gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(corev1.Resource("secret"), backupSecretName))
+
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, gomock.Any())
+
+				_, err := actuator.Reconcile(ctx, log, managedSeed, managedSeed.Status.Conditions, managedSeed.Spec.Gardenlet.Deployment, &gardenlet.Config, *managedSeed.Spec.Gardenlet.Bootstrap, *managedSeed.Spec.Gardenlet.MergeWithParent)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not reconcile seed test secrets: the configured backup secret does not exist and shoot infrastructure credentials will not be reused"))
+			})
+
+			It("should remove owner reference from backup secret", func() {
+				shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), gomock.Any()).Return(nil)
+
+				expectGetSeed(false)
+				expectCheckSeedSpec()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring gardenlet namespace in target cluster")
+				expectCreateGardenNamespace()
+				recorder.EXPECT().Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
+
+				gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).SetArg(2, *backupSecret).Return(nil)
+				gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).SetArg(2, *backupSecret).Return(nil)
+
+				gardenClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"labels":{"secret.backup.gardener.cloud/status":"previously-managed"},"ownerReferences":null}}`))
+					return nil
 				})
 
-				It("should return error when backup secret does not exist", func() {
-					expectCheckSeedSpec()
-					recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring gardenlet namespace in target cluster")
-					expectCreateGardenNamespace()
-					recorder.EXPECT().Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Deploying gardenlet into target cluster")
+				expectMergeWithParent()
+				expectPrepareGardenClientConnection(true)
+				expectGetGardenletChartValues(true, false, false)
+				expectApplyGardenletChart()
 
-					gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(corev1.Resource("secret"), backupSecretName))
-
-					recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, gomock.Any())
-
-					_, err := actuator.Reconcile(ctx, log, managedSeed, managedSeed.Status.Conditions, managedSeed.Spec.Gardenlet.Deployment, &gardenlet.Config, *managedSeed.Spec.Gardenlet.Bootstrap, *managedSeed.Spec.Gardenlet.MergeWithParent)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("could not reconcile seed test secrets: the configured backup secret does not exist, however the feature gate DoNotCopyBackupCredentials is enabled and shoot infrastructure credentials will not be reused"))
-				})
-
-				It("should remove owner reference from backup secret", func() {
-					shootClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), gomock.Any()).Return(nil)
-
-					expectGetSeed(false)
-					expectCheckSeedSpec()
-					recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring gardenlet namespace in target cluster")
-					expectCreateGardenNamespace()
-					recorder.EXPECT().Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
-
-					gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).SetArg(2, *backupSecret).Return(nil)
-					gardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: backupSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).SetArg(2, *backupSecret).Return(nil)
-
-					gardenClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-						Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"labels":{"secret.backup.gardener.cloud/status":"previously-managed"},"ownerReferences":null}}`))
-						return nil
-					})
-
-					recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Deploying gardenlet into target cluster")
-					expectMergeWithParent()
-					expectPrepareGardenClientConnection(true)
-					expectGetGardenletChartValues(true, false, false)
-					expectApplyGardenletChart()
-
-					conditions, err := actuator.Reconcile(ctx, log, managedSeed, managedSeed.Status.Conditions, managedSeed.Spec.Gardenlet.Deployment, &gardenlet.Config, *managedSeed.Spec.Gardenlet.Bootstrap, *managedSeed.Spec.Gardenlet.MergeWithParent)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(conditions).To(ContainCondition(
-						OfType(seedmanagementv1alpha1.SeedRegistered),
-						WithStatus(gardencorev1beta1.ConditionTrue),
-						WithReason(gardencorev1beta1.EventReconciled),
-					))
-				})
+				conditions, err := actuator.Reconcile(ctx, log, managedSeed, managedSeed.Status.Conditions, managedSeed.Spec.Gardenlet.Deployment, &gardenlet.Config, *managedSeed.Spec.Gardenlet.Bootstrap, *managedSeed.Spec.Gardenlet.MergeWithParent)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(conditions).To(ContainCondition(
+					OfType(seedmanagementv1alpha1.SeedRegistered),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason(gardencorev1beta1.EventReconciled),
+				))
 			})
 
 			It("should create the garden namespace and seed secrets, and deploy gardenlet (with bootstrap and non-expired gardenlet client cert)", func() {

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -541,7 +541,7 @@ var _ = Describe("Interface", func() {
 
 				_, err := actuator.Reconcile(ctx, log, managedSeed, managedSeed.Status.Conditions, managedSeed.Spec.Gardenlet.Deployment, &gardenlet.Config, *managedSeed.Spec.Gardenlet.Bootstrap, *managedSeed.Spec.Gardenlet.MergeWithParent)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("could not reconcile seed test secrets: the configured backup secret does not exist"))
+				Expect(err).To(MatchError(ContainSubstring("could not reconcile seed test secrets: the configured backup secret does not exist")))
 			})
 
 			It("should remove owner reference from backup secret", func() {

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -33,19 +33,15 @@ import (
 	mockgardenletdepoyer "github.com/gardener/gardener/pkg/controller/gardenletdeployer/mock"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockrecord "github.com/gardener/gardener/third_party/mock/client-go/tools/record"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 const (
-	name              = "test"
-	namespace         = "garden"
-	seedName          = "test-seed"
-	secretBindingName = "test-secret-binding"
-	secretName        = "test-secret"
-	backupSecretName  = "test-backup-secret"
+	name             = "test"
+	namespace        = "garden"
+	backupSecretName = "test-backup-secret"
 )
 
 var _ = Describe("Interface", func() {
@@ -109,13 +105,6 @@ var _ = Describe("Interface", func() {
 					return false, err
 				}
 				return true, nil
-			},
-			GetInfrastructureSecret: func(ctx context.Context) (*corev1.Secret, error) {
-				shootSecretBinding := &gardencorev1beta1.SecretBinding{}
-				if err := gardenClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "test-secret-binding"}, shootSecretBinding); err != nil {
-					return nil, err
-				}
-				return kubernetesutils.GetSecretByReference(ctx, gardenClient, &shootSecretBinding.SecretRef)
 			},
 			GetTargetDomain: func() string {
 				return ""

--- a/pkg/controller/gardenletdeployer/gardenletdeployer_suite_test.go
+++ b/pkg/controller/gardenletdeployer/gardenletdeployer_suite_test.go
@@ -9,12 +9,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestGardenletDeployer(t *testing.T) {
-	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller GardenletDeployer Suite")
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// owner: @dimityrmirchev
 	// alpha: v1.121.0
 	// beta: v1.123.0
+	// GA: v1.134.0
 	DoNotCopyBackupCredentials featuregate.Feature = "DoNotCopyBackupCredentials"
 
 	// OpenTelemetryCollector enables the usage of an OpenTelemetry Collector instance in the Control Plane of Shoot clusters.
@@ -119,7 +120,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	InPlaceNodeUpdates:            {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:           {Default: false, PreRelease: featuregate.Alpha},
 	CloudProfileCapabilities:      {Default: false, PreRelease: featuregate.Alpha},
-	DoNotCopyBackupCredentials:    {Default: true, PreRelease: featuregate.Beta},
+	DoNotCopyBackupCredentials:    {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	OpenTelemetryCollector:        {Default: false, PreRelease: featuregate.Alpha},
 	UseUnifiedHTTPProxyPort:       {Default: false, PreRelease: featuregate.Alpha},
 	VPAInPlaceUpdates:             {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -265,7 +265,6 @@ func newGardenletDeployer(b *botanist.GardenadmBotanist, gardenClientSet kuberne
 		CheckIfVPAAlreadyExists: func(_ context.Context) (bool, error) {
 			return false, nil
 		},
-		GetInfrastructureSecret: func(_ context.Context) (*corev1.Secret, error) { return nil, nil },
 		GetTargetDomain: func() string {
 			return ""
 		},

--- a/pkg/operator/controller/gardenlet/reconciler.go
+++ b/pkg/operator/controller/gardenlet/reconciler.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	gardenlet := &seedmanagementv1alpha1.Gardenlet{}
 	if err := r.VirtualClient.Get(ctx, request.NamespacedName, gardenlet); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.V(1).Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}

--- a/test/integration/gardenlet/managedseed/managedseed_test.go
+++ b/test/integration/gardenlet/managedseed/managedseed_test.go
@@ -264,9 +264,6 @@ var _ = Describe("ManagedSeed controller test", func() {
 				APIVersion: gardenletconfigv1alpha1.SchemeGroupVersion.String(),
 				Kind:       "GardenletConfiguration",
 			},
-			FeatureGates: map[string]bool{
-				"DoNotCopyBackupCredentials": true,
-			},
 			GardenClientConnection: &gardenletconfigv1alpha1.GardenClientConnection{
 				KubeconfigSecret: &corev1.SecretReference{
 					Name:      "gardenlet-kubeconfig",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality security
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Follow up after https://github.com/gardener/gardener/pull/12414
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
Let's merge this after 1.133 is released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `DoNotCopyBackupCredentials` feature gate has been promoted to GA and can no longer be disabled. The `Seed` backup secret is no longer copied from the `Shoot` infrastructure credentials in case an operator does not provide an existing backup secret. If you configure `seed.spec.backup.credentialsRef`, make sure that the referred credential already exists. For production setups, it is advised that operators configure a separate set of credentials for `Seed` backup and `Shoot` infrastructure.
```

```noteworthy operator
As the `DoNotCopyBackupCredentials` feature gate cannot be disabled, backup secrets that were copied from `Shoot` infrastructure credentials in previous reconciliations are labeled with `secret.backup.gardener.cloud/status=previously-managed` and Gardener no longer takes care of them. Operators are responsible to delete those if unused for other scenarios.
```