### PR TITLE
Update etcd-druid to v0.34.0 and integrate `EtcdOpsTask` changes

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -134,6 +134,7 @@ rules:
   resourceNames:
   - etcds.druid.gardener.cloud
   - etcdcopybackupstasks.druid.gardener.cloud
+  - etcdopstasks.druid.gardener.cloud
   - destinationrules.networking.istio.io
   - envoyfilters.networking.istio.io
   - gateways.networking.istio.io
@@ -245,6 +246,7 @@ rules:
   resources:
   - etcds
   - etcdcopybackupstasks
+  - etcdopstasks
   verbs:
   - create
   - delete

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -193,6 +193,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				ResourceNames: []string{
 					"etcds.druid.gardener.cloud",
 					"etcdcopybackupstasks.druid.gardener.cloud",
+					"etcdopstasks.druid.gardener.cloud",
 					"destinationrules.networking.istio.io",
 					"envoyfilters.networking.istio.io",
 					"gateways.networking.istio.io",
@@ -276,7 +277,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"druid.gardener.cloud"},
-				Resources: []string{"etcds", "etcdcopybackupstasks"},
+				Resources: []string{"etcds", "etcdcopybackupstasks", "etcdopstasks"},
 				Verbs:     []string{"create", "delete", "get", "list", "watch", "patch", "update"},
 			},
 			{

--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -168,6 +168,7 @@ rules:
   resources:
   - etcds
   - etcdcopybackupstasks
+  - etcdopstasks
   verbs:
   - get
   - list

--- a/charts/gardener/operator/templates/role.yaml
+++ b/charts/gardener/operator/templates/role.yaml
@@ -107,6 +107,7 @@ rules:
   resources:
   - etcds
   - etcdcopybackupstasks
+  - etcdopstasks
   verbs:
   - create
   - delete

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fluent/fluent-operator/v3 v3.5.0
 	github.com/gardener/cert-management v0.19.0
 	github.com/gardener/dependency-watchdog v1.6.0
-	github.com/gardener/etcd-druid/api v0.33.0
+	github.com/gardener/etcd-druid/api v0.34.0
 	github.com/gardener/machine-controller-manager v0.60.2
 	github.com/gardener/terminal-controller-manager v0.34.0
 	github.com/go-jose/go-jose/v4 v4.1.3

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/gardener/cert-management v0.19.0 h1:BNumdw748Pg9798NzxHmmpKuXFRLHSPuv
 github.com/gardener/cert-management v0.19.0/go.mod h1:u5OKwiDyUdCuW9vhDV92ozCVkynXUBrYCMHr4rVNiCY=
 github.com/gardener/dependency-watchdog v1.6.0 h1:ARCIbcNmhjefmV7ex8ADReeD2MPsEawwT/MoZKTQV/M=
 github.com/gardener/dependency-watchdog v1.6.0/go.mod h1:NXkna7bW5O+IGxLAX0KdEaW8yFREDfSHSccuoY+YZu0=
-github.com/gardener/etcd-druid/api v0.33.0 h1:YwgsYYldaLig2laJMAAMX/dg9/XsQx/LPz8+iL52V6w=
-github.com/gardener/etcd-druid/api v0.33.0/go.mod h1:Qpl1PDJ+bKa6OPWk4o7WBzvjPqZc/CxIXbiTkdRhCrg=
+github.com/gardener/etcd-druid/api v0.34.0 h1:GNeKNN/KS9Iy1su0N695/wq/VtNW9ekeRjihAza5xbc=
+github.com/gardener/etcd-druid/api v0.34.0/go.mod h1:SvgJtzYbrtBMPRL+AkRV5tXV2LjbSLCSBFu3cC6XjJs=
 github.com/gardener/machine-controller-manager v0.60.2 h1:lY6z67lDlwl9dQUEmlJbrmpxWK10o/rVRUu4JB7xK4U=
 github.com/gardener/machine-controller-manager v0.60.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/gardener/terminal-controller-manager v0.34.0 h1:qE8xIKsOFnVr1yZ2meesRR0q65uZ1Nyf5oSluAiLTeM=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -74,7 +74,7 @@ images:
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-    tag: "v0.33.0"
+    tag: "v0.34.0"
   - name: etcd
     sourceRepository: github.com/etcd-io/etcd
     repository: quay.io/coreos/etcd

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -193,12 +193,12 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				},
 				{
 					APIGroups: []string{druidcorev1alpha1.SchemeGroupVersion.Group},
-					Resources: []string{"etcds", "etcdcopybackupstasks"},
+					Resources: []string{"etcds", "etcdcopybackupstasks", "etcdopstasks"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 				{
 					APIGroups: []string{druidcorev1alpha1.SchemeGroupVersion.Group},
-					Resources: []string{"etcds/status", "etcds/finalizers", "etcdcopybackupstasks/status", "etcdcopybackupstasks/finalizers"},
+					Resources: []string{"etcds/status", "etcds/finalizers", "etcdcopybackupstasks/status", "etcdcopybackupstasks/finalizers", "etcdopstasks/status", "etcdopstasks/finalizers"},
 					Verbs:     []string{"get", "update", "patch", "create"},
 				},
 				{
@@ -599,6 +599,8 @@ func getDruidDeployArgs(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, namespac
 		"--enable-backup-compaction=" + strconv.FormatBool(*etcdConfig.BackupCompactionController.EnableBackupCompaction),
 		"--compaction-workers=" + strconv.FormatInt(*etcdConfig.BackupCompactionController.Workers, 10),
 		"--etcd-events-threshold=" + strconv.FormatInt(*etcdConfig.BackupCompactionController.EventsThreshold, 10),
+		"--etcd-ops-task-workers=3",
+		"--etcd-ops-task-requeue-interval=15s",
 		fmt.Sprintf("--reconciler-service-account=%s%s:%s", serviceaccount.ServiceAccountUsernamePrefix, namespace, druidServiceAccountName),
 	}
 

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -179,12 +179,12 @@ var _ = Describe("Etcd", func() {
 					},
 					{
 						APIGroups: []string{druidcorev1alpha1.GroupName},
-						Resources: []string{"etcds", "etcdcopybackupstasks"},
+						Resources: []string{"etcds", "etcdcopybackupstasks", "etcdopstasks"},
 						Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 					},
 					{
 						APIGroups: []string{druidcorev1alpha1.GroupName},
-						Resources: []string{"etcds/status", "etcds/finalizers", "etcdcopybackupstasks/status", "etcdcopybackupstasks/finalizers"},
+						Resources: []string{"etcds/status", "etcds/finalizers", "etcdcopybackupstasks/status", "etcdcopybackupstasks/finalizers", "etcdopstasks/status", "etcdopstasks/finalizers"},
 						Verbs:     []string{"get", "update", "patch", "create"},
 					},
 					{
@@ -319,6 +319,8 @@ var _ = Describe("Etcd", func() {
 										"--enable-backup-compaction=true",
 										"--compaction-workers=3",
 										"--etcd-events-threshold=1000000",
+										"--etcd-ops-task-workers=3",
+										"--etcd-ops-task-requeue-interval=15s",
 										"--reconciler-service-account=system:serviceaccount:" + namespace + ":etcd-druid",
 										"--metrics-scrape-wait-duration=1m0s",
 										"--active-deadline-duration=3h0m0s",
@@ -416,6 +418,8 @@ var _ = Describe("Etcd", func() {
 										"--enable-backup-compaction=true",
 										"--compaction-workers=3",
 										"--etcd-events-threshold=1000000",
+										"--etcd-ops-task-workers=3",
+										"--etcd-ops-task-requeue-interval=15s",
 										"--reconciler-service-account=system:serviceaccount:" + namespace + ":etcd-druid",
 										"--metrics-scrape-wait-duration=1m0s",
 										"--active-deadline-duration=3h0m0s",

--- a/pkg/component/etcd/etcd/crd_test.go
+++ b/pkg/component/etcd/etcd/crd_test.go
@@ -38,7 +38,7 @@ var _ = Describe("CRD", func() {
 		})
 
 		JustBeforeEach(func() {
-			Expect(crdDeployer.Deploy(ctx)).To(Succeed(), "Etcd/EtcdCopyBackupsTask CRD deployment succeeds")
+			Expect(crdDeployer.Deploy(ctx)).To(Succeed(), "Etcd/EtcdCopyBackupsTask/EtcdOpsTask CRD deployment succeeds")
 		})
 
 		DescribeTable("CRD is deployed",
@@ -48,6 +48,7 @@ var _ = Describe("CRD", func() {
 
 			Entry("Etcd", "etcds.druid.gardener.cloud"),
 			Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+			Entry("EtcdOpsTask", "etcdopstasks.druid.gardener.cloud"),
 		)
 
 		DescribeTable("should re-create CRD if it is deleted",
@@ -60,6 +61,7 @@ var _ = Describe("CRD", func() {
 
 			Entry("Etcd", "etcds.druid.gardener.cloud"),
 			Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+			Entry("EtcdOpsTask", "etcdopstasks.druid.gardener.cloud"),
 		)
 
 		Describe("CRD is destroyed", func() {
@@ -75,6 +77,7 @@ var _ = Describe("CRD", func() {
 
 				Entry("Etcd", "etcds.druid.gardener.cloud"),
 				Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+				Entry("EtcdOpsTask", "etcdopstasks.druid.gardener.cloud"),
 			)
 		})
 	})
@@ -96,13 +99,15 @@ var _ = Describe("CRD", func() {
 
 			Entry("Etcd", "etcds.druid.gardener.cloud"),
 			Entry("EtcdCopyBackupsTask", "etcdcopybackupstasks.druid.gardener.cloud"),
+			Entry("EtcdOpsTask", "etcdopstasks.druid.gardener.cloud"),
 		)
 
 		Describe("Get all CRDs", func() {
 			allCRDs := crdGetter.GetAllCRDs()
-			Expect(allCRDs).To(HaveLen(2))
+			Expect(allCRDs).To(HaveLen(3))
 			Expect(allCRDs).To(HaveKey("etcds.druid.gardener.cloud"))
 			Expect(allCRDs).To(HaveKey("etcdcopybackupstasks.druid.gardener.cloud"))
+			Expect(allCRDs).To(HaveKey("etcdopstasks.druid.gardener.cloud"))
 		})
 	})
 })

--- a/pkg/component/etcd/etcd/waiter_test.go
+++ b/pkg/component/etcd/etcd/waiter_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	druidapicommon "github.com/gardener/etcd-druid/api/common"
 	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -129,7 +130,7 @@ var _ = Describe("#Wait", func() {
 		)()
 		mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 		delete(expected.Annotations, v1beta1constants.GardenerOperation)
-		expected.Status.LastErrors = []druidcorev1alpha1.LastError{}
+		expected.Status.LastErrors = []druidapicommon.LastError{}
 		expected.Status.ObservedGeneration = ptr.To(expected.Generation)
 		expected.Status.Conditions = []druidcorev1alpha1.Condition{
 			{
@@ -341,7 +342,7 @@ var _ = Describe("#CheckEtcdObject", func() {
 	})
 
 	It("should return error if reconciliation failed", func() {
-		obj.Status.LastErrors = []druidcorev1alpha1.LastError{{Code: "ERROR_FOO", Description: "foo", ObservedAt: metav1.Now()}}
+		obj.Status.LastErrors = []druidapicommon.LastError{{Code: "ERROR_FOO", Description: "foo", ObservedAt: metav1.Now()}}
 		err := CheckEtcdObject(obj)
 		Expect(err).To(MatchError(fmt.Sprintf("errors during reconciliation: %+v", obj.Status.LastErrors)))
 		Expect(retry.IsRetriable(err)).To(BeTrue())

--- a/pkg/gardenadm/botanist/customresourcedefinitions_test.go
+++ b/pkg/gardenadm/botanist/customresourcedefinitions_test.go
@@ -90,6 +90,7 @@ var _ = Describe("CustomResourceDefinitions", func() {
 					HaveField("ObjectMeta.Name", "controlplanes.extensions.gardener.cloud"),
 					HaveField("ObjectMeta.Name", "dnsrecords.extensions.gardener.cloud"),
 					HaveField("ObjectMeta.Name", "etcdcopybackupstasks.druid.gardener.cloud"),
+					HaveField("ObjectMeta.Name", "etcdopstasks.druid.gardener.cloud"),
 					HaveField("ObjectMeta.Name", "etcds.druid.gardener.cloud"),
 					HaveField("ObjectMeta.Name", "extensions.extensions.gardener.cloud"),
 					HaveField("ObjectMeta.Name", "filters.fluentbit.fluent.io"),

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -515,6 +515,7 @@ var _ = Describe("Seed controller tests", func() {
 						// etcd-druid
 						"etcds.druid.gardener.cloud",
 						"etcdcopybackupstasks.druid.gardener.cloud",
+						"etcdopstasks.druid.gardener.cloud",
 						"managedresources.resources.gardener.cloud",
 						// istio
 						"destinationrules.networking.istio.io",

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -437,6 +437,7 @@ spec:
 		deployedCRDs := []string{
 			"etcds.druid.gardener.cloud",
 			"etcdcopybackupstasks.druid.gardener.cloud",
+			"etcdopstasks.druid.gardener.cloud",
 			"managedresources.resources.gardener.cloud",
 			"verticalpodautoscalers.autoscaling.k8s.io",
 			"verticalpodautoscalercheckpoints.autoscaling.k8s.io",

--- a/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
+++ b/test/integration/resourcemanager/crddeletionprotection/crddeletionprotection_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "dnsrecords.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "etcds.druid.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "etcdcopybackupstasks.druid.gardener.cloud"}},
+			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "etcdopstasks.druid.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "extensions.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "infrastructures.extensions.gardener.cloud"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "managedresources.resources.gardener.cloud"}},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
* This PR upgrades the `etcd-druid` version to `v0.34.0`.
* `EtcdOpsTask` was introduced in the [v0.34.0 release](https://github.com/gardener/gardener/pull/13615) of etcd-druid. This PR integrates the changes required for `EtcdOpsTask` to work. 



**Special notes for your reviewer**:
This PR only enables `EtcdOpsTask` to be used in the context of Gardener. Further changes needed for the `CRD` will be introduced in upcoming PRs.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following dependencies have been updated:
- `gardener/etcd-druid` from `v0.33.0` to `v0.34.0`. [Release Notes](https://redirect.github.com/gardener/etcd-druid/releases/tag/v0.34.0)
- `github.com/gardener/etcd-druid/api` from `v0.33.0` to `v0.34.0`. 
```
