### PR TITLE
Harmonize logging and keep alive settings for apiserver-proxy endpoint when `IstioTLSTermination` is active

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -26,6 +26,14 @@ spec:
             typed_config:
               "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
               stat_prefix: {{ .TargetClusterAPIServerProxy }}
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog"
+                    path: /dev/stdout
+                    log_format:
+                      text_format_source:
+                        inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
               route_config:
                 name: {{ .TargetClusterAPIServerProxy }}
                 virtual_hosts:
@@ -141,7 +149,11 @@ spec:
       value:
         name: {{ .TargetClusterAPIServerProxy }}
         type: STATIC
-        connect_timeout: 1s
+        connect_timeout: 10s
+        upstream_connection_options:
+          tcp_keepalive:
+            keepalive_interval: 75
+            keepalive_time: 7200
         load_assignment:
           cluster_name: {{ .TargetClusterAPIServerProxy }}
           endpoints:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Currently, we don't see any access logs for connections via `apiserver-proxy` (e.g. to the `kubernetes.default.svc.cluster.local` endpoint) in istio access logs when `IstioTLSTermination` feature gate is active.
With this PR we enable logging here too using the same logging format. Requests via apiserver-proxy now appear like this in istio access logs.
```
istio-ingressgateway-6677dbbfb7-vxzvl istio-proxy [2025-11-29T11:53:03.251Z] "GET /api/v1/namespaces/default/pods?limit=500 HTTP/2" 403 - via_upstream - "-" 0 282 1 1 "-" "kubectl/v1.34.2 (linux/arm64) kubernetes/8cc511e" "da692ee5-d471-456f-82fb-8c11842a10ae" "kubernetes.default.svc.cluster.local:443" "10.1.254.115:443" outbound|443||kube-apiserver.shoot--local--local.svc.cluster.local 10.1.155.113:58944 @kube-apiservers/shoot--local--local @kube-apiservers/shoot--local--local - -
```
~~When we merge this, we should also adapt #13548 that the logs are dispatched to the shoot valis. Otherwise, [this regex](https://github.com/gardener/gardener/pull/13548/files#diff-5700c1679fd84c9d7fb8b344b60b379bc11badf47526455b671f6fcab6bd0f44R72) could be confused by `kubernetes.default.svc.cluster.local:443`.~~ ℹ️ done

Additionally, the keep alive settings & connection timeout for `apiserver-proxy` endpoint are set to the same values as for the default endpoints ([ref](https://github.com/gardener/gardener/blob/100191c88f47d47cc52fa21f3cd4e1b3f62537ba/pkg/utils/istio/destinationrule.go#L83-L85)).

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:
/cc @ScheererJ @axel7born 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Istio-gateways now provide access logs for requests to kube-apiservers via the `apiserver-proxy` endpoint when `IstioTLSTermination` feature gate is active.
```
```other operator
`apiserver-proxy` endpoints now using the same keep alive settings and connection timeout as default kube-apiserver endpoints when `IstioTLSTermination` feature gate is active.
```