### PR TITLE
Adapted mount path of Dashboard custom assets to new location

### DIFF
--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -567,7 +567,7 @@ frontend:
 				})
 				obj.Spec.Template.Spec.Containers[0].VolumeMounts = append(obj.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 					Name:      "gardener-dashboard-assets",
-					MountPath: "/app/public/static/assets",
+					MountPath: "/app/public/static/custom-assets",
 				})
 			}
 

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -41,7 +41,7 @@ const (
 
 	volumeMountPathConfig      = "/etc/gardener-dashboard/config"
 	volumeMountPathLoginConfig = "/app/public/" + dataKeyLoginConfig
-	volumeMountPathAssets      = "/app/public/static/assets"
+	volumeMountPathAssets      = "/app/public/static/custom-assets"
 
 	volumeSubPathSession           = "sessionSecret"
 	volumeMountPathSession         = "/etc/gardener-dashboard/secrets/session/sessionSecret"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind api-change

**What this PR does / why we need it**:
The location of custom static assets for Gardener Dashboard has changed with this PR: https://github.com/gardener/dashboard/pull/2687

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support replacement of individual assets for the gardener dashboard ([gardener/dashboard#2687](https://github.com/gardener/dashboard/pull/2687))
```
