### PR TITLE
Make `resourceLimit.size` truly optional

### DIFF
--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -572,7 +572,7 @@ type ResourceLimit struct {
 	Resources []string `json:"resources"`
 	// Size specifies the imposed limit.
 	// +optional
-	Size *resource.Quantity `json:"size"`
+	Size *resource.Quantity `json:"size,omitempty"`
 	// Count specifies the maximum number of resources of the given kind. Only cluster-scoped resources are considered.
 	// +optional
 	Count *int64 `json:"count,omitempty"`


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

In #12916, I forgot to add the `omitempty` json tag in the `Garden` API, leading to the problem that operators could not _only_ specify a `count` limit. For details, see #13475.

**Which issue(s) this PR fixes**:
Fixes #13475

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where operators could not exclusively specify `count` limits in the Garden's `spec.virtualCluster.gardener.gardenerAdmissionController.resourceAdmissionConfiguration.limit` field.
```
