### PR TITLE
extensions/controller: document the extension interfaces

### DIFF
--- a/extensions/pkg/controller/backupbucket/actuator.go
+++ b/extensions/pkg/controller/backupbucket/actuator.go
@@ -12,10 +12,18 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon BackupBucket resources.
+// Actuator acts upon [extensionsv1alpha1.BackupBucket] resources.
 type Actuator interface {
-	// Reconcile reconciles the BackupBucket.
+	// Reconcile reconciles the [extensionsv1alpha1.BackupBucket] resource.
+	//
+	// Implementations should ensure that the backup bucket is created or
+	// updated to reach the desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.BackupBucket) error
-	// Delete deletes the BackupBucket.
+
+	// Delete is invoked when the [extensionsv1alpha1.BackupBucket]
+	// resource is deleted.
+	//
+	// Implementations must wait until the backup bucket is gracefully
+	// deleted.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.BackupBucket) error
 }

--- a/extensions/pkg/controller/backupentry/actuator.go
+++ b/extensions/pkg/controller/backupentry/actuator.go
@@ -12,14 +12,42 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon BackupEntry resources.
+// Actuator acts upon [extensionsv1alpha1.BackupEntry] resources.
 type Actuator interface {
-	// Reconcile reconciles the BackupEntry.
+	// Reconcile reconciles the [extensionsv1alpha1.BackupEntry] resource.
+	//
+	// Implementations should ensure that the backup entry is created or
+	// updated to reach the desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry) error
-	// Delete deletes the BackupEntry.
+
+	// Delete is invoked when [extensionsv1alpha1.BackupEntry] resource is
+	// deleted.
+	//
+	// Implementations must wait until the backup entry is gracefully
+	// deleted.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry) error
-	// Restore restores the BackupEntry.
+
+	// Restore restores the [extensionsv1alpha1.BackupEntry] from a
+	// previously saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.BackupEntry] resource is being restored on the
+	// target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry) error
-	// Migrate migrates the BackupEntry.
+
+	// Migrate prepares the [extensionsv1alpha1.BackupEntry] resource for
+	// migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.BackupEntry] resource is being migrated to
+	// another seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.BackupEntry) error
 }

--- a/extensions/pkg/controller/bastion/actuator.go
+++ b/extensions/pkg/controller/bastion/actuator.go
@@ -13,12 +13,34 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon Bastion resources.
+// Actuator acts upon [extensionsv1alpha1.Bastion] resources.
 type Actuator interface {
-	// Reconcile reconciles the Bastion.
+	// Reconcile reconciles the [extensionsv1alpha1.Bastion] resource.
+	//
+	// Implementations should ensure that the bastion host is created or
+	// updated in order to reach its desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.Bastion, *extensionscontroller.Cluster) error
-	// Delete deletes the Bastion.
+
+	// Delete is invoked when the [extensionsv1alpha1.Bastion] resource is
+	// deleted.
+	//
+	// Implementations should take care of cleaning up any resources created
+	// by the extension during its lifecycle.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.Bastion, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the Bastion.
+
+	// ForceDelete is invoked when the [extensionsv1alpha1.Bastion] resource
+	// is being deleted in a forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, and
+	// also skip waiting for external resources, if they cannot be deleted
+	// gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.Bastion, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/containerruntime/actuator.go
+++ b/extensions/pkg/controller/containerruntime/actuator.go
@@ -13,16 +13,60 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon ContainerRuntime resources.
+// Actuator acts upon [extensionsv1alpha1.ContainerRuntime] resources.
 type Actuator interface {
-	// Reconcile the ContainerRuntime resource.
+	// Reconcile reconciles the [extensionsv1alpha1.ContainerRuntime]
+	// resource.
+	//
+	// Implementations should ensure that the desired container runtime is
+	// deployed or updated for relevant worker pools.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
-	// Delete the ContainerRuntime resource.
+
+	// Delete is invoked when the [extensionsv1alpha1.ContainerRuntime]
+	// resource is deleted.
+	//
+	// Implementations should take care of cleaning up any resources such as
+	// ManagedResources, Secrets, etc., which were created by the Extension.
+	//
+	// Implementations must also wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the ContainerRuntime.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.ContainerRuntime] resource is being deleted in a
+	// forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, and also skip waiting
+	// for external resources, if they cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
-	// Restore the ContainerRuntime resource.
+
+	// Restore restores the [extensionsv1alpha1.ContainerRuntime] resource
+	// from a previously saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.ContainerRuntime] resource is being restored on
+	// the target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
-	// Migrate the ContainerRuntime resource.
+
+	// Migrate prepares the [extensionsv1alpha1.ContainerRuntime] resource
+	// for migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.ContainerRuntime] resource is being migrated to
+	// another seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.ContainerRuntime, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/dnsrecord/actuator.go
+++ b/extensions/pkg/controller/dnsrecord/actuator.go
@@ -13,16 +13,61 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon DNSRecord resources.
+// Actuator acts upon [extensionsv1alpha1.DNSRecord] resources.
 type Actuator interface {
-	// Reconcile reconciles the DNSRecord.
+	// Reconcile reconciles the [extensionsv1alpha1.DNSRecord] resource.
+	//
+	// Implementations should ensure that DNS records are created or updated
+	// in order to reach their desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.DNSRecord, *extensionscontroller.Cluster) error
-	// Delete deletes the DNSRecord.
+
+	// Delete is invoked when the [extensionsv1alpha1.DNSRecord] resource is
+	// deleted.
+	//
+	// Implementations should take care of cleaning up any DNS records, and
+	// any other related resources, which the extension has created as part
+	// of its lifecycle.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.DNSRecord, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the DNSRecord.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.DNSRecord] resource is being deleted in a
+	// forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, and also skip waiting
+	// for external resources (e.g. DNS records), if they cannot be deleted
+	// gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.DNSRecord, *extensionscontroller.Cluster) error
-	// Restore restores the DNSRecord.
+
+	// Restore restores the [exensionsv1alpha1.DNSRecord] resource from a
+	// previously saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.DNSRecord] resource is being restored on the
+	// target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.DNSRecord, *extensionscontroller.Cluster) error
-	// Migrate migrates the DNSRecord.
+
+	// Migrate prepares the [extensionsv1alpha1.DNSRecord] resource for
+	// migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.DNSRecord] resource is being migrated to another
+	// seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.DNSRecord, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/extension/actuator.go
+++ b/extensions/pkg/controller/extension/actuator.go
@@ -12,16 +12,68 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon Extension resources.
+// Actuator acts upon [extensionsv1alpha1.Extension] resources.
+//
+// Actuator implementations plug into the generic reconciliation flow for
+// functionality that does not belong to the specialized resources such as
+// Bastion, ControlPlane, Network, etc.
 type Actuator interface {
-	// Reconcile the Extension resource.
+	// Reconcile reconciles the [extensionsv1alpha1.Extension] resource.
+	//
+	// Implementations should ensure that any resources
+	// (e.g. ManagedResources, Secrets, etc.) are created or updated to
+	// reach their desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.Extension) error
-	// Delete the Extension resource.
+
+	// Delete is invoked when the [extensionsv1alpha1.Extension] resource is
+	// deleted.
+	//
+	// Deletion of the [extensionsv1alpha1.Extension] resource may happen
+	// either because the extension has been deactivated for the shoot, or
+	// the shoot cluster has been marked for deletion.
+	//
+	// Implementations should take care of cleaning up any resources
+	// (e.g. ManagedResources, Secrets, etc.), which were created by the
+	// Extension.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.Extension) error
-	// ForceDelete forcefully deletes the Extension resource.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Extension] resource is being deleted in a
+	// forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, etc., and also skip
+	// waiting for external resources, if they cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.Extension) error
-	// Restore the Extension resource.
+
+	// Restore restores the [extensionsv1alpha1.Extension] from a previously
+	// saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Extension] resource is being restored on the
+	// target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.Extension) error
-	// Migrate the Extension resource.
+
+	// Migrate prepares the [extensionsv1alpha1.Extension] resource for migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Extension] resource is being migrated to another
+	// seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.Extension) error
 }

--- a/extensions/pkg/controller/infrastructure/actuator.go
+++ b/extensions/pkg/controller/infrastructure/actuator.go
@@ -13,16 +13,61 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon Infrastructure resources.
+// Actuator acts upon [extensionsv1alpha1.Infrastructure] resources.
 type Actuator interface {
-	// Reconcile the Infrastructure config.
+	// Reconcile reconciles the [extensionsv1alpha1.Infrastructure] resource.
+	//
+	// Implementations should ensure that required infrastructure resources
+	// are created or updated to reach the desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
-	// Delete the Infrastructure config.
+
+	// Delete is invoked when the [extensionsv1alpha1.Infrastructure]
+	// resource is deleted.
+	//
+	// Implementations should take care of cleaning up any infrastructure
+	// related resources (e.g. subnets, routers, etc.) which were created by
+	// the Extension.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the Infrastructure config.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Infrastructure] resource is being deleted in a
+	// forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, etc., and also skip
+	// waiting for external resources (e.g. subnets, routers, etc.), if they
+	// cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
-	// Restore takes the state of the Infrastructure resource and applies it to the terraform pod's output state
+
+	// Restore restores the [extensionsv1alpha1.Infrastructure] from a
+	// previously saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Infrastructure] resource is being restored on the
+	// target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
-	// Migrate deletes the terraform k8s resources without deleting the corresponding resources in the IaaS provider
+
+	// Migrate prepares the [extensionsv1alpha1.Infrastructure] resource for
+	// migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Infrastructure] resource is being migrated to
+	// another seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/network/actuator.go
+++ b/extensions/pkg/controller/network/actuator.go
@@ -13,16 +13,61 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon Network resources.
+// Actuator acts upon [extensionsv1alpha1.Network] resources.
 type Actuator interface {
-	// Reconcile reconciles the Network resource.
+	// Reconcile reconciles the [extensionsv1alpha1.Network] resource.
+	//
+	// Implementations should ensure that any resources
+	// (e.g. ManagedResources, Secrets, etc.) are created or updated in
+	// order to reach their desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.Network, *extensionscontroller.Cluster) error
-	// Delete deletes the Network resource.
+
+	// Delete is invoked when the [extensionsv1alpha1.Network] resource is
+	// deleted.
+	//
+	// Implementations should take care of cleaning up any resources
+	// (e.g. ManagedResources, Secrets, etc.), which were created by the
+	// Extension.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.Network, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the Network resource.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Network] resource is being deleted in a
+	// forceful manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, etc., and also skip
+	// waiting for external resources, if they cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.Network, *extensionscontroller.Cluster) error
-	// Restore restores the Network resource.
+
+	// Restore restores the [extensionsv1alpha1.Network] resource from a
+	// previously saved state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Network] resource is being restored on the target
+	// seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.Network, *extensionscontroller.Cluster) error
-	// Migrate migrates the Network resource.
+
+	// Migrate prepares the [extensionsv1alpha1.Network] resource for
+	// migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Network] resource is being migrated to another
+	// seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.Network, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/operatingsystemconfig/actuator.go
+++ b/extensions/pkg/controller/operatingsystemconfig/actuator.go
@@ -12,16 +12,60 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon OperatingSystemConfig resources.
+// Actuator acts upon [extensionsv1alpha1.OperatingSystemConfig] resources.
 type Actuator interface {
-	// Reconcile the operating system config.
+	// Reconcile reconciles the [extensionsv1alpha1.OperatingSystemConfig]
+	// resource.
+	//
+	// Implementations should ensure that any resources (e.g. systemd units,
+	// files, etc.) are created or updated in order to reach their desired
+	// state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, []extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus, error)
-	// Delete the operating system config.
+
+	// Delete is invoked when the [extensionsv1alpha1.OperatingSystemConfig]
+	// resource is deleted.
+	//
+	// Implementations should take care of cleaning up any resources
+	// (e.g. systemd units, files, etc.), which were created by the
+	// Extension.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) error
-	// ForceDelete forcefully deletes the operating system config.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.OperatingSystemConfig] is deleted in a forceful
+	// manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any related resources, and skip waiting for
+	// external resources, if they cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) error
-	// Restore the operating system config.
+
+	// Restore restores the operating system config from a previously saved
+	// state.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.OperatingSystemConfig] resource is being restored
+	// on the target seed cluster.
+	//
+	// Implementations may use the persisted data in the .status.state field
+	// for restoring the state, when the shoot is being migrated to a
+	// different seed cluster.
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, []extensionsv1alpha1.Unit, []extensionsv1alpha1.File, *extensionsv1alpha1.InPlaceUpdatesStatus, error)
-	// Migrate the operating system config.
+
+	// Migrate prepares the extension for migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.OperatingSystemResource] resource is being
+	// migrated to another seed cluster.
+	//
+	// Implementations should take care of storing any required state in the
+	// .status.state field, so that it can later be restored from this
+	// state.
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.OperatingSystemConfig) error
 }

--- a/extensions/pkg/controller/worker/actuator.go
+++ b/extensions/pkg/controller/worker/actuator.go
@@ -13,17 +13,57 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// Actuator acts upon Worker resources.
+// Actuator acts upon [extensionsv1alpha1.Worker] resources.
 type Actuator interface {
-	// Reconcile reconciles the Worker.
+	// Reconcile reconciles the [extensionsv1alpha1.Worker] resource.
+	//
+	// Implementations should ensure that any resources
+	// (e.g. MachineClasses, MachineDeployments, Secrets, etc.) are created
+	// or updated in order to reach their desired state.
 	Reconcile(context.Context, logr.Logger, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
-	// Delete deletes the Worker.
+
+	// Delete is invoked when the [extensionsv1alpha1.Worker] resource is
+	// deleted.
+	//
+	// Implementations should take care of cleaning up any resources
+	// (e.g. MachineClasses, MachineDeployments, Secrets, etc.), which were
+	// created by the Extension.
+	//
+	// Implementations must wait until all resources managed by the
+	// extension have been gracefully cleaned up.
 	Delete(context.Context, logr.Logger, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
-	// ForceDelete forcefully deletes the Worker.
+
+	// ForceDelete is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Worker] resource is being deleted in a forceful
+	// manner.
+	//
+	// Implementations should take care of unblocking the deletion flow by
+	// attempting to cleanup any resources created by the extension, remove
+	// any finalizers created for custom resources, etc., and also skip
+	// waiting for external resources, if they cannot be deleted gracefully.
+	//
+	// If some resources managed by the extension implementation cannot be
+	// deleted gracefully, this method should still succeed, even if some
+	// resources are orphaned.
 	ForceDelete(context.Context, logr.Logger, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
-	// Restore reads from the worker.status.state field and deploys the machines and machineSet
+
+	// Restore restores the [extensionsv1alpha1.Worker] from a previously
+	// saved state.
+	//
+	// For more details please refer to the following documentation.
+	//
+	// https://gardener.cloud/docs/gardener/extensions/migration/#implementation-details
 	Restore(context.Context, logr.Logger, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
-	// Migrate deletes the MCM, machineDeployments, machineClasses, machineClassSecrets,
-	// machineSets and the machines. The underlying VMs representing the Shoot nodes are not deleted
+
+	// Migrate prepares the [extensionsv1alpha1.Worker] resource for
+	// migration.
+	//
+	// This method is invoked when the shoot cluster associated with the
+	// [extensionsv1alpha1.Extension] resource is being migrated to another
+	// seed cluster.
+	//
+	// For more details, please refer to the following documentation.
+	//
+	// https://gardener.cloud/docs/gardener/extensions/migration/#implementation-details
 	Migrate(context.Context, logr.Logger, *extensionsv1alpha1.Worker, *extensionscontroller.Cluster) error
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

This PR improves the docstrings for the various extension interfaces.

Additional improvement to the extensions API would be to make the interfaces a bit more consistent -- for example some interface methods are passing the `Cluster` instance to extension controllers, while others do not. 

As part of a future PR we should probably standardize these, however that would be a breaking change, and will be addressed in a future PR.

This PR contains only improvement to the interface documentation.

cc: @rfranzke, @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
