### PR TITLE
Switch registry port in local setup from `:5000` to `:5001` again.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ kind-single-node-down kind-multi-node-down kind-multi-zone-down: $(KIND)
 export SKAFFOLD_BUILD_CONCURRENCY = 0
 # build the images for the platform matching the nodes of the active kubernetes cluster, even in `skaffold build`, which doesn't enable this by default
 export SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS = true
-export SKAFFOLD_DEFAULT_REPO = registry.local.gardener.cloud:5000
+export SKAFFOLD_DEFAULT_REPO = registry.local.gardener.cloud:5001
 export SKAFFOLD_PUSH = true
 export SOURCE_DATE_EPOCH = $(shell date -d $(BUILD_DATE) +%s)
 export GARDENER_VERSION = $(VERSION)

--- a/dev-setup/registry/config.yaml
+++ b/dev-setup/registry/config.yaml
@@ -10,9 +10,9 @@ storage:
   tag:
     concurrencylimit: 5
 http:
-  addr: ":5000"
+  addr: ":5001"
   debug:
-    addr: ":5001"
+    addr: ":5002"
 health:
   storagedriver:
     enabled: true

--- a/dev-setup/registry/docker-compose.yaml
+++ b/dev-setup/registry/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     container_name: registry
     image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
     ports:
-      - "5000:5000"
+      - "5001:5001"
     volumes:
       - ../../dev/local-registry/localhost:/var/lib/registry
       - ./config.yaml:/etc/distribution/config.yml

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -53,7 +53,7 @@ All following steps assume that you are using this kubeconfig.
 Additionally, this command also deploys a local container registry to the cluster, as well as a few registry mirrors, that are set up as a pull-through cache for all upstream registries Gardener uses by default.
 This is done to speed up image pulls across local clusters.
 
-The local registry can now be accessed either via `localhost:5000` or `registry.local.gardener.cloud:5000` for pushing and pulling.
+The local registry can now be accessed either via `localhost:5001` or `registry.local.gardener.cloud:5001` for pushing and pulling.
 The storage directories of the registries are mounted to the host machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 
@@ -81,7 +81,7 @@ First, ensure that your `/etc/hosts` file contains entries resolving `registry.l
 ```
 
 Typically, only `ip6-localhost` is mapped to `::1` on linux machines.
-However, we need `registry.local.gardener.cloud` to resolve to both `127.0.0.1` and `::1` so that we can talk to our registry via a single address (`registry.local.gardener.cloud:5000`).
+However, we need `registry.local.gardener.cloud` to resolve to both `127.0.0.1` and `::1` so that we can talk to our registry via a single address (`registry.local.gardener.cloud:5001`).
 
 Next, we need to configure NAT for outgoing traffic from the kind network to the internet.
 After executing `make kind-up IPFAMILY=ipv6`, execute the following command to set up the corresponding iptables rules:

--- a/docs/deployment/getting_started_locally_with_extensions.md
+++ b/docs/deployment/getting_started_locally_with_extensions.md
@@ -94,7 +94,7 @@ All of the following steps assume that you are using this kubeconfig.
 Additionally, this command deploys a local container registry to the cluster as well as a few registry mirrors that are set up as a pull-through cache for all upstream registries Gardener uses by default.
 This is done to speed up image pulls across local clusters.
 
-The local registry can now be accessed either via `localhost:5000` or `registry.local.gardener.cloud:5000` for pushing and pulling.
+The local registry can now be accessed either via `localhost:5001` or `registry.local.gardener.cloud:5001` for pushing and pulling.
 The storage directories of the registries are mounted to your machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 

--- a/docs/development/ipv6.md
+++ b/docs/development/ipv6.md
@@ -31,7 +31,7 @@ Please also take a look at the guide on [Deploying Gardener Locally](../deployme
 > $ mkdir -p /etc/docker
 > $ cat <<EOF > /etc/docker/daemon.json
 > {
->   "insecure-registries" : [ "registry.local.gardener.cloud:5000" ]
+>   "insecure-registries" : [ "registry.local.gardener.cloud:5001" ]
 > }
 > EOF
 > $ kill -1 $(pgrep dockerd)

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -128,7 +128,7 @@ function configure_node_mirror_new_local_registry() {
 }
 
 # TODO(LucaBernstein): remove this after v1.135 has been released.
-# To avoid issues in the upgrade test with the registry already listening to port 5001 instead of 5000, but the helmregistry only disabling tls for registry on port 5000.
+# To avoid issues in the upgrade test where the registry is already listening on port 5001 instead of 5000, but the helmregistry only disables tls for registry on port 5000.
 # see: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13661/pull-gardener-e2e-kind-upgrade/2000837721429381120
 function patch_helmregistry_registry_url_port() {
   sed -i 's|registry.local.gardener.cloud:5000|registry.local.gardener.cloud:5001|g' "$PWD/pkg/utils/oci/helmregistry.go"

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -101,6 +101,7 @@ function install_previous_release() {
   copy_kubeconfig_from_kubeconfig_env_var
   migrate_kind_network_range
   configure_node_mirror_new_local_registry
+  patch_helmregistry_registry_url_port
   gardener_up
   popd >/dev/null
 }
@@ -124,9 +125,12 @@ function configure_node_mirror_new_local_registry() {
   # and need to configure containerd to use HTTP for pulling from the local registry
   cp "$next_version_dir/pkg/provider-local/node/Dockerfile" "$PWD/pkg/provider-local/node"
   cp -r "$next_version_dir/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5001" "$PWD/pkg/provider-local/node/containerd"
-  # TODO(LucaBernstein): remove this after v1.135 has been released.
-  # To avoid issues in the upgrade test with the registry already listening to port 5001 instead of 5000, but the helmregistry only disabling tls for registry on port 5000.
-  # see: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13661/pull-gardener-e2e-kind-upgrade/2000837721429381120
+}
+
+# TODO(LucaBernstein): remove this after v1.135 has been released.
+# To avoid issues in the upgrade test with the registry already listening to port 5001 instead of 5000, but the helmregistry only disabling tls for registry on port 5000.
+# see: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13661/pull-gardener-e2e-kind-upgrade/2000837721429381120
+function patch_helmregistry_registry_url_port() {
   sed -i 's|registry.local.gardener.cloud:5000|registry.local.gardener.cloud:5001|g' "$PWD/pkg/utils/oci/helmregistry.go"
 }
 

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -124,6 +124,10 @@ function configure_node_mirror_new_local_registry() {
   # and need to configure containerd to use HTTP for pulling from the local registry
   cp "$next_version_dir/pkg/provider-local/node/Dockerfile" "$PWD/pkg/provider-local/node"
   cp -r "$next_version_dir/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5001" "$PWD/pkg/provider-local/node/containerd"
+  # TODO(LucaBernstein): remove this after v1.135 has been released.
+  # To avoid issues in the upgrade test with the registry already listening to port 5001 instead of 5000, but the helmregistry only disabling tls for registry on port 5000.
+  # see: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13661/pull-gardener-e2e-kind-upgrade/2000837721429381120
+  sed -i 's|registry.local.gardener.cloud:5000|registry.local.gardener.cloud:5001|g' "$PWD/pkg/utils/oci/helmregistry.go"
 }
 
 function upgrade_to_next_release() {

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -38,6 +38,9 @@ function gardener_up() {
   # TODO(timebertt): remove sed and SKAFFOLD_DEFAULT_REPO override after v1.134 has been released
   # see https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13551/pull-gardener-e2e-kind-upgrade/1993794625793429504
   sed -i 's|garden.local.gardener.cloud:5001|registry.local.gardener.cloud:5001|g' skaffold*.yaml
+  # TODO(LucaBernstein,timebertt): remove sed override after v1.135 has been released
+  # due to reverting the port of the local registry from 5000 to 5001 again: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13661/pull-gardener-e2e-kind-upgrade/2000609122042515456
+  sed -i 's|registry.local.gardener.cloud:5000|registry.local.gardener.cloud:5001|g' skaffold*.yaml
   case "$SHOOT_FAILURE_TOLERANCE_TYPE" in
   node)
     make operator-seed-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001

--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -37,16 +37,16 @@ function copy_kubeconfig_from_kubeconfig_env_var() {
 function gardener_up() {
   # TODO(timebertt): remove sed and SKAFFOLD_DEFAULT_REPO override after v1.134 has been released
   # see https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13551/pull-gardener-e2e-kind-upgrade/1993794625793429504
-  sed -i 's|garden.local.gardener.cloud:5001|registry.local.gardener.cloud:5000|g' skaffold*.yaml
+  sed -i 's|garden.local.gardener.cloud:5001|registry.local.gardener.cloud:5001|g' skaffold*.yaml
   case "$SHOOT_FAILURE_TOLERANCE_TYPE" in
   node)
-    make operator-seed-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5000
+    make operator-seed-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001
     ;;
   zone)
-    make operator-seed-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5000
+    make operator-seed-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001
     ;;
   *)
-    make gardener-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5000
+    make gardener-up SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001
     ;;
   esac
 }
@@ -120,7 +120,7 @@ function configure_node_mirror_new_local_registry() {
   # this is necessary because we already push the images to the new local registry (see the SKAFFOLD_DEFAULT_REPO hack above)
   # and need to configure containerd to use HTTP for pulling from the local registry
   cp "$next_version_dir/pkg/provider-local/node/Dockerfile" "$PWD/pkg/provider-local/node"
-  cp -r "$next_version_dir/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5000" "$PWD/pkg/provider-local/node/containerd"
+  cp -r "$next_version_dir/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5001" "$PWD/pkg/provider-local/node/containerd"
 }
 
 function upgrade_to_next_release() {

--- a/hack/gardener-extensions-up.sh
+++ b/hack/gardener-extensions-up.sh
@@ -47,13 +47,13 @@ fi
 echo "Configure seed cluster"
 "$SCRIPT_DIR"/../example/provider-extensions/seed/configure-seed.sh "$PATH_GARDEN_KUBECONFIG" "$PATH_SEED_KUBECONFIG" "$SEED_NAME" "$WORKLOAD_IDENTITY_SUPPORT"
 echo "Start bootstrapping Gardener"
-SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5000 SKAFFOLD_PUSH=true skaffold run -m etcd,controlplane -p extensions
+SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001 SKAFFOLD_PUSH=true skaffold run -m etcd,controlplane -p extensions
 if [[ "$WORKLOAD_IDENTITY_SUPPORT" == "true" ]]; then
   SKAFFOLD_EXTENSIONS_PROFILE=extensions-with-workload-identity
 else
   SKAFFOLD_EXTENSIONS_PROFILE=extensions-without-workload-identity
 fi
-SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5000 SKAFFOLD_PUSH=true skaffold run -m extensions-env -p "$SKAFFOLD_EXTENSIONS_PROFILE"
+SKAFFOLD_DEFAULT_REPO=registry.local.gardener.cloud:5001 SKAFFOLD_PUSH=true skaffold run -m extensions-env -p "$SKAFFOLD_EXTENSIONS_PROFILE"
 echo "Configure admission controllers"
 "$SCRIPT_DIR"/../example/provider-extensions/garden/configure-admission.sh "$PATH_GARDEN_KUBECONFIG" apply
 echo "Registering controllers"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -111,11 +111,11 @@ setup_containerd_registry_mirrors() {
     # For the local registry, we don't need a mirror config for switching the URL, but only for configuring containerd
     # to use HTTP instead of HTTPS. Probably, we could use the insecure registries config for this. However, configuring
     # mirrors is supported by gardener-node-agent via the OSC, so we use the same approach everywhere.
-    setup_containerd_registry_mirror "$NODE" "registry.local.gardener.cloud:5000" "http://registry.local.gardener.cloud:5000" "http://registry.local.gardener.cloud:5000"
-    setup_containerd_registry_mirror "$NODE" "gcr.io" "https://gcr.io" "http://gcr.registry-cache.local.gardener.cloud:5000"
-    setup_containerd_registry_mirror "$NODE" "registry.k8s.io" "https://registry.k8s.io" "http://k8s.registry-cache.local.gardener.cloud:5000"
-    setup_containerd_registry_mirror "$NODE" "quay.io" "https://quay.io" "http://quay.registry-cache.local.gardener.cloud:5000"
-    setup_containerd_registry_mirror "$NODE" "europe-docker.pkg.dev" "https://europe-docker.pkg.dev" "http://europe-docker-pkg-dev.registry-cache.local.gardener.cloud:5000"
+    setup_containerd_registry_mirror "$NODE" "registry.local.gardener.cloud:5001" "http://registry.local.gardener.cloud:5001" "http://registry.local.gardener.cloud:5001"
+    setup_containerd_registry_mirror "$NODE" "gcr.io" "https://gcr.io" "http://gcr.registry-cache.local.gardener.cloud:5001"
+    setup_containerd_registry_mirror "$NODE" "registry.k8s.io" "https://registry.k8s.io" "http://k8s.registry-cache.local.gardener.cloud:5001"
+    setup_containerd_registry_mirror "$NODE" "quay.io" "https://quay.io" "http://quay.registry-cache.local.gardener.cloud:5001"
+    setup_containerd_registry_mirror "$NODE" "europe-docker.pkg.dev" "https://europe-docker.pkg.dev" "http://europe-docker-pkg-dev.registry-cache.local.gardener.cloud:5001"
   done
 }
 
@@ -147,10 +147,10 @@ change_registry_upstream_urls_to_prow_caches() {
   REGISTRY_COMPOSE_FILE="$mutated_compose_file"
 
   declare -A prow_registry_cache_urls=(
-    [gcr]="http://registry-gcr-io.kube-system.svc.cluster.local:5000"
-    [k8s]="http://registry-registry-k8s-io.kube-system.svc.cluster.local:5000"
-    [quay]="http://registry-quay-io.kube-system.svc.cluster.local:5000"
-    [europe-docker-pkg-dev]="http://registry-europe-docker-pkg-dev.kube-system.svc.cluster.local:5000"
+    [gcr]="http://registry-gcr-io.kube-system.svc.cluster.local:5001"
+    [k8s]="http://registry-registry-k8s-io.kube-system.svc.cluster.local:5001"
+    [quay]="http://registry-quay-io.kube-system.svc.cluster.local:5001"
+    [europe-docker-pkg-dev]="http://registry-europe-docker-pkg-dev.kube-system.svc.cluster.local:5001"
   )
 
   echo "Running in CI. Checking availability of registry-cache instances in prow cluster"
@@ -158,9 +158,9 @@ change_registry_upstream_urls_to_prow_caches() {
   for key in "${!prow_registry_cache_urls[@]}"; do
     registry_cache_url="${prow_registry_cache_urls[$key]}"
 
-    # Extract DNS from URL (remove http:// and :5000)
+    # Extract DNS from URL (remove http:// and :5001)
     registry_cache_dns="${registry_cache_url#http://}"
-    registry_cache_dns="${registry_cache_dns%:5000}"
+    registry_cache_dns="${registry_cache_dns%:5001}"
 
     registry_cache_ip=$(getent hosts "$registry_cache_dns" | awk '{ print $1 }' || true)
     if [[ "$registry_cache_ip" == "" ]]; then

--- a/hack/push-helm.sh
+++ b/hack/push-helm.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-# IMAGE is set from skaffold, and looks like "registry.local.gardener.cloud:5000/europe-docker_pkg_dev_gardener-project_releases_gardener_extensions_provider-local:v1.95.0-dev-2f85d6a4e-dirty"
+# IMAGE is set from skaffold, and looks like "registry.local.gardener.cloud:5001/europe-docker_pkg_dev_gardener-project_releases_gardener_extensions_provider-local:v1.95.0-dev-2f85d6a4e-dirty"
 # IMG looks the same and comes from requires.alias in the skaffold Config.
 
 chart_path=${1:-./charts/gardener/provider-local}
@@ -32,7 +32,7 @@ yq -i ".name |= \"$name\"" "$chart_dir/Chart.yaml"
 
 helm package "$chart_dir" -d "$chart_dir" --version "$tag"
 
-if echo $registry | grep -q -F "registry.local.gardener.cloud:5000"; then
+if echo $registry | grep -q -F "registry.local.gardener.cloud:5001"; then
     push_http="--plain-http"
 fi 
 

--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -10,7 +10,7 @@ RUN rm -f /etc/systemd/system/kubelet.service && \
 # copy containerd hosts configurations for local registry mirrors
 COPY containerd /etc/containerd/certs.d/
 # names with colon are not allowed in the directory name checked into Git as it breaks go mod if gardener/gardener is used as a module
-RUN mv /etc/containerd/certs.d/registry.local.gardener.cloud_5000 /etc/containerd/certs.d/registry.local.gardener.cloud:5000
+RUN mv /etc/containerd/certs.d/registry.local.gardener.cloud_5001 /etc/containerd/certs.d/registry.local.gardener.cloud:5001
 
 # add our userdata executor unit
 COPY run-userdata.sh /run-userdata.sh

--- a/pkg/provider-local/node/containerd/europe-docker.pkg.dev/hosts.toml
+++ b/pkg/provider-local/node/containerd/europe-docker.pkg.dev/hosts.toml
@@ -1,5 +1,5 @@
 # europe-docker.pkg.dev upstream is required for loading the Hyperkube image.
 server = "https://europe-docker.pkg.dev"
 
-[host."http://europe-docker-pkg-dev.registry-cache.local.gardener.cloud:5000"]
+[host."http://europe-docker-pkg-dev.registry-cache.local.gardener.cloud:5001"]
   capabilities = ["pull", "resolve"]

--- a/pkg/provider-local/node/containerd/gcr.io/hosts.toml
+++ b/pkg/provider-local/node/containerd/gcr.io/hosts.toml
@@ -1,4 +1,4 @@
 server = "https://gcr.io"
 
-[host."http://gcr.registry-cache.local.gardener.cloud:5000"]
+[host."http://gcr.registry-cache.local.gardener.cloud:5001"]
   capabilities = ["pull", "resolve"]

--- a/pkg/provider-local/node/containerd/quay.io/hosts.toml
+++ b/pkg/provider-local/node/containerd/quay.io/hosts.toml
@@ -1,4 +1,4 @@
 server = "https://quay.io"
 
-[host."http://quay.registry-cache.local.gardener.cloud:5000"]
+[host."http://quay.registry-cache.local.gardener.cloud:5001"]
   capabilities = ["pull", "resolve"]

--- a/pkg/provider-local/node/containerd/registry.k8s.io/hosts.toml
+++ b/pkg/provider-local/node/containerd/registry.k8s.io/hosts.toml
@@ -1,4 +1,4 @@
 server = "https://registry.k8s.io"
 
-[host."http://k8s.registry-cache.local.gardener.cloud:5000"]
+[host."http://k8s.registry-cache.local.gardener.cloud:5001"]
   capabilities = ["pull", "resolve"]

--- a/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5000/hosts.toml
+++ b/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5000/hosts.toml
@@ -1,5 +1,0 @@
-# Enable containerd to reach registry at registry.local.gardener.cloud:5000 via HTTP.
-server = "http://registry.local.gardener.cloud:5000"
-
-[host."http://registry.local.gardener.cloud:5000"]
-  capabilities = ["pull", "resolve"]

--- a/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5001/hosts.toml
+++ b/pkg/provider-local/node/containerd/registry.local.gardener.cloud_5001/hosts.toml
@@ -1,0 +1,6 @@
+# Enable containerd to reach registry at registry.local.gardener.cloud:5001 via HTTP.
+# Beware: Port `:5000` cannot be used, as it conflicts with the default port allocation for the `AirPlay Receiver` on MacOS.
+server = "http://registry.local.gardener.cloud:5001"
+
+[host."http://registry.local.gardener.cloud:5001"]
+  capabilities = ["pull", "resolve"]

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -25,7 +25,7 @@ import (
 const (
 	mediaTypeHelm = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
-	localRegistry = "registry.local.gardener.cloud:5000"
+	localRegistry = "registry.local.gardener.cloud:5001"
 )
 
 type pullSecretNamespace struct{}

--- a/pkg/utils/oci/helmregistry_test.go
+++ b/pkg/utils/oci/helmregistry_test.go
@@ -190,8 +190,8 @@ var _ = Describe("buildRef", func() {
 			mustNewDigest("example.com/foo@"+digest),
 		),
 		Entry("configure insecure in local setup when using registry.local.gardener.cloud",
-			&gardencorev1.OCIRepository{Ref: ptr.To("registry.local.gardener.cloud:5000/foo:1.0.0")},
-			name.MustParseReference("registry.local.gardener.cloud:5000/foo:1.0.0", name.Insecure),
+			&gardencorev1.OCIRepository{Ref: ptr.To("registry.local.gardener.cloud:5001/foo:1.0.0")},
+			name.MustParseReference("registry.local.gardener.cloud:5001/foo:1.0.0", name.Insecure),
 		),
 	)
 })

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1011,7 +1011,7 @@ build:
                 kubectl --kubeconfig="$VIRTUAL_GARDEN_KUBECONFIG" -n garden patch gardenlet self-hosted-shoot-root --type=merge -p "{\"spec\":{\"deployment\":{\"helm\":{\"ociRepository\":{\"ref\":\"$SKAFFOLD_IMAGE\"}}}}}" || true
 
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'
@@ -1032,7 +1032,7 @@ build:
       context: pkg/provider-local/node
       docker: {}
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'
@@ -1304,7 +1304,7 @@ build:
         - image: local-skaffold/gardener-extension-provider-local
           alias: IMG
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -977,7 +977,7 @@ build:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-admission-controller
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'
@@ -1429,7 +1429,7 @@ build:
           paths:
             - charts/gardener/admission-local/charts/application
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -8,7 +8,7 @@ build:
       context: pkg/provider-local/node
       docker: {}
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
 manifests:
   kustomize:
     paths:
@@ -660,7 +660,7 @@ build:
               - image
               - gardener-node-agent
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -546,7 +546,7 @@ build:
           - '{{.LD_FLAGS}}'
         main: ./cmd/gardener-admission-controller
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'
@@ -905,7 +905,7 @@ build:
         - image: local-skaffold/gardener-extension-provider-local
           alias: IMG
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'
@@ -1623,7 +1623,7 @@ build:
               - image
               - gardener-node-agent
   insecureRegistries:
-    - registry.local.gardener.cloud:5000
+    - registry.local.gardener.cloud:5001
   tagPolicy:
     customTemplate:
       template: '{{.version}}-{{.sha}}'

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -176,7 +176,7 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 			for file, content := range map[string]string{
 				"manifests/shootstate.yaml":  "apiVersion: core.gardener.cloud/v1beta1\nkind: ShootState\n",
 				"manifests/manifests.yaml":   "apiVersion: core.gardener.cloud/v1beta1\nkind: Shoot\n",
-				"imagevector-overwrite.yaml": "registry.local.gardener.cloud:5000/local-skaffold_gardenadm",
+				"imagevector-overwrite.yaml": "registry.local.gardener.cloud:5001/local-skaffold_gardenadm",
 			} {
 				Eventually(ctx, func(g Gomega) *gbytes.Buffer {
 					stdOut, _, err := RunInMachine(ctx, technicalID, 0, "cat", "/var/lib/gardenadm/"+file)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Port `:5000` conflicts with the default port for the `AirPlay Receiver` on MacOS which seems to be enabled by default. It can be disabled via `System Settings > General > AirDrop & Handoff > AirPlay Receiver`, though best would be to switch to port `:5001` again for our registry.

**Which issue(s) this PR fixes**:
This commit partly reverts 7d0b1a60584955172100e0548ecb63e24e3e8399.

**Special notes for your reviewer**:
/cc @rfranzke @timuthy
fyi @timebertt @marc1404

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
Change the registry port in the local setup to `:5001`.
```
