### PR TITLE
Update the developer guidelines for validation

### DIFF
--- a/docs/development/validation-guidelines.md
+++ b/docs/development/validation-guidelines.md
@@ -150,7 +150,8 @@ Frequently used validation functions for creation:
   - Use this function only for labels which are not part of the object metadata. `apivalidation.ValidateObjectMeta` already validates the object metadata labels. See [example usage](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/apis/core/validation/shoot.go#L1926).
 - [`metav1validation.ValidateLabelSelector`](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/validation#ValidateLabelSelector)
   - Use this function to validate fields of type `metav1.LabelSelector`. See [example usage](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/apis/core/validation/shoot.go#L272-L274).
-
+- [`apivalidation.ValidateNamespaceName`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/validation#ValidateNamespaceName), [`apivalidation.ValidateServiceAccountName`](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/validation#ValidateServiceAccountName)
+  - Use these functions to validate fields which represent Namespace name (Project's `.spec.namespace` field, CredentialsBinding's `.credentialsRef.namespace` field) or ServiceAccount name (ManagedSeed's `.spec.gardenlet.deployment.serviceAccountName`).
 - [`validation.IsDNS1123Subdomain`](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1123Subdomain)
   - Validates that the value is a DNS subdomain. See [DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 - [`validation.IsValidIP`](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsValidIP)

--- a/docs/development/validation-guidelines.md
+++ b/docs/development/validation-guidelines.md
@@ -231,8 +231,8 @@ Frequently used ones are:
   - Consider if updates to the field value should be allowed and are supported by the underlying controller. If not, consider making the field immutable. Add a doc string to the field to denote the immutability constraint.
 - Introducing new validation for existing field or making existing validation more restrictive might be a breaking change.
   - When working with existing field, aim to add validation which is obvious and unlikely to break a working functionality.
-  - If breaking change is inevitable and it is likely to break a working functionality consider the following alternatives:
+  - If a breaking change is inevitable and it is likely to break a working functionality, consider the following alternatives:
     - Consider using "ratcheting" validation to incrementally tighten validation. See [Ratcheting validation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#ratcheting-validation).
-      - An example usage of "ratcheting" validation - allow invalid field value if the value is not updated; otherwise - do not allow. Example: https://github.com/gardener/gardener/pull/10664
+      - An example usage of "ratcheting" validation - allow invalid field value if the value is not updated; otherwise, do not allow. Example: https://github.com/gardener/gardener/pull/10664
     - Consider using a feature gate to roll out the breaking change. The feature gate gives control when to impose the breaking change. In case of issues, it is possible to revert back to the old behavior by disabling the feature gate.
-    - In case the functionality is _relevant to the majority of the end-users_ , consider imposing the breaking change only with the upcoming minor Kubernetes version. This way, end-users are forced to actively adapt their manifests when performing Kubernetes upgrades.
+    - In case the functionality is _relevant to the majority of the end-users_, consider imposing the breaking change only with the upcoming minor Kubernetes version. This way, end-users are forced to actively adapt their manifests when performing Kubernetes upgrades.

--- a/docs/development/validation-guidelines.md
+++ b/docs/development/validation-guidelines.md
@@ -150,6 +150,7 @@ Frequently used validation functions for creation:
   - Use this function only for labels which are not part of the object metadata. `apivalidation.ValidateObjectMeta` already validates the object metadata labels. See [example usage](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/apis/core/validation/shoot.go#L1926).
 - [`metav1validation.ValidateLabelSelector`](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/validation#ValidateLabelSelector)
   - Use this function to validate fields of type `metav1.LabelSelector`. See [example usage](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/apis/core/validation/shoot.go#L272-L274).
+
 - [`validation.IsDNS1123Subdomain`](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsDNS1123Subdomain)
   - Validates that the value is a DNS subdomain. See [DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
 - [`validation.IsValidIP`](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsValidIP)
@@ -229,7 +230,8 @@ Frequently used ones are:
   - Consider if updates to the field value should be allowed and are supported by the underlying controller. If not, consider making the field immutable. Add a doc string to the field to denote the immutability constraint.
 - Introducing new validation for existing field or making existing validation more restrictive might be a breaking change.
   - When working with existing field, aim to add validation which is obvious and unlikely to break a working functionality.
-  - If breaking change is inevitable and it is likely to break a working functionality:
-    - In case the functionality is _relevant to end-users_ , consider imposing the breaking change only with the upcoming minor Kubernetes version. This way, end-users are forced to actively adapt their manifests when performing Kubernetes upgrades.
+  - If breaking change is inevitable and it is likely to break a working functionality consider the following alternatives:
     - Consider using "ratcheting" validation to incrementally tighten validation. See [Ratcheting validation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#ratcheting-validation).
+      - An example usage of "ratcheting" validation - allow invalid field value if the value is not updated; otherwise - do not allow. Example: https://github.com/gardener/gardener/pull/10664
     - Consider using a feature gate to roll out the breaking change. The feature gate gives control when to impose the breaking change. In case of issues, it is possible to revert back to the old behavior by disabling the feature gate.
+    - In case the functionality is _relevant to the majority of the end-users_ , consider imposing the breaking change only with the upcoming minor Kubernetes version. This way, end-users are forced to actively adapt their manifests when performing Kubernetes upgrades.

--- a/docs/extensions/validation-guidelines-for-extensions.md
+++ b/docs/extensions/validation-guidelines-for-extensions.md
@@ -15,11 +15,16 @@ Extension admission components should decode the provider configuration and perf
 
 ### `ConfigValidator` Interfaces
 
-Validation code that performs requests to external systems (e.g. the cloud provider API) should be written in `ConfigValidator` implementations.
-Performing requests to external systems in the extension admission component (or in a webhook, in general) is considered a bad practice.
+Validation code that performs requests to an external system (e.g. the cloud provider API) should be written in `ConfigValidator` implementations.
+Performing requests to an external system in the extension admission component (or in a webhook, in general) is considered a bad practice.
 A downtime of the external system then results in rejection of requests by the webhook.
 For this purpose, the extension library leverages the `ConfigValidator` interfaces (e.g. see the [`ConfigValidator` interface for Infrastructure](./resources/infrastructure.md#configvalidator-interface)).
-They must be used to validate the provider configuration against the cloud provider API - e.g. validate the provided AWS VPC ID exists and conforms to the provider extension requirements.
+They validate the provider configuration against the cloud provider API - e.g. validate the provided AWS VPC ID exists and conforms to the provider extension requirements.
+The `ConfigValidator` implementations are invoked by the corresponding extension controller before the main reconciliation logic of the extension resource.
+A validation failure in the provider configuration results in a reconciliation error.
+Usually, an appropriate non-retryable error code is returned and later on propagated up to the Shoot status.
+A failure to perform request to the cloud provider API results in a reconciliation error.
+In this way, a failure to perform the validation due to unavailability of a cloud provider API results in a reconciliation error instead of a rejected CREATE/UPDATE request for a Shoot by an extension admission component.
 
 ## Validation of Referenced Resources
 

--- a/docs/extensions/validation-guidelines-for-extensions.md
+++ b/docs/extensions/validation-guidelines-for-extensions.md
@@ -13,6 +13,14 @@ They should be validated by extension admission components.
 Provider configuration fields are of type `*runtime.RawExtension`.
 Extension admission components should decode the provider configuration and perform validation of it.
 
+### `ConfigValidator` Interfaces
+
+Validation code that performs requests to external systems (e.g. the cloud provider API) should be written in `ConfigValidator` implementations.
+Performing requests to external systems in extension admission component (or in a webhook, in general) is considered as a bad practice.
+A downtime of the external system then results in rejection of requests by the webhook.
+For this purpose, the extension library leverages the `ConfigValidator` interfaces (e.g. see the [`ConfigValidator` interface for Infrastructure](./resources/infrastructure.md#configvalidator-interface)).
+They must be used to validate the provider configuration against the cloud provider API - e.g. validate the provided AWS VPC ID exists and conforms to the provider extension requirements.
+
 ## Validation of Referenced Resources
 
 The provider configuration may contain references to another resources.

--- a/docs/extensions/validation-guidelines-for-extensions.md
+++ b/docs/extensions/validation-guidelines-for-extensions.md
@@ -16,7 +16,7 @@ Extension admission components should decode the provider configuration and perf
 ### `ConfigValidator` Interfaces
 
 Validation code that performs requests to external systems (e.g. the cloud provider API) should be written in `ConfigValidator` implementations.
-Performing requests to external systems in extension admission component (or in a webhook, in general) is considered as a bad practice.
+Performing requests to external systems in the extension admission component (or in a webhook, in general) is considered a bad practice.
 A downtime of the external system then results in rejection of requests by the webhook.
 For this purpose, the extension library leverages the `ConfigValidator` interfaces (e.g. see the [`ConfigValidator` interface for Infrastructure](./resources/infrastructure.md#configvalidator-interface)).
 They must be used to validate the provider configuration against the cloud provider API - e.g. validate the provided AWS VPC ID exists and conforms to the provider extension requirements.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Update the validation guidelines with recent learnings and feedback:
1. 82cc62131fa1e4f2dc83835b392643e87b7ac21c - we should promote "ratcheting" validation as the first option for dealing with breaking changes. The commit adds example usage for "ratcheting" validation.
2. 7578b16766e446b0c13b33ae638a5d7023d356f5 - this was a learning from https://github.com/gardener/gardener/pull/13258. See https://github.com/gardener/gardener/pull/13258#discussion_r2481778144.
3. 54ee93b542055e4dcb6b4447645819ced150fe76 - feedback from Marin N. that `ConfigValidator` interfaces are not properly documented.

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/12811

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
