### PR TITLE
Update NamescapedCloudProfile documentation

### DIFF
--- a/docs/usage/project/namespaced-cloud-profiles.md
+++ b/docs/usage/project/namespaced-cloud-profiles.md
@@ -25,7 +25,7 @@ Please see [this](../../../example/35-namespacedcloudprofile.yaml) example manif
 
 In order to make changes to specific fields in the `NamespacedCloudProfile`, a user must be granted custom RBAC verbs.
 Modifications of these fields need to be performed with caution and might require additional validation steps or accompanying changes.
-Permissions for modifying these fields are configured by landscape operators. If you require access to modify any of these restricted fields, please create a support ticket.
+Permissions for modifying these fields are granted to the landscape operators. Please contact your landscape operator for support.
 
 Changing the following fields require the corresponding custom verbs:
 

--- a/docs/usage/project/namespaced-cloud-profiles.md
+++ b/docs/usage/project/namespaced-cloud-profiles.md
@@ -9,6 +9,9 @@ They enable project administrators to create and manage cloud profiles specific 
 As opposed to `CloudProfile`s, `NamespacedCloudProfile`s are namespaced and thus limit configuration options for `Shoot`s, such as special machine types, to the associated project only.
 These profiles inherit from a parent `CloudProfile` and can override or extend certain fields while maintaining backward compatibility.
 
+> [!NOTE]
+> The ability for project administrators to create and manage `NamespacedCloudProfile`s is a configurable feature that may not be enabled in your Gardener environment. Please contact your landscape operator to confirm availability and request access if needed.
+
 Project viewers have the permission to see `NamespacedCloudProfile`s associated with a particular project.
 Project administrators can generally create, edit, or delete `NamespacedCloudProfile`s but with some exceptions (see the [restrictions](#field-modification-restrictions) outlined below).
 
@@ -22,9 +25,10 @@ Please see [this](../../../example/35-namespacedcloudprofile.yaml) example manif
 
 In order to make changes to specific fields in the `NamespacedCloudProfile`, a user must be granted custom RBAC verbs.
 Modifications of these fields need to be performed with caution and might require additional validation steps or accompanying changes.
-By default, only landscape operators have the permission to change these fields, as they are usually able to judge the implications.
+Permissions for modifying these fields are configured by landscape operators. If you require access to modify any of these restricted fields, please create a support ticket.
 
 Changing the following fields require the corresponding custom verbs:
+
 * For changing the `.spec.kubernetes` field, the custom verb `modify-spec-kubernetes` is required.
 * For changing the `.spec.machineImages` field, the custom verb `modify-spec-machineimages` is required.
 * For changing the `.spec.providerConfig` field, the custom verb `modify-spec-providerconfig` is required.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR resolves issues in the documentation regarding the creation and management `NamespacedCloudProfile`s and the availability of these actions to specific users.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
