### PR TITLE
Add a helper function to check for dual-stack IP family

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -49,6 +49,20 @@ func IsIPv6SingleStack(ipFamilies []IPFamily) bool {
 	return len(ipFamilies) == 1 && ipFamilies[0] == IPFamilyIPv6
 }
 
+// IsDualStack determines whether the given list of IP families specifies dual-stack networking (both IPv4 and IPv6).
+func IsDualStack(ipFamilies []IPFamily) bool {
+	hasIPv4 := false
+	hasIPv6 := false
+	for _, f := range ipFamilies {
+		if f == IPFamilyIPv4 {
+			hasIPv4 = true
+		} else if f == IPFamilyIPv6 {
+			hasIPv6 = true
+		}
+	}
+	return hasIPv4 && hasIPv6
+}
+
 // AccessRestriction describes an access restriction for a Kubernetes cluster (e.g., EU access-only).
 type AccessRestriction struct {
 	// Name is the name of the restriction.

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -53,10 +53,11 @@ func IsIPv6SingleStack(ipFamilies []IPFamily) bool {
 func IsDualStack(ipFamilies []IPFamily) bool {
 	hasIPv4 := false
 	hasIPv6 := false
-	for _, f := range ipFamilies {
-		if f == IPFamilyIPv4 {
+	for _, family := range ipFamilies {
+		switch family {
+		case IPFamilyIPv4:
 			hasIPv4 = true
-		} else if f == IPFamilyIPv6 {
+		case IPFamilyIPv6:
 			hasIPv6 = true
 		}
 	}

--- a/pkg/apis/core/types_test.go
+++ b/pkg/apis/core/types_test.go
@@ -44,6 +44,24 @@ var _ = Describe("API Types", func() {
 		})
 	})
 
+	Describe("#IsDualStack", func() {
+		It("should return false for empty IP families", func() {
+			Expect(IsDualStack(nil)).To(BeFalse())
+		})
+		It("should return false for IPv4 single-stack", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv4})).To(BeFalse())
+		})
+		It("should return false for IPv6 single-stack", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6})).To(BeFalse())
+		})
+		It("should return true for dual-stack in IPv4, IPv6 order", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv4, IPFamilyIPv6})).To(BeTrue())
+		})
+		It("should return true for dual-stack in IPv6, IPv4 order", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6, IPFamilyIPv4})).To(BeTrue())
+		})
+	})
+
 	DescribeTable("#VersionClassification.IsActive", func(v VersionClassification, want bool) {
 		Expect(v.IsActive()).To(Equal(want))
 	},

--- a/pkg/apis/core/types_test.go
+++ b/pkg/apis/core/types_test.go
@@ -54,6 +54,9 @@ var _ = Describe("API Types", func() {
 		It("should return false for IPv6 single-stack", func() {
 			Expect(IsDualStack([]IPFamily{IPFamilyIPv6})).To(BeFalse())
 		})
+		It("should return false for passing IPv6 twice", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6, IPFamilyIPv6})).To(BeFalse())
+		})
 		It("should return true for dual-stack in IPv4, IPv6 order", func() {
 			Expect(IsDualStack([]IPFamily{IPFamilyIPv4, IPFamilyIPv6})).To(BeTrue())
 		})

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -43,6 +43,20 @@ func IsIPv6SingleStack(ipFamilies []IPFamily) bool {
 	return len(ipFamilies) == 1 && ipFamilies[0] == IPFamilyIPv6
 }
 
+// IsDualStack determines whether the given list of IP families specifies dual-stack networking (both IPv4 and IPv6).
+func IsDualStack(ipFamilies []IPFamily) bool {
+	hasIPv4 := false
+	hasIPv6 := false
+	for _, family := range ipFamilies {
+		if family == IPFamilyIPv4 {
+			hasIPv4 = true
+		} else if family == IPFamilyIPv6 {
+			hasIPv6 = true
+		}
+	}
+	return hasIPv4 && hasIPv6
+}
+
 // AccessRestriction describes an access restriction for a Kubernetes cluster (e.g., EU access-only).
 type AccessRestriction struct {
 	// Name is the name of the restriction.

--- a/pkg/apis/core/v1beta1/types.go
+++ b/pkg/apis/core/v1beta1/types.go
@@ -48,9 +48,10 @@ func IsDualStack(ipFamilies []IPFamily) bool {
 	hasIPv4 := false
 	hasIPv6 := false
 	for _, family := range ipFamilies {
-		if family == IPFamilyIPv4 {
+		switch family {
+		case IPFamilyIPv4:
 			hasIPv4 = true
-		} else if family == IPFamilyIPv6 {
+		case IPFamilyIPv6:
 			hasIPv6 = true
 		}
 	}

--- a/pkg/apis/core/v1beta1/types_test.go
+++ b/pkg/apis/core/v1beta1/types_test.go
@@ -44,6 +44,24 @@ var _ = Describe("Types", func() {
 		})
 	})
 
+	Describe("#IsDualStack", func() {
+		It("should return false for empty IP families", func() {
+			Expect(IsDualStack(nil)).To(BeFalse())
+		})
+		It("should return false for IPv4 single-stack", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv4})).To(BeFalse())
+		})
+		It("should return false for IPv6 single-stack", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6})).To(BeFalse())
+		})
+		It("should return true for dual-stack in IPv4, IPv6 order", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv4, IPFamilyIPv6})).To(BeTrue())
+		})
+		It("should return true for dual-stack in IPv6, IPv4 order", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6, IPFamilyIPv4})).To(BeTrue())
+		})
+	})
+
 	DescribeTable("#VersionClassification.IsActive", func(v VersionClassification, want bool) {
 		Expect(v.IsActive()).To(Equal(want))
 	},

--- a/pkg/apis/core/v1beta1/types_test.go
+++ b/pkg/apis/core/v1beta1/types_test.go
@@ -54,6 +54,9 @@ var _ = Describe("Types", func() {
 		It("should return false for IPv6 single-stack", func() {
 			Expect(IsDualStack([]IPFamily{IPFamilyIPv6})).To(BeFalse())
 		})
+		It("should return false for passing IPv6 twice", func() {
+			Expect(IsDualStack([]IPFamily{IPFamilyIPv6, IPFamilyIPv6})).To(BeFalse())
+		})
 		It("should return true for dual-stack in IPv4, IPv6 order", func() {
 			Expect(IsDualStack([]IPFamily{IPFamilyIPv4, IPFamilyIPv6})).To(BeTrue())
 		})

--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -860,8 +859,7 @@ func getSearchPathRewrites(clusterDomain string, commonSuffixes []string) string
 
 // GetIPFamilyPolicy returns the IPFamilyPolicy for the CoreDNS service based on the provided IP families and cluster IPs.
 func GetIPFamilyPolicy(ipFamilies []gardencorev1beta1.IPFamily, clusterIPs []net.IP) corev1.IPFamilyPolicy {
-	ipFamiliesSet := sets.New(ipFamilies...)
-	if ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv4) && ipFamiliesSet.Has(gardencorev1beta1.IPFamilyIPv6) && hasIPv4andIPv6Address(clusterIPs) {
+	if gardencorev1beta1.IsDualStack(ipFamilies) && hasIPv4andIPv6Address(clusterIPs) {
 		return corev1.IPFamilyPolicyPreferDualStack
 	}
 	return corev1.IPFamilyPolicySingleStack

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -7,7 +7,6 @@ package gardener
 import (
 	"errors"
 	"fmt"
-	"slices"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
@@ -95,7 +94,7 @@ func getIPStackForFamilies(ipFamilies []gardencorev1beta1.IPFamily) string {
 	if gardencorev1beta1.IsIPv6SingleStack(ipFamilies) {
 		return AnnotationValueIPStackIPv6
 	}
-	if len(ipFamilies) == 2 && slices.Contains(ipFamilies, gardencorev1beta1.IPFamilyIPv4) && slices.Contains(ipFamilies, gardencorev1beta1.IPFamilyIPv6) {
+	if gardencorev1beta1.IsDualStack(ipFamilies) {
 		return AnnotationValueIPStackIPDualStack
 	}
 	// Fall-back to IPv4 per default


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
This PR adds dual-stack IP family detection and simplifies the related logic.
The newly introduced functionality can be reused by extension projects to react to specific network configurations. 

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
A new helper function is introduced to check for dual-stack IP family - `github.com/gardener/gardener/pkg/apis/{core,core/v1beta1}.IsDualStack`.
```
