### PR TITLE
Fix running `gardener-operator` migrations before `manager` startup

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -180,6 +180,10 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *o
 	if err := mgr.Add(reconcileWebhookConfigurations(ctx, mgr, validatingWebhookConfiguration, mutatingWebhookConfiguration)); err != nil {
 		return fmt.Errorf("failed adding webhook config reconciliation func: %w", err)
 	}
+	log.Info("Adding migrations runnable func to manager")
+	if err := mgr.Add(runMigrations(ctx, mgr.GetClient(), log)); err != nil {
+		return fmt.Errorf("failed adding migrations runnable func to manager: %w", err)
+	}
 
 	log.Info("Adding webhook handlers to manager")
 	if err := webhook.AddToManager(mgr); err != nil {
@@ -202,10 +206,6 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *o
 	log.Info("Adding controllers to manager")
 	if err := controller.AddToManager(cancel, mgr, cfg, gardenClientMap); err != nil {
 		return fmt.Errorf("failed adding controllers to manager: %w", err)
-	}
-
-	if err := runMigrations(ctx, mgr.GetClient(), log); err != nil {
-		return err
 	}
 
 	log.Info("Starting manager")

--- a/cmd/internal/migration/vpa.go
+++ b/cmd/internal/migration/vpa.go
@@ -128,7 +128,12 @@ func MigrateVPAEmptyPatch(ctx context.Context, c client.Client, log logr.Logger)
 		filterFn:      filterFn,
 		mutateFn:      mutateFunc,
 	}
-	return migrateVPA(ctx, &cfg)
+	if err := migrateVPA(ctx, &cfg); err != nil {
+		return err
+	}
+
+	log.Info("Successfully migrated VerticalPodAutoscalers")
+	return nil
 }
 
 // MigrateVPAUpdateModeToRecreate applies a patch to VerticalPodAutoscaler resources that
@@ -169,5 +174,10 @@ func MigrateVPAUpdateModeToRecreate(ctx context.Context, c client.Client, log lo
 		filterFn:      filterFn,
 		mutateFn:      mutateFn,
 	}
-	return migrateVPA(ctx, &cfg)
+	if err := migrateVPA(ctx, &cfg); err != nil {
+		return err
+	}
+
+	log.Info("Successfully migrated VerticalPodAutoscalers to update mode Recreate")
+	return nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:

This PR adds the `gardener-operator` _startup_ migrations as [manager.RunnableFunc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#RunnableFunc) to the operator's manager, so that they are applied only after the [manager.Start()](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#example-Manager-Start) is invoked and it's `cache` API server client is constructed.

⚠️  Since the _migrations_ rely on the `cache` client to query the API server for `VerticalPodAutoscaler` resources, we need to have it initialized beforehand or we risk to cause the `gardener-operator` Pod(s) to end up in `CrashLoopBackOff` state with

```
failed to migrate VerticalPodAutoscaler with 'MigrateVPAEmptyPatch' migration: failed listing VerticalPodAutoscaler resources: the cache is not started, can not read objects"
```

error.

**Which issue(s) this PR fixes**:

Follow up on https://github.com/gardener/gardener/pull/13573

**Special notes for your reviewer**:

Not applicable.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
