### PR TITLE
Reliably capture kernel logs using `SYSLOG_IDENTIFIER`

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -99,11 +99,26 @@ receivers:
     start_at: beginning
     storage: file_storage
     matches:
-      - _TRANSPORT: kernel
+      - SYSLOG_IDENTIFIER: kernel
       - _SYSTEMD_UNIT: kubelet.service
       - _SYSTEMD_UNIT: containerd.service
       - _SYSTEMD_UNIT: gardener-node-agent.service
+    # A cleaner approach would be to use the 'identifier' field instead of the
+    # 'matches' field. However, the 'identifier' field uses the 'SYSLOG_IDENTIFIER'
+    # journal field, which does not include the '-service' suffix of systemd units.
+    # Due to backwards compatibility, we want to continue representing the 'unit'
+    # field with the full systemd unit name (including the '-service' suffix).
+    # Due to this, it is required we filter based on the '_SYSTEMD_UNIT' field.
+    # We can then rely on it to set the 'resource.unit' field correctly.
+    # TODO(rrhubenov): Reimplement this using the 'identifier' field once
+    # we move from 'Vali' to 'VictoriaLogs'. Revisit whether 
+    # - we still want to call the field 'unit'
+    # - we can remove the '-service' suffix
     operators:
+      - type: move
+        if: 'body.SYSLOG_IDENTIFIER == "kernel"'
+        from: body.SYSLOG_IDENTIFIER
+        to:  body._SYSTEMD_UNIT
       - type: move
         from: body._SYSTEMD_UNIT
         to: resource.unit


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
The previous way to capture kernel logs was unreliable due to the "kernel" logs not always being with a _TRANSPORT=kernel in journald.
This fix aims to rectify this.

Valitail currently does this by relying on the `SYSLOG_IDENTIFIER` field from the systemd.journal-field.
However, for some reason the `valitail` is specifically configured so that there is a '-service' suffix for the `unit` label when identifying the logging resource. This requires that there is also such a mechanism in the collector so that there is backwards compatibility between the label and label values.

This is done by relying on the `_SYSTEMD_UNIT` journal field.
Actually, valitail does almost the same thing currently.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Refactor the collector `journald` receiver to capture kernel logs via a more stable method.
```
