### PR TITLE
Configure clusterDNSAddresses for `kublet` as single-stack as long as `kube-dns` service is not yet dual-stack.

### DIFF
--- a/docs/usage/networking/dual-stack-networking-migration.md
+++ b/docs/usage/networking/dual-stack-networking-migration.md
@@ -78,7 +78,7 @@ Once all nodes are migrated, the remaining control plane components and the Cont
 
 ### Step 6: Restart of CoreDNS Pods
 
-With the next reconciliation, CoreDNS pods are restarted to obtain IPv6 addresses. The constraint `DNSServiceMigrationReady` is set to status `true` once all pods have both IPv4 and IPv6 addresses.
+With the next reconciliation, CoreDNS pods are restarted to obtain IPv6 addresses. The constraint `DNSServiceMigrationReady` is set to status `true` once all pods have both IPv4 and IPv6 addresses. As pods are restarted asynchronously, this will take an other reconiliation.
 
 ### Step 7: Switch Service `kube-dns` to Dual-Stack
 

--- a/pkg/gardenlet/operation/botanist/dualstackmigration.go
+++ b/pkg/gardenlet/operation/botanist/dualstackmigration.go
@@ -47,9 +47,10 @@ func (b *Botanist) createConstraintRemovalFunction(isSingleStack, allNodesMigrat
 		if isSingleStack && !allNodesMigrated {
 			return nil // Don't remove constraint yet
 		}
-
+		if v1beta1helper.GetCondition(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady) == nil {
+			return nil // Constraint already removed
+		}
 		shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootDualStackNodesMigrationReady)
-
 		if !isSingleStack && !b.hasDNSMigrationConstraint(shoot) {
 			b.addDNSMigrationConstraint(shoot)
 		}


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue, where /etc/resolve.conf contained an IPv6 address even though kube-dns didn't have an IPv6 clusterIP.  For pods `/etc/resolve.conf` is created by the kublet. During a migration we configured the cluster DNS addresses for the kubelet before the migration was finished. With this PR we only use the address from the primary IPFamily, as long the respective migration constraints are set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed DNS resolution issues during dual-stack migration by ensuring `/etc/resolv.conf` only contains the IPv4 DNS server address until the `kube-dns` service is fully migrated.
```
