### PR TITLE
Fix faulty unit test in `ManagedSeed` admission plugin tests

### DIFF
--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -258,8 +258,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("metadata.namespace"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("metadata.namespace"),
+					"Detail": ContainSubstring("namespace must be garden"),
 				})),
 			))
 		})
@@ -271,8 +272,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot name is required"),
 				})),
 			))
 		})
@@ -315,8 +317,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot garden/foo does not specify a domain"),
 				})),
 			))
 		})
@@ -334,8 +337,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller"),
 				})),
 			))
 		})
@@ -347,8 +351,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot VPA has to be enabled for managed seeds"),
 				})),
 			))
 		})
@@ -374,8 +379,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot garden/foo already registered as seed by managed seed garden/bar"),
 				})),
 			))
 		})
@@ -614,6 +620,7 @@ var _ = Describe("ManagedSeed", func() {
 
 				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
 				Expect(err).To(BeInternalServerError())
+				Expect(err).To(MatchError(ContainSubstring("expected *gardenletconfigv1alpha1.GardenletConfiguration but got *v1.Pod")))
 			})
 
 			It("should forbid the ManagedSeed creation if the seed spec contains invalid values", func() {

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -279,6 +279,9 @@ var _ = Describe("ManagedSeed", func() {
 
 		It("should forbid the ManagedSeed creation if the Shoot does not exist", func() {
 			Expect(coreInformerFactory.Core().V1beta1().Shoots().Informer().GetStore().Delete(shoot)).To(Succeed())
+			coreClient.AddReactor("get", "shoots", func(_ testing.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewNotFound(gardencorev1beta1.Resource("shoot"), name)
+			})
 
 			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
 			Expect(err).To(BeInvalidError())

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -284,8 +284,9 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(BeInvalidError())
 			Expect(getErrorList(err)).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shoot.name"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot garden/foo not found"),
 				})),
 			))
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
While working on splitting the `ManagedSeed` admission plugin into separate mutating and validating interfaces, I stumbled upon a faulty unit test.

https://github.com/gardener/gardener/blob/e1de8959286064d0b11e9419a03b0a4590057b98/plugin/pkg/managedseed/validator/admission_test.go#L280-L291

It doesn't cover what it pretends to test. When the test is executed, the fake Clientset in https://github.com/gardener/gardener/blob/2ae613cbb25dcebf106a52b2ea54f2a620091e33/plugin/pkg/managedseed/validator/admission.go#L600 returns a shoot initialized with empty value. In the test, we don't have expectation for the concrete error. Due to the empty values, the check that really fails is https://github.com/gardener/gardener/blob/2ae613cbb25dcebf106a52b2ea54f2a620091e33/plugin/pkg/managedseed/validator/admission.go#L220-L222 and not https://github.com/gardener/gardener/blob/2ae613cbb25dcebf106a52b2ea54f2a620091e33/plugin/pkg/managedseed/validator/admission.go#L213-L215.

This PR fixes the test and adds to all unit tests of the `ManagedSeed` admission plugin expectations for the concrete error. In this way, we are sure that we cover the case we expect.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
