### PR TITLE
Improve `extractObjectsFromSecret` function to ignore whitespaces

### DIFF
--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -457,7 +457,7 @@ func GetObjects(ctx context.Context, c client.Client, namespace, name string) ([
 			return nil, fmt.Errorf("could not get secret %q: %w", client.ObjectKey{Name: secretRef.Name, Namespace: managedResource.Namespace}, err)
 		}
 
-		objectsFromSecret, err := extractObjectsFromSecret(decoder, secret)
+		objectsFromSecret, err := ExtractObjectsFromSecret(decoder, secret)
 		if err != nil {
 			return nil, fmt.Errorf("could not extract objects from secret %q: %w", client.ObjectKeyFromObject(secret), err)
 		}
@@ -468,7 +468,8 @@ func GetObjects(ctx context.Context, c client.Client, namespace, name string) ([
 	return objects, nil
 }
 
-func extractObjectsFromSecret(decoder runtime.Decoder, secret *corev1.Secret) ([]client.Object, error) {
+// ExtractObjectsFromSecret extracts and decodes all objects stored in the given secret.
+func ExtractObjectsFromSecret(decoder runtime.Decoder, secret *corev1.Secret) ([]client.Object, error) {
 	var objects []client.Object
 
 	for key, value := range secret.Data {

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -486,7 +486,7 @@ func extractObjectsFromSecret(decoder runtime.Decoder, secret *corev1.Secret) ([
 		}
 
 		for _, objRaw := range strings.Split(string(data), "---\n") {
-			if objRaw == "" {
+			if strings.TrimSpace(objRaw) == "" {
 				continue
 			}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Ignore whitespace-only YAML chunks when parsing ManagedResource secrets by replacing strict parsing, preventing decoder errors from trailing --- separators. Additional tests were added for the ExtractObjectsFromSecret function.

Error message:
```
{"time":"2025-12-09T15:25:43.646696918Z","level":"INFO","prefix":"-","file":"actuator_reconcile.go","line":"312","message":"failed to get objects for ManagedResource \"extension-networking-calico-config\": could not extract objects from secret \"shoot--garden--d068290l-v4/managedresource-extension-networking-calico-config-972cb8fb\": could not decode object: Object 'Kind' is missing in '\n'"}
```

A simple example would be:
```
apiVersion: crd.projectcalico.org/v1  
kind: IPPool
metadata:
  name: default-ipv4-ippool
spec:
  cidr: "10.255.0.0/17"
  ipipMode: "Never"
  natOutgoing: true
  nodeSelector: all()
  vxlanMode: "Never"
---


```

Which is a valid yaml file.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Ignore whitespace-only YAML chunks when parsing `ManagedResource` secrets. This prevents decoder errors from trailing `---` separators.
```
