### PR TITLE
Propagate operator-provided static manifests in `Seed`s to `Shoot`s

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -237,6 +237,7 @@
 * [Extending project roles](extensions/project-roles.md)
 * [Referenced resources](extensions/referenced-resources.md)
 * [Validation Guidelines For Extensions](extensions/validation-guidelines-for-extensions.md)
+* [Static Manifest Propagation From Seed To Shoot](extensions/static-manifests.md)
 
 ## Deployment
 

--- a/docs/extensions/static-manifests.md
+++ b/docs/extensions/static-manifests.md
@@ -1,0 +1,146 @@
+# Static Manifest Propagation From Seed To Shoots
+
+## Overview
+
+Static manifest propagation is a mechanism that allows operators to distribute predefined Kubernetes resources across all Shoot clusters automatically.
+By placing labeled `Secret`s in the seed cluster's `garden` namespace, operators can ensure that specific manifests (such as RBAC rules, quotas, config policies, or compliance objects) are consistently deployed to every Shoot cluster without manual intervention.
+
+## Why Use Static Manifests?
+
+Static manifest propagation provides several benefits for cluster operators:
+
+- **Centralized Management**: Update manifests in one location (the seed's `garden` namespace) and have changes automatically propagate to all Shoots
+- **Consistency**: Ensure all Shoot clusters have the same baseline configurations, policies, or resources
+- **Simplified Operations**: Eliminate the need for manual per-Shoot provisioning or custom controllers
+- **Generic Distribution**: Works independently of cloud provider or extension logic
+- **Compliance & Governance**: Easily enforce organization-wide policies, quotas, or security configurations across all clusters
+
+Common use cases include:
+
+- Deploying RBAC rules or `ClusterRole`s
+- Setting `ResourceQuota`s or `LimitRange`s
+- Distributing `NetworkPolicy`s
+- Injecting compliance or audit configurations
+- Providing common `ConfigMap`s or monitoring agents
+
+## How It Works
+
+During Shoot reconciliation, the `gardenlet` performs the following steps:
+
+1. Scans the seed cluster's `garden` namespace for `Secret`s labeled with `shoot.gardener.cloud/static-manifests=true`.
+2. Copies all matching `Secret`s into each Shoot namespace.
+3. Creates a single `ManagedResource` that references these `Secret`s.
+4. The `ManagedResource` ensures the manifests are applied to the Shoot cluster.
+
+This process happens automatically during every Shoot reconciliation, ensuring manifests stay synchronized.
+
+## How to Propagate Static Manifests
+
+### Step 1: Prepare Your Manifests
+
+Create a YAML file containing the Kubernetes resources you want to deploy to all Shoot clusters. For example:
+
+```yaml
+# my-manifests.yaml
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: default-quota
+  namespace: default
+spec:
+  hard:
+    requests.cpu: "100"
+    requests.memory: 200Gi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: org-viewer
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch"]
+```
+
+### Step 2: Create a Secret in the Seed Cluster
+
+Create a `Secret` in the seed cluster's `garden` namespace containing your manifests.
+The `Secret` must be labeled with `shoot.gardener.cloud/static-manifests=true`.
+
+```bash
+# Create the Secret with the required label
+kubectl create secret generic my-static-manifests \
+  --from-file=manifests.yaml=my-manifests.yaml \
+  --namespace=garden \
+  --dry-run=client -o yaml | \
+  kubectl label --local -f - shoot.gardener.cloud/static-manifests=true --dry-run=client -o yaml | \
+  kubectl apply -f -
+```
+
+Or create it declaratively:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-static-manifests
+  namespace: garden
+  labels:
+    shoot.gardener.cloud/static-manifests: "true"
+type: Opaque
+data:
+  manifests.yaml: <base64-encoded-yaml-content>
+```
+
+### Step 3: Verify Propagation
+
+After the next Shoot reconciliation, verify that the manifests have been propagated:
+
+1. **Check the Shoot namespace** in the seed cluster for the copied `Secret`:
+   ```bash
+   kubectl get secret my-static-manifests -n shoot--<project>--<shoot>
+   ```
+
+2. **Check the `ManagedResource`** referencing your `Secret`:
+   ```bash
+   kubectl get managedresource static-manifests-from-seed -n shoot--<project>--<shoot>
+   ```
+
+3. **Check the Shoot cluster** to confirm resources are applied:
+   ```bash
+   # Using the Shoot cluster kubeconfig
+   kubectl get resourcequota default-quota -n default
+   kubectl get clusterrole org-viewer
+   ```
+
+## Updating Static Manifests
+
+To update manifests across all Shoot clusters:
+
+1. Update the `Secret` in the seed's `garden` namespace with the new manifest content.
+2. Wait for the next Shoot reconciliation cycle, or manually trigger reconciliation.
+3. The `gardenlet` will detect the change and update the `ManagedResource` in each Shoot namespace.
+4. The updated manifests will be applied to all Shoot clusters.
+
+## Removing Static Manifests
+
+To stop propagating manifests to Shoot clusters:
+
+1. Delete the `Secret` from the seed's `garden` namespace:
+   ```bash
+   kubectl delete secret my-static-manifests -n garden
+   ```
+
+2. During the next reconciliation, the `gardenlet` will remove the `Secret` from Shoot namespaces.
+3. The associated resources will be deleted from the Shoot clusters via the `ManagedResource` cleanup.
+
+## Important Considerations
+
+- **No Templating or Dynamic Logic**: Manifests must be completely static. No templating, variable substitution, or dynamic logic is supported. The same exact manifests are deployed to all Shoot clusters without modification. If you need per-Shoot customization, Shoot-specific values, or sophisticated logic (e.g., conditional deployment, templating based on Shoot properties), you must write a Gardener extension instead.
+- **Namespace Scoping**: Ensure manifests use appropriate namespaces. Resources without a namespace will be created in the default namespace of the Shoot cluster.
+- **Resource Conflicts**: Avoid creating resources that might conflict with Gardener-managed resources or Shoot-specific configurations.
+- **Secret Naming**: Use descriptive names for `Secret`s to distinguish between different sets of manifests.
+- **Multiple Secrets**: You can create multiple labeled `Secret`s in the `garden` namespace; all will be propagated.
+- **Label Requirement**: The label `shoot.gardener.cloud/static-manifests=true` is mandatory. `Secret`s without this label will not be propagated.
+- **Reconciliation Timing**: Changes may take time to propagate depending on the Shoot reconciliation schedule.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1076,6 +1076,8 @@ const (
 
 	// GardenPurposeMachineClass is a constant for the 'machineclass' value in a label.
 	GardenPurposeMachineClass = "machineclass"
+	// GardenPurposeShootStaticManifest is a constant for the 'shoot-static-manifest' value in a label.
+	GardenPurposeShootStaticManifest = "shoot-static-manifest"
 
 	// LabelInjectGardenKubeconfig is a constant for a label on workload resources that indicates that a kubeconfig to
 	// the garden cluster should be injected.
@@ -1098,9 +1100,6 @@ const (
 	// whether an endpoint is advertised for a shoot.
 	LabelShootEndpointAdvertise = LabelShootEndpointPrefix + "advertise"
 
-	// LabelShootStaticManifests is the name of a label on Secrets in the garden namespace of seeds which contain static
-	// manifests that should be propagated to all shoots.
-	LabelShootStaticManifests = "shoot.gardener.cloud/static-manifests"
 	// AnnotationStaticManifestsShootSelector is the name of an annotation on Secrets in the garden namespace of seeds
 	// that contains a label selector for shoots. The static manifests will only be propagated for shoots matching the
 	// selector.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1097,4 +1097,7 @@ const (
 	// LabelShootEndpointAdvertise is the name of the label which controls
 	// whether an endpoint is advertised for a shoot.
 	LabelShootEndpointAdvertise = LabelShootEndpointPrefix + "advertise"
+	// LabelShootStaticManifests is the name of a label on Secrets in the garden namespace of seeds which contain static
+	// manifests that should be propagated to all shoots.
+	LabelShootStaticManifests = "shoot.gardener.cloud/static-manifests"
 )

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1097,7 +1097,12 @@ const (
 	// LabelShootEndpointAdvertise is the name of the label which controls
 	// whether an endpoint is advertised for a shoot.
 	LabelShootEndpointAdvertise = LabelShootEndpointPrefix + "advertise"
+
 	// LabelShootStaticManifests is the name of a label on Secrets in the garden namespace of seeds which contain static
 	// manifests that should be propagated to all shoots.
 	LabelShootStaticManifests = "shoot.gardener.cloud/static-manifests"
+	// AnnotationStaticManifestsShootSelector is the name of an annotation on Secrets in the garden namespace of seeds
+	// that contains a label selector for shoots. The static manifests will only be propagated for shoots matching the
+	// selector.
+	AnnotationStaticManifestsShootSelector = "static-manifests.shoot.gardener.cloud/selector"
 )

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -656,6 +656,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			SkipIf:       o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, initializeShootClients, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Populating static manifests from seed to shoot",
+			Fn:           flow.TaskFn(botanist.PopulateStaticManifestsFromSeedToShoot).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, waitUntilShootNamespacesReady),
+		})
 		deployCoreDNS = g.Add(flow.Task{
 			Name: "Deploying CoreDNS system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {

--- a/pkg/gardenlet/operation/botanist/resources.go
+++ b/pkg/gardenlet/operation/botanist/resources.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,13 +142,7 @@ func (b *Botanist) PopulateStaticManifestsFromSeedToShoot(ctx context.Context) e
 			return secret.Name == secretNamePrefix+s.Name
 		}) {
 			tasks = append(tasks, func(ctx context.Context) error {
-				if err := kubernetesutils.DeleteObject(ctx, b.SeedClientSet.Client(), &secret); err != nil {
-					return fmt.Errorf("failed deleting secret %q: %w", client.ObjectKeyFromObject(&secret), err)
-				}
-
-				timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
-				defer cancel()
-				return kubernetesutils.WaitUntilResourceDeleted(timeoutCtx, b.SeedClientSet.Client(), &secret, time.Second)
+				return kubernetesutils.DeleteObject(ctx, b.SeedClientSet.Client(), &secret)
 			})
 		}
 	}

--- a/pkg/gardenlet/operation/botanist/resources.go
+++ b/pkg/gardenlet/operation/botanist/resources.go
@@ -7,15 +7,21 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
-const managedResourceName = "referenced-resources"
+const managedResourceNameReferencedResources = "referenced-resources"
 
 // DeployReferencedResources reads all referenced resources from the Garden cluster and writes a managed resource to the Seed cluster.
 func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
@@ -25,8 +31,9 @@ func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 	}
 
 	// Create managed resource from the slice of unstructured objects
+
 	if err := managedresources.CreateFromUnstructured(
-		ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, managedResourceName,
+		ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, managedResourceNameReferencedResources,
 		false, v1beta1constants.SeedResourceManagerClass, unstructuredObjs, false, nil,
 	); err != nil {
 		return fmt.Errorf("failed to create managed resource for referenced resources: %w", err)
@@ -49,9 +56,73 @@ func (b *Botanist) DestroyReferencedResources(ctx context.Context) error {
 		return fmt.Errorf("failed to destroy referenced workload identities: %w", err)
 	}
 
-	if err := client.IgnoreNotFound(managedresources.Delete(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, managedResourceName, false)); err != nil {
+	if err := client.IgnoreNotFound(managedresources.Delete(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, managedResourceNameReferencedResources, false)); err != nil {
 		return fmt.Errorf("failed to delete managed resource for referenced resources: %w", err)
 	}
 
 	return nil
+}
+
+// PopulateStaticManifestsFromSeedToShoot reads all Secrets in the seed's garden namespace labeled with
+// shoot.gardener.cloud/static-manifests=true and copies them into the Shoot namespace. A ManagedResource is created
+// referencing all of them.
+func (b *Botanist) PopulateStaticManifestsFromSeedToShoot(ctx context.Context) error {
+	var (
+		managedResourceName = "static-manifests-propagated-from-seed"
+		secretNamePrefix    = "static-manifests-"
+		managedResource     = managedresources.NewForShoot(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, managedResourceName, managedresources.LabelValueGardener, false)
+	)
+
+	secretListGardenNamespace := &corev1.SecretList{}
+	if err := b.SeedClientSet.Client().List(ctx, secretListGardenNamespace, client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.LabelShootStaticManifests: "true"}); err != nil {
+		return fmt.Errorf("failed listing secrets with static manifests in %s namespace: %w", v1beta1constants.GardenNamespace, err)
+	}
+
+	secretListShootControlPlaneNamespace := &corev1.SecretList{}
+	if err := b.SeedClientSet.Client().List(ctx, secretListShootControlPlaneNamespace, client.InNamespace(b.Shoot.ControlPlaneNamespace), client.MatchingLabels{v1beta1constants.LabelShootStaticManifests: "true"}); err != nil {
+		return fmt.Errorf("failed listing secrets with static manifests in %s namespace: %w", b.Shoot.ControlPlaneNamespace, err)
+	}
+
+	var tasks []flow.TaskFn
+
+	// populate current secrets into Shoot's control plane namespace
+	for _, secret := range secretListGardenNamespace.Items {
+		secretInShootNamespace := secret.DeepCopy()
+		secretInShootNamespace.SetName(secretNamePrefix + secret.Name)
+		secretInShootNamespace.SetNamespace(b.Shoot.ControlPlaneNamespace)
+		secretInShootNamespace.SetResourceVersion("")
+		secretInShootNamespace.SetManagedFields(nil)
+
+		tasks = append(tasks, func(ctx context.Context) error {
+			_, err := controllerutils.GetAndCreateOrMergePatch(ctx, b.SeedClientSet.Client(), secretInShootNamespace, func() error {
+				secretInShootNamespace.Immutable = ptr.To(false)
+				secretInShootNamespace.Type = secret.Type
+				secretInShootNamespace.Data = secret.Data
+				return nil
+			})
+			return err
+		})
+
+		managedResource.WithSecretRef(secretInShootNamespace.Name)
+	}
+
+	// cleanup old Secrets from Shoot's control plane namespace
+	for _, secret := range secretListShootControlPlaneNamespace.Items {
+		if !slices.ContainsFunc(secretListGardenNamespace.Items, func(s corev1.Secret) bool {
+			return secret.Name == secretNamePrefix+s.Name
+		}) {
+			tasks = append(tasks, func(ctx context.Context) error {
+				return kubernetesutils.DeleteObject(ctx, b.SeedClientSet.Client(), &secret)
+			})
+		}
+	}
+
+	if err := flow.Parallel(tasks...)(ctx); err != nil {
+		return fmt.Errorf("failed reconciling Secrets with static manifests in Shoot namespace: %w", err)
+	}
+
+	if len(secretListGardenNamespace.Items) == 0 {
+		return managedResource.Delete(ctx)
+	}
+	return managedResource.Reconcile(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -245,4 +245,287 @@ var _ = Describe("Resources", func() {
 			Expect(workloadIdentitySecrets.Items).To(BeEmpty())
 		})
 	})
+
+	Describe("#PopulateStaticManifestsFromSeedToShoot", func() {
+		var (
+			managedResourceName = "static-manifests-propagated-from-seed"
+			secretNamePrefix    = "static-manifests-"
+			shootLabels         = map[string]string{"environment": "production", "purpose": "testing"}
+		)
+
+		BeforeEach(func() {
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shoot",
+					Namespace: "garden",
+					Labels:    shootLabels,
+				},
+			})
+		})
+
+		Context("when there are no secrets with static manifests label", func() {
+			It("should delete the managed resource if it exists", func() {
+				managedResource := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceName,
+						Namespace: controlPlaneNamespace,
+					},
+				}
+				Expect(seedClient.Create(ctx, managedResource)).To(Succeed())
+
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(managedResource), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+			})
+
+			It("should not fail if managed resource does not exist", func() {
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+			})
+		})
+
+		Context("when there are secrets with static manifests label", func() {
+			var secret1, secret2, secret3 *corev1.Secret
+
+			BeforeEach(func() {
+				secret1 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "manifest-1",
+						Namespace: "garden",
+						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{"manifest": []byte("data1")},
+				}
+
+				secret2 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "manifest-2",
+						Namespace: "garden",
+						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+					},
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
+				}
+
+				secret3 = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "manifest-3",
+						Namespace: "garden",
+						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{"manifest": []byte("data3")},
+				}
+			})
+
+			It("should copy secrets to shoot control plane namespace with prefix", func() {
+				Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+				Expect(seedClient.Create(ctx, secret2)).To(Succeed())
+
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				copiedSecret1 := &corev1.Secret{}
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, copiedSecret1)).To(Succeed())
+				Expect(copiedSecret1.Type).To(Equal(secret1.Type))
+				Expect(copiedSecret1.Data).To(Equal(secret1.Data))
+				Expect(copiedSecret1.Immutable).To(Equal(ptr.To(false)))
+				Expect(copiedSecret1.Labels).To(HaveKeyWithValue("shoot.gardener.cloud/static-manifests", "true"))
+
+				copiedSecret2 := &corev1.Secret{}
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret2.Name}, copiedSecret2)).To(Succeed())
+				Expect(copiedSecret2.Type).To(Equal(secret2.Type))
+				Expect(copiedSecret2.Data).To(Equal(secret2.Data))
+			})
+
+			It("should create a managed resource referencing all copied secrets", func() {
+				Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+				Expect(seedClient.Create(ctx, secret2)).To(Succeed())
+
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				managedResource := &resourcesv1alpha1.ManagedResource{}
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: managedResourceName}, managedResource)).To(Succeed())
+				Expect(managedResource.Spec.SecretRefs).To(ConsistOf(
+					corev1.LocalObjectReference{Name: secretNamePrefix + secret1.Name},
+					corev1.LocalObjectReference{Name: secretNamePrefix + secret2.Name},
+				))
+				Expect(managedResource.Labels).To(HaveKeyWithValue("origin", "gardener"))
+				Expect(managedResource.Spec.InjectLabels).To(HaveKeyWithValue("shoot.gardener.cloud/no-cleanup", "true"))
+			})
+
+			It("should update existing secrets in shoot control plane namespace", func() {
+				Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				// Update the secret in garden namespace
+				secret1.Data = map[string][]byte{"manifest": []byte("updated-data")}
+				Expect(seedClient.Update(ctx, secret1)).To(Succeed())
+
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				copiedSecret := &corev1.Secret{}
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, copiedSecret)).To(Succeed())
+				Expect(copiedSecret.Data).To(Equal(map[string][]byte{"manifest": []byte("updated-data")}))
+			})
+
+			Context("with shoot selector annotation", func() {
+				It("should include secrets matching the shoot selector", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"production"}}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+				})
+
+				It("should exclude secrets not matching the shoot selector", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"development"}}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				})
+
+				It("should include secrets with matchExpressions selector", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchExpressions":[{"key":"environment","operator":"In","values":["production","staging"]}]}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+				})
+
+				It("should include secrets without selector annotation", func() {
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+					secret2.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"development"}}`,
+					}
+					Expect(seedClient.Create(ctx, secret2)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// secret1 should be copied (no selector)
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+
+					// secret2 should not be copied (non-matching selector)
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret2.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				})
+
+				It("should return error for invalid selector JSON", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{invalid json}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(MatchError(ContainSubstring("failed unmarshalling shoot selector")))
+				})
+
+				It("should return error for invalid label selector", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchExpressions":[{"key":"","operator":"Invalid","values":["test"]}]}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(MatchError(ContainSubstring("failed parsing label selector")))
+				})
+			})
+
+			Context("cleanup of old secrets", func() {
+				It("should delete secrets from shoot namespace that are no longer in garden namespace", func() {
+					// Create secrets in garden namespace
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+					Expect(seedClient.Create(ctx, secret2)).To(Succeed())
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// Remove secret2 from garden namespace
+					Expect(seedClient.Delete(ctx, secret2)).To(Succeed())
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// secret1 should still exist
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+
+					// secret2 should be deleted
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret2.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				})
+
+				It("should not delete unrelated secrets in shoot namespace", func() {
+					unrelatedSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unrelated-secret",
+							Namespace: controlPlaneNamespace,
+							Labels:    map[string]string{"some-other-label": "true"},
+						},
+						Data: map[string][]byte{"data": []byte("test")},
+					}
+					Expect(seedClient.Create(ctx, unrelatedSecret)).To(Succeed())
+
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// Unrelated secret (without static manifests label) should still exist
+					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(unrelatedSecret), &corev1.Secret{})).To(Succeed())
+				})
+
+				It("should handle secrets that no longer match the selector", func() {
+					secret1.Annotations = map[string]string{
+						"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"production"}}`,
+					}
+					Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// Verify secret was copied
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+
+					// Update selector to not match
+					secret1.Annotations["static-manifests.shoot.gardener.cloud/selector"] = `{"matchLabels":{"environment":"development"}}`
+					Expect(seedClient.Update(ctx, secret1)).To(Succeed())
+					Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+					// Secret should be deleted from shoot namespace
+					Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				})
+			})
+
+			It("should handle multiple secrets with mixed selectors", func() {
+				secret1.Annotations = map[string]string{
+					"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"production"}}`,
+				}
+				Expect(seedClient.Create(ctx, secret1)).To(Succeed())
+
+				// secret2 has no selector
+				Expect(seedClient.Create(ctx, secret2)).To(Succeed())
+
+				secret3.Annotations = map[string]string{
+					"static-manifests.shoot.gardener.cloud/selector": `{"matchLabels":{"environment":"development"}}`,
+				}
+				Expect(seedClient.Create(ctx, secret3)).To(Succeed())
+
+				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				// secret1 should be copied (matching selector)
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret1.Name}, &corev1.Secret{})).To(Succeed())
+
+				// secret2 should be copied (no selector)
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret2.Name}, &corev1.Secret{})).To(Succeed())
+
+				// secret3 should not be copied (non-matching selector)
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret3.Name}, &corev1.Secret{})).To(BeNotFoundError())
+
+				// Verify managed resource references only secret1 and secret2
+				managedResource := &resourcesv1alpha1.ManagedResource{}
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: managedResourceName}, managedResource)).To(Succeed())
+				Expect(managedResource.Spec.SecretRefs).To(HaveExactElements(
+					corev1.LocalObjectReference{Name: secretNamePrefix + secret1.Name},
+					corev1.LocalObjectReference{Name: secretNamePrefix + secret2.Name},
+				))
+			})
+		})
+	})
 })

--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Resources", func() {
 			})
 		})
 
-		Context("when there are no secrets with static manifests label", func() {
+		When("there are no secrets with static manifests label", func() {
 			It("should delete the managed resource if it exists", func() {
 				managedResource := &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
@@ -280,10 +280,18 @@ var _ = Describe("Resources", func() {
 
 			It("should not fail if managed resource does not exist", func() {
 				Expect(botanist.PopulateStaticManifestsFromSeedToShoot(ctx)).To(Succeed())
+
+				managedResource := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceName,
+						Namespace: controlPlaneNamespace,
+					},
+				}
+				Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(managedResource), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
 			})
 		})
 
-		Context("when there are secrets with static manifests label", func() {
+		When("there are secrets with static manifests label", func() {
 			var secret1, secret2, secret3 *corev1.Secret
 
 			BeforeEach(func() {
@@ -291,7 +299,7 @@ var _ = Describe("Resources", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "manifest-1",
 						Namespace: "garden",
-						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+						Labels:    map[string]string{"gardener.cloud/purpose": "shoot-static-manifest"},
 					},
 					Type: corev1.SecretTypeOpaque,
 					Data: map[string][]byte{"manifest": []byte("data1")},
@@ -301,7 +309,7 @@ var _ = Describe("Resources", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "manifest-2",
 						Namespace: "garden",
-						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+						Labels:    map[string]string{"gardener.cloud/purpose": "shoot-static-manifest"},
 					},
 					Type: corev1.SecretTypeTLS,
 					Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
@@ -311,7 +319,7 @@ var _ = Describe("Resources", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "manifest-3",
 						Namespace: "garden",
-						Labels:    map[string]string{"shoot.gardener.cloud/static-manifests": "true"},
+						Labels:    map[string]string{"gardener.cloud/purpose": "shoot-static-manifest"},
 					},
 					Type: corev1.SecretTypeOpaque,
 					Data: map[string][]byte{"manifest": []byte("data3")},
@@ -329,7 +337,7 @@ var _ = Describe("Resources", func() {
 				Expect(copiedSecret1.Type).To(Equal(secret1.Type))
 				Expect(copiedSecret1.Data).To(Equal(secret1.Data))
 				Expect(copiedSecret1.Immutable).To(Equal(ptr.To(false)))
-				Expect(copiedSecret1.Labels).To(HaveKeyWithValue("shoot.gardener.cloud/static-manifests", "true"))
+				Expect(copiedSecret1.Labels).To(HaveKeyWithValue("gardener.cloud/purpose", "shoot-static-manifest"))
 
 				copiedSecret2 := &corev1.Secret{}
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: secretNamePrefix + secret2.Name}, copiedSecret2)).To(Succeed())


### PR DESCRIPTION
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Implements propagation of shoot‐selected static manifests from the Seed cluster, as defined in the proposal in gardener/gardener#13574.  
The `gardenlet` now evaluates a shoot label selector on `Secret` resources that contain static manifests. `Secret`s matching the selector are copied into the respective shoot’s control plane namespace in the Seed. This enables operators to manage shoot-specific static add-ons declaratively in the Seed clusters, without extending existing extension points.

The change introduces:
- Business logic for selecting and applying static-manifest `Secret`s per shoot.
- A new label selector field on static-manifest definitions.
- End-to-end propagation logic from Seed to shoot namespaces.
- Comprehensive tests and documentation.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13574

**Special notes for your reviewer**:
The design follows the discussion and requirements captured in #13574, including the final resource model and selector semantics. Reviewers should pay particular attention to:
- Selector evaluation and matching behavior.
- Resource and ownership handling in the Seed.
- Secret copying process and update semantics.

> [!NOTE]
> Any dynamics and templating is out of scope—any more sophisticated/complicated logic for providing manifests to all shoot namespaces is recommended to be performed via a Gardener extension.

FYI @vlerenc @ScheererJ @timebertt 

**Release note**:
```feature operator
`gardenlet` can now propagate static manifests stored in the seed cluster's `garden` namespace to all shoot namespaces. Read all about it [here](https://github.com/gardener/gardener/tree/master/docs/extensions/static-manifests.md).
```