### PR TITLE
Use `OperatorConfiguration` to setup `etcd-druid` instead of CLI flags

### DIFF
--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -662,6 +662,10 @@ func getEtcdOperatorConfig(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, names
 				ConcurrentSyncs: ptr.To(int(*etcdConfig.BackupCompactionController.Workers)),
 				EventsThreshold: *etcdConfig.BackupCompactionController.EventsThreshold,
 			},
+			EtcdCopyBackupsTask: druidconfigv1alpha1.EtcdCopyBackupsTaskControllerConfiguration{
+				// Preserve backwards-compatibility with CLI flags, where it is enabled by default.
+				Enabled: true,
+			},
 			EtcdOpsTask: druidconfigv1alpha1.EtcdOpsTaskControllerConfiguration{
 				ConcurrentSyncs: ptr.To(3),
 				RequeueInterval: &metav1.Duration{Duration: 15 * time.Second},

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -674,7 +673,10 @@ func getEtcdOperatorConfig(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, names
 				ExemptServiceAccounts: []string{
 					"system:serviceaccount:kube-system:generic-garbage-collector",
 				},
-				ReconcilerServiceAccountFQDN: ptr.To(fmt.Sprintf("%s%s:%s", serviceaccount.ServiceAccountUsernamePrefix, namespace, druidServiceAccountName)),
+				ServiceAccountInfo: &druidconfigv1alpha1.ServiceAccountInfo{
+					Name:      druidServiceAccountName,
+					Namespace: namespace,
+				},
 			},
 		},
 	}

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -676,6 +676,9 @@ func getEtcdOperatorConfig(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, names
 				ExemptServiceAccounts: []string{
 					"system:serviceaccount:kube-system:generic-garbage-collector",
 				},
+				// `AutomountServiceAccountToken` is set to false for the etcd-druid controller deployment,
+				// but GRM has a mutating webhook to mount the service account token as a projected volume.
+				// So, it is safe to provide this service account configuration to the etcd-druid controller.
 				ServiceAccountInfo: &druidconfigv1alpha1.ServiceAccountInfo{
 					Name:      druidServiceAccountName,
 					Namespace: namespace,

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -609,7 +609,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	}
 
 	configMapOperatorConfig.Data = map[string]string{druidConfigMapOperatorConfigDataKey: etcdOperatorConfigYAML}
-	utilruntime.Must(kubernetesutils.MakeUnique(configMapOperatorConfig))
 	resourcesToAdd = append(resourcesToAdd, configMapOperatorConfig)
 
 	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -69,6 +69,61 @@ var _ = Describe("Etcd", func() {
 
 		managedResourceName       = "etcd-druid"
 		managedResourceSecretName = "managedresource-" + managedResourceName
+		etcdOperatorConfigYAML    = ptr.To(`clientConnection:
+  acceptContentTypes: ""
+  burst: 150
+  contentType: ""
+  qps: 100
+controllers:
+  compaction:
+    activeDeadlineDuration: 3h0m0s
+    concurrentSyncs: 3
+    enabled: true
+    eventsThreshold: 1000000
+    metricsScrapeWaitDuration: 1m0s
+    triggerFullSnapshotThreshold: 3000000
+  disableLeaseCache: false
+  etcd:
+    concurrentSyncs: 25
+    disableEtcdServiceAccountAutomount: true
+    enableEtcdSpecAutoReconcile: false
+    etcdMember:
+      notReadyThreshold: 5m0s
+      unknownThreshold: 1m0s
+    etcdStatusSyncPeriod: 15s
+  etcdCopyBackupsTask:
+    enabled: false
+  etcdOpsTask:
+    concurrentSyncs: 3
+    requeueInterval: 15s
+  secret:
+    concurrentSyncs: 10
+leaderElection:
+  enabled: true
+  leaseDuration: 15s
+  renewDeadline: 10s
+  resourceLock: leases
+  resourceName: druid-leader-election
+  retryPeriod: 2s
+logging:
+  logFormat: json
+  logLevel: info
+server:
+  metrics:
+    bindAddress: ""
+    port: 8080
+  webhooks:
+    bindAddress: ""
+    port: 10250
+    serverCertDir: /etc/webhook-server-tls
+webhooks:
+  etcdComponentProtection:
+    enabled: true
+    exemptServiceAccounts:
+    - system:serviceaccount:kube-system:generic-garbage-collector
+    reconcilerServiceAccountFQDN: system:serviceaccount:` + namespace + `:etcd-druid
+    serviceAccountInfo: null
+`)
 	)
 
 	JustBeforeEach(func() {
@@ -116,7 +171,8 @@ var _ = Describe("Etcd", func() {
 		var (
 			expectedResources []client.Object
 
-			configMapName = "etcd-druid-imagevector-overwrite-4475dd36"
+			imageVectorConfigMapName    = "etcd-druid-imagevector-overwrite-4475dd36"
+			operatorConfigConfigMapName = "etcd-druid-operator-config-7b7155bb"
 
 			serviceAccount = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
@@ -263,7 +319,7 @@ var _ = Describe("Etcd", func() {
 
 			configMapImageVectorOverwrite = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
+					Name:      imageVectorConfigMapName,
 					Namespace: namespace,
 					Labels: map[string]string{
 						"gardener.cloud/role": "etcd-druid",
@@ -272,6 +328,21 @@ var _ = Describe("Etcd", func() {
 				},
 				Data: map[string]string{
 					"images_overwrite.yaml": *imageVectorOverwriteFull,
+				},
+				Immutable: ptr.To(true),
+			}
+
+			configMapOperatorConfig = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      operatorConfigConfigMapName,
+					Namespace: namespace,
+					Labels: map[string]string{
+						"gardener.cloud/role": "etcd-druid",
+						"resources.gardener.cloud/garbage-collectable-reference": "true",
+					},
+				},
+				Data: map[string]string{
+					"config.yaml": *etcdOperatorConfigYAML,
 				},
 				Immutable: ptr.To(true),
 			}
@@ -285,7 +356,8 @@ var _ = Describe("Etcd", func() {
 						"high-availability-config.resources.gardener.cloud/type": "controller",
 					},
 					Annotations: map[string]string{
-						references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"): "etcd-druid-webhook",
+						references.AnnotationKey(references.KindConfigMap, operatorConfigConfigMapName): operatorConfigConfigMapName,
+						references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"):           "etcd-druid-webhook",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -305,29 +377,15 @@ var _ = Describe("Etcd", func() {
 								"networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080": "allowed",
 							},
 							Annotations: map[string]string{
-								references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"): "etcd-druid-webhook",
+								references.AnnotationKey(references.KindConfigMap, operatorConfigConfigMapName): operatorConfigConfigMapName,
+								references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"):           "etcd-druid-webhook",
 							},
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
 									Args: []string{
-										"--enable-leader-election=true",
-										"--disable-etcd-serviceaccount-automount=true",
-										"--etcd-workers=25",
-										"--enable-etcd-spec-auto-reconcile=false",
-										"--webhook-server-port=10250",
-										"--webhook-server-tls-server-cert-dir=/etc/webhook-server-tls",
-										"--enable-etcd-components-webhook=true",
-										"--etcd-components-webhook-exempt-service-accounts=system:serviceaccount:kube-system:generic-garbage-collector",
-										"--enable-backup-compaction=true",
-										"--compaction-workers=3",
-										"--etcd-events-threshold=1000000",
-										"--etcd-ops-task-workers=3",
-										"--etcd-ops-task-requeue-interval=15s",
-										"--reconciler-service-account=system:serviceaccount:" + namespace + ":etcd-druid",
-										"--metrics-scrape-wait-duration=1m0s",
-										"--active-deadline-duration=3h0m0s",
+										"--config=/operator_config/config.yaml",
 									},
 									Image:           etcdDruidImage,
 									ImagePullPolicy: corev1.PullIfNotPresent,
@@ -352,6 +410,11 @@ var _ = Describe("Etcd", func() {
 											Name:      "webhook-server-tls-cert",
 											ReadOnly:  true,
 										},
+										{
+											MountPath: "/operator_config",
+											Name:      "operator-config",
+											ReadOnly:  true,
+										},
 									},
 								},
 							},
@@ -365,6 +428,16 @@ var _ = Describe("Etcd", func() {
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "etcd-druid-webhook",
 											DefaultMode: ptr.To[int32](420),
+										},
+									},
+								},
+								{
+									Name: "operator-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: operatorConfigConfigMapName,
+											},
 										},
 									},
 								},
@@ -383,8 +456,9 @@ var _ = Describe("Etcd", func() {
 						"high-availability-config.resources.gardener.cloud/type": "controller",
 					},
 					Annotations: map[string]string{
-						references.AnnotationKey(references.KindConfigMap, configMapName):     configMapName,
-						references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"): "etcd-druid-webhook",
+						references.AnnotationKey(references.KindConfigMap, imageVectorConfigMapName):    imageVectorConfigMapName,
+						references.AnnotationKey(references.KindConfigMap, operatorConfigConfigMapName): operatorConfigConfigMapName,
+						references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"):           "etcd-druid-webhook",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -404,30 +478,16 @@ var _ = Describe("Etcd", func() {
 								"networking.resources.gardener.cloud/to-all-shoots-etcd-main-client-tcp-8080": "allowed",
 							},
 							Annotations: map[string]string{
-								references.AnnotationKey(references.KindConfigMap, configMapName):     configMapName,
-								references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"): "etcd-druid-webhook",
+								references.AnnotationKey(references.KindConfigMap, imageVectorConfigMapName):    imageVectorConfigMapName,
+								references.AnnotationKey(references.KindConfigMap, operatorConfigConfigMapName): operatorConfigConfigMapName,
+								references.AnnotationKey(references.KindSecret, "etcd-druid-webhook"):           "etcd-druid-webhook",
 							},
 						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
 									Args: []string{
-										"--enable-leader-election=true",
-										"--disable-etcd-serviceaccount-automount=true",
-										"--etcd-workers=25",
-										"--enable-etcd-spec-auto-reconcile=false",
-										"--webhook-server-port=10250",
-										"--webhook-server-tls-server-cert-dir=/etc/webhook-server-tls",
-										"--enable-etcd-components-webhook=true",
-										"--etcd-components-webhook-exempt-service-accounts=system:serviceaccount:kube-system:generic-garbage-collector",
-										"--enable-backup-compaction=true",
-										"--compaction-workers=3",
-										"--etcd-events-threshold=1000000",
-										"--etcd-ops-task-workers=3",
-										"--etcd-ops-task-requeue-interval=15s",
-										"--reconciler-service-account=system:serviceaccount:" + namespace + ":etcd-druid",
-										"--metrics-scrape-wait-duration=1m0s",
-										"--active-deadline-duration=3h0m0s",
+										"--config=/operator_config/config.yaml",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -463,6 +523,11 @@ var _ = Describe("Etcd", func() {
 											Name:      "imagevector-overwrite",
 											ReadOnly:  true,
 										},
+										{
+											MountPath: "/operator_config",
+											Name:      "operator-config",
+											ReadOnly:  true,
+										},
 									},
 								},
 							},
@@ -484,7 +549,17 @@ var _ = Describe("Etcd", func() {
 									VolumeSource: corev1.VolumeSource{
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
-												Name: configMapName,
+												Name: imageVectorConfigMapName,
+											},
+										},
+									},
+								},
+								{
+									Name: "operator-config",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: operatorConfigConfigMapName,
 											},
 										},
 									},
@@ -738,6 +813,7 @@ var _ = Describe("Etcd", func() {
 			Expect(managedResource).To(DeepEqual(expectedMr))
 
 			expectedResources = []client.Object{
+				configMapOperatorConfig,
 				serviceAccount,
 				clusterRole,
 				clusterRoleBinding,

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -69,7 +69,8 @@ var _ = Describe("Etcd", func() {
 
 		managedResourceName       = "etcd-druid"
 		managedResourceSecretName = "managedresource-" + managedResourceName
-		etcdOperatorConfigYAML    = ptr.To(`clientConnection:
+		etcdOperatorConfigYAML    = ptr.To(`apiVersion: config.druid.gardener.cloud/v1alpha1
+clientConnection:
   acceptContentTypes: ""
   burst: 150
   contentType: ""
@@ -98,6 +99,7 @@ controllers:
     requeueInterval: 15s
   secret:
     concurrentSyncs: 10
+kind: OperatorConfiguration
 leaderElection:
   enabled: true
   leaseDuration: 15s
@@ -172,7 +174,7 @@ webhooks:
 			expectedResources []client.Object
 
 			imageVectorConfigMapName    = "etcd-druid-imagevector-overwrite-4475dd36"
-			operatorConfigConfigMapName = "etcd-druid-operator-config-7b7155bb"
+			operatorConfigConfigMapName = "etcd-druid-operator-config-3b019ffb"
 
 			serviceAccount = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -551,21 +551,21 @@ webhooks:
 									},
 								},
 								{
-									Name: "imagevector-overwrite",
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: imageVectorConfigMapName,
-											},
-										},
-									},
-								},
-								{
 									Name: "operator-config",
 									VolumeSource: corev1.VolumeSource{
 										ConfigMap: &corev1.ConfigMapVolumeSource{
 											LocalObjectReference: corev1.LocalObjectReference{
 												Name: operatorConfigConfigMapName,
+											},
+										},
+									},
+								},
+								{
+									Name: "imagevector-overwrite",
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: imageVectorConfigMapName,
 											},
 										},
 									},

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -93,7 +93,8 @@ controllers:
       unknownThreshold: 1m0s
     etcdStatusSyncPeriod: 15s
   etcdCopyBackupsTask:
-    enabled: false
+    concurrentSyncs: 3
+    enabled: true
   etcdOpsTask:
     concurrentSyncs: 3
     requeueInterval: 15s
@@ -175,7 +176,7 @@ webhooks:
 			expectedResources []client.Object
 
 			imageVectorConfigMapName    = "etcd-druid-imagevector-overwrite-4475dd36"
-			operatorConfigConfigMapName = "etcd-druid-operator-config-3b019ffb"
+			operatorConfigConfigMapName = "etcd-druid-operator-config-735336e3"
 
 			serviceAccount = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -176,7 +176,7 @@ webhooks:
 			expectedResources []client.Object
 
 			imageVectorConfigMapName    = "etcd-druid-imagevector-overwrite-4475dd36"
-			operatorConfigConfigMapName = "etcd-druid-operator-config-735336e3"
+			operatorConfigConfigMapName = "etcd-druid-operator-config"
 
 			serviceAccount = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{
@@ -342,13 +342,11 @@ webhooks:
 					Namespace: namespace,
 					Labels: map[string]string{
 						"gardener.cloud/role": "etcd-druid",
-						"resources.gardener.cloud/garbage-collectable-reference": "true",
 					},
 				},
 				Data: map[string]string{
 					"config.yaml": *etcdOperatorConfigYAML,
 				},
-				Immutable: ptr.To(true),
 			}
 
 			deploymentWithoutImageVectorOverwriteFor = &appsv1.Deployment{

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -123,8 +123,9 @@ webhooks:
     enabled: true
     exemptServiceAccounts:
     - system:serviceaccount:kube-system:generic-garbage-collector
-    reconcilerServiceAccountFQDN: system:serviceaccount:` + namespace + `:etcd-druid
-    serviceAccountInfo: null
+    serviceAccountInfo:
+      name: etcd-druid
+      namespace: ` + namespace + `
 `)
 	)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area quality
/kind enhancement

**What this PR does / why we need it**:

[`etcd-druid` v0.31.0](https://github.com/gardener/etcd-druid/releases/tag/v0.31.0) introduced [`OperatorConfiguration`](https://gardener.github.io/etcd-druid/deployment/configure-etcd-druid.html?h=operatorconfiguration#operator-configuration) as a replacement to the existing `etcd-druid` CLI flags. The existing CLI flags have been marked as deprecated. This PR adapts the CLI flags passed to `etcd-druid` by `gardener` to use `OperatorConfiguration` instead.

Fixes #13686

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`etcd-druid` is now configured with `OperatorConfiguration` instead of the deprecated CLI flags.
```
