### PR TITLE
OSC File Checker bootstrapper 

### DIFF
--- a/cmd/gardener-node-agent/app/app.go
+++ b/cmd/gardener-node-agent/app/app.go
@@ -182,7 +182,19 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *n
 	if err := mgr.Add(&controllerutils.ControlledRunner{
 		Manager: mgr,
 		BootstrapRunnables: []manager.Runnable{
-			&bootstrappers.KubeletBootstrapKubeconfig{Log: log.WithName("kubelet-bootstrap-kubeconfig-creator"), FS: fs, APIServerConfig: cfg.APIServer},
+			&bootstrappers.KubeletBootstrapKubeconfig{
+				Log:             log.WithName("kubelet-bootstrap-kubeconfig-creator"),
+				FS:              fs,
+				APIServerConfig: cfg.APIServer,
+			},
+			&bootstrappers.OSCChecker{
+				Log:      log.WithName("osc-checker"),
+				FS:       fs,
+				Client:   mgr.GetClient(),
+				Recorder: mgr.GetEventRecorderFor("osc-checker"),
+				DBus:     dbus.New(log),
+				NodeName: nodeName,
+			},
 		},
 		ActualRunnables: []manager.Runnable{
 			manager.RunnableFunc(func(ctx context.Context) error {

--- a/pkg/apis/config/nodeagent/v1alpha1/types.go
+++ b/pkg/apis/config/nodeagent/v1alpha1/types.go
@@ -32,6 +32,8 @@ const (
 	MachineNameFilePath = BaseDir + "/machine-name"
 	// ZoneFilePath is the file path on the worker node that contains the zone name for the node.
 	ZoneFilePath = BaseDir + "/zone"
+	// LastAppliedOperatingSystemConfigFilePath is the file path on the worker node that contains the last applied OSC information.
+	LastAppliedOperatingSystemConfigFilePath = BaseDir + "/last-applied-osc.yaml"
 
 	// UnitName is the name of the gardener-node-agent systemd service.
 	UnitName = "gardener-node-agent.service"

--- a/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper.go
+++ b/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper.go
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrappers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/go-logr/logr"
+	"github.com/spf13/afero"
+	"go.yaml.in/yaml/v4"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	dbuspkg "github.com/gardener/gardener/pkg/nodeagent/dbus"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+const (
+	// Systemd directory paths
+	systemdSystemPath = "/etc/systemd/system"
+	systemdUsrLibPath = "/usr/lib/systemd/system"
+	systemdLibPath    = "/lib/systemd/system"
+)
+
+// OSCChecker is a bootstrapper that checks the consistency of OperatingSystemConfig resources
+// against the actual state of files and systemd units on the node.
+type OSCChecker struct {
+	Log      logr.Logger
+	FS       afero.Afero
+	Client   client.Client
+	Recorder record.EventRecorder
+	DBus     dbuspkg.DBus
+	NodeName string
+
+	node *corev1.Node
+}
+
+// Start performs the OSC consistency checks by comparing the last applied OperatingSystemConfig
+// against the actual state of files and systemd units on the node.
+func (c *OSCChecker) Start(ctx context.Context) error {
+	c.Log.Info("Starting OSC checker")
+
+	var node corev1.Node
+	if err := c.Client.Get(ctx, client.ObjectKey{Name: c.NodeName}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			c.Log.Info("Node not found yet, skipping OSC checks", "node", c.NodeName)
+			return nil
+		}
+		return fmt.Errorf("failed getting node: %w", err)
+	}
+	c.node = &node
+
+	oscFileContent, err := c.FS.ReadFile(nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath)
+	if err != nil {
+		if errors.Is(err, afero.ErrFileNotFound) {
+			c.Log.Info("No last-applied OSC found, skipping")
+			return nil
+		}
+		return fmt.Errorf("cannot read last-applied OSC: %w", err)
+	}
+
+	var osc v1alpha1.OperatingSystemConfig
+	if err := yaml.Unmarshal(oscFileContent, &osc); err != nil {
+		return fmt.Errorf("cannot parse OSC YAML: %w", err)
+	}
+
+	unitList, err := c.DBus.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed listing systemd units: %w", err)
+	}
+	unitMap := make(map[string]dbus.UnitStatus, len(unitList))
+	for _, u := range unitList {
+		unitMap[u.Name] = u
+	}
+
+	for _, f := range osc.Spec.Files {
+		c.checkFile(f)
+	}
+
+	for _, unit := range osc.Spec.Units {
+		c.checkUnitFile(&unit)
+
+		for _, di := range unit.DropIns {
+			diPath := c.resolveDropInPath(unit.Name, di.Name)
+			c.checkDropInFile(diPath, &di, unit.Name)
+		}
+
+		if unit.Enable != nil {
+			c.checkUnitEnabled(unit.Name, *unit.Enable, unitMap)
+		}
+
+		for _, dep := range unit.FilePaths {
+			exists, err := c.FS.Exists(dep)
+			if err != nil || !exists {
+				c.Log.Info("Dependency missing", "unit", unit.Name, "file", dep)
+				c.emitEvent(
+					"DependencyMissing",
+					fmt.Sprintf("Dependency file %s for unit %s is missing", dep, unit.Name),
+				)
+			}
+		}
+	}
+
+	c.Log.Info("OSC checker finished")
+	return nil
+}
+
+func (c *OSCChecker) checkFile(file v1alpha1.File) {
+	inline := file.Content.Inline
+	if inline == nil || inline.Data == "" || file.Content.ImageRef != nil {
+		return
+	}
+
+	var expected []byte
+	switch inline.Encoding {
+	case "", "plain":
+		expected = []byte(inline.Data)
+	case "b64", "base64":
+		var err error
+		if expected, err = utils.DecodeBase64(inline.Data); err != nil {
+			c.emitEvent(
+				"FileDecodeError",
+				fmt.Sprintf("Failed to decode base64 content for file %s", file.Path),
+			)
+			return
+		}
+	default:
+		c.emitEvent(
+			"FileUnsupportedEncoding",
+			fmt.Sprintf("Unsupported encoding %s for file %s", inline.Encoding, file.Path),
+		)
+		return
+	}
+
+	expectedHash := utils.ComputeSHA256Hex(expected)
+	actual, err := c.FS.ReadFile(filepath.Clean(file.Path))
+	if err != nil {
+		if errors.Is(err, afero.ErrFileNotFound) {
+			c.emitEvent(
+				"FileMissing",
+				fmt.Sprintf("File %s is missing", file.Path),
+			)
+		} else {
+			c.emitEvent(
+				"FileReadError",
+				fmt.Sprintf("Failed to read file %s", file.Path),
+			)
+		}
+		return
+	}
+
+	actualHash := utils.ComputeSHA256Hex(actual)
+	if expectedHash != actualHash {
+		c.emitEvent(
+			"FileMismatch",
+			fmt.Sprintf("File %s mismatch: expected %s, actual %s", file.Path, expectedHash, actualHash),
+		)
+	}
+}
+
+func (c *OSCChecker) checkUnitFile(unit *v1alpha1.Unit) {
+	path := c.resolveUnitPath(unit.Name)
+
+	raw, err := c.FS.ReadFile(path)
+	if err != nil {
+		c.emitEvent(
+			"UnitFileMissing",
+			fmt.Sprintf("Unit file %s is missing", unit.Name),
+		)
+		return
+	}
+
+	if unit.Content == nil {
+		return
+	}
+
+	expectedHash := utils.ComputeSHA256Hex([]byte(*unit.Content))
+	actualHash := utils.ComputeSHA256Hex(raw)
+
+	if expectedHash != actualHash {
+		c.emitEvent(
+			"UnitMismatch",
+			fmt.Sprintf("Unit %s content mismatch", unit.Name),
+		)
+	}
+}
+
+func (c *OSCChecker) checkDropInFile(path string, dropIn *v1alpha1.DropIn, unitName string) {
+	raw, err := c.FS.ReadFile(path)
+	if err != nil {
+		c.emitEvent(
+			"DropInMissing",
+			fmt.Sprintf("Drop-in %s for unit %s is missing", dropIn.Name, unitName),
+		)
+		return
+	}
+
+	expectedHash := utils.ComputeSHA256Hex([]byte(dropIn.Content))
+	actualHash := utils.ComputeSHA256Hex(raw)
+
+	if expectedHash != actualHash {
+		c.emitEvent(
+			"DropInMismatch",
+			fmt.Sprintf("Drop-in %s for unit %s mismatch", dropIn.Name, unitName),
+		)
+	}
+}
+
+func (c *OSCChecker) checkUnitEnabled(name string, expectedEnabled bool, unitMap map[string]dbus.UnitStatus) {
+	_, isEnabled := unitMap[name]
+
+	if !isEnabled && expectedEnabled {
+		unitPath := c.resolveUnitPath(name)
+		if data, err := c.FS.ReadFile(unitPath); err == nil {
+			if !strings.Contains(string(data), "[Install]") {
+				isEnabled = true // static unit
+			}
+		}
+	}
+
+	if isEnabled != expectedEnabled {
+		c.emitEvent(
+			"UnitEnableMismatch",
+			fmt.Sprintf("Unit %s enable state mismatch: expected %t, actual %t",
+				name, expectedEnabled, isEnabled),
+		)
+	}
+}
+
+func (c *OSCChecker) resolveUnitPath(name string) string {
+	paths := []string{
+		filepath.Join(systemdSystemPath, name),
+		filepath.Join(systemdUsrLibPath, name),
+		filepath.Join(systemdLibPath, name),
+	}
+
+	for _, p := range paths {
+		if exists, err := c.FS.Exists(p); exists && err == nil {
+			return p
+		}
+	}
+	return filepath.Join(systemdSystemPath, name) // fallback
+}
+
+func (c *OSCChecker) resolveDropInPath(unitName, dropInName string) string {
+	unitPath := c.resolveUnitPath(unitName)
+	unitDir := filepath.Dir(unitPath)
+
+	return filepath.Join(unitDir, unitName+".d", dropInName)
+}
+
+func (c *OSCChecker) emitEvent(reason, message string) {
+	if c.node == nil {
+		return
+	}
+
+	c.Log.Info("Emitting OSC event",
+		"node", c.node.Name,
+		"reason", reason,
+		"message", message,
+	)
+
+	c.Recorder.Event(c.node, corev1.EventTypeWarning, reason, message)
+}

--- a/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper.go
+++ b/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper.go
@@ -89,15 +89,24 @@ func (c *OSCChecker) Start(ctx context.Context) error {
 	}
 
 	for _, unit := range osc.Spec.Units {
-		c.checkUnitFile(&unit)
+		unitPath := c.resolveUnitPath(unit.Name)
+		if unitPath == "" {
+			c.emitEvent(
+				"UnitFileMissing",
+				fmt.Sprintf("Unit file %s is missing", unit.Name),
+			)
+			continue
+		}
+
+		c.checkUnitFile(&unit, unitPath)
 
 		for _, di := range unit.DropIns {
-			diPath := c.resolveDropInPath(unit.Name, di.Name)
+			diPath := c.resolveDropInPath(unitPath, di.Name)
 			c.checkDropInFile(diPath, &di, unit.Name)
 		}
 
 		if unit.Enable != nil {
-			c.checkUnitEnabled(unit.Name, *unit.Enable, unitMap)
+			c.checkUnitEnabled(unit.Name, *unit.Enable, unitMap, unitPath)
 		}
 
 		for _, dep := range unit.FilePaths {
@@ -169,9 +178,7 @@ func (c *OSCChecker) checkFile(file v1alpha1.File) {
 	}
 }
 
-func (c *OSCChecker) checkUnitFile(unit *v1alpha1.Unit) {
-	path := c.resolveUnitPath(unit.Name)
-
+func (c *OSCChecker) checkUnitFile(unit *v1alpha1.Unit, path string) {
 	raw, err := c.FS.ReadFile(path)
 	if err != nil {
 		c.emitEvent(
@@ -217,11 +224,10 @@ func (c *OSCChecker) checkDropInFile(path string, dropIn *v1alpha1.DropIn, unitN
 	}
 }
 
-func (c *OSCChecker) checkUnitEnabled(name string, expectedEnabled bool, unitMap map[string]dbus.UnitStatus) {
+func (c *OSCChecker) checkUnitEnabled(name string, expectedEnabled bool, unitMap map[string]dbus.UnitStatus, unitPath string) {
 	_, isEnabled := unitMap[name]
 
 	if !isEnabled && expectedEnabled {
-		unitPath := c.resolveUnitPath(name)
 		if data, err := c.FS.ReadFile(unitPath); err == nil {
 			if !strings.Contains(string(data), "[Install]") {
 				isEnabled = true // static unit
@@ -250,13 +256,12 @@ func (c *OSCChecker) resolveUnitPath(name string) string {
 			return p
 		}
 	}
-	return filepath.Join(systemdSystemPath, name) // fallback
+	return "" // fallback
 }
 
-func (c *OSCChecker) resolveDropInPath(unitName, dropInName string) string {
-	unitPath := c.resolveUnitPath(unitName)
+func (c *OSCChecker) resolveDropInPath(unitPath, dropInName string) string {
 	unitDir := filepath.Dir(unitPath)
-
+	unitName := filepath.Base(unitPath)
 	return filepath.Join(unitDir, unitName+".d", dropInName)
 }
 

--- a/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper_test.go
+++ b/pkg/nodeagent/bootstrappers/file_consistency_bootstrapper_test.go
@@ -1,0 +1,522 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrappers_test
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	"go.yaml.in/yaml/v4"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/nodeagent/bootstrappers"
+	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
+)
+
+var _ = Describe("FileConsistencyBootstrapper (OSCChecker)", func() {
+	var (
+		ctx context.Context
+
+		fakeFS       afero.Afero
+		fakeRecorder *record.FakeRecorder
+		fakeClient   client.Client
+
+		checker *bootstrappers.OSCChecker
+
+		nodeName           = "node-1"
+		lastAppliedOSCPath = "/var/lib/gardener-node-agent/last-applied-osc.yaml"
+		fakeDBus           *fakedbus.DBus
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		fakeRecorder = record.NewFakeRecorder(100)
+		fakeDBus = fakedbus.New()
+
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+		checker = &bootstrappers.OSCChecker{
+			Log:      logr.Discard(),
+			FS:       fakeFS,
+			DBus:     fakeDBus,
+			Client:   fakeClient,
+			Recorder: fakeRecorder,
+			NodeName: nodeName,
+		}
+	})
+
+	Describe("Start", func() {
+		Context("when the node does not exist yet", func() {
+			It("should skip all checks and emit no events", func() {
+				// No node created in fake client
+
+				Expect(checker.Start(ctx)).To(Succeed())
+
+				// No events should be emitted
+				Consistently(fakeRecorder.Events).ShouldNot(Receive())
+			})
+		})
+
+		Context("when the node exists but no OSC file exists", func() {
+			It("should do nothing", func() {
+				// Create node
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+				// lastAppliedOSCPath NOT written
+
+				Expect(checker.Start(ctx)).To(Succeed())
+
+				// Still no events
+				Consistently(fakeRecorder.Events).ShouldNot(Receive())
+			})
+		})
+
+		Context("when the node and OSC exist with a missing file", func() {
+			It("should perform checks and emit expected events", func() {
+				// Create node
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+				// Write minimal OSC with a missing file
+				osc := v1alpha1.OperatingSystemConfig{
+					Spec: v1alpha1.OperatingSystemConfigSpec{
+						Files: []v1alpha1.File{
+							{
+								Path: "/etc/testfile",
+								Content: v1alpha1.FileContent{
+									Inline: &v1alpha1.FileContentInline{
+										Data: "test",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				oscYAML, err := yaml.Marshal(&osc)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeFS.WriteFile(lastAppliedOSCPath, oscYAML, 0644)).To(Succeed())
+
+				Expect(checker.Start(ctx)).To(Succeed())
+
+				var event string
+				Eventually(fakeRecorder.Events).Should(Receive(&event))
+
+				// Sanity check event content
+				Expect(event).To(ContainSubstring("FileMissing"))
+				Expect(event).To(ContainSubstring("/etc/testfile"))
+			})
+		})
+
+		Context("when node, OSC and all files exist with no mismatches", func() {
+			It("should complete successfully without emitting any events", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+				filePath := "/etc/config-file"
+				fileContent := "expected-content"
+				unitName := "test.service"
+				unitPath := "/etc/systemd/system/" + unitName
+				unitContent := "[Unit]\nDescription=Test"
+
+				osc := v1alpha1.OperatingSystemConfig{
+					Spec: v1alpha1.OperatingSystemConfigSpec{
+						Files: []v1alpha1.File{
+							{
+								Path: filePath,
+								Content: v1alpha1.FileContent{
+									Inline: &v1alpha1.FileContentInline{
+										Data: fileContent,
+									},
+								},
+							},
+						},
+						Units: []v1alpha1.Unit{
+							{
+								Name:    unitName,
+								Content: &unitContent,
+							},
+						},
+					},
+				}
+
+				oscYAML, err := yaml.Marshal(&osc)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fakeFS.WriteFile(lastAppliedOSCPath, oscYAML, 0644)).To(Succeed())
+
+				// Create matching file
+				Expect(fakeFS.MkdirAll(filepath.Dir(filePath), 0755)).To(Succeed())
+				Expect(fakeFS.WriteFile(filePath, []byte(fileContent), 0644)).To(Succeed())
+
+				// Create matching unit file
+				Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+				Expect(fakeFS.WriteFile(unitPath, []byte(unitContent), 0644)).To(Succeed())
+
+				Expect(checker.Start(ctx)).To(Succeed())
+
+				// No events should be emitted
+				Consistently(fakeRecorder.Events).ShouldNot(Receive())
+			})
+		})
+
+		Describe("File checks", func() {
+			BeforeEach(func() {
+				// Node exists
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			})
+
+			Context("when a file is missing", func() {
+				It("should emit FileMissing event", func() {
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Files: []v1alpha1.File{
+								{
+									Path: "/etc/missing-file",
+									Content: v1alpha1.FileContent{
+										Inline: &v1alpha1.FileContentInline{
+											Data: "content",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("FileMissing"))
+					Expect(event).To(ContainSubstring("/etc/missing-file"))
+				})
+			})
+
+			Context("when a file content mismatches", func() {
+				It("should emit FileMismatch event", func() {
+					filePath := "/etc/config-file"
+
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Files: []v1alpha1.File{
+								{
+									Path: filePath,
+									Content: v1alpha1.FileContent{
+										Inline: &v1alpha1.FileContentInline{
+											Data: "expected-content",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(filePath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(filePath, []byte("actual-different-content"), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("FileMismatch"))
+					Expect(event).To(ContainSubstring(filePath))
+				})
+			})
+
+			Context("when a file matches", func() {
+				It("should emit no event", func() {
+					filePath := "/etc/matching-file"
+					content := "matching-content"
+
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Files: []v1alpha1.File{
+								{
+									Path: filePath,
+									Content: v1alpha1.FileContent{
+										Inline: &v1alpha1.FileContentInline{
+											Data: content,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(filePath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(filePath, []byte(content), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					Consistently(fakeRecorder.Events).ShouldNot(Receive())
+				})
+			})
+		})
+
+		Describe("Unit file checks", func() {
+			var (
+				unitName    = "test.service"
+				unitPath    = "/etc/systemd/system/" + unitName
+				unitContent = "UNIT_CONTENT"
+			)
+
+			BeforeEach(func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			})
+
+			Context("when unit file is missing", func() {
+				It("should emit UnitFileMissing event", func() {
+					content := unitContent
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name:    unitName,
+									Content: &content,
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("UnitFileMissing"))
+					Expect(event).To(ContainSubstring(unitName))
+				})
+			})
+
+			Context("when unit content mismatches", func() {
+				It("should emit UnitMismatch event", func() {
+					content := unitContent
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name:    unitName,
+									Content: &content,
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(unitPath, []byte("DIFFERENT_CONTENT"), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("UnitMismatch"))
+					Expect(event).To(ContainSubstring(unitName))
+				})
+			})
+
+			Context("when unit content matches", func() {
+				It("should emit no event", func() {
+					content := unitContent
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name:    unitName,
+									Content: &content,
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(unitPath, []byte(content), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					Consistently(fakeRecorder.Events).ShouldNot(Receive())
+				})
+			})
+		})
+
+		Describe("Drop-in checks", func() {
+			var (
+				unitName      = "test.service"
+				unitPath      = "/etc/systemd/system/" + unitName
+				dropInName    = "10-override.conf"
+				dropInPath    = "/etc/systemd/system/test.service.d/10-override.conf"
+				dropInContent = "DROP_IN_CONTENT"
+			)
+
+			BeforeEach(func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				}
+				Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			})
+
+			Context("when drop-in file is missing", func() {
+				It("should emit DropInMissing event", func() {
+					// Create unit file first (required for resolveDropInPath to work)
+					Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(unitPath, []byte("[Unit]"), 0644)).To(Succeed())
+
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name: unitName,
+									DropIns: []v1alpha1.DropIn{
+										{
+											Name:    dropInName,
+											Content: dropInContent,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("DropInMissing"))
+					Expect(event).To(ContainSubstring(dropInName))
+					Expect(event).To(ContainSubstring(unitName))
+				})
+			})
+
+			Context("when drop-in content mismatches", func() {
+				It("should emit DropInMismatch event", func() {
+					Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(unitPath, []byte("[Unit]"), 0644)).To(Succeed())
+
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name: unitName,
+									DropIns: []v1alpha1.DropIn{
+										{
+											Name:    dropInName,
+											Content: dropInContent,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(dropInPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(dropInPath, []byte("DIFFERENT_CONTENT"), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					var event string
+					Eventually(fakeRecorder.Events).Should(Receive(&event))
+					Expect(event).To(ContainSubstring("DropInMismatch"))
+					Expect(event).To(ContainSubstring(dropInName))
+					Expect(event).To(ContainSubstring(unitName))
+				})
+			})
+
+			Context("when drop-in content matches", func() {
+				It("should emit no event", func() {
+					Expect(fakeFS.MkdirAll(filepath.Dir(unitPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(unitPath, []byte("[Unit]"), 0644)).To(Succeed())
+
+					content := dropInContent
+					osc := v1alpha1.OperatingSystemConfig{
+						Spec: v1alpha1.OperatingSystemConfigSpec{
+							Units: []v1alpha1.Unit{
+								{
+									Name: unitName,
+									DropIns: []v1alpha1.DropIn{
+										{
+											Name:    dropInName,
+											Content: content,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					raw, err := yaml.Marshal(&osc)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(fakeFS.WriteFile(lastAppliedOSCPath, raw, 0644)).To(Succeed())
+
+					Expect(fakeFS.MkdirAll(filepath.Dir(dropInPath), 0755)).To(Succeed())
+					Expect(fakeFS.WriteFile(dropInPath, []byte(content), 0644)).To(Succeed())
+
+					Expect(checker.Start(ctx)).To(Succeed())
+
+					Consistently(fakeRecorder.Events).ShouldNot(Receive())
+				})
+			})
+		})
+	})
+})

--- a/pkg/nodeagent/controller/operatingsystemconfig/changes.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/changes.go
@@ -102,10 +102,10 @@ func computeOperatingSystemConfigChanges(
 	// The reason for assigning files to units is the detection of changes which require the restart of a unit.
 	newOSCFiles := CollectAllFiles(newOSC, hostName)
 
-	oldOSCRaw, err := fs.ReadFile(lastAppliedOperatingSystemConfigFilePath)
+	oldOSCRaw, err := fs.ReadFile(nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath)
 	if err != nil {
 		if !errors.Is(err, afero.ErrFileNotFound) {
-			return nil, fmt.Errorf("error reading last applied OSC from file path %s: %w", lastAppliedOperatingSystemConfigFilePath, err)
+			return nil, fmt.Errorf("error reading last applied OSC from file path %s: %w", nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath, err)
 		}
 
 		var (
@@ -150,7 +150,7 @@ func computeOperatingSystemConfigChanges(
 
 	oldOSC := &extensionsv1alpha1.OperatingSystemConfig{}
 	if err := runtime.DecodeInto(decoder, oldOSCRaw, oldOSC); err != nil {
-		return nil, fmt.Errorf("unable to decode the old OSC read from file path %s: %w", lastAppliedOperatingSystemConfigFilePath, err)
+		return nil, fmt.Errorf("unable to decode the old OSC read from file path %s: %w", nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath, err)
 	}
 
 	oldOSCFiles := CollectAllFiles(oldOSC, hostName)

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -66,7 +66,6 @@ import (
 )
 
 const (
-	lastAppliedOperatingSystemConfigFilePath         = nodeagentconfigv1alpha1.BaseDir + "/last-applied-osc.yaml"
 	lastComputedOperatingSystemConfigChangesFilePath = nodeagentconfigv1alpha1.BaseDir + "/last-computed-osc-changes.yaml"
 
 	annotationUpdatingOperatingSystemVersion = "node-agent.gardener.cloud/updating-operating-system-version"
@@ -346,14 +345,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Info("Successfully applied operating system config")
 
 	if !r.SkipWritingStateFiles {
-		log.Info("Persisting current operating system config as 'last-applied' file to the disk", "path", lastAppliedOperatingSystemConfigFilePath)
+		log.Info("Persisting current operating system config as 'last-applied' file to the disk", "path", nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath)
 		oscRaw, err := runtime.Encode(codec, osc)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("unable to encode OSC: %w", err)
 		}
 
-		if err := r.FS.WriteFile(lastAppliedOperatingSystemConfigFilePath, oscRaw, 0600); err != nil {
-			return reconcile.Result{}, fmt.Errorf("unable to write current OSC to file path %q: %w", lastAppliedOperatingSystemConfigFilePath, err)
+		if err := r.FS.WriteFile(nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath, oscRaw, 0600); err != nil {
+			return reconcile.Result{}, fmt.Errorf("unable to write current OSC to file path %q: %w", nodeagentconfigv1alpha1.LastAppliedOperatingSystemConfigFilePath, err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds another gardener-node-agent bootstrapper, that checks (in case /var/lib/gardener-node-agent /last-applied-osc.yaml exists) if the files, units and drop-ins mentioned in OSC have the same state/content as described in the latest version of OSC available. In case it is not, this bootstrapper will create events in the node (that is also the shoot cluster) which would mention the specific mismatches. It will also log everything. 
This is supposed to address the issue that during reconciliation of OSC controller there is no further checks if the actual content of the OSC matches with what you have locally, if /var/lib/gardener-node-agent /last-applied-osc.yaml has the same checksum as the checksum in OSC secret.

**Which issue(s) this PR fixes**:
Fixes #10819

**Special notes for your reviewer**:

**Release note**:

<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
