### PR TITLE
Split the `ManagedSeed` admission plugin into mutating and validating admission plugin (part 2)

### DIFF
--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -201,25 +201,6 @@ func (v *ManagedSeed) Admit(ctx context.Context, a admission.Attributes, _ admis
 
 	gardenerutils.MaintainSeedNameLabels(managedSeed, shoot.Spec.SeedName)
 
-	switch a.GetOperation() {
-	case admission.Create:
-		errs, err := v.validateManagedSeedCreate(managedSeed, shoot)
-		if err != nil {
-			return err
-		}
-		allErrs = append(allErrs, errs...)
-	case admission.Update:
-		oldManagedSeed, ok := a.GetOldObject().(*seedmanagement.ManagedSeed)
-		if !ok {
-			return apierrors.NewInternalError(errors.New("could not convert old resource into ManagedSeed object"))
-		}
-		errs, err := v.validateManagedSeedUpdate(oldManagedSeed, managedSeed, shoot)
-		if err != nil {
-			return err
-		}
-		allErrs = append(allErrs, errs...)
-	}
-
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(gk, managedSeed.Name, allErrs)
 	}
@@ -599,6 +580,25 @@ func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ ad
 	}
 	if ms != nil && ms.Name != managedSeed.Name {
 		allErrs = append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s already registered as seed by managed seed %s", client.ObjectKeyFromObject(shoot), client.ObjectKeyFromObject(ms))))
+	}
+
+	switch a.GetOperation() {
+	case admission.Create:
+		errs, err := v.validateManagedSeedCreate(managedSeed, shoot)
+		if err != nil {
+			return err
+		}
+		allErrs = append(allErrs, errs...)
+	case admission.Update:
+		oldManagedSeed, ok := a.GetOldObject().(*seedmanagement.ManagedSeed)
+		if !ok {
+			return apierrors.NewInternalError(errors.New("could not convert old resource into ManagedSeed object"))
+		}
+		errs, err := v.validateManagedSeedUpdate(oldManagedSeed, managedSeed, shoot)
+		if err != nil {
+			return err
+		}
+		allErrs = append(allErrs, errs...)
 	}
 
 	if len(allErrs) > 0 {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR is part 2 of the split of the `ManagedSeed` admission plugin into mutating and validating admission plugin. The end goal of this workstream is to move all validations from the initially mutating `ManagedSeed` admission plugin to new validating `ManagedSeed` admission plugin.

This PR moves the validations performed via the `validateManagedSeedCreate` and `validateManagedSeedUpdate` funcs from the mutating `ManagedSeed` admission to the validating one.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13618

**Special notes for your reviewer**:
~~This PR is based on https://github.com/gardener/gardener/pull/13621. Hence, it is in draft state until https://github.com/gardener/gardener/pull/13621 is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
