### PR TITLE
Add `SecretsManager` utility for garden extensions

### DIFF
--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -131,8 +131,8 @@ func lastSecretRotationStartTimesFromCluster(cluster *extensionscontroller.Clust
 // If garden.status.credentials.certificateAuthorities.lastInitiationTime is set, it adds the time for all given
 // CA configs. If it's not set or no CA configs are given, nil will be returned.
 func lastSecretRotationStartTimesFromGarden(garden *operatorv1alpha1.Garden, secretConfigs []SecretConfigWithOptions) map[string]time.Time {
-	if shootStatus := garden.Status; shootStatus.Credentials != nil && shootStatus.Credentials.Rotation != nil {
-		return lastSecretRotationStartTimesFromCARotation(shootStatus.Credentials.Rotation.CertificateAuthorities, secretConfigs)
+	if gardenStatus := garden.Status; gardenStatus.Credentials != nil && gardenStatus.Credentials.Rotation != nil {
+		return lastSecretRotationStartTimesFromCARotation(gardenStatus.Credentials.Rotation.CertificateAuthorities, secretConfigs)
 	}
 
 	return nil

--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -95,7 +95,7 @@ func SecretsManagerForGarden(
 }
 
 // secretsManager wraps another SecretsManager in order to automatically fulfill the CA rotation requirements based on
-// the Shoot status from the given Cluster object.
+// the given rotation phase.
 type secretsManager struct {
 	secretsmanager.Interface
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
Add a `SecretsManager` utility for extensions that support deployment to the garden cluster. With this change, extensions can, for instance, manage certificates for webhooks while leveraging Gardener's certificate automation features (such as CA rotation, renewal, etc.).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev @theoddora

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to create a `SecretsManager` based on a `Garden` resource. Extensions can, for instance, manage certificates for webhooks in the garden runtime cluster while leveraging Gardener's certificate automation features (such as CA rotation, renewal, etc.).
```
