### PR TITLE
[GEP-28] Split `gardener-resource-manager` into two deployments

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
         - --backupbucket-container-mount-path={{ .Values.controllers.backupbucket.containerMountPath }}
         - --heartbeat-namespace={{ .Release.Namespace }}
         - --heartbeat-renew-interval-seconds={{ .Values.controllers.heartbeat.renewIntervalSeconds }}
+        {{- if eq (include "coredns.enabled" .) "false" }}
+        - --disable-webhooks=dnsconfig
+        {{- end }}
         {{- if .Values.gardener.runtimeCluster.enabled }}
         - --disable-webhooks=controlplane,dnsconfig,networkpolicy,prometheus,shoot
         - --controllers=backupbucket,dnsrecord,local-ext-shoot

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -82,3 +82,4 @@ data:
   bashrc: |
     export KUBECONFIG=/etc/kubernetes/admin.conf
     alias k=kubectl
+    alias kg='kubectl -n garden'

--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -23,6 +23,7 @@ It is built on top of the `ConfigInterface` and `DataInterface` interfaces part 
   - `IgnoreOldSecretsAfter(time.Duration)`: This specifies that old secrets should not be considered and loaded once a given duration after rotation has passed. It can be used to clean up old secrets after automatic rotation (e.g. the Seed cluster CA is automatically rotated when its validity will soon end and the old CA will be cleaned up 24 hours after triggering the rotation).
   - `Validity(time.Duration)`: This specifies how long the secret should be valid. For certificate secret configurations, the manager will automatically deduce this information from the generated certificate.
   - `RenewAfterValidityPercentage(int)`: This specifies the percentage of validity for renewal. The secret will be renewed based on whichever comes first: The specified percentage of validity or 10 days before end of validity. If not specified, the default percentage is `80`.
+  - `Namespace(string)`: This overrides the namespace where the secret is stored (by default, it's the first namespace provided to `secretsmanager.New`)
 
 - `Get(string, ...GetOption) (*corev1.Secret, bool)`
 

--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -36,10 +36,10 @@ type SecretConfigWithOptions struct {
 // - keeps old CA secrets during CA rotation
 // - removes old CA secrets on Cleanup() if cluster.shoot.status.credentials.rotation.certificateAuthorities.phase == Completing
 func SecretsManagerForCluster(ctx context.Context, logger logr.Logger, clock clock.Clock, c client.Client, cluster *extensionscontroller.Cluster, identity string, secretConfigs []SecretConfigWithOptions) (secretsmanager.Interface, error) {
-	sm, err := secretsmanager.New(ctx, logger, clock, c, cluster.ObjectMeta.Name, identity, secretsmanager.Config{
+	sm, err := secretsmanager.New(ctx, logger, clock, c, identity, secretsmanager.Config{
 		CASecretAutoRotation: false,
 		SecretNamesToTimes:   lastSecretRotationStartTimesFromCluster(cluster, secretConfigs),
-	})
+	}, cluster.ObjectMeta.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -240,9 +240,9 @@ func (r *reconciler) newSecretsManager(ctx context.Context, log logr.Logger, c c
 		log.WithName("secretsmanager"),
 		r.Clock,
 		c,
-		r.Namespace,
 		r.Identity,
 		secretsmanager.Config{CASecretAutoRotation: true},
+		r.Namespace,
 	)
 }
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -10,9 +10,12 @@ import (
 
 const (
 	// SecretManagerIdentityControllerManager is the identity for the secret manager used inside controller-manager.
-	SecretManagerIdentityControllerManager = "controller-manager"
+	SecretManagerIdentityControllerManager = "controller-manager" // #nosec G101 -- No credential.
 	// SecretManagerIdentityGardenlet is the identity for the secret manager used inside gardenlet.
-	SecretManagerIdentityGardenlet = "gardenlet"
+	SecretManagerIdentityGardenlet = "gardenlet" // #nosec G101 -- No credential.
+	// SecretManagerIdentitySelfHostedShoot is the identity for the secret manager used inside gardenadm or the shoot
+	// gardenlet.
+	SecretManagerIdentitySelfHostedShoot = "self-hosted-shoot" // #nosec G101 -- No credential.
 
 	// SecretNameCACluster is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of a shoot cluster.

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -351,6 +351,7 @@ var _ = Describe("Etcd", func() {
 									},
 								},
 							},
+							Tolerations:        []corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: "Exists"}},
 							PriorityClassName:  priorityClassName,
 							ServiceAccountName: "etcd-druid",
 							Volumes: []corev1.Volume{
@@ -461,6 +462,7 @@ var _ = Describe("Etcd", func() {
 									},
 								},
 							},
+							Tolerations:        []corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: "Exists"}},
 							PriorityClassName:  priorityClassName,
 							ServiceAccountName: "etcd-druid",
 							Volumes: []corev1.Volume{

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -1532,11 +1532,12 @@ var _ = Describe("Etcd", func() {
 						logr.New(logf.NullLogSink{}),
 						testclock.NewFakeClock(time.Now()),
 						fakeClient,
-						testNamespace,
 						"",
 						secretsmanager.Config{
 							SecretNamesToTimes: secretNamesToTimes,
-						})
+						},
+						testNamespace,
+					)
 					Expect(err).ToNot(HaveOccurred())
 
 					// Create new etcd CA
@@ -1639,11 +1640,12 @@ var _ = Describe("Etcd", func() {
 					logr.New(logf.NullLogSink{}),
 					testclock.NewFakeClock(time.Now()),
 					fakeClient,
-					testNamespace,
 					"",
 					secretsmanager.Config{
 						SecretNamesToTimes: secretNamesToTimes,
-					})
+					},
+					testNamespace,
+				)
 				Expect(err).ToNot(HaveOccurred())
 
 				// Create new etcd CA

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -509,12 +509,12 @@ var _ = Describe("ResourceManager", func() {
 				config.Webhooks.VPAInPlaceUpdates.Enabled = true
 			}
 
-			if responsibilityMode == ForSeedOrGardenRuntime {
+			if responsibilityMode == ForRuntime {
 				config.Webhooks.EndpointSliceHints.Enabled = true
 				config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled = true
 			}
 
-			if responsibilityMode == ForShootOrVirtualGarden || responsibilityMode == ForSelfHostedShoot {
+			if responsibilityMode == ForShootOrVirtualGarden {
 				config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 					Enabled: !isWorkerless,
 					NodeSelector: map[string]string{
@@ -926,30 +926,27 @@ var _ = Describe("ResourceManager", func() {
 			var namespaceSelectorMatchExpressions []metav1.LabelSelectorRequirement
 
 			switch responsibilityMode {
-			case ForSeedOrGardenRuntime:
-				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
-					Key:      "kubernetes.io/metadata.name",
-					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   []string{"kube-system", "kubernetes-dashboard"},
-				}}
+			case ForRuntime:
+				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{
+					{
+						Key:      "gardener.cloud/role",
+						Operator: metav1.LabelSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"kube-system", "kubernetes-dashboard"},
+					},
+				}
 			case ForShootOrVirtualGarden:
 				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
 					Key:      "kubernetes.io/metadata.name",
 					Operator: metav1.LabelSelectorOpIn,
 					Values:   []string{"kube-system", "kubernetes-dashboard"},
 				}}
-			case ForSelfHostedShoot:
-				namespaceSelectorMatchExpressions = []metav1.LabelSelectorRequirement{{
-					Key:      "gardener.cloud/role",
-					Operator: metav1.LabelSelectorOpExists,
-				}}
 			}
 
 			ignoreStaticPods := func(in []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
-				if responsibilityMode != ForSelfHostedShoot {
-					return in
-				}
-
 				return append(in, metav1.LabelSelectorRequirement{
 					Key:      "static-pod",
 					Operator: metav1.LabelSelectorOpNotIn,
@@ -1138,7 +1135,7 @@ var _ = Describe("ResourceManager", func() {
 			)
 
 			switch responsibilityMode {
-			case ForSeedOrGardenRuntime:
+			case ForRuntime:
 				obj.Webhooks = append(obj.Webhooks,
 					admissionregistrationv1.MutatingWebhook{
 						Name: "pod-kube-apiserver-load-balancing.resources.gardener.cloud",
@@ -1152,6 +1149,9 @@ var _ = Describe("ResourceManager", func() {
 						}},
 						NamespaceSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"foobar": "barfoo"},
+						},
+						ObjectSelector: &metav1.LabelSelector{
+							MatchExpressions: ignoreStaticPods(nil),
 						},
 						ClientConfig: admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
@@ -1180,13 +1180,13 @@ var _ = Describe("ResourceManager", func() {
 							MatchLabels: map[string]string{"barbaz": "bazbar"},
 						},
 						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
+							MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{
 								{
 									Key:      v1beta1constants.LabelApp,
 									Operator: metav1.LabelSelectorOpNotIn,
 									Values:   []string{"gardener-resource-manager"},
 								},
-							},
+							}),
 						},
 						ClientConfig: admissionregistrationv1.WebhookClientConfig{
 							Service: &admissionregistrationv1.ServiceReference{
@@ -1227,39 +1227,6 @@ var _ = Describe("ResourceManager", func() {
 						AdmissionReviewVersions: []string{"v1beta1", "v1"},
 						FailurePolicy:           &failurePolicyFail,
 						MatchPolicy:             &matchPolicyEquivalent,
-						SideEffects:             &sideEffect,
-						TimeoutSeconds:          ptr.To[int32](10),
-					},
-				)
-			case ForSelfHostedShoot:
-				obj.Webhooks = append(obj.Webhooks,
-					admissionregistrationv1.MutatingWebhook{
-						Name: "system-components-config.resources.gardener.cloud",
-						Rules: []admissionregistrationv1.RuleWithOperations{{
-							Rule: admissionregistrationv1.Rule{
-								APIGroups:   []string{""},
-								APIVersions: []string{"v1"},
-								Resources:   []string{"pods"},
-							},
-							Operations: []admissionregistrationv1.OperationType{"CREATE"},
-						}},
-						NamespaceSelector: &metav1.LabelSelector{MatchExpressions: namespaceSelectorMatchExpressions},
-						ObjectSelector: &metav1.LabelSelector{
-							MatchExpressions: ignoreStaticPods([]metav1.LabelSelectorRequirement{{
-								Key:      "system-components-config.resources.gardener.cloud/skip",
-								Operator: metav1.LabelSelectorOpDoesNotExist,
-							}}),
-						},
-						ClientConfig: admissionregistrationv1.WebhookClientConfig{
-							Service: &admissionregistrationv1.ServiceReference{
-								Name:      "gardener-resource-manager",
-								Namespace: deployNamespace,
-								Path:      ptr.To("/webhooks/system-components-config"),
-							},
-						},
-						AdmissionReviewVersions: []string{"v1beta1", "v1"},
-						FailurePolicy:           &failurePolicyFail,
-						MatchPolicy:             &matchPolicyExact,
 						SideEffects:             &sideEffect,
 						TimeoutSeconds:          ptr.To[int32](10),
 					},
@@ -1373,6 +1340,10 @@ webhooks:
       operator: NotIn
       values:
       - gardener-resource-manager
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
   rules:
   - apiGroups:
     - ""
@@ -1439,7 +1410,12 @@ webhooks:
   matchPolicy: Exact
   name: pod-scheduler-name.resources.gardener.cloud
   namespaceSelector: {}
-  objectSelector: {}
+  objectSelector:
+    matchExpressions:
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
   rules:
   - apiGroups:
     - ""
@@ -1471,6 +1447,10 @@ webhooks:
       operator: NotIn
       values:
       - disable
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
   reinvocationPolicy: Never
   rules:
   - apiGroups:
@@ -1497,6 +1477,11 @@ webhooks:
     matchLabels:
       foobar: barfoo
   objectSelector:
+    matchExpressions:
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
     matchLabels:
       networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
   rules:
@@ -1527,6 +1512,10 @@ webhooks:
 	  operator: NotIn
 	  values:
 	  - gardener-resource-manager
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
   rules:
   - apiGroups:
     - ""
@@ -1559,6 +1548,10 @@ webhooks:
     matchExpressions:
     - key: system-components-config.resources.gardener.cloud/skip
       operator: DoesNotExist
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
     matchLabels:
       resources.gardener.cloud/managed-by: gardener
   rules:
@@ -1597,6 +1590,10 @@ webhooks:
       - gardener-resource-manager
     - key: topology-spread-constraints.resources.gardener.cloud/skip
       operator: DoesNotExist
+    - key: static-pod
+      operator: NotIn
+      values:
+      - "true"
     matchLabels:
       resources.gardener.cloud/managed-by: gardener
   rules:
@@ -2519,7 +2516,7 @@ subjects:
 				delete(service.Annotations, "networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports")
 				service.Annotations["networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports"] = `[{"protocol":"TCP","port":8080}]`
 				service.Annotations["networking.resources.gardener.cloud/from-world-to-ports"] = `[{"protocol":"TCP","port":10250}]`
-				configMap = configMapFor(&watchedNamespace, ForSeedOrGardenRuntime, false, false)
+				configMap = configMapFor(&watchedNamespace, ForRuntime, false, false)
 				deployment = deploymentFor(configMap.Name, false, nil, false)
 
 				deployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes[:len(deployment.Spec.Template.Spec.Volumes)-2]
@@ -2546,7 +2543,7 @@ subjects:
 				cfg.DefaultSeccompProfileEnabled = true
 				cfg.EndpointSliceHintsEnabled = true
 				cfg.SchedulingProfile = nil
-				cfg.ResponsibilityMode = ForSeedOrGardenRuntime
+				cfg.ResponsibilityMode = ForRuntime
 				cfg.PodKubeAPIServerLoadBalancingWebhook.Enabled = true
 				cfg.VPAInPlaceUpdatesEnabled = true
 				resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2604,7 +2601,7 @@ subjects:
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{}), gomock.Any()).
 						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(mutatingWebhookConfigurationFor(ForSeedOrGardenRuntime, false)))
+							Expect(obj).To(DeepEqual(mutatingWebhookConfigurationFor(ForRuntime, false)))
 						}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{}), gomock.Any()).
@@ -2613,191 +2610,6 @@ subjects:
 						}),
 				)
 				Expect(resourceManager.Deploy(ctx)).To(Succeed())
-			})
-		})
-
-		Context("responsibility mode 'source and target'", func() {
-			BeforeEach(func() {
-				clusterRole.Rules = allowAll
-				delete(service.Annotations, "networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports")
-				delete(service.Annotations, "networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports")
-				service.Annotations["networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports"] = `[{"protocol":"TCP","port":8080}]`
-				service.Annotations["networking.resources.gardener.cloud/from-world-to-ports"] = `[{"protocol":"TCP","port":10250}]`
-				configMap = configMapFor(&watchedNamespace, ForSelfHostedShoot, false, false)
-				deployment = deploymentFor(configMap.Name, false, nil, false)
-
-				deployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes[:len(deployment.Spec.Template.Spec.Volumes)-2]
-				deployment.Spec.Template.Spec.Containers[0].VolumeMounts = deployment.Spec.Template.Spec.Containers[0].VolumeMounts[:len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts)-2]
-				deployment.Spec.Template.Labels["gardener.cloud/role"] = "seed"
-				pdb.Spec.Selector.MatchLabels["gardener.cloud/role"] = "seed"
-				for i := range deployment.Spec.Template.Spec.TopologySpreadConstraints {
-					deployment.Spec.Template.Spec.TopologySpreadConstraints[i].LabelSelector.MatchLabels["gardener.cloud/role"] = "seed"
-				}
-
-				// Remove controlplane label from resources
-				delete(serviceAccount.Labels, v1beta1constants.GardenRole)
-				delete(clusterRole.Labels, v1beta1constants.GardenRole)
-				delete(clusterRoleBinding.Labels, v1beta1constants.GardenRole)
-				delete(service.Labels, v1beta1constants.GardenRole)
-				delete(deployment.Labels, v1beta1constants.GardenRole)
-				delete(vpa.Labels, v1beta1constants.GardenRole)
-				delete(pdb.Labels, v1beta1constants.GardenRole)
-				// Remove networking label from deployment template
-				delete(deployment.Spec.Template.Labels, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443")
-
-				utilruntime.Must(references.InjectAnnotations(deployment))
-
-				cfg.DefaultSeccompProfileEnabled = true
-				cfg.VPAInPlaceUpdatesEnabled = true
-				cfg.SchedulingProfile = nil
-				cfg.ResponsibilityMode = ForSelfHostedShoot
-				resourceManager = New(c, deployNamespace, sm, cfg)
-				resourceManager.SetSecrets(secrets)
-			})
-
-			It("should deploy the expected resources", func() {
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, client.ObjectKey{Name: "managedresources.resources.gardener.cloud"}, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{}), gomock.Any()),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(serviceAccount))
-						}),
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
-						Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(configMap))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(clusterRole))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(clusterRoleBinding))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(service))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(deployment))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(pdb))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(vpa))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "seed-gardener-resource-manager"}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(serviceMonitorFor("seed")))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(mutatingWebhookConfigurationFor(ForSelfHostedShoot, false)))
-						}),
-					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{}), gomock.Any()).
-						Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(validatingWebhookConfiguration))
-						}),
-				)
-				Expect(resourceManager.Deploy(ctx)).To(Succeed())
-			})
-
-			When("bootstrap control plane node is set to true", func() {
-				BeforeEach(func() {
-					DeferCleanup(test.WithVar(&SuggestPort, func(string) (int, string, error) {
-						return 10250, "", nil
-					}))
-
-					configMap = configMapFor(&watchedNamespace, ForSelfHostedShoot, false, true)
-					resourceManager = New(c, deployNamespace, sm, cfg)
-					resourceManager.SetSecrets(secrets)
-					resourceManager.SetBootstrapControlPlaneNode(true)
-
-					deployment = deploymentFor(configMap.Name, false, nil, true)
-
-					deployment.Spec.Template.Labels["gardener.cloud/role"] = "seed"
-					for i := range deployment.Spec.Template.Spec.TopologySpreadConstraints {
-						deployment.Spec.Template.Spec.TopologySpreadConstraints[i].LabelSelector.MatchLabels["gardener.cloud/role"] = "seed"
-					}
-					delete(deployment.Spec.Template.Labels, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443")
-				})
-
-				It("should deploy the expected resources", func() {
-					gomock.InOrder(
-						c.EXPECT().Get(ctx, client.ObjectKey{Name: "managedresources.resources.gardener.cloud"}, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{}), gomock.Any()),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.ServiceAccount{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.ServiceAccount{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(serviceAccount))
-							}),
-						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
-							Do(func(_ context.Context, obj *corev1.ConfigMap, _ ...client.CreateOption) {
-								Expect(obj).To(DeepEqual(configMap))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRole{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(clusterRole))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Name: clusterRoleName}, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(clusterRoleBinding))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&corev1.Service{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(service))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(deployment))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: pdb.Name}, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&policyv1.PodDisruptionBudget{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(pdb))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(vpa))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "seed-gardener-resource-manager"}, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&monitoringv1.ServiceMonitor{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(serviceMonitorFor("seed")))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.MutatingWebhookConfiguration{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(mutatingWebhookConfigurationFor(ForSelfHostedShoot, true)))
-							}),
-						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "gardener-resource-manager"}, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&admissionregistrationv1.ValidatingWebhookConfiguration{}), gomock.Any()).
-							Do(func(_ context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-								Expect(obj).To(DeepEqual(validatingWebhookConfiguration))
-							}),
-					)
-					Expect(resourceManager.Deploy(ctx)).To(Succeed())
-				})
 			})
 		})
 	})
@@ -2996,35 +2808,8 @@ subjects:
 
 		Context("target equals source cluster", func() {
 			BeforeEach(func() {
-				cfg.ResponsibilityMode = ForSeedOrGardenRuntime
+				cfg.ResponsibilityMode = ForRuntime
 				cfg.PodKubeAPIServerLoadBalancingWebhook.Enabled = true
-				cfg.WatchedNamespace = nil
-				resourceManager = New(c, deployNamespace, sm, cfg)
-			})
-
-			It("should delete all created resources", func() {
-				gomock.InOrder(
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&apiextensionsv1.CustomResourceDefinition{}), gomock.Any()),
-					c.EXPECT().Delete(ctx, &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "managedresources.resources.gardener.cloud"}}),
-					c.EXPECT().Delete(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName}}),
-					c.EXPECT().Delete(ctx, &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleName}}),
-					c.EXPECT().Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager-vpa"}}),
-					c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "gardener-resource-manager"}}),
-					c.EXPECT().Delete(ctx, &monitoringv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{Namespace: deployNamespace, Name: "seed-gardener-resource-manager", Labels: map[string]string{"prometheus": "seed"}}}),
-				)
-
-				Expect(resourceManager.Destroy(ctx)).To(Succeed())
-			})
-		})
-
-		Context("responsibility mode 'source and target'", func() {
-			BeforeEach(func() {
-				cfg.ResponsibilityMode = ForSelfHostedShoot
 				cfg.WatchedNamespace = nil
 				resourceManager = New(c, deployNamespace, sm, cfg)
 			})
@@ -3156,8 +2941,8 @@ subjects:
 					&kubernetesutils.WaitTimeout, 10*time.Millisecond,
 				))
 
-				cfg.ResponsibilityMode = ForSeedOrGardenRuntime
-				configMap = configMapFor(nil, ForSeedOrGardenRuntime, false, false)
+				cfg.ResponsibilityMode = ForRuntime
+				configMap = configMapFor(nil, ForRuntime, false, false)
 				deployment = deploymentFor(configMap.Name, false, nil, false)
 				resourceManager = New(fakeClient, deployNamespace, nil, cfg)
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -286,6 +286,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 				PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane300,
 				ServiceAccountName:            serviceAccount.Name,
 				TerminationGracePeriodSeconds: ptr.To[int64](5),
+				Tolerations:                   []corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists}},
 			},
 		}
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -285,6 +285,7 @@ var _ = Describe("MachineControllerManager", func() {
 						PriorityClassName:             "gardener-system-300",
 						ServiceAccountName:            "machine-controller-manager",
 						TerminationGracePeriodSeconds: ptr.To[int64](5),
+						Tolerations:                   []corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists}},
 					},
 				},
 			},

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -52,7 +52,7 @@ func runtimeGardenerResourceManagerDefaultValues() resourcemanager.Values {
 		VPAInPlaceUpdatesEnabled:            false,
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
-		ResponsibilityMode:                  resourcemanager.ForSource,
+		ResponsibilityMode:                  resourcemanager.ForSeedOrGardenRuntime,
 	}
 }
 
@@ -88,7 +88,7 @@ func targetGardenerResourceManagerDefaultValues(namespaceName *string) resourcem
 		MaxConcurrentCSRApproverWorkers:    ptr.To(5),
 		MaxConcurrentHealthWorkers:         ptr.To(10),
 		MaxConcurrentTokenRequestorWorkers: ptr.To(5),
-		ResponsibilityMode:                 resourcemanager.ForTarget,
+		ResponsibilityMode:                 resourcemanager.ForShootOrVirtualGarden,
 		WatchedNamespace:                   namespaceName,
 	}
 }
@@ -117,7 +117,7 @@ func NewTargetGardenerResourceManager(
 	return resourcemanager.New(c, namespaceName, secretsManager, values), nil
 }
 
-func combinedGardenerResourceManagerDefaultValues() resourcemanager.Values {
+func selfHostedShootResourceManager() resourcemanager.Values {
 	var (
 		values        = resourcemanager.Values{}
 		runtimeValues = runtimeGardenerResourceManagerDefaultValues()
@@ -128,14 +128,14 @@ func combinedGardenerResourceManagerDefaultValues() resourcemanager.Values {
 	applyDefaults(&values, targetValues)
 
 	values.ResourceClass = ptr.To(resourcemanagerconfigv1alpha1.AllResourceClass)
-	values.ResponsibilityMode = resourcemanager.ForSourceAndTarget
+	values.ResponsibilityMode = resourcemanager.ForSelfHostedShoot
 
 	return values
 }
 
-// NewCombinedGardenerResourceManager instantiates a new `gardener-resource-manager` component configured to reconcile
-// objects in a self-hosted shoot cluster.
-func NewCombinedGardenerResourceManager(c client.Client,
+// NewSelfHostedShootGardenerResourceManager instantiates a new `gardener-resource-manager` component configured to
+// reconcile objects in a self-hosted shoot cluster.
+func NewSelfHostedShootGardenerResourceManager(c client.Client,
 	namespaceName string,
 	secretsManager secretsmanager.Interface,
 	values resourcemanager.Values,
@@ -149,7 +149,7 @@ func NewCombinedGardenerResourceManager(c client.Client,
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	defaultValues := combinedGardenerResourceManagerDefaultValues()
+	defaultValues := selfHostedShootResourceManager()
 	defaultValues.Image = image.String()
 
 	values.Replicas = ptr.To[int32](2)

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -52,7 +52,7 @@ func runtimeGardenerResourceManagerDefaultValues() resourcemanager.Values {
 		VPAInPlaceUpdatesEnabled:            false,
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
-		ResponsibilityMode:                  resourcemanager.ForSeedOrGardenRuntime,
+		ResponsibilityMode:                  resourcemanager.ForRuntime,
 	}
 }
 
@@ -112,50 +112,6 @@ func NewTargetGardenerResourceManager(
 
 	defaultValues := targetGardenerResourceManagerDefaultValues(&namespaceName)
 	defaultValues.Image = image.String()
-
-	applyDefaults(&values, defaultValues)
-	return resourcemanager.New(c, namespaceName, secretsManager, values), nil
-}
-
-func selfHostedShootResourceManager() resourcemanager.Values {
-	var (
-		values        = resourcemanager.Values{}
-		runtimeValues = runtimeGardenerResourceManagerDefaultValues()
-		targetValues  = targetGardenerResourceManagerDefaultValues(nil)
-	)
-
-	applyDefaults(&values, runtimeValues)
-	applyDefaults(&values, targetValues)
-
-	values.ResourceClass = ptr.To(resourcemanagerconfigv1alpha1.AllResourceClass)
-	values.ResponsibilityMode = resourcemanager.ForSelfHostedShoot
-
-	return values
-}
-
-// NewSelfHostedShootGardenerResourceManager instantiates a new `gardener-resource-manager` component configured to
-// reconcile objects in a self-hosted shoot cluster.
-func NewSelfHostedShootGardenerResourceManager(c client.Client,
-	namespaceName string,
-	secretsManager secretsmanager.Interface,
-	values resourcemanager.Values,
-) (
-	resourcemanager.Interface,
-	error,
-) {
-	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenerResourceManager)
-	if err != nil {
-		return nil, err
-	}
-	image.WithOptionalTag(version.Get().GitVersion)
-
-	defaultValues := selfHostedShootResourceManager()
-	defaultValues.Image = image.String()
-
-	values.Replicas = ptr.To[int32](2)
-	if values.BootstrapControlPlaneNode {
-		values.Replicas = ptr.To[int32](1)
-	}
 
 	applyDefaults(&values, defaultValues)
 	return resourcemanager.New(c, namespaceName, secretsManager, values), nil

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ResourceManager", func() {
 				VPAInPlaceUpdatesEnabled:            false,
 				Replicas:                            ptr.To[int32](2),
 				ResourceClass:                       ptr.To("seed"),
-				ResponsibilityMode:                  resourcemanager.ForSeedOrGardenRuntime,
+				ResponsibilityMode:                  resourcemanager.ForRuntime,
 			}))
 		})
 

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ResourceManager", func() {
 				VPAInPlaceUpdatesEnabled:            false,
 				Replicas:                            ptr.To[int32](2),
 				ResourceClass:                       ptr.To("seed"),
-				ResponsibilityMode:                  resourcemanager.ForSource,
+				ResponsibilityMode:                  resourcemanager.ForSeedOrGardenRuntime,
 			}))
 		})
 
@@ -93,7 +93,7 @@ var _ = Describe("ResourceManager", func() {
 				MaxConcurrentCSRApproverWorkers:    ptr.To(5),
 				MaxConcurrentHealthWorkers:         ptr.To(10),
 				MaxConcurrentTokenRequestorWorkers: ptr.To(5),
-				ResponsibilityMode:                 resourcemanager.ForTarget,
+				ResponsibilityMode:                 resourcemanager.ForShootOrVirtualGarden,
 				TargetNamespaces:                   []string{},
 				WatchedNamespace:                   &namespace,
 			}))

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -283,6 +283,9 @@ func (a *Actuator) ensureGardenNamespace(ctx context.Context, targetClient clien
 	gardenNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: a.GardenletNamespaceTarget,
+			Labels: map[string]string{
+				v1beta1constants.GardenRole: v1beta1constants.GardenRoleGarden,
+			},
 		},
 	}
 	if err := targetClient.Get(ctx, client.ObjectKeyFromObject(gardenNamespace), gardenNamespace); err != nil {

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -237,6 +237,7 @@ var _ = Describe("Interface", func() {
 			shootClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(
 				func(_ context.Context, ns *corev1.Namespace, _ ...client.CreateOption) error {
 					Expect(ns.Name).To(Equal(v1beta1constants.GardenNamespace))
+					Expect(ns.Labels).To(HaveKeyWithValue("gardener.cloud/role", "garden"))
 					return nil
 				},
 			)

--- a/pkg/controllermanager/bootstrappers/bootstrap.go
+++ b/pkg/controllermanager/bootstrappers/bootstrap.go
@@ -43,7 +43,7 @@ func (b *Bootstrapper) Start(parentCtx context.Context) error {
 		return fmt.Errorf("failed creating kubernetes client: %w", err)
 	}
 
-	secretsManager, err := secretsmanager.New(ctx, b.Log.WithName("secretsmanager"), clock.RealClock{}, b.Client, v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, secretsmanager.Config{})
+	secretsManager, err := secretsmanager.New(ctx, b.Log.WithName("secretsmanager"), clock.RealClock{}, b.Client, v1beta1constants.SecretManagerIdentityControllerManager, secretsmanager.Config{}, v1beta1constants.GardenNamespace)
 	if err != nil {
 		return fmt.Errorf("failed creating new secrets manager: %w", err)
 	}

--- a/pkg/gardenadm/botanist/etcd.go
+++ b/pkg/gardenadm/botanist/etcd.go
@@ -50,7 +50,7 @@ func (b *GardenadmBotanist) DeployEtcdDruid(ctx context.Context) error {
 
 	deployer, err := sharedcomponent.NewEtcdDruid(
 		b.SeedClientSet.Client(),
-		b.Shoot.ControlPlaneNamespace,
+		v1beta1constants.GardenNamespace,
 		b.Shoot.KubernetesVersion,
 		componentImageVectors,
 		gardenletConfig.ETCDConfig,

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -171,6 +171,7 @@ func (b *GardenadmBotanist) ReconcileExtensionControllerInstallations(ctx contex
 		Identity:                  &b.Shoot.GetInfo().Status.Gardener,
 		GardenNamespace:           b.Shoot.ControlPlaneNamespace,
 		BootstrapControlPlaneNode: bootstrapMode,
+		ForSelfHostedShoot:        true,
 	}
 
 	for _, extension := range b.Extensions {

--- a/pkg/gardenadm/botanist/resource_manager.go
+++ b/pkg/gardenadm/botanist/resource_manager.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
+	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
+	"github.com/gardener/gardener/pkg/features"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+// NewRuntimeGardenerResourceManager returns the gardener-resource-manager component for deploying it to the garden
+// namespace.
+func (b *GardenadmBotanist) NewRuntimeGardenerResourceManager() (resourcemanager.Interface, error) {
+	return sharedcomponent.NewRuntimeGardenerResourceManager(b.SeedClientSet.Client(), v1beta1constants.GardenNamespace, b.SecretsManager, resourcemanager.Values{
+		DefaultSeccompProfileEnabled:         features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
+		HighAvailabilityConfigWebhookEnabled: true,
+		PriorityClassName:                    v1beta1constants.PriorityClassNameShootControlPlane400,
+		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
+		SystemComponentTolerations:           gardenerutils.ExtractSystemComponentsTolerations(b.Shoot.GetInfo().Spec.Provider.Workers),
+	})
+}

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -45,7 +45,7 @@ func (b *GardenadmBotanist) ConnectToControlPlaneMachine(ctx context.Context) er
 	}
 
 	conn, err := sshutils.Dial(ctx, sshAddr,
-		sshutils.WithProxyConnection(b.Bastion.Connection),
+		sshutils.WithProxyConnection(b.Components.Bastion.Connection),
 		sshutils.WithUser("gardener"),
 		sshutils.WithPrivateKeyBytes(sshKeypairSecret.Data[secretsutils.DataKeyRSAPrivateKey]),
 	)

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -269,8 +269,8 @@ func run(ctx context.Context, opts *Options) error {
 		deployBastion = g.Add(flow.Task{
 			Name: "Deploying and connecting to bastion host",
 			Fn: func(ctx context.Context) error {
-				b.Bastion.Values.IngressCIDRs = opts.BastionIngressCIDRs
-				return component.OpWait(b.Bastion).Deploy(ctx)
+				b.Components.Bastion.Values.IngressCIDRs = opts.BastionIngressCIDRs
+				return component.OpWait(b.Components.Bastion).Deploy(ctx)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilInfrastructureReady),
 		})

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -606,10 +606,7 @@ func (r *Reconciler) MutateSpecForSelfHostedShootExtensions(obj runtime.Object) 
 			kubernetesutils.InjectKubernetesServiceHostEnv(podSpec.Containers, "localhost")
 		}
 
-		podSpec.Tolerations = append(podSpec.Tolerations,
-			corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-			corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-		)
+		podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule})
 	})
 }
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -604,6 +604,10 @@ func (r *Reconciler) MutateSpecForSelfHostedShootExtensions(obj runtime.Object) 
 			podSpec.HostNetwork = r.BootstrapControlPlaneNode
 			kubernetesutils.InjectKubernetesServiceHostEnv(podSpec.InitContainers, "localhost")
 			kubernetesutils.InjectKubernetesServiceHostEnv(podSpec.Containers, "localhost")
+
+			// extensions must even start on unready nodes in order to deploy the CNI plugin (nodes only become ready
+			// when networking is available)
+			podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule})
 		}
 
 		podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists})

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -606,7 +606,7 @@ func (r *Reconciler) MutateSpecForSelfHostedShootExtensions(obj runtime.Object) 
 			kubernetesutils.InjectKubernetesServiceHostEnv(podSpec.Containers, "localhost")
 		}
 
-		podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule})
+		podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists})
 	})
 }
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -96,10 +96,7 @@ var _ = Describe("Reconciler", func() {
 						}
 					}
 
-					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{
-						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-					}))
+					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}}))
 				}
 
 				assert = func(bootstrapControlPlaneNode bool) {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Reconciler", func() {
 						}
 					}
 
-					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}}))
+					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists}}))
 				}
 
 				assert = func(bootstrapControlPlaneNode bool) {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Reconciler", func() {
 		reconciler = &Reconciler{}
 	})
 
-	Describe("#MutateSpecForControlPlaneNodeBootstrapping", func() {
+	Describe("#MutateSpecForSelfHostedShootExtensions", func() {
 		var (
 			pod         *corev1.Pod
 			deployment  *appsv1.Deployment
@@ -52,83 +52,114 @@ var _ = Describe("Reconciler", func() {
 			cronJob = &batchv1.CronJob{Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}}
 		})
 
-		It("should not change objects if not bootstrapping control plane node", func() {
-			reconciler.BootstrapControlPlaneNode = false
+		It("should not change objects if not responsible for self-hosted shoots", func() {
+			reconciler.ForSelfHostedShoot = false
 
 			p := pod.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(p)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(p)).To(Succeed())
 			Expect(p).To(Equal(pod))
 
 			d := deployment.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(d)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(d)).To(Succeed())
 			Expect(d).To(Equal(deployment))
 
 			s := statefulSet.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(s)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(s)).To(Succeed())
 			Expect(s).To(Equal(statefulSet))
 
 			ds := daemonSet.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(ds)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(ds)).To(Succeed())
 			Expect(ds).To(Equal(daemonSet))
 
 			j := job.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(j)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(j)).To(Succeed())
 			Expect(j).To(Equal(job))
 
 			c := cronJob.DeepCopy()
-			Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(c)).To(Succeed())
+			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(c)).To(Succeed())
 			Expect(c).To(Equal(cronJob))
 		})
 
-		It("should adapt objects if bootstrapping control plane node", func() {
-			reconciler.BootstrapControlPlaneNode = true
+		When("responsible for self-hosted shoots", func() {
+			var (
+				checkPodSpec = func(podSpec *corev1.PodSpec, bootstrapControlPlaneNode bool) {
+					GinkgoHelper()
 
-			checkPodSpec := func(podSpec *corev1.PodSpec) {
-				GinkgoHelper()
+					if bootstrapControlPlaneNode {
+						Expect(podSpec.HostNetwork).To(BeTrue())
 
-				Expect(podSpec.HostNetwork).To(BeTrue())
-				Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{
-					{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
-					{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
-				}))
+						for _, container := range podSpec.InitContainers {
+							Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"}), fmt.Sprintf("init container %s should have KUBERNETES_SERVICE_HOST env var", container.Name))
+						}
+						for _, container := range podSpec.Containers {
+							Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"}), fmt.Sprintf("container %s should have KUBERNETES_SERVICE_HOST env var", container.Name))
+						}
+					}
 
-				for _, container := range podSpec.InitContainers {
-					Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"}), fmt.Sprintf("init container %s should have KUBERNETES_SERVICE_HOST env var", container.Name))
+					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+						{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
+					}))
 				}
-				for _, container := range podSpec.Containers {
-					Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"}), fmt.Sprintf("container %s should have KUBERNETES_SERVICE_HOST env var", container.Name))
-				}
-			}
 
-			for _, obj := range []struct {
-				object    runtime.Object
-				checkFunc func()
-			}{
-				{pod, func() {
-					checkPodSpec(&pod.Spec)
-				}},
-				{deployment, func() {
-					Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
-					Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
-					Expect(deployment.Spec.Strategy.RollingUpdate).To(BeNil())
-					checkPodSpec(&deployment.Spec.Template.Spec)
-				}},
-				{statefulSet, func() {
-					checkPodSpec(&statefulSet.Spec.Template.Spec)
-				}},
-				{daemonSet, func() {
-					checkPodSpec(&daemonSet.Spec.Template.Spec)
-				}},
-				{job, func() {
-					checkPodSpec(&job.Spec.Template.Spec)
-				}},
-				{cronJob, func() {
-					checkPodSpec(&cronJob.Spec.JobTemplate.Spec.Template.Spec)
-				}},
-			} {
-				Expect(reconciler.MutateSpecForControlPlaneNodeBootstrapping(obj.object)).To(Succeed(), "for %T", obj.object)
-				obj.checkFunc()
-			}
+				assert = func(bootstrapControlPlaneNode bool) {
+					for _, obj := range []struct {
+						object    runtime.Object
+						checkFunc func()
+					}{
+						{pod, func() {
+							checkPodSpec(&pod.Spec, bootstrapControlPlaneNode)
+						}},
+						{deployment, func() {
+							if bootstrapControlPlaneNode {
+								Expect(deployment.Spec.Replicas).To(Equal(ptr.To(int32(1))))
+								Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+								Expect(deployment.Spec.Strategy.RollingUpdate).To(BeNil())
+							}
+							checkPodSpec(&deployment.Spec.Template.Spec, bootstrapControlPlaneNode)
+						}},
+						{statefulSet, func() {
+							checkPodSpec(&statefulSet.Spec.Template.Spec, bootstrapControlPlaneNode)
+						}},
+						{daemonSet, func() {
+							checkPodSpec(&daemonSet.Spec.Template.Spec, bootstrapControlPlaneNode)
+						}},
+						{job, func() {
+							checkPodSpec(&job.Spec.Template.Spec, bootstrapControlPlaneNode)
+						}},
+						{cronJob, func() {
+							checkPodSpec(&cronJob.Spec.JobTemplate.Spec.Template.Spec, bootstrapControlPlaneNode)
+						}},
+					} {
+						Expect(reconciler.MutateSpecForSelfHostedShootExtensions(obj.object)).To(Succeed(), "for %T", obj.object)
+						obj.checkFunc()
+					}
+				}
+			)
+
+			BeforeEach(func() {
+				reconciler.ForSelfHostedShoot = true
+			})
+
+			When("BootstrapControlPlaneNode is true", func() {
+				BeforeEach(func() {
+					reconciler.BootstrapControlPlaneNode = true
+				})
+
+				It("should mutate the objects", func() {
+					assert(reconciler.BootstrapControlPlaneNode)
+				})
+			})
+
+			When("BootstrapControlPlaneNode is false", func() {
+				BeforeEach(func() {
+					reconciler.BootstrapControlPlaneNode = false
+				})
+
+				It("should mutate the objects", func() {
+					assert(reconciler.BootstrapControlPlaneNode)
+				})
+			})
 		})
 	})
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -94,9 +94,11 @@ var _ = Describe("Reconciler", func() {
 						for _, container := range podSpec.Containers {
 							Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "localhost"}), fmt.Sprintf("container %s should have KUBERNETES_SERVICE_HOST env var", container.Name))
 						}
+
+						Expect(podSpec.Tolerations).To(ContainElement(corev1.Toleration{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}))
 					}
 
-					Expect(podSpec.Tolerations).To(Equal([]corev1.Toleration{{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists}}))
+					Expect(podSpec.Tolerations).To(ContainElement(corev1.Toleration{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.TolerationOpExists}))
 				}
 
 				assert = func(bootstrapControlPlaneNode bool) {

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -131,9 +131,9 @@ func (r *Reconciler) runReconcileSeedFlow(
 		log.WithName("secretsmanager"),
 		clock.RealClock{},
 		r.SeedClientSet.Client(),
-		r.GardenNamespace,
 		v1beta1constants.SecretManagerIdentityGardenlet,
 		secretsmanager.Config{CASecretAutoRotation: true},
+		r.GardenNamespace,
 	)
 	if err != nil {
 		return err

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -36,7 +36,13 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	var (
 		b   = &Botanist{Operation: o}
 		err error
+
+		secretsManagerIdentity = v1beta1constants.SecretManagerIdentityGardenlet
 	)
+
+	if o.Shoot.IsSelfHosted() {
+		secretsManagerIdentity = v1beta1constants.SecretManagerIdentitySelfHostedShoot
+	}
 
 	o.SecretsManager, err = secretsmanager.New(
 		ctx,
@@ -44,7 +50,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		clock.RealClock{},
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
-		v1beta1constants.SecretManagerIdentityGardenlet,
+		secretsManagerIdentity,
 		secretsmanager.Config{
 			CASecretAutoRotation: false,
 			SecretNamesToTimes:   b.lastSecretRotationStartTimes(),

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -49,12 +49,12 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		b.Logger.WithName("secretsmanager"),
 		clock.RealClock{},
 		b.SeedClientSet.Client(),
-		b.Shoot.ControlPlaneNamespace,
 		secretsManagerIdentity,
 		secretsmanager.Config{
 			CASecretAutoRotation: false,
 			SecretNamesToTimes:   b.lastSecretRotationStartTimes(),
 		},
+		b.Shoot.ControlPlaneNamespace,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -38,10 +38,12 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		err error
 
 		secretsManagerIdentity = v1beta1constants.SecretManagerIdentityGardenlet
+		namespaces             = []string{b.Shoot.ControlPlaneNamespace}
 	)
 
 	if o.Shoot.IsSelfHosted() {
 		secretsManagerIdentity = v1beta1constants.SecretManagerIdentitySelfHostedShoot
+		namespaces = append(namespaces, v1beta1constants.GardenNamespace)
 	}
 
 	o.SecretsManager, err = secretsmanager.New(
@@ -54,7 +56,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 			CASecretAutoRotation: false,
 			SecretNamesToTimes:   b.lastSecretRotationStartTimes(),
 		},
-		b.Shoot.ControlPlaneNamespace,
+		namespaces...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -42,6 +42,11 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	)
 
 	if o.Shoot.IsSelfHosted() {
+		// `gardenadm init` will generate secrets for gardener-resource-manager and etcd-druid in the `garden` namespace
+		// with the `self-hosted-shoot` identity. Later, when `gardener-operator` or the seed `gardenlet` will take over
+		// management of those shared components, they will generate new secrets with their identity and thereby orphan
+		// the existing ones. When the shoot `gardenlet` reconciles the self-hosted shoot, calling the secrets manager
+		// `Cleanup` will delete the orphaned secrets from the `garden` namespace.
 		secretsManagerIdentity = v1beta1constants.SecretManagerIdentitySelfHostedShoot
 		namespaces = append(namespaces, v1beta1constants.GardenNamespace)
 	}

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -70,7 +70,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		values.KubernetesServiceHost = nil
 
 		if b.Shoot.RunsControlPlane() {
-			newFunc = shared.NewCombinedGardenerResourceManager
+			newFunc = shared.NewSelfHostedShootGardenerResourceManager
 			values.TargetNamespaces = nil
 		} else {
 			newFunc = shared.NewRuntimeGardenerResourceManager

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -69,10 +69,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	if b.Shoot.IsSelfHosted() {
 		values.KubernetesServiceHost = nil
 
-		if b.Shoot.RunsControlPlane() {
-			newFunc = shared.NewSelfHostedShootGardenerResourceManager
-			values.TargetNamespaces = nil
-		} else {
+		if !b.Shoot.RunsControlPlane() {
 			newFunc = shared.NewRuntimeGardenerResourceManager
 			values.HighAvailabilityConfigWebhookEnabled = false
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -102,12 +102,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		log.WithName("secretsmanager"),
 		r.Clock,
 		r.RuntimeClientSet.Client(),
-		r.GardenNamespace,
 		operatorv1alpha1.SecretManagerIdentityOperator,
 		secretsmanager.Config{
 			CASecretAutoRotation: true,
 			SecretNamesToTimes:   lastSecretRotationStartTimes(garden),
 		},
+		r.GardenNamespace,
 	)
 	if err != nil {
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, garden, err, operationType)

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -30,7 +30,6 @@ import (
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/component-base/version"
-	podsecurityadmissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -106,16 +105,9 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	// create + label garden namespace
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: r.GardenNamespace}}
-	log.Info("Labeling and annotating namespace", "namespaceName", namespace.Name)
-	if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, r.RuntimeClientSet.Client(), namespace, func() error {
-		metav1.SetMetaDataLabel(&namespace.ObjectMeta, podsecurityadmissionapi.EnforceLevelLabel, string(podsecurityadmissionapi.LevelPrivileged))
-		metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
-		metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(garden.Spec.RuntimeCluster.Provider.Zones, ","))
-		return nil
-	}); err != nil {
-		return reconcile.Result{}, err
+	log.Info("Labeling and annotating namespace", "namespaceName", r.GardenNamespace)
+	if err := gardenerutils.ReconcileGardenNamespace(ctx, r.RuntimeClientSet.Client(), r.GardenNamespace, garden.Spec.RuntimeCluster.Provider.Zones, true, nil); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile garden namespace %q: %w", r.GardenNamespace, err)
 	}
 
 	log.Info("Generating CA certificates for runtime and virtual clusters")

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -20,12 +20,14 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
+	"k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -476,4 +478,22 @@ func GetRequiredGardenWildcardCertificate(ctx context.Context, c client.Client, 
 	}
 
 	return tlsSecret, nil
+}
+
+// ReconcileGardenNamespace ensures that the Garden namespace exists with the appropriate labels and annotations.
+func ReconcileGardenNamespace(ctx context.Context, client client.Client, namespaceName string, zones []string, manageMetadata bool, mutateFn func(namespace *corev1.Namespace)) error {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+	_, err := controllerutils.CreateOrGetAndMergePatch(ctx, client, namespace, func() error {
+		if manageMetadata {
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, api.EnforceLevelLabel, string(api.LevelPrivileged))
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
+			metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
+		}
+
+		if mutateFn != nil {
+			mutateFn(namespace)
+		}
+		return nil
+	})
+	return err
 }

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -487,6 +487,7 @@ func ReconcileGardenNamespace(ctx context.Context, client client.Client, namespa
 		if manageMetadata {
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, api.EnforceLevelLabel, string(api.LevelPrivileged))
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleGarden)
 			metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(zones, ","))
 		}
 

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -914,6 +914,7 @@ var _ = Describe("Garden", func() {
 				Expect(namespace.Labels).To(And(
 					HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"),
 					HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"),
+					HaveKeyWithValue("gardener.cloud/role", "garden"),
 				))
 			})
 
@@ -926,7 +927,7 @@ var _ = Describe("Garden", func() {
 						},
 						Labels: map[string]string{
 							"pod-security.kubernetes.io/enforce":                         "unprivileged",
-							"high-availability-config.resources.gardener.cloud/consider": "false",
+							"high-availability-config.resources.gardener.cloud/consider": "",
 						},
 					},
 				}
@@ -942,6 +943,7 @@ var _ = Describe("Garden", func() {
 					HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"),
 					HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"),
 					HaveKeyWithValue("foo", "bar"),
+					HaveKeyWithValue("gardener.cloud/role", "garden"),
 				))
 			})
 		})

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -84,12 +84,17 @@ var _ = Describe("Gardenlet", func() {
 			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
 		})
 
-		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled", func() {
+		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled correctly", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "kube-system"}}})).To(Succeed())
+			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
+		})
+
+		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled at all", func() {
 			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})).To(Succeed())
 			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 
-		It("should return an error no kube-system namespace found", func() {
+		It("should return an error no kube-system namespace is found", func() {
 			result, err := SeedIsSelfHostedShoot(ctx, fakeClient)
 			Expect(err).To(BeNotFoundError())
 			Expect(result).To(BeFalse())

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
@@ -80,17 +80,19 @@ var _ = Describe("Gardenlet", func() {
 		})
 
 		It("should return that the seed is a self-hosted shoot", func() {
-			Expect(fakeClient.Create(ctx, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardenlet",
-					Namespace: "kube-system",
-				},
-			})).To(Succeed())
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "shoot"}}})).To(Succeed())
 			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
 		})
 
-		It("should return that the seed is not a self-hosted shoot because no gardenlet deployment found", func() {
+		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})).To(Succeed())
 			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
+		})
+
+		It("should return an error no kube-system namespace found", func() {
+			result, err := SeedIsSelfHostedShoot(ctx, fakeClient)
+			Expect(err).To(BeNotFoundError())
+			Expect(result).To(BeFalse())
 		})
 	})
 

--- a/pkg/utils/secrets/manager/cleanup.go
+++ b/pkg/utils/secrets/manager/cleanup.go
@@ -20,9 +20,7 @@ func (m *manager) Cleanup(ctx context.Context) error {
 
 	var fns []flow.TaskFn
 
-	for _, s := range secretList.Items {
-		secret := s
-
+	for _, secret := range secretList.Items {
 		name := secret.Labels[LabelKeyName]
 		if v, ok := secret.Labels[LabelKeyBundleFor]; ok {
 			name = v
@@ -36,7 +34,7 @@ func (m *manager) Cleanup(ctx context.Context) error {
 		}
 
 		fns = append(fns, func(ctx context.Context) error {
-			m.logger.Info("Deleting stale secret", "namespace", secret.Namespace, "name", secret.Name)
+			m.logger.Info("Deleting stale secret", "secret", client.ObjectKeyFromObject(&secret))
 			return client.IgnoreNotFound(m.client.Delete(ctx, &secret))
 		})
 	}

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -27,9 +27,10 @@ import (
 var _ = Describe("Manager", func() {
 	Describe("#New", func() {
 		var (
-			ctx       = context.TODO()
-			namespace = "some-namespace"
-			identity  = "test"
+			ctx        = context.TODO()
+			namespace  = "some-namespace"
+			namespace2 = "some-other-namespace"
+			identity   = "test"
 
 			m          *manager
 			fakeClient client.Client
@@ -40,8 +41,13 @@ var _ = Describe("Manager", func() {
 			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 		})
 
+		It("should fail creating a new instance when no namespace was provided", func() {
+			_, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{})
+			Expect(err).To(MatchError(ContainSubstring("must specify at least one namespace")))
+		})
+
 		It("should create a new instance w/ empty last rotation initiation times map", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -49,7 +55,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should create a new instance w/ provided last rotation initiation times", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -71,11 +77,28 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"secret1": fakeClock.Now()}})
+			existingSecret2 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret2",
+					Namespace: namespace2,
+					Labels: map[string]string{
+						"name":                          "secret2",
+						"managed-by":                    "secrets-manager",
+						"manager-identity":              identity,
+						"last-rotation-initiation-time": "-100",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingSecret2)).To(Succeed())
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{SecretNamesToTimes: map[string]time.Time{"secret1": fakeClock.Now()}}, namespace, namespace2)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
-			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-62135596800"}))
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{
+				"secret1": "-62135596800",
+				"secret2": "-100",
+			}))
 		})
 
 		It("should create a new instance w/ both existing and provided last rotation initiation times", func() {
@@ -93,7 +116,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -122,7 +145,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -148,7 +171,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -174,7 +197,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -228,7 +251,7 @@ var _ = Describe("Manager", func() {
 				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 			}
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{}, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -265,7 +288,7 @@ var _ = Describe("Manager", func() {
 			It("should create a new instance and auto-renew the CA secret because CASecretAutoRotation=true", func() {
 				fakeClock = testclock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
 
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: true})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{CASecretAutoRotation: true}, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -273,7 +296,7 @@ var _ = Describe("Manager", func() {
 			})
 
 			It("should create a new instance and NOT auto-renew the CA secret because CASecretAutoRotation=false", func() {
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: false})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, identity, Config{CASecretAutoRotation: false}, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -466,6 +466,7 @@ var _ = Describe("Seed controller tests", func() {
 						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(testNamespace), testNamespace)).To(Succeed())
 						g.Expect(testNamespace.Labels).To(And(
 							HaveKeyWithValue("role", "garden"),
+							HaveKeyWithValue("gardener.cloud/role", "garden"),
 							HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"),
 							HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"),
 						))

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -540,8 +540,11 @@ spec:
 		By("Verify that garden namespace was labeled and annotated appropriately")
 		Eventually(func(g Gomega) {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(testNamespace), testNamespace)).To(Succeed())
-			g.Expect(testNamespace.Labels).To(HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"))
-			g.Expect(testNamespace.Labels).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"))
+			g.Expect(testNamespace.Labels).To(And(
+				HaveKeyWithValue("gardener.cloud/role", "garden"),
+				HaveKeyWithValue("pod-security.kubernetes.io/enforce", "privileged"),
+				HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"),
+			))
 			g.Expect(testNamespace.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "a,b,c"))
 		}).Should(Succeed())
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
- `gardener-resource-manager` usually has one of the two responsibility areas: either for the runtime cluster (garden runtime or seed), or for the target cluster (shoot or virtual garden)
- In `master`, there is only one `gardener-resource-manager` deployment for self-hosted shoots which is configured to combine both responsibility areas
- This causes issues down the road when you try to install Gardener into a self-hosted shoot
  - `gardener-operator` also comes with its own `gardener-resource-manager` — when running in a self-hosted shoot, we want to reuse the existing one
  - With a combined GRM, this not only causes configuration issues but also problems during Gardener upgrades
    - For the "target responsibilities" (webhooks, etc), we don't want `gardener-operator` to rollout a new version before the self-hosted shoot is reconciled
    - OTOH, `gardener-operator` might depend on a new version as part of its `Garden` reconciliation
    - If the GRM responsibilities were split, this dependency cycle would be broken through
- Hence, this PR splits the combined `gardener-resource-manager` for self-hosted shoots into two
  - The `gardener-resource-manager` in `garden` namespace is responsibility for runtime resources
  - The `gardener-resource-manager` in `kube-system` namespace is responsibility for target resources
  - `etcd-druid` has also been moved to `garden` namespace so that it can become reusable for `gardener-operator`

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
cc @timebertt @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The signature of the `github.com/gardener/gardener/pkg/utils/secrets/manager.New` function has been changed. The `namespace` parameter was previously the 5th parameter passed to the function. Instead, the function now accepts `namespaces` as a variadic parameter.
```
