### PR TITLE
[GEP-28] `gardenadm bootstrap`: More retries for connecting to Bastion/Machine

### DIFF
--- a/pkg/component/etcd/copybackupstask/copybackupstask.go
+++ b/pkg/component/etcd/copybackupstask/copybackupstask.go
@@ -179,7 +179,7 @@ func waitForConditions(obj client.Object) error {
 }
 
 // checkConditions checks the EtcdCopyBackupsTask conditions to determine if the copy operation has completed successfully or not.
-func (e *etcdCopyBackupsTask) checkConditions() error {
+func (e *etcdCopyBackupsTask) checkConditions(_ context.Context) error {
 	for _, condition := range e.task.Status.Conditions {
 		if condition.Type == druidcorev1alpha1.EtcdCopyBackupsTaskFailed && condition.Status == druidcorev1alpha1.ConditionTrue {
 			return fmt.Errorf("condition %s has status %s: %s", condition.Type, condition.Status, condition.Message)

--- a/pkg/component/extensions/bastion/bastion.go
+++ b/pkg/component/extensions/bastion/bastion.go
@@ -75,8 +75,8 @@ func New(
 		Values:         values,
 
 		Clock:               &clock.RealClock{},
-		WaitInterval:        5 * time.Second,
-		WaitSevereThreshold: 30 * time.Second,
+		WaitInterval:        10 * time.Second,
+		WaitSevereThreshold: 6 * time.Minute,
 		WaitTimeout:         15 * time.Minute,
 		SSHDial:             sshutils.Dial,
 

--- a/pkg/component/extensions/bastion/bastion.go
+++ b/pkg/component/extensions/bastion/bastion.go
@@ -21,7 +21,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	sshutils "github.com/gardener/gardener/pkg/utils/ssh"
@@ -36,13 +35,11 @@ type Bastion struct {
 	Values         *Values
 
 	// exposed for testing
-	Clock                clock.PassiveClock
-	WaitInterval         time.Duration
-	WaitSevereThreshold  time.Duration
-	WaitTimeout          time.Duration
-	ConnectRetryInterval time.Duration
-	ConnectRetryTimeout  time.Duration
-	SSHDial              func(ctx context.Context, addr string, opts ...sshutils.Option) (*sshutils.Connection, error)
+	Clock               clock.PassiveClock
+	WaitInterval        time.Duration
+	WaitSevereThreshold time.Duration
+	WaitTimeout         time.Duration
+	SSHDial             func(ctx context.Context, addr string, opts ...sshutils.Option) (*sshutils.Connection, error)
 
 	bastion          *extensionsv1alpha1.Bastion
 	sshKeypairSecret *corev1.Secret
@@ -77,13 +74,11 @@ func New(
 		secretsManager: secretsManager,
 		Values:         values,
 
-		Clock:                &clock.RealClock{},
-		WaitInterval:         10 * time.Second,
-		WaitSevereThreshold:  6 * time.Minute,
-		WaitTimeout:          15 * time.Minute,
-		ConnectRetryInterval: 5 * time.Second,
-		ConnectRetryTimeout:  1 * time.Minute,
-		SSHDial:              sshutils.Dial,
+		Clock:               &clock.RealClock{},
+		WaitInterval:        5 * time.Second,
+		WaitSevereThreshold: 6 * time.Minute,
+		WaitTimeout:         15 * time.Minute,
+		SSHDial:             sshutils.Dial,
 
 		bastion: &extensionsv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -135,30 +130,9 @@ func (b *Bastion) Wait(ctx context.Context) error {
 		b.WaitSevereThreshold,
 		b.WaitTimeout,
 		func() error {
-			// perform an inner retry loop (outer loop in WaitUntilExtensionObjectReady
-			// would return SevereError on connection failure).
-			return b.connectWithRetry(ctx)
+			return b.connect(ctx)
 		},
 	)
-}
-
-// connectWithRetry wraps the connect call with retry logic to handle transient connectivity issues.
-func (b *Bastion) connectWithRetry(ctx context.Context) error {
-	var lastErr error
-	if err := retry.UntilTimeout(ctx, b.ConnectRetryInterval, b.ConnectRetryTimeout, func(ctx context.Context) (bool, error) {
-		if err := b.connect(ctx); err != nil {
-			lastErr = err
-			b.log.Info("Failed to connect to bastion, will retry", "error", err.Error())
-			return retry.MinorError(err)
-		}
-		return retry.Ok()
-	}); err != nil {
-		if lastErr != nil {
-			return lastErr
-		}
-		return err
-	}
-	return nil
 }
 
 // Destroy deletes all resources related to the Bastion object.

--- a/pkg/component/extensions/bastion/bastion.go
+++ b/pkg/component/extensions/bastion/bastion.go
@@ -129,7 +129,7 @@ func (b *Bastion) Wait(ctx context.Context) error {
 		b.WaitInterval,
 		b.WaitSevereThreshold,
 		b.WaitTimeout,
-		func() error {
+		func(ctx context.Context) error {
 			return b.connect(ctx)
 		},
 	)

--- a/pkg/component/extensions/bastion/bastion_test.go
+++ b/pkg/component/extensions/bastion/bastion_test.go
@@ -71,8 +71,6 @@ var _ = Describe("Bastion", func() {
 		b.WaitInterval = time.Millisecond
 		b.WaitSevereThreshold = 250 * time.Millisecond
 		b.WaitTimeout = 500 * time.Millisecond
-		b.ConnectRetryInterval = 5 * time.Millisecond
-		b.ConnectRetryTimeout = 50 * time.Millisecond
 
 		bastion = &extensionsv1alpha1.Bastion{
 			ObjectMeta: metav1.ObjectMeta{
@@ -230,8 +228,8 @@ systemctl start sshd || systemctl start ssh
 					}
 
 					Expect(b.Wait(ctx)).To(MatchError(ContainSubstring("connection refused")))
-					// Should have retried multiple times (50ms timeout / 5ms interval = ~10 attempts - some buffer)
-					Expect(callCount).To(BeNumerically(">", 5))
+					// Should have retried multiple times (more than x times)
+					Expect(callCount).To(BeNumerically(">", 10))
 				})
 
 				When("the Bastion has an ingress hostname instead of IP", func() {

--- a/pkg/component/extensions/controlplane/controlplane.go
+++ b/pkg/component/extensions/controlplane/controlplane.go
@@ -175,7 +175,7 @@ func (c *controlPlane) Wait(ctx context.Context) error {
 		c.waitInterval,
 		c.waitSevereThreshold,
 		c.waitTimeout,
-		func() error {
+		func(_ context.Context) error {
 			c.providerStatus = c.controlPlane.Status.ProviderStatus
 			return nil
 		},

--- a/pkg/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/component/extensions/infrastructure/infrastructure.go
@@ -198,7 +198,7 @@ func (i *infrastructure) Wait(ctx context.Context) error {
 		i.waitInterval,
 		i.waitSevereThreshold,
 		i.waitTimeout,
-		func() error {
+		func(_ context.Context) error {
 			i.extractStatus(i.infrastructure.Status)
 			return nil
 		})

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
@@ -129,7 +129,7 @@ func (c *controlPlaneBootstrap) Wait(ctx context.Context) error {
 		c.waitInterval,
 		c.waitSevereThreshold,
 		c.waitTimeout,
-		func() error {
+		func(ctx context.Context) error {
 			if c.osc.Object.Status.CloudConfig == nil {
 				return fmt.Errorf("no cloud config information provided in status")
 			}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -448,7 +448,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 			o.waitInterval,
 			o.waitSevereThreshold,
 			o.waitTimeout,
-			func() error {
+			func(ctx context.Context) error {
 				if purpose != extensionsv1alpha1.OperatingSystemConfigPurposeProvision {
 					return nil
 				}

--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -342,7 +342,7 @@ func (w *worker) Wait(ctx context.Context) error {
 		w.waitInterval,
 		w.waitSevereThreshold,
 		w.waitTimeout,
-		func() error {
+		func(ctx context.Context) error {
 			// In Restore, we add the machine-state from the ShootState to Worker.status.state, so that the extension
 			// controller can pick it up and restore the MachineDeployments, MachineSets, and Machines.
 			// After the Worker has been successfully restored/reconciled, we need to clear Worker.status.state to not keep
@@ -370,7 +370,7 @@ func (w *worker) WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx context.Cont
 		w.waitInterval,
 		w.waitSevereThreshold,
 		w.waitTimeout,
-		func() error {
+		func(_ context.Context) error {
 			w.machineDeployments = w.worker.Status.MachineDeployments
 			return nil
 		},

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -45,7 +45,7 @@ func WaitUntilExtensionObjectReady(
 	interval time.Duration,
 	severeThreshold time.Duration,
 	timeout time.Duration,
-	postReadyFunc func() error,
+	postReadyFunc func(context.Context) error,
 ) error {
 	return WaitUntilObjectReadyWithHealthFunction(ctx, c, log, health.CheckExtensionObject, obj, kind, interval, severeThreshold, timeout, postReadyFunc)
 }
@@ -64,7 +64,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 	interval time.Duration,
 	severeThreshold time.Duration,
 	timeout time.Duration,
-	postReadyFunc func() error,
+	postReadyFunc func(context.Context) error,
 ) error {
 	var (
 		lastObservedError     error
@@ -111,7 +111,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 		}
 
 		if postReadyFunc != nil {
-			if err := postReadyFunc(); err != nil {
+			if err := postReadyFunc(ctx); err != nil {
 				lastObservedError = err
 
 				if retry.IsRetriable(err) {

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -113,7 +113,11 @@ func WaitUntilObjectReadyWithHealthFunction(
 		if postReadyFunc != nil {
 			if err := postReadyFunc(); err != nil {
 				lastObservedError = err
-				return retry.SevereError(err)
+
+				if retry.IsRetriable(err) {
+					return retry.MinorOrSevereError(retryCountUntilSevere, int(severeThreshold.Nanoseconds()/interval.Nanoseconds()), err)
+				}
+				return retry.MinorError(err)
 			}
 		}
 

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -155,7 +155,7 @@ var _ = Describe("extensions", func() {
 			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
 				passedObj, extensionsv1alpha1.WorkerResource,
-				defaultInterval, defaultThreshold, defaultTimeout, func() error {
+				defaultInterval, defaultThreshold, defaultTimeout, func(_ context.Context) error {
 					val++
 					return nil
 				},
@@ -328,7 +328,7 @@ var _ = Describe("extensions", func() {
 					return nil
 				},
 				expected, extensionsv1alpha1.WorkerResource,
-				defaultInterval, defaultThreshold, defaultTimeout, func() error {
+				defaultInterval, defaultThreshold, defaultTimeout, func(_ context.Context) error {
 					val++
 					return nil
 				},

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -278,7 +278,7 @@ func run(ctx context.Context, opts *Options) error {
 
 		connectToMachine = g.Add(flow.Task{
 			Name:         "Connecting to the first control plane machine",
-			Fn:           flow.TaskFn(b.ConnectToControlPlaneMachine).RetryUntilTimeout(5*time.Second, 5*time.Minute),
+			Fn:           flow.TaskFn(b.ConnectToControlPlaneMachine).RetryUntilTimeout(5*time.Second, 6*time.Minute),
 			Dependencies: flow.NewTaskIDs(listControlPlaneMachines, deployBastion),
 		})
 		copyManifests = g.Add(flow.Task{

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -883,6 +883,6 @@ func waitUntilLoadBalancerIsReadyInTest(_ context.Context, _ logr.Logger, _ clie
 	return "someingress.example.com", nil
 }
 
-func waitUntilExtensionObjectReadyInTest(_ context.Context, _ client.Client, _ logr.Logger, _ extensionsv1alpha1.Object, _ string, _, _, _ time.Duration, _ func() error) error {
+func waitUntilExtensionObjectReadyInTest(_ context.Context, _ client.Client, _ logr.Logger, _ extensionsv1alpha1.Object, _ string, _, _, _ time.Duration, _ func(context.Context) error) error {
 	return nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR increases robustness of the Bastion connection for the self-hosted managed infrastructure ([GEP-28](https://github.com/gardener/gardener/blob/master/docs/proposals/28-self-hosted-shoot-clusters.md)) scenario.

We need this PR, as in testing I noticed that the gardenadm boostrap fails due to the short `WaitSevereThreshold` and the fact waiting for the observed generation of the CR to sync + VM provisioning takes longer than 30s (current default). The provisioning creates a lastError which is a retriable error, causing a SevereError after those 30s passed, not trying to reconnect to the bastion.

For this, two parts are added:
1. Increase `WaitInterval` from 5s to 10s. Increase `WaitSevereThreshold` from 30s to 6min. This ensures that the gardenadm bootrap job waits longer for the bastion to become ready, as provisioning of VMs can be part of the lastError, causing a SevereError when the `WaitSevereThreshold` is over.
2. Add a retry mechanism to Bastion connect (`postReadyFunc`). This protects from issues like short connectivity issues. The retry logic of `connectWithRetry` runs in the same context of the `WaitTimeout` and `WaitSevereThreshold`, so they respect the overall timeouts.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @timebertt
Added unit tests.
I tried other things first, like adding a custom health function to `WaitUntilObjectReadyWithHealthFunction` which would find provisioning messages in the Error Description based on keywords like `creating` to make those errors non-retriable, but I think those solutions are brittle, ideally the CRs and their Status should all be consistent in their Conditions (Status Progressing, transitive errors,...).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
