### PR TITLE
Fix kube-apiserver metrics from being scraped multiple times when `IstioTLSTermination` is active

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -496,8 +496,9 @@ var _ = Describe("KubeAPIServer", func() {
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-							"app":  "kubernetes",
-							"role": "apiserver",
+							"app":                   "kubernetes",
+							"role":                  "apiserver",
+							"metrics-scrape-target": "true",
 						}},
 						Endpoints: []monitoringv1.Endpoint{{
 							TargetPort: ptr.To(intstr.FromInt32(443)),

--- a/pkg/component/kubernetes/apiserverexposure/service.go
+++ b/pkg/component/kubernetes/apiserverexposure/service.go
@@ -155,6 +155,11 @@ func (s *service) Deploy(ctx context.Context) error {
 		gardenerutils.ReconcileTopologyAwareRoutingSettings(obj, s.values.topologyAwareRoutingEnabled, s.values.runtimeKubernetesVersion)
 
 		obj.Labels = utils.MergeStringMaps(obj.Labels, getLabels())
+		// Only the primary service should be scraped for metrics. Otherwise, we would have duplicate metrics.
+		if s.values.nameSuffix == "" {
+			obj.Labels[kubeapiserver.LabelMetricsScrapeTarget] = "true"
+		}
+
 		obj.Spec.Type = corev1.ServiceTypeClusterIP
 		obj.Spec.Selector = getLabels()
 		obj.Spec.Ports = kubernetesutils.ReconcileServicePorts(obj.Spec.Ports, []corev1.ServicePort{

--- a/pkg/component/kubernetes/apiserverexposure/service_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/service_test.go
@@ -80,8 +80,9 @@ var _ = Describe("#Service", func() {
 				Name:      expectedName,
 				Namespace: namespace.Name,
 				Labels: map[string]string{
-					"app":  "kubernetes",
-					"role": "apiserver",
+					"app":                   "kubernetes",
+					"role":                  "apiserver",
+					"metrics-scrape-target": "true",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -257,6 +258,26 @@ var _ = Describe("#Service", func() {
 				Expect(actual.Labels).To(HaveKeyWithValue("endpoint-slice-hints.resources.gardener.cloud/consider", "true"))
 			})
 		})
+	})
+
+	Context("when service has a suffix", func() {
+		BeforeEach(func() {
+			values.NameSuffix = "-foo"
+			expectedName = expectedName + "-foo"
+			expected.Name = expectedName
+
+			expected.Annotations = utils.MergeStringMaps(map[string]string{
+				"foo":                          "bar",
+				"networking.istio.io/exportTo": "*",
+			}, netpolAnnotations())
+
+			expected.Labels = map[string]string{
+				"app":  "kubernetes",
+				"role": "apiserver",
+			}
+		})
+
+		assertService()
 	})
 })
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane monitoring
/kind bug

**What this PR does / why we need it**:
We recently discovered that when we enable `IstioTLSTermination` the kube-apiserver requests (`apiserver_request_total`) are thrice as high according to our metrics (other apiserver related metrics are affected too).
Fortunately, this is not really the case. It is a bug when scraping the metrics.
When the feature gate is enabled, we deploy 2 additional services for `kube-apiserver` (`kube-apiserver-mtls` and `kube-apiserver-connection-upgrade`). All these services select the same endpoints and share the same labels. As the apiserver service monitor selects by these labels, the metrics are scraped thrice now.
This PR adds an additional label (`"metrics-scrape-target": "true"`) to the service without a suffix. This label is also used in the matcher of the service monitor.

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug which caused kube-apiserver metrics to be scraped thrice when `IstioTLSTermination` feature gate is active has been fixed.
```
