### PR TITLE
Split the `ManagedSeed` admission plugin into mutating and validating admission plugin (part 1)

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -106,7 +106,7 @@ In case of `Shoot`s, the `gardener` finalizer can only be removed if the last op
 
 ## `ManagedSeed`
 
-**Type**: Mutating. **Enabled by default**: Yes.
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `ManagedSeeds`s.
 It validates certain configuration values in the specification against the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -119,8 +119,8 @@ func (d *DeletionConfirmation) ValidateInitialization() error {
 }
 
 var (
-	_ admission.ValidationInterface = (*DeletionConfirmation)(nil)
 	_ admission.MutationInterface   = (*DeletionConfirmation)(nil)
+	_ admission.ValidationInterface = (*DeletionConfirmation)(nil)
 )
 
 // Admit maintains the deletion.gardener.cloud/confirmed-by annotation.

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -153,7 +153,10 @@ func (v *ManagedSeed) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = (*ManagedSeed)(nil)
+var (
+	_ admission.MutationInterface   = (*ManagedSeed)(nil)
+	_ admission.ValidationInterface = (*ManagedSeed)(nil)
+)
 
 // Admit validates and if appropriate mutates the given managed seed against the shoot that it references.
 func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
@@ -601,4 +604,9 @@ func (v *ManagedSeed) getShoot(ctx context.Context, namespace, name string) (*ga
 	}
 
 	return shoot, err
+}
+
+// Validate validates the given managed seed against the shoot that it references.
+func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	return nil
 }

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -183,13 +183,10 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 		return statusErr
 	}
 
-	var allErrs field.ErrorList
-
-	// Ensure shoot can be registered as seed
-	shootNamePath := field.NewPath("spec", "shoot", "name")
-	if v1beta1helper.IsWorkerless(shoot) {
-		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "workerless shoot cannot be used to create managed seed")))
-	}
+	var (
+		allErrs       field.ErrorList
+		shootNamePath = field.NewPath("spec", "shoot", "name")
+	)
 
 	// Ensure shoot is not already registered as seed
 	ms, err := admissionutils.GetManagedSeed(ctx, v.seedManagementClient, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
@@ -659,6 +656,9 @@ func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ ad
 	}
 	if !v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot VPA has to be enabled for managed seeds")))
+	}
+	if v1beta1helper.IsWorkerless(shoot) {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "workerless shoot cannot be used to create managed seed")))
 	}
 
 	return nil

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -187,9 +187,6 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 
 	// Ensure shoot can be registered as seed
 	shootNamePath := field.NewPath("spec", "shoot", "name")
-	if !v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
-		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot VPA has to be enabled for managed seeds")))
-	}
 	if v1beta1helper.IsWorkerless(shoot) {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "workerless shoot cannot be used to create managed seed")))
 	}
@@ -659,6 +656,9 @@ func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ ad
 	}
 	if v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller")))
+	}
+	if !v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot VPA has to be enabled for managed seeds")))
 	}
 
 	return nil

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -187,9 +187,6 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 
 	// Ensure shoot can be registered as seed
 	shootNamePath := field.NewPath("spec", "shoot", "name")
-	if v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
-		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller")))
-	}
 	if !v1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot VPA has to be enabled for managed seeds")))
 	}
@@ -659,6 +656,9 @@ func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ ad
 	shootNamePath := field.NewPath("spec", "shoot", "name")
 	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil || *shoot.Spec.DNS.Domain == "" {
 		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s does not specify a domain", client.ObjectKeyFromObject(shoot)))))
+	}
+	if v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, "shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller")))
 	}
 
 	return nil

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -295,20 +295,6 @@ var _ = Describe("ManagedSeed", func() {
 			))
 		})
 
-		It("should forbid the ManagedSeed if the Shoot does not have any worker", func() {
-			shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{}
-
-			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.shoot.name"),
-					"Detail": ContainSubstring("workerless shoot cannot be used to create managed seed"),
-				})),
-			))
-		})
-
 		It("should forbid the ManagedSeed creation if the Shoot is already registered as Seed", func() {
 			anotherManagedSeed := &seedmanagementv1alpha1.ManagedSeed{
 				ObjectMeta: metav1.ObjectMeta{
@@ -995,6 +981,12 @@ var _ = Describe("ManagedSeed", func() {
 							Enabled: true,
 						},
 					},
+					Provider: gardencorev1beta1.Provider{
+						Type: provider,
+						Workers: []gardencorev1beta1.Worker{
+							{Zones: []string{zone1, zone2}},
+						},
+					},
 				},
 			}
 
@@ -1121,6 +1113,20 @@ var _ = Describe("ManagedSeed", func() {
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("spec.shoot.name"),
 					"Detail": ContainSubstring("shoot VPA has to be enabled for managed seeds"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed if the Shoot does not have any worker", func() {
+			shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{}
+
+			err := admissionHandler.Validate(ctx, getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("workerless shoot cannot be used to create managed seed"),
 				})),
 			))
 		})

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -1134,6 +1134,13 @@ var _ = Describe("ManagedSeed", func() {
 				})),
 			))
 		})
+
+		Context("gardenlet", func() {
+			It("should allow the ManagedSeed creation if the Shoot exists and can be registered as Seed", func() {
+				err := admissionHandler.Validate(ctx, getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("#Register", func() {

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -309,20 +309,6 @@ var _ = Describe("ManagedSeed", func() {
 			))
 		})
 
-		It("should forbid the ManagedSeed creation if the Shoot does not specify a domain", func() {
-			shoot.Spec.DNS = nil
-
-			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.shoot.name"),
-					"Detail": ContainSubstring("shoot garden/foo does not specify a domain"),
-				})),
-			))
-		})
-
 		It("should forbid the ManagedSeed creation if the Shoot enables the nginx-ingress addon", func() {
 			shoot.Spec.Addons = &gardencorev1beta1.Addons{
 				NginxIngress: &gardencorev1beta1.NginxIngress{
@@ -1033,6 +1019,11 @@ var _ = Describe("ManagedSeed", func() {
 					Name:      name,
 					Namespace: namespace,
 				},
+				Spec: gardencorev1beta1.ShootSpec{
+					DNS: &gardencorev1beta1.DNS{
+						Domain: ptr.To(domain),
+					},
+				},
 			}
 
 			var err error
@@ -1110,6 +1101,20 @@ var _ = Describe("ManagedSeed", func() {
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("spec.shoot.name"),
 					"Detail": ContainSubstring("shoot garden/foo not found"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed creation if the Shoot does not specify a domain", func() {
+			shoot.Spec.DNS = nil
+
+			err := admissionHandler.Validate(ctx, getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot garden/foo does not specify a domain"),
 				})),
 			))
 		})

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -264,7 +264,7 @@ var _ = Describe("ManagedSeed", func() {
 			Expect(err).To(MatchError("could not convert object to ManagedSeed"))
 		})
 
-		It("should forbid the ManagedSeed creation if a Shoot name is not specified", func() {
+		It("should do nothing if a Shoot name is not specified", func() {
 			managedSeed.Spec.Shoot.Name = ""
 
 			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -268,14 +268,7 @@ var _ = Describe("ManagedSeed", func() {
 			managedSeed.Spec.Shoot.Name = ""
 
 			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("spec.shoot.name"),
-					"Detail": ContainSubstring("shoot name is required"),
-				})),
-			))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should forbid the ManagedSeed creation if the Shoot does not exist", func() {
@@ -1014,18 +1007,11 @@ var _ = Describe("ManagedSeed", func() {
 			))
 		})
 
-		It("should forbid the ManagedSeed creation if a Shoot name is not specified", func() {
+		It("should do nothing if a Shoot name is not specified", func() {
 			managedSeed.Spec.Shoot.Name = ""
 
 			err := admissionHandler.Validate(ctx, getManagedSeedAttributes(managedSeed), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("spec.shoot.name"),
-					"Detail": ContainSubstring("shoot name is required"),
-				})),
-			))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should forbid the ManagedSeed creation if the Shoot does not exist", func() {

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -1005,6 +1005,10 @@ var _ = Describe("ManagedSeed", func() {
 		})
 	})
 
+	Describe("#Validate", func() {
+
+	})
+
 	Describe("#Register", func() {
 		It("should register the plugin", func() {
 			plugins := admission.NewPlugins()

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -309,26 +309,6 @@ var _ = Describe("ManagedSeed", func() {
 			))
 		})
 
-		It("should forbid the ManagedSeed creation if the Shoot enables the nginx-ingress addon", func() {
-			shoot.Spec.Addons = &gardencorev1beta1.Addons{
-				NginxIngress: &gardencorev1beta1.NginxIngress{
-					Addon: gardencorev1beta1.Addon{
-						Enabled: true,
-					},
-				},
-			}
-
-			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.shoot.name"),
-					"Detail": ContainSubstring("shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller"),
-				})),
-			))
-		})
-
 		It("should forbid the ManagedSeed creation if the Shoot does not enable VPA", func() {
 			shoot.Spec.Kubernetes.VerticalPodAutoscaler.Enabled = false
 
@@ -1115,6 +1095,26 @@ var _ = Describe("ManagedSeed", func() {
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("spec.shoot.name"),
 					"Detail": ContainSubstring("shoot garden/foo does not specify a domain"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed creation if the Shoot enables the nginx-ingress addon", func() {
+			shoot.Spec.Addons = &gardencorev1beta1.Addons{
+				NginxIngress: &gardencorev1beta1.NginxIngress{
+					Addon: gardencorev1beta1.Addon{
+						Enabled: true,
+					},
+				},
+			}
+
+			err := admissionHandler.Validate(ctx, getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": ContainSubstring("shoot ingress addon is not supported for managed seeds - use the managed seed ingress controller"),
 				})),
 			))
 		})

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -112,8 +112,8 @@ func (t *TolerationRestriction) ValidateInitialization() error {
 }
 
 var (
-	_ admission.ValidationInterface = (*TolerationRestriction)(nil)
 	_ admission.MutationInterface   = (*TolerationRestriction)(nil)
+	_ admission.ValidationInterface = (*TolerationRestriction)(nil)
 )
 
 // Admit defaults shoot tolerations with both global and project defaults.

--- a/test/integration/envtest/environment_test.go
+++ b/test/integration/envtest/environment_test.go
@@ -29,7 +29,7 @@ var _ = Describe("GardenerTestEnvironment", func() {
 
 	It("should be able to manipulate resource from seedmanagement.gardener.cloud/v1alpha1", func() {
 		managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{GenerateName: "test-", Namespace: "garden"}}
-		Expect(testClient.Create(ctx, managedSeed)).To(MatchError(ContainSubstring("ManagedSeed.seedmanagement.gardener.cloud \"\" is invalid")))
+		Expect(testClient.Create(ctx, managedSeed)).To(MatchError(MatchRegexp("ManagedSeed.seedmanagement.gardener.cloud \"test-.+\" is invalid")))
 	})
 
 	It("should be able to manipulate resource from settings.gardener.cloud/v1alpha1", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR is part 1 of the split of the `ManagedSeed` admission plugin into mutating and validating admission plugin. The end goal of this workstream is to move all validations from the initially mutating `ManagedSeed` admission plugin to new validating `ManagedSeed` admission plugin.

This PR makes the `ManagedSeed` admission plugin also validating. It additionally moves several validations to it - validations about the referenced Shoot by the ManagedSeed. 

With other PRs, the validations from the mutating `ManagedSeed` admission plugin (the `Admit` func) will be moved to the validating `ManagedSeed` (the `Validate` func) gradually.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13618

**Special notes for your reviewer**:
~~This PR is conflicts with https://github.com/gardener/gardener/pull/13616. Hence, it is in draft state until https://github.com/gardener/gardener/pull/13616 is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The mutating `ManagedSeed` admission plugin is now also a validating one. Validations which are executed by this admission plugin during the mutation phase will be gradually moved to the validating `ManagedSeed` admission plugin.
```
