### PR TITLE
Add CommandLineProgressReporter for cmd line tools that use flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/docker/cli v29.1.2+incompatible
+	github.com/fatih/color v1.18.0
 	github.com/fluent/fluent-operator/v3 v3.5.0
 	github.com/gardener/cert-management v0.19.0
 	github.com/gardener/dependency-watchdog v1.6.0
@@ -133,7 +134,6 @@ require (
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
-	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -7,6 +7,7 @@ package connect
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -92,7 +93,8 @@ func run(ctx context.Context, opts *Options) error {
 		}
 
 		var (
-			g = flow.NewGraph("connect")
+			g        = flow.NewGraph("connect")
+			reporter = flow.NewCommandLineProgressReporter(os.Stdout)
 
 			retrieveShortLivedKubeconfig = g.Add(flow.Task{
 				Name: "Retrieving short-lived kubeconfig for garden cluster to prepare Gardener resources",
@@ -141,7 +143,8 @@ func run(ctx context.Context, opts *Options) error {
 		)
 
 		if err := g.Compile().Run(ctx, flow.Opts{
-			Log: opts.Log,
+			Log:              opts.Log,
+			ProgressReporter: reporter,
 		}); err != nil {
 			return flow.Errors(err)
 		}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -239,11 +239,11 @@ func run(ctx context.Context, opts *Options) error {
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.ReconcileExtensionControllerInstallations(ctx, false)
 			}),
-			SkipIf:       podNetworkAvailable,
-			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerInPodNetworkReady),
 			Interval:     5 * time.Second,
 			Timeout:      30 * time.Second,
 			Reporter:     reporter,
+			SkipIf:       podNetworkAvailable,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerInPodNetworkReady),
 		})
 		waitUntilExtensionControllersInPodNetworkReady = g.Add(flow.Task{
 			Name:         "Waiting until extension controllers (in pod network) report readiness",
@@ -332,7 +332,8 @@ func run(ctx context.Context, opts *Options) error {
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{
-		Log: opts.Log,
+		Log:              opts.Log,
+		ProgressReporter: reporter,
 	}); err != nil {
 		return flow.Errors(err)
 	}
@@ -439,7 +440,8 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 	)
 
 	if err := g.Compile().Run(ctx, flow.Opts{
-		Log: b.Logger,
+		Log:              b.Logger,
+		ProgressReporter: reporter,
 	}); err != nil {
 		return nil, flow.Errors(err)
 	}

--- a/pkg/gardenadm/cmd/join/join.go
+++ b/pkg/gardenadm/cmd/join/join.go
@@ -7,6 +7,7 @@ package join
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -93,6 +94,7 @@ func run(ctx context.Context, opts *Options) error {
 	if !alreadyJoined {
 		var (
 			g                           = flow.NewGraph("join")
+			reporter                    = flow.NewCommandLineProgressReporter(os.Stdout)
 			gardenerNodeAgentSecretName string
 
 			retrieveShortLivedKubeconfig = g.Add(flow.Task{
@@ -136,7 +138,8 @@ func run(ctx context.Context, opts *Options) error {
 		)
 
 		if err := g.Compile().Run(ctx, flow.Opts{
-			Log: opts.Log,
+			Log:              opts.Log,
+			ProgressReporter: reporter,
 		}); err != nil {
 			return flow.Errors(err)
 		}

--- a/pkg/utils/flow/progress_reporter.go
+++ b/pkg/utils/flow/progress_reporter.go
@@ -22,6 +22,14 @@ type ProgressReporter interface {
 	Report(context.Context, *Stats)
 }
 
+// TaskRetryReporter is used to report the state of a task. This can be passed to a RetryableTask as a reporter.
+type TaskRetryReporter interface {
+	ProgressReporter
+
+	// ReportRetry reports that the task failed with the given error and will be retried.
+	ReportRetry(ctx context.Context, id TaskID, err error)
+}
+
 // MakeDescription returns a description based on the stats.
 func MakeDescription(stats *Stats) string {
 	if stats.ProgressPercent() == 0 {

--- a/pkg/utils/flow/progress_reporter_commandline.go
+++ b/pkg/utils/flow/progress_reporter_commandline.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package flow
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/fatih/color"
+)
+
+const infoTemplate = `Flow: {{ .stat.FlowName }}
+{{ green (printf "Succeeded: %d" (.stat.Succeeded | len ))}} | Failed: {{ .stat.Failed | len }} | Pending: {{.stat.Pending | len }} | Running: {{ .stat.Running | len }}
+Running Tasks: 
+{{- range $id, $empty := .stat.Running }}
+== {{ $id }}
+{{- with index $.lastErrs $id }}
+{{ red "Last Error:" }} {{ . }}
+{{- end }}
+{{- end }}
+`
+
+// NewCommandLineProgressReporter returns a new progress reporter that writes the current status of the flow to the
+// given output, when a SIGINFO is received (usually Ctrl+T).
+//
+// If you want insight into the last error of a task, you need to pass the reporter to a RetryableTask.
+func NewCommandLineProgressReporter(out io.Writer) TaskRetryReporter {
+	if out == nil {
+		out = os.Stdout
+	}
+	return &progressReporterCommandline{
+		out:      out,
+		template: parseTemplate(),
+		lastErrs: make(map[TaskID]error),
+	}
+}
+
+func parseTemplate() *template.Template {
+	t, err := template.New("").
+		Option("missingkey=zero").
+		Funcs(map[string]interface{}{
+			"red":   color.RedString,
+			"green": color.GreenString,
+		}).
+		Parse(infoTemplate)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+type progressReporterCommandline struct {
+	lock      sync.Mutex
+	ctxCancel context.CancelFunc
+	lastStats *Stats
+
+	template *template.Template
+	out      io.Writer
+	lastErrs map[TaskID]error
+
+	// signalChan allows tests to inject a channel to trigger printing
+	// without relying on actual OS signals.
+	signalChan chan os.Signal
+}
+
+func (p *progressReporterCommandline) Start(ctx context.Context) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	ctx, cancel := context.WithCancel(ctx)
+	p.ctxCancel = cancel
+
+	var sig <-chan os.Signal
+	if p.signalChan != nil {
+		sig = p.signalChan
+	} else {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, infoSignals()...)
+		sig = c
+	}
+	go func() {
+		for {
+			select {
+			case <-sig:
+				p.printInfo()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (p *progressReporterCommandline) Stop() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.ctxCancel != nil {
+		p.ctxCancel()
+	}
+}
+
+func (p *progressReporterCommandline) Report(_ context.Context, stats *Stats) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.lastStats = stats
+}
+
+func (p *progressReporterCommandline) ReportRetry(_ context.Context, id TaskID, err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.lastErrs[id] = err
+}
+
+func (p *progressReporterCommandline) printInfo() {
+	err := p.template.Execute(p.out, map[string]interface{}{
+		"stat":     p.lastStats,
+		"lastErrs": p.lastErrs,
+	})
+	if err != nil {
+		fmt.Fprintf(p.out, "Failed to print progress: %v", err)
+	}
+}

--- a/pkg/utils/flow/progress_reporter_commandline_test.go
+++ b/pkg/utils/flow/progress_reporter_commandline_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package flow
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("CommandLineProgressReporter", func() {
+	var (
+		reporter  *progressReporterCommandline
+		outBuf    *gbytes.Buffer
+		ctx       context.Context
+		debugChan chan os.Signal
+		testStats *Stats
+	)
+
+	BeforeEach(func() {
+		outBuf = gbytes.NewBuffer()
+		debugChan = make(chan os.Signal, 1)
+		ctx = context.Background()
+
+		reporter = &progressReporterCommandline{
+			out:        outBuf,
+			lastErrs:   make(map[TaskID]error),
+			signalChan: debugChan,
+			template:   parseTemplate(),
+		}
+
+		testStats = &Stats{
+			FlowName:  "Test-Flow",
+			Succeeded: newTaskIDs("task_success_1", "task_success_2"),
+			Failed:    newTaskIDs("task_fail_1"),
+			Pending:   newTaskIDs("task_pending_1"),
+			Running:   newTaskIDs("task_running_1"),
+		}
+	})
+
+	AfterEach(func() {
+		if reporter != nil {
+			reporter.Stop()
+		}
+	})
+
+	It("should write the template to output when the injected signal is received", func() {
+		Expect(reporter.Start(ctx)).To(Succeed())
+
+		reporter.Report(ctx, testStats)
+		reporter.ReportRetry(ctx, "task_running_1", errors.New("connection timeout"))
+
+		debugChan <- os.Interrupt
+
+		Eventually(outBuf).Should(And(
+			gbytes.Say("Flow: Test-Flow"),
+			gbytes.Say("Succeeded: 2"),
+			gbytes.Say("Failed: 1"),
+		))
+
+		// Verify Running tasks section
+		Eventually(outBuf).Should(And(
+			gbytes.Say("Running Tasks:"),
+			gbytes.Say("== task_running_1"),
+		))
+
+		// Verify Error reporting
+		Eventually(outBuf).Should(And(
+			gbytes.Say("Last Error:"),
+			gbytes.Say("connection timeout"),
+		))
+	})
+})
+
+func newTaskIDs(ids ...string) TaskIDs {
+	t := make(TaskIDs)
+	for _, id := range ids {
+		t.Insert(TaskID(id))
+	}
+	return t
+}

--- a/pkg/utils/flow/signals_darwin.go
+++ b/pkg/utils/flow/signals_darwin.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package flow
+
+import (
+	"os"
+	"syscall"
+)
+
+// infoSignals returns the signals used for status dumping on macOS
+func infoSignals() []os.Signal {
+	return []os.Signal{syscall.SIGINFO}
+}

--- a/pkg/utils/flow/signals_linux.go
+++ b/pkg/utils/flow/signals_linux.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package flow
+
+import (
+	"os"
+	"syscall"
+)
+
+// InfoSignals returns the signals used for status dumping on macOS
+func infoSignals() []os.Signal {
+	return []os.Signal{syscall.SIGUSR1}
+}


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a new `CommandLineProgressReporter`, which can print the current state of a flow run when it is signaled (`SIGINFO` on Mac, `SIGUSR1` on Linux). Additionally it prints the last errors of any retryable tasks that are currently running.

<img width="424" height="110" alt="image" src="https://github.com/user-attachments/assets/21c2a01b-e2df-4c15-a0a6-1e1ace6b6544" />

**Which issue(s) this PR fixes**:
Fast Track from the Gardener Hackathon Winter 2025 for @timebertt and @rfranzke . Authored with @dergeberl 

**Special notes for your reviewer**:
It was quite hard to get the last error info from the `TaskFn` all the way to the reporter. Since `TaskFn` is just a function, we cannot just "attach" some data to it. The current approach was the best I could come up with.

Technically, this changes the function signature of `graph.Add(Task)` to `graph.Add(Tasker)`. But since Task implements Tasker no code changes are needed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
