### PR TITLE
Create `OwnerReferences` for objects in `istio-ingress` namespaces which depend on shoot & garden control-planes

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -111,6 +111,14 @@ var _ = Describe("#SNI", func() {
 
 		sm = fakesecretsmanager.New(c, namespace)
 
+		expectedOwnerReferences := []metav1.OwnerReference{{
+			APIVersion:         "v1",
+			Kind:               "Namespace",
+			Name:               "test-namespace",
+			UID:                "foo",
+			BlockOwnerDeletion: ptr.To(true),
+		}}
+
 		expectedDestinationRule = &istionetworkingv1beta1.DestinationRule{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-apiserver",
@@ -150,28 +158,34 @@ var _ = Describe("#SNI", func() {
 			},
 		}
 		expectedEnvoyFilterObjectMetaAPIServerProxy = metav1.ObjectMeta{
-			Name:      namespace + "-apiserver-proxy",
-			Namespace: istioNamespace,
+			Name:            namespace + "-apiserver-proxy",
+			Namespace:       istioNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedEnvoyFilterObjectMetaIstioTLSTermination = metav1.ObjectMeta{
-			Name:      namespace + "-istio-tls-termination",
-			Namespace: istioNamespace,
+			Name:            namespace + "-istio-tls-termination",
+			Namespace:       istioNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedWildcardEnvoyFilterObjectMetaIstioTLSTermination = metav1.ObjectMeta{
-			Name:      namespace + "-istio-tls-termination",
-			Namespace: istioWildcardNamespace,
+			Name:            namespace + "-istio-tls-termination",
+			Namespace:       istioWildcardNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedSecretObjectMetaIstioMTLS = metav1.ObjectMeta{
-			Name:      namespace + "-kube-apiserver-istio-mtls",
-			Namespace: istioNamespace,
+			Name:            namespace + "-kube-apiserver-istio-mtls",
+			Namespace:       istioNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedWildcardSecretObjectMetaIstioMTLS = metav1.ObjectMeta{
-			Name:      namespace + "-kube-apiserver-istio-mtls",
-			Namespace: istioWildcardNamespace,
+			Name:            namespace + "-kube-apiserver-istio-mtls",
+			Namespace:       istioWildcardNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedSecretObjectMetaIstioTLS = metav1.ObjectMeta{
-			Name:      namespace + "-kube-apiserver-tls",
-			Namespace: istioNamespace,
+			Name:            namespace + "-kube-apiserver-tls",
+			Namespace:       istioNamespace,
+			OwnerReferences: expectedOwnerReferences,
 		}
 		expectedGateway = &istionetworkingv1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
@@ -306,6 +320,8 @@ var _ = Describe("#SNI", func() {
 	})
 
 	JustBeforeEach(func() {
+		By("Create namespace")
+		Expect(c.Create(ctx, &corev1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}, ObjectMeta: metav1.ObjectMeta{Name: namespace, UID: "foo"}})).To(Succeed())
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: namespace}})).To(Succeed())
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-client", Namespace: namespace}})).To(Succeed())

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -3,6 +3,12 @@ kind: EnvoyFilter
 metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    kind: Namespace
+    name: {{ .ControlPlaneNamespace }}
+    uid: {{ .ControlPlaneNamespaceUID }}
 spec:
   workloadSelector:
     labels:

--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-istio-tls-termination.yaml
@@ -4,6 +4,12 @@ kind: EnvoyFilter
 metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    kind: Namespace
+    name: {{ .ControlPlaneNamespace }}
+    uid: {{ .ControlPlaneNamespaceUID }}
 spec:
   workloadSelector:
     labels:

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -82,6 +82,9 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	ann[resourcesv1alpha1.OriginAnnotation] = origin
 	newObject.SetAnnotations(ann)
 
+	// Update owner references
+	newObject.SetOwnerReferences(desired.GetOwnerReferences())
+
 	// keep status of old object if it is set and not empty
 	var oldStatus map[string]any
 	if oldStatusInterface, containsStatus := oldObject.Object["status"]; containsStatus {

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -82,7 +82,6 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	ann[resourcesv1alpha1.OriginAnnotation] = origin
 	newObject.SetAnnotations(ann)
 
-	// Update owner references
 	newObject.SetOwnerReferences(desired.GetOwnerReferences())
 
 	// keep status of old object if it is set and not empty


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane robustness
/kind enhancement

**What this PR does / why we need it**:
When (shoot) control planes are manually purged and IstioTLSTermination is active it might happen that some dependent EnvoyFilters and Secrets remain in the istio-ingressgateway namespace.

The orphan EnvoyFilters are the reason for warnings in the logs of istio-ingressgateway.
```
2025-12-05T12:18:37.865018Z	warning	envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:138	gRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) shoot--local--local--kube-apiserver-socket: route: unknown cluster 'outbound|443||kube-apiserver-mtls.shoot--local--local.svc.cluster.local'
```
When this happens istio-ingressgateway pods might get unhealthy.

As we care about the health of our istio-ingressgateways, this PR add `OwnerReferences` to these EnvoyFilters. It also adds OwnerReferences to the TLS secrets of the shoots in the istio-ingressgateway namespace. They don't make the pods unhealthy, but it is still nice to clean them up. The OwnerReferences use the namespace of the (shoot) control-planes.

This should not happen in normal operations since the EnvoyFilters and Secrets are managed by ManagedResources. However, we already saw this issue and since Istio is an important component for the entire seed, this is the safety net.

GRM also needed to be adapted for this to work properly. Before it only added `OwnerReferences` when it created new objects but not while updating them. 
With this PR GRM updates `OwnerReferences` on existing objects and enforces the desired state. This means that it also deletes custom `OwnerReferences`. Those are not desired anyway since they could cause a battle between KCM and GRM. 

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OwnerReferences now ensure that no orphan EnvoyFilters and Secrets remain in istio-ingressgateway namespaces when a shoot was purged manually. 
```
```breaking operator
gardener-resource-manager now enforces the desired OwnerReferences for objects it manages. Previously, it set OwnerReferences only when creating objects and did not update them afterwards.
```
