### PR TITLE
Ensure secrets management is initialized before updating advertised addresses in shoot flows

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -226,7 +226,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Ensuring advertised addresses for the Shoot",
 			Fn:           botanist.UpdateAdvertisedAddresses,
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerServiceIsReady),
+			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name: "Deploying internal domain DNS record",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
`botanist.UpdateAdvertisedAddresses` depends on initialization of secrets management to determine if there is a wildcard endpoint to be advertised (see [here](https://github.com/gardener/gardener/blob/2f727c53bfdc9eae8d2cace2f82af9c38b87f4f3/pkg/gardenlet/operation/botanist/advertisedaddresses.go#L49) and [here](https://github.com/gardener/gardener/blob/2f727c53bfdc9eae8d2cace2f82af9c38b87f4f3/pkg/gardenlet/operation/botanist/secrets.go#L54) and [here](https://github.com/gardener/gardener/blob/2f727c53bfdc9eae8d2cace2f82af9c38b87f4f3/pkg/gardenlet/operation/botanist/secrets.go#L518)).
However, there was neither a direct nor an indirect dependency to the corresponding step in the flow so far. This lead to a race which usually results in the wildcard endpoint not to be advertised.
This PR adds the missing dependency. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug which prevented the wildcard certificate endpoints to be advertised in the shoot status has been fixed.
```
