### PR TITLE
Enable generic mutator for `virtual-garden` resources

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -729,7 +729,7 @@ func (g *garden) updateProcessingShootStatusToAborted(ctx context.Context, garde
 	return flow.Parallel(taskFns...)(ctx)
 }
 
-const virtualGardenService = operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+const virtualGardenService = operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer
 
 // overwriteGardenHostWhenDeployedInRuntimeCluster overwrites the garden REST config host to the internal service host
 // if the gardenlet is deployed in the runtime cluster of the garden and L7 load balancing is not active.

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -50,6 +50,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -728,7 +729,7 @@ func (g *garden) updateProcessingShootStatusToAborted(ctx context.Context, garde
 	return flow.Parallel(taskFns...)(ctx)
 }
 
-const virtualGardenService = "virtual-garden-" + v1beta1constants.DeploymentNameKubeAPIServer
+const virtualGardenService = operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
 
 // overwriteGardenHostWhenDeployedInRuntimeCluster overwrites the garden REST config host to the internal service host
 // if the gardenlet is deployed in the runtime cluster of the garden and L7 load balancing is not active.

--- a/docs/extensions/controlplane-webhooks.md
+++ b/docs/extensions/controlplane-webhooks.md
@@ -11,6 +11,10 @@ Gardener creates the Shoot controlplane in several steps of the Shoot flow. At d
 
 In order to apply any provider-specific changes to the configuration provided by Gardener for the standard controlplane components, cloud extension providers can install mutating admission webhooks for the resources created by Gardener in the Shoot namespace.
 
+The controlplane of a virtual garden managed by the [gardener-operator](../concepts/operator.md) contains similar _core components_ as a regular workerless shoot cluster.
+Extensions controllers deploying webhooks for the garden controlplane may follow the same principles.
+In this scope, the term _Shoot_ refers to the virtual garden, whereas the term _Seed_ refers to the physical/runtime cluster hosting the virtual garden.
+
 ## What needs to be implemented to support a new cloud provider?
 
 In order to support a new cloud provider, you should install "controlplane" mutating webhooks for any of the following resources:
@@ -38,7 +42,7 @@ This section specifies the contract that Gardener and webhooks should adhere to 
 
 ### kube-apiserver
 
-To deploy kube-apiserver, Gardener **shall** create a deployment and a service both named `kube-apiserver` in the Shoot namespace. They can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
+To deploy the kube-apiserver, Gardener **shall** create a deployment and a service both named `kube-apiserver` in the Shoot namespace (`virtual-garden-kube-apiserver` in the `garden` namespace for the virtual garden). They can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
 
 The pod template of the `kube-apiserver` deployment **shall** contain a container named `kube-apiserver`.
 
@@ -74,7 +78,7 @@ The `kube-apiserver` `Service` **will** be of type `ClusterIP`. In this case, Ga
 
 ### kube-controller-manager
 
-To deploy kube-controller-manager, Gardener **shall** create a deployment named `kube-controller-manager` in the Shoot namespace. It can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
+To deploy kube-controller-manager, Gardener **shall** create a deployment named `kube-controller-manager` in the Shoot namespace (`virtual-garden-kube-controller-manager` in the `garden` namespace for the virtual garden). It can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
 
 The pod template of the `kube-controller-manager` deployment **shall** contain a container named `kube-controller-manager`.
 
@@ -126,7 +130,7 @@ The kube-scheduler command line can't contain provider-specific flags, and it ma
 
 ### etcd-main and etcd-events
 
-To deploy etcd, Gardener **shall** create 2 [Etcd](https://github.com/gardener/etcd-druid/blob/1d427e9167adac1476d1847c0e265c2c09d6bc62/config/samples/druid_v1alpha1_etcd.yaml) named `etcd-main` and `etcd-events` in the Shoot namespace. They can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
+To deploy etcd, Gardener **shall** create 2 [Etcd](https://github.com/gardener/etcd-druid/blob/1d427e9167adac1476d1847c0e265c2c09d6bc62/config/samples/druid_v1alpha1_etcd.yaml) named `etcd-main` and `etcd-events` in the Shoot namespace (`virtual-garden-etcd-{main,events}` in the `garden` namespace for the virtual garden). They can be mutated by webhooks to apply any provider-specific changes to the standard configuration provided by Gardener.
 
 Gardener **shall** configure the `Etcd` resource completely to set up an etcd cluster which uses the default storage class of the seed cluster.
 

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -26,6 +26,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
@@ -138,10 +139,10 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 
 		switch x.Name {
-		case v1beta1constants.DeploymentNameKubeAPIServer:
+		case v1beta1constants.DeploymentNameKubeAPIServer, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureKubeAPIServerDeployment(ctx, gctx, x, oldDep)
-		case v1beta1constants.DeploymentNameKubeControllerManager:
+		case v1beta1constants.DeploymentNameKubeControllerManager, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeControllerManager:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureKubeControllerManagerDeployment(ctx, gctx, x, oldDep)
 		case v1beta1constants.DeploymentNameKubeScheduler:
@@ -189,7 +190,7 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 	case *druidcorev1alpha1.Etcd:
 		switch x.Name {
-		case v1beta1constants.ETCDMain, v1beta1constants.ETCDEvents:
+		case v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.ETCDMain, v1beta1constants.ETCDEvents, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.ETCDEvents:
 			var oldEtcd *druidcorev1alpha1.Etcd
 			if old != nil {
 				var ok bool

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -139,10 +139,10 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 
 		switch x.Name {
-		case v1beta1constants.DeploymentNameKubeAPIServer, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer:
+		case v1beta1constants.DeploymentNameKubeAPIServer, operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureKubeAPIServerDeployment(ctx, gctx, x, oldDep)
-		case v1beta1constants.DeploymentNameKubeControllerManager, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeControllerManager:
+		case v1beta1constants.DeploymentNameKubeControllerManager, operatorv1alpha1.DeploymentNameVirtualGardenKubeControllerManager:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureKubeControllerManagerDeployment(ctx, gctx, x, oldDep)
 		case v1beta1constants.DeploymentNameKubeScheduler:
@@ -190,7 +190,7 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		}
 	case *druidcorev1alpha1.Etcd:
 		switch x.Name {
-		case v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.ETCDMain, v1beta1constants.ETCDEvents, operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.ETCDEvents:
+		case v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenETCDMain, v1beta1constants.ETCDEvents, operatorv1alpha1.VirtualGardenETCDEvents:
 			var oldEtcd *druidcorev1alpha1.Etcd
 			if old != nil {
 				var ok bool

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -179,6 +179,13 @@ var _ = Describe("Mutator", func() {
 				},
 			),
 			Entry(
+				"EnsureKubeAPIServerDeployment with a virtual-garden-kube-apiserver deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-kube-apiserver"}}
+					ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
 				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment and existing deployment",
 				func() {
 					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
@@ -190,6 +197,13 @@ var _ = Describe("Mutator", func() {
 				"EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment",
 				func() {
 					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager}}
+					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureKubeControllerManagerDeployment with a virtual-garden-kube-controller-manager deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-kube-controller-manager"}}
 					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
@@ -297,6 +311,11 @@ var _ = Describe("Mutator", func() {
 				nil,
 			),
 			Entry(
+				"with a virtual-garden-etcd-main",
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-etcd-main", Namespace: namespace}},
+				nil,
+			),
+			Entry(
 				"with a etcd-main and existing druid",
 				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
 				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
@@ -304,6 +323,11 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"with a etcd-events",
 				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+				nil,
+			),
+			Entry(
+				"with a virtual-garden-etcd-events",
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-etcd-events", Namespace: namespace}},
 				nil,
 			),
 			Entry(

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	extensionsmockgenericmutator "github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator/mock"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockkubelet "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/mock"
 	mockutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils/mock"
@@ -174,7 +173,7 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"}}
 					ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
@@ -188,7 +187,7 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureKubeAPIServerDeployment with a kube-apiserver deployment and existing deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureKubeAPIServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -196,7 +195,7 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager"}}
 					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
@@ -210,7 +209,7 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureKubeControllerManagerDeployment with a kube-controller-manager deployment and existing deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureKubeControllerManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -218,14 +217,14 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureKubeSchedulerDeployment with a kube-scheduler deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-scheduler"}}
 					ensurer.EXPECT().EnsureKubeSchedulerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
 			Entry(
 				"EnsureKubeSchedulerDeployment with a kube-scheduler deployment and existing deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "kube-scheduler"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureKubeSchedulerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -233,14 +232,14 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureClusterAutoscalerDeployment with a cluster-autoscaler deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameClusterAutoscaler}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cluster-autoscaler"}}
 					ensurer.EXPECT().EnsureClusterAutoscalerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
 			Entry(
 				"EnsureMachineControllerManagerDeployment with a machine-controller-manager deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameMachineControllerManager}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "machine-controller-manager"}}
 					ensurer.EXPECT().EnsureMachineControllerManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
@@ -254,7 +253,7 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureClusterAutoscalerDeployment with a cluster-autoscaler deployment and existing deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameClusterAutoscaler}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cluster-autoscaler"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureClusterAutoscalerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -262,14 +261,14 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureVPNSeedServerDeployment with a vpn-seed-server deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPNSeedServer}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server"}}
 					ensurer.EXPECT().EnsureVPNSeedServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
 			Entry(
 				"EnsureVPNSeedServerDeployment with a vpn-seed-server deployment and existing deployment",
 				func() {
-					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPNSeedServer}}
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureVPNSeedServerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -277,14 +276,14 @@ var _ = Describe("Mutator", func() {
 			Entry(
 				"EnsureVPNSeedServerStatefulSet with a vpn-seed-server statefulset",
 				func() {
-					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameVPNSeedServer}}
+					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server"}}
 					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
 			Entry(
 				"EnsureVPNSeedServerStatefulSet with a vpn-seed-server statefulset and existing statefulset",
 				func() {
-					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameVPNSeedServer}}
+					newObj = &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server"}}
 					oldObj = newObj.DeepCopyObject().(client.Object)
 					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
@@ -307,7 +306,7 @@ var _ = Describe("Mutator", func() {
 		},
 			Entry(
 				"with a etcd-main",
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-main", Namespace: namespace}},
 				nil,
 			),
 			Entry(
@@ -317,12 +316,12 @@ var _ = Describe("Mutator", func() {
 			),
 			Entry(
 				"with a etcd-main and existing druid",
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain, Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-main", Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-main", Namespace: namespace}},
 			),
 			Entry(
 				"with a etcd-events",
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-events", Namespace: namespace}},
 				nil,
 			),
 			Entry(
@@ -332,8 +331,8 @@ var _ = Describe("Mutator", func() {
 			),
 			Entry(
 				"with a etcd-events and existing druid",
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
-				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents, Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-events", Namespace: namespace}},
+				&druidcorev1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: "etcd-events", Namespace: namespace}},
 			),
 		)
 
@@ -350,7 +349,7 @@ var _ = Describe("Mutator", func() {
 					newOSC = &extensionsv1alpha1.OperatingSystemConfig{
 						ObjectMeta: metav1.ObjectMeta{Name: "test-provision", Namespace: "test"},
 						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
-							Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
+							Purpose: "provision",
 						},
 					}
 				})
@@ -393,7 +392,7 @@ var _ = Describe("Mutator", func() {
 					newOSC = &extensionsv1alpha1.OperatingSystemConfig{
 						ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
 						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
-							Purpose: extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
+							Purpose: "reconcile",
 							CRIConfig: &extensionsv1alpha1.CRIConfig{
 								Name: "containerd",
 								Containerd: &extensionsv1alpha1.ContainerdConfig{
@@ -404,13 +403,13 @@ var _ = Describe("Mutator", func() {
 							},
 							Units: []extensionsv1alpha1.Unit{
 								{
-									Name:    v1beta1constants.OperatingSystemConfigUnitNameKubeletService,
+									Name:    "kubelet.service",
 									Content: ptr.To(newServiceContent),
 								},
 							},
 							Files: []extensionsv1alpha1.File{
 								{
-									Path: v1beta1constants.OperatingSystemConfigFilePathKubeletConfig,
+									Path: "/var/lib/kubelet/config/kubelet",
 									Content: extensionsv1alpha1.FileContent{
 										Inline: &extensionsv1alpha1.FileContentInline{
 											Data: newKubeletConfigData,
@@ -418,7 +417,7 @@ var _ = Describe("Mutator", func() {
 									},
 								},
 								{
-									Path: v1beta1constants.OperatingSystemConfigFilePathKernelSettings,
+									Path: "/etc/sysctl.d/99-k8s-general.conf",
 									Content: extensionsv1alpha1.FileContent{
 										Inline: &extensionsv1alpha1.FileContentInline{
 											Data: newKubernetesGeneralConfigData,
@@ -585,7 +584,7 @@ var _ = Describe("Mutator", func() {
 					err := mutator.Mutate(context.Background(), newOSC, oldOSC)
 					Expect(err).To(Not(HaveOccurred()))
 
-					general := extensionswebhook.FileWithPath(newOSC.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
+					general := extensionswebhook.FileWithPath(newOSC.Spec.Files, "/etc/sysctl.d/99-k8s-general.conf")
 					Expect(general).To(Not(BeNil()))
 					Expect(general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: newKubernetesGeneralConfigData}))
 					cloudProvider := extensionswebhook.FileWithPath(newOSC.Spec.Files, genericmutator.CloudProviderConfigPath)
@@ -597,7 +596,7 @@ var _ = Describe("Mutator", func() {
 })
 
 func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
-	kubeletUnit := extensionswebhook.UnitWithName(osc.Spec.Units, v1beta1constants.OperatingSystemConfigUnitNameKubeletService)
+	kubeletUnit := extensionswebhook.UnitWithName(osc.Spec.Units, "kubelet.service")
 	ExpectWithOffset(1, kubeletUnit).To(Not(BeNil()))
 	ExpectWithOffset(1, kubeletUnit.Content).To(Equal(ptr.To(mutatedServiceContent)))
 
@@ -607,17 +606,17 @@ func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 	customFile := extensionswebhook.FileWithPath(osc.Spec.Files, "/test/path")
 	ExpectWithOffset(1, customFile).To(Not(BeNil()))
 
-	kubeletFile := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKubeletConfig)
+	kubeletFile := extensionswebhook.FileWithPath(osc.Spec.Files, "/var/lib/kubelet/config/kubelet")
 	ExpectWithOffset(1, kubeletFile).To(Not(BeNil()))
 	ExpectWithOffset(1, kubeletFile.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubeletConfigData}))
 
-	general := extensionswebhook.FileWithPath(osc.Spec.Files, v1beta1constants.OperatingSystemConfigFilePathKernelSettings)
+	general := extensionswebhook.FileWithPath(osc.Spec.Files, "/etc/sysctl.d/99-k8s-general.conf")
 	ExpectWithOffset(1, general).To(Not(BeNil()))
 	ExpectWithOffset(1, general.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: mutatedKubernetesGeneralConfigData}))
 
-	cloudProvider := extensionswebhook.FileWithPath(osc.Spec.Files, genericmutator.CloudProviderConfigPath)
+	cloudProvider := extensionswebhook.FileWithPath(osc.Spec.Files, "/var/lib/kubelet/cloudprovider.conf")
 	ExpectWithOffset(1, cloudProvider).To(Not(BeNil()))
-	ExpectWithOffset(1, cloudProvider.Path).To(Equal(genericmutator.CloudProviderConfigPath))
+	ExpectWithOffset(1, cloudProvider.Path).To(Equal("/var/lib/kubelet/cloudprovider.conf"))
 	ExpectWithOffset(1, cloudProvider.Permissions).To(PointTo(Equal(uint32(0644))))
 	ExpectWithOffset(1, cloudProvider.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}))
 }

--- a/pkg/apis/operator/v1alpha1/constants.go
+++ b/pkg/apis/operator/v1alpha1/constants.go
@@ -4,6 +4,10 @@
 
 package v1alpha1
 
+import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
 const (
 	// SecretManagerIdentityOperator is the identity for the secret manager used inside gardener-operator.
 	SecretManagerIdentityOperator = "gardener-operator"
@@ -31,4 +35,19 @@ const (
 
 	// VirtualGardenNamePrefix is a constant to prefix various resource names for the virtual garden.
 	VirtualGardenNamePrefix = "virtual-garden-"
+
+	// DeploymentNameVirtualGardenKubeAPIServer is a constant for the name of a Kubernetes deployment object that contains the kube-apiserver pod of the virtual garden.
+	DeploymentNameVirtualGardenKubeAPIServer = VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+	// DeploymentNameVirtualGardenKubeControllerManager is a constant for the name of a Kubernetes deployment object that contains the kube-controller-manager pod of the virtual garden.
+	DeploymentNameVirtualGardenKubeControllerManager = VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeControllerManager
+	// DeploymentNameVirtualGardenGardenerResourceManager is a constant for the name of a Kubernetes deployment object that contains the gardener-resource-manager pod of the virtual garden.
+	DeploymentNameVirtualGardenGardenerResourceManager = VirtualGardenNamePrefix + v1beta1constants.DeploymentNameGardenerResourceManager
+
+	// VirtualGardenETCDMain is a constant for the name of etcd-main Etcd object of the virtual garden.
+	VirtualGardenETCDMain = VirtualGardenNamePrefix + v1beta1constants.ETCDMain
+	// VirtualGardenETCDEvents is a constant for the name of etcd-events Etcd object of the virtual garden.
+	VirtualGardenETCDEvents = VirtualGardenNamePrefix + v1beta1constants.ETCDEvents
+
+	// VirtualGardenDefaultSNIIngressNamespace is the default sni ingress namespace of the virtual garden.
+	VirtualGardenDefaultSNIIngressNamespace = VirtualGardenNamePrefix + v1beta1constants.DefaultSNIIngressNamespace
 )

--- a/pkg/apis/operator/v1alpha1/constants.go
+++ b/pkg/apis/operator/v1alpha1/constants.go
@@ -28,4 +28,7 @@ const (
 	// OperationRotateWorkloadIdentityKeyComplete is a constant for an annotation on a Shoot indicating that the
 	// rotation of the workload identity signing key shall be completed.
 	OperationRotateWorkloadIdentityKeyComplete = "rotate-workload-identity-key-complete"
+
+	// VirtualGardenNamePrefix is a constant to prefix various resource names for the virtual garden.
+	VirtualGardenNamePrefix = "virtual-garden-"
 )

--- a/pkg/component/gardener/admissioncontroller/deployment.go
+++ b/pkg/component/gardener/admissioncontroller/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -50,7 +51,7 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/admissioncontroller/deployment.go
+++ b/pkg/component/gardener/admissioncontroller/deployment.go
@@ -51,7 +51,7 @@ func (a *gardenerAdmissionController) deployment(secretServerCert, secretGeneric
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -90,7 +90,7 @@ func (g *gardenerAPIServer) deployment(
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                          v1beta1constants.LabelNetworkPolicyAllowed,
 						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyWebhookTargets: v1beta1constants.LabelNetworkPolicyAllowed,
 						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient): v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):              v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port):                                          v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
@@ -84,12 +85,12 @@ func (g *gardenerAPIServer) deployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
-						v1beta1constants.LabelNetworkPolicyToDNS:                                                                                                   v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToPublicNetworks:                                                                                        v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                                                                       v1beta1constants.LabelNetworkPolicyAllowed,
-						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyWebhookTargets:                                              v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient): v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):              v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToDNS:                                                      v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPublicNetworks:                                           v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                          v1beta1constants.LabelNetworkPolicyAllowed,
+						"networking.resources.gardener.cloud/to-" + v1beta1constants.LabelNetworkPolicyWebhookTargets: v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+etcdconstants.ServiceName(v1beta1constants.ETCDRoleMain), etcdconstants.PortEtcdClient): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port):              v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{
@@ -152,7 +153,7 @@ func (g *gardenerAPIServer) deployment(
 	}
 
 	injectWorkloadIdentitySettings(deployment, g.values.WorkloadIdentityTokenIssuer, secretWorkloadIdentitySigningKey)
-	apiserver.InjectDefaultSettings(deployment, "virtual-garden-", g.values.Values, secretCAETCD, secretETCDClient, secretServer)
+	apiserver.InjectDefaultSettings(deployment, operatorv1alpha1.VirtualGardenNamePrefix, g.values.Values, secretCAETCD, secretETCDClient, secretServer)
 	apiserver.InjectAuditSettings(deployment, configMapAuditPolicy, secretAuditWebhookKubeconfig, g.values.Audit)
 	apiserver.InjectAdmissionSettings(deployment, configMapAdmissionConfigs, secretAdmissionKubeconfigs, g.values.Values)
 	apiserver.InjectEncryptionSettings(deployment, secretETCDEncryptionConfiguration)

--- a/pkg/component/gardener/controllermanager/deployment.go
+++ b/pkg/component/gardener/controllermanager/deployment.go
@@ -48,7 +48,7 @@ func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, sec
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/controllermanager/deployment.go
+++ b/pkg/component/gardener/controllermanager/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -47,7 +48,7 @@ func (g *gardenerControllerManager) deployment(secretGenericTokenKubeconfig, sec
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -91,7 +91,7 @@ func (g *gardenerDashboard) deployment(
 						v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -90,7 +91,7 @@ func (g *gardenerDashboard) deployment(
 						v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/dashboard/terminal/deployment.go
+++ b/pkg/component/gardener/dashboard/terminal/deployment.go
@@ -49,11 +49,11 @@ func (t *terminal) deployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(getLabels(), map[string]string{
-						v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToPublicNetworks:   v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToDNS:                                                                                 v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                                                                    v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPublicNetworks:                                                                      v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:                                                                     v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/dashboard/terminal/deployment.go
+++ b/pkg/component/gardener/dashboard/terminal/deployment.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -52,7 +53,7 @@ func (t *terminal) deployment(
 						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPublicNetworks:   v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/discoveryserver/deployment.go
+++ b/pkg/component/gardener/discoveryserver/deployment.go
@@ -64,7 +64,7 @@ func (g *gardenerDiscoveryServer) deployment(
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(labels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/discoveryserver/deployment.go
+++ b/pkg/component/gardener/discoveryserver/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -63,7 +64,7 @@ func (g *gardenerDiscoveryServer) deployment(
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(labels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/scheduler/deployment.go
+++ b/pkg/component/gardener/scheduler/deployment.go
@@ -48,7 +48,7 @@ func (g *gardenerScheduler) deployment(secretGenericTokenKubeconfig, secretVirtu
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/gardener/scheduler/deployment.go
+++ b/pkg/component/gardener/scheduler/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -47,7 +48,7 @@ func (g *gardenerScheduler) deployment(secretGenericTokenKubeconfig, secretVirtu
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
@@ -40,7 +40,7 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
@@ -39,7 +40,7 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS: v1beta1constants.LabelNetworkPolicyAllowed,
-						gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+						gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -648,7 +648,7 @@ func PrepareGardenletChartValues(
 	if isGarden {
 		gardenletDeployment.PodLabels = utils.MergeStringMaps(
 			map[string]string{
-				gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			gardenletDeployment.PodLabels,
 		)

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -27,6 +27,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -647,7 +648,7 @@ func PrepareGardenletChartValues(
 	if isGarden {
 		gardenletDeployment.PodLabels = utils.MergeStringMaps(
 			map[string]string{
-				gardenerutils.NetworkPolicyLabel("virtual-garden-"+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
+				gardenerutils.NetworkPolicyLabel(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, kubeapiserverconstants.Port): v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 			gardenletDeployment.PodLabels,
 		)

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -149,7 +148,7 @@ func AddToManager(operatorCancel context.CancelFunc, mgr manager.Manager, cfg *o
 		if err := (&service.Reconciler{}).AddToManager(mgr, predicate.And(
 			virtualGardenIstioIngressPredicate,
 			predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return obj.GetNamespace() == operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace
+				return obj.GetNamespace() == operatorv1alpha1.VirtualGardenDefaultSNIIngressNamespace
 			})),
 		); err != nil {
 			return fmt.Errorf("failed adding Service controller: %w", err)

--- a/pkg/operator/controller/add.go
+++ b/pkg/operator/controller/add.go
@@ -149,7 +149,7 @@ func AddToManager(operatorCancel context.CancelFunc, mgr manager.Manager, cfg *o
 		if err := (&service.Reconciler{}).AddToManager(mgr, predicate.And(
 			virtualGardenIstioIngressPredicate,
 			predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return obj.GetNamespace() == "virtual-garden-"+v1beta1constants.DefaultSNIIngressNamespace
+				return obj.GetNamespace() == operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace
 			})),
 		); err != nil {
 			return fmt.Errorf("failed adding Service controller: %w", err)

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -135,8 +135,8 @@ func (h *health) checkVirtualComponents(ctx context.Context, condition gardencor
 	if exitCondition, err := h.healthChecker.CheckControlPlane(
 		ctx,
 		h.gardenNamespace,
-		sets.New(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameGardenerResourceManager, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeControllerManager),
-		sets.New(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.ETCDEvents),
+		sets.New(operatorv1alpha1.DeploymentNameVirtualGardenGardenerResourceManager, operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, operatorv1alpha1.DeploymentNameVirtualGardenKubeControllerManager),
+		sets.New(operatorv1alpha1.VirtualGardenETCDMain, operatorv1alpha1.VirtualGardenETCDEvents),
 		condition,
 	); err != nil || exitCondition != nil {
 		return exitCondition, err

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -26,8 +26,6 @@ import (
 	healthchecker "github.com/gardener/gardener/pkg/utils/kubernetes/health/checker"
 )
 
-const virtualGardenPrefix = "virtual-garden-"
-
 // health contains information needed to execute health checks for garden.
 type health struct {
 	garden              *operatorv1alpha1.Garden
@@ -137,8 +135,8 @@ func (h *health) checkVirtualComponents(ctx context.Context, condition gardencor
 	if exitCondition, err := h.healthChecker.CheckControlPlane(
 		ctx,
 		h.gardenNamespace,
-		sets.New(virtualGardenPrefix+v1beta1constants.DeploymentNameGardenerResourceManager, virtualGardenPrefix+v1beta1constants.DeploymentNameKubeAPIServer, virtualGardenPrefix+v1beta1constants.DeploymentNameKubeControllerManager),
-		sets.New(virtualGardenPrefix+v1beta1constants.ETCDMain, virtualGardenPrefix+v1beta1constants.ETCDEvents),
+		sets.New(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameGardenerResourceManager, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeControllerManager),
+		sets.New(operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.ETCDMain, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.ETCDEvents),
 		condition,
 	); err != nil || exitCondition != nil {
 		return exitCondition, err

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -960,7 +960,7 @@ func (r *Reconciler) newSNI(ctx context.Context, garden *operatorv1alpha1.Garden
 
 	return kubeapiserverexposure.NewSNI(
 		r.RuntimeClientSet.Client(),
-		operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer,
+		operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer,
 		r.GardenNamespace,
 		secretsManager,
 		func() *kubeapiserverexposure.SNIValues {
@@ -983,7 +983,7 @@ func (r *Reconciler) newGardenerAccess(garden *operatorv1alpha1.Garden, secretsM
 		r.GardenNamespace,
 		secretsManager,
 		gardeneraccess.Values{
-			ServerInCluster:       fmt.Sprintf("%s%s.%s.svc.cluster.local", operatorv1alpha1.VirtualGardenNamePrefix, v1beta1constants.DeploymentNameKubeAPIServer, r.GardenNamespace),
+			ServerInCluster:       fmt.Sprintf("%s.%s.svc.cluster.local", kubeapiserverconstants.ServiceName(operatorv1alpha1.VirtualGardenNamePrefix), r.GardenNamespace),
 			ServerOutOfCluster:    v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
 			ManagedResourceLabels: map[string]string{v1beta1constants.LabelCareConditionType: string(operatorv1alpha1.VirtualComponentsHealthy)},
 			IsGardenCluster:       true,

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -422,7 +422,7 @@ func (r *Reconciler) updateStatusOperationError(ctx context.Context, garden *ope
 }
 
 func (r *Reconciler) generateGenericTokenKubeconfig(ctx context.Context, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) error {
-	kubeAPIServerAddress := namePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+	kubeAPIServerAddress := operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		kubeAPIServerAddress = v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name)
 	}

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -422,7 +422,7 @@ func (r *Reconciler) updateStatusOperationError(ctx context.Context, garden *ope
 }
 
 func (r *Reconciler) generateGenericTokenKubeconfig(ctx context.Context, garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) error {
-	kubeAPIServerAddress := operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+	kubeAPIServerAddress := operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer
 	if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
 		kubeAPIServerAddress = v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name)
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -496,7 +496,7 @@ func (r *Reconciler) reconcile(
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling encrypted resources after modification of encryption config or to re-encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, secretsManager, r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
+				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, secretsManager, r.GardenNamespace, operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf: helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 				sets.New(resourcesToEncrypt...).Equal(sets.New(encryptedResources...)),
@@ -505,7 +505,7 @@ func (r *Reconciler) reconcile(
 		snapshotETCD = g.Add(flow.Task{
 			Name: "Snapshotting ETCD after modification of encryption config or resources are re-encrypted with new ETCD encryption key",
 			Fn: func(ctx context.Context) error {
-				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, r.RuntimeClientSet.Client(), r.snapshotETCDFunc(secretsManager, c.etcdMain), r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer)
+				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, r.RuntimeClientSet.Client(), r.snapshotETCDFunc(secretsManager, c.etcdMain), r.GardenNamespace, operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer)
 			},
 			SkipIf: !backupConfigured ||
 				(helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing &&
@@ -515,7 +515,7 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name: "Removing label from re-encrypted resources after modification of encryption config or rotation of ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs); err != nil {
+				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, r.GardenNamespace, operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs); err != nil {
 					return err
 				}
 
@@ -816,7 +816,7 @@ func etcdMainBackupBucket(garden *operatorv1alpha1.Garden) *extensionsv1alpha1.B
 }
 
 func etcdMainBackupBucketNameAndPrefix(garden *operatorv1alpha1.Garden) (string, string) {
-	prefix := operatorv1alpha1.VirtualGardenNamePrefix + "etcd-main"
+	prefix := operatorv1alpha1.VirtualGardenETCDMain
 	if backup := helper.GetETCDMainBackup(garden); backup != nil && backup.BucketName != nil {
 		name := *backup.BucketName
 		if idx := strings.Index(name, "/"); idx != -1 {
@@ -987,7 +987,7 @@ func (r *Reconciler) deployVirtualGardenGardenerResourceManager(secretsManager s
 				return 2, nil
 			},
 			func() string {
-				return operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+				return operatorv1alpha1.DeploymentNameVirtualGardenKubeAPIServer
 			},
 		)
 	}
@@ -1181,7 +1181,7 @@ func (r *Reconciler) reconcileDNSRecords(ctx context.Context, log logr.Logger, g
 		staleDNSRecordNames.Insert(dnsRecord.Name)
 	}
 
-	istioIngressGatewayLoadBalancerAddress, err := kubernetesutils.WaitUntilLoadBalancerIsReady(ctx, log, r.RuntimeClientSet.Client(), operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, time.Minute)
+	istioIngressGatewayLoadBalancerAddress, err := kubernetesutils.WaitUntilLoadBalancerIsReady(ctx, log, r.RuntimeClientSet.Client(), operatorv1alpha1.VirtualGardenDefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, time.Minute)
 	if err != nil {
 		return fmt.Errorf("failed waiting until %s/%s is ready: %w", operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, err)
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -496,7 +496,7 @@ func (r *Reconciler) reconcile(
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling encrypted resources after modification of encryption config or to re-encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, secretsManager, r.GardenNamespace, namePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
+				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, secretsManager, r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs)
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
 			SkipIf: helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 				sets.New(resourcesToEncrypt...).Equal(sets.New(encryptedResources...)),
@@ -505,7 +505,7 @@ func (r *Reconciler) reconcile(
 		snapshotETCD = g.Add(flow.Task{
 			Name: "Snapshotting ETCD after modification of encryption config or resources are re-encrypted with new ETCD encryption key",
 			Fn: func(ctx context.Context) error {
-				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, r.RuntimeClientSet.Client(), r.snapshotETCDFunc(secretsManager, c.etcdMain), r.GardenNamespace, namePrefix+v1beta1constants.DeploymentNameKubeAPIServer)
+				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, r.RuntimeClientSet.Client(), r.snapshotETCDFunc(secretsManager, c.etcdMain), r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer)
 			},
 			SkipIf: !backupConfigured ||
 				(helper.GetETCDEncryptionKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing &&
@@ -515,7 +515,7 @@ func (r *Reconciler) reconcile(
 		_ = g.Add(flow.Task{
 			Name: "Removing label from re-encrypted resources after modification of encryption config or rotation of ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, r.GardenNamespace, namePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs); err != nil {
+				if err := secretsrotation.RewriteEncryptedDataRemoveLabel(ctx, log, r.RuntimeClientSet.Client(), virtualClusterClientSet, r.GardenNamespace, operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameKubeAPIServer, resourcesToEncrypt, encryptedResources, defaultEncryptedGVKs); err != nil {
 					return err
 				}
 
@@ -816,7 +816,7 @@ func etcdMainBackupBucket(garden *operatorv1alpha1.Garden) *extensionsv1alpha1.B
 }
 
 func etcdMainBackupBucketNameAndPrefix(garden *operatorv1alpha1.Garden) (string, string) {
-	prefix := "virtual-garden-etcd-main"
+	prefix := operatorv1alpha1.VirtualGardenNamePrefix + "etcd-main"
 	if backup := helper.GetETCDMainBackup(garden); backup != nil && backup.BucketName != nil {
 		name := *backup.BucketName
 		if idx := strings.Index(name, "/"); idx != -1 {
@@ -986,7 +986,9 @@ func (r *Reconciler) deployVirtualGardenGardenerResourceManager(secretsManager s
 			func(_ context.Context) (int32, error) {
 				return 2, nil
 			},
-			func() string { return namePrefix + v1beta1constants.DeploymentNameKubeAPIServer },
+			func() string {
+				return operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DeploymentNameKubeAPIServer
+			},
 		)
 	}
 }
@@ -1179,9 +1181,9 @@ func (r *Reconciler) reconcileDNSRecords(ctx context.Context, log logr.Logger, g
 		staleDNSRecordNames.Insert(dnsRecord.Name)
 	}
 
-	istioIngressGatewayLoadBalancerAddress, err := kubernetesutils.WaitUntilLoadBalancerIsReady(ctx, log, r.RuntimeClientSet.Client(), namePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, time.Minute)
+	istioIngressGatewayLoadBalancerAddress, err := kubernetesutils.WaitUntilLoadBalancerIsReady(ctx, log, r.RuntimeClientSet.Client(), operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, time.Minute)
 	if err != nil {
-		return fmt.Errorf("failed waiting until %s/%s is ready: %w", namePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, err)
+		return fmt.Errorf("failed waiting until %s/%s is ready: %w", operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DefaultSNIIngressNamespace, v1beta1constants.DefaultSNIIngressServiceName, err)
 	}
 
 	var taskFns []flow.TaskFn


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the generic webhook mutator to consider the `kube-apiserver`, `kube-controller-manager` and `etcd`s of the virtual garden.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev @theoddora

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The generic control-plane webhook is now capable of ensuring the `kube-apiserver` and `kube-controller-manager` deployments, as well as `etcd`s, of the virtual garden cluster.
```
