### PR TITLE
Minor improvements to the `ShootMutator` admission plugin

### DIFF
--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -488,14 +488,11 @@ func (c *mutationContext) ensureMachineImage(oldWorkers []core.Worker, worker co
 		}
 
 		if oldWorker.Machine.Image.Name == worker.Machine.Image.Name {
-			// image name was not changed -> keep version from the new worker if specified, otherwise use the old worker image version
-			if len(worker.Machine.Image.Version) != 0 {
-				return getDefaultMachineImage(c.cloudProfileSpec.MachineImages, worker.Machine.Image, worker.Machine.Architecture, machineType, c.cloudProfileSpec.MachineCapabilities, helper.IsUpdateStrategyInPlace(worker.UpdateStrategy), fldPath)
+			// image name was not changed
+			if len(worker.Machine.Image.Version) == 0 || worker.Machine.Image.Version == oldWorker.Machine.Image.Version {
+				// if the version from the new worker is not specified or it is equal to the old worker image version -> keep the old one
+				return oldWorker.Machine.Image, nil
 			}
-			return oldWorker.Machine.Image, nil
-		} else if len(worker.Machine.Image.Version) != 0 {
-			// image name was changed -> keep version from new worker if specified, otherwise default the image version
-			return getDefaultMachineImage(c.cloudProfileSpec.MachineImages, worker.Machine.Image, worker.Machine.Architecture, machineType, c.cloudProfileSpec.MachineCapabilities, helper.IsUpdateStrategyInPlace(worker.UpdateStrategy), fldPath)
 		}
 	}
 

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -219,6 +219,7 @@ func (c *mutationContext) addMetadataAnnotations(a admission.Attributes) {
 	if a.GetOperation() == admission.Create {
 		addInfrastructureDeploymentTask(c.shoot)
 		addDNSRecordDeploymentTasks(c.shoot)
+		return
 	}
 
 	var (
@@ -229,30 +230,25 @@ func (c *mutationContext) addMetadataAnnotations(a admission.Attributes) {
 	if !newIsHibernated && oldIsHibernated {
 		addInfrastructureDeploymentTask(c.shoot)
 		addDNSRecordDeploymentTasks(c.shoot)
-	}
+	} else {
+		if !reflect.DeepEqual(c.oldShoot.Spec.DNS, c.shoot.Spec.DNS) {
+			addDNSRecordDeploymentTasks(c.shoot)
+		}
 
-	if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
-		c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && len(c.oldShoot.Spec.Networking.IPFamilies) < len(c.shoot.Spec.Networking.IPFamilies) {
-		addInfrastructureDeploymentTask(c.shoot)
-	}
-
-	// We rely that SSHAccess is defaulted in the shoot creation, that is why we do not check for nils for the new shoot object.
-	if c.oldShoot.Spec.Provider.WorkersSettings != nil &&
-		c.oldShoot.Spec.Provider.WorkersSettings.SSHAccess != nil &&
-		c.oldShoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled != c.shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled {
-		addInfrastructureDeploymentTask(c.shoot)
-	}
-
-	if !reflect.DeepEqual(c.oldShoot.Spec.DNS, c.shoot.Spec.DNS) {
-		addDNSRecordDeploymentTasks(c.shoot)
-	}
-
-	if sets.New(
-		v1beta1constants.ShootOperationRotateSSHKeypair,
-		v1beta1constants.OperationRotateCredentialsStart,
-		v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
-	).HasAny(v1beta1helper.GetShootGardenerOperations(c.shoot.Annotations)...) {
-		addInfrastructureDeploymentTask(c.shoot)
+		if !reflect.DeepEqual(c.oldShoot.Spec.Provider.InfrastructureConfig, c.shoot.Spec.Provider.InfrastructureConfig) ||
+			c.oldShoot.Spec.Networking != nil && c.oldShoot.Spec.Networking.IPFamilies != nil && len(c.oldShoot.Spec.Networking.IPFamilies) < len(c.shoot.Spec.Networking.IPFamilies) {
+			addInfrastructureDeploymentTask(c.shoot)
+		} else if c.oldShoot.Spec.Provider.WorkersSettings != nil &&
+			c.oldShoot.Spec.Provider.WorkersSettings.SSHAccess != nil &&
+			c.oldShoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled != c.shoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled { // We rely that SSHAccess is defaulted in the shoot creation, that is why we do not check for nils for the new shoot object.
+			addInfrastructureDeploymentTask(c.shoot)
+		} else if sets.New(
+			v1beta1constants.ShootOperationRotateSSHKeypair,
+			v1beta1constants.OperationRotateCredentialsStart,
+			v1beta1constants.OperationRotateCredentialsStartWithoutWorkersRollout,
+		).HasAny(v1beta1helper.GetShootGardenerOperations(c.shoot.Annotations)...) {
+			addInfrastructureDeploymentTask(c.shoot)
+		}
 	}
 
 	if c.shoot.Spec.Maintenance != nil &&


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Incorporate optional PR review feedback from the ShootValidator [split](https://github.com/gardener/gardener/issues/2158):
- removes the redundant calls to `addInfrastructureDeploymentTask` and `addDNSRecordDeploymentTasks` functions.
- simplify the logic in `ensureMachineImage` function.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
