### PR TITLE
Forbid setting anonymous authentication through the Shoot spec for Kubernetes >= 1.35

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1541,9 +1541,9 @@ spec:
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 
-                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+                              This field is forbidden for clusters with Kubernetes version >= 1.35.
                               Please use anonymous authentication configuration instead.
-                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                             type: boolean
                           encryptionConfig:
                             description: EncryptionConfig contains customizable encryption

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -6706,10 +6706,9 @@ bool
 <p>EnableAnonymousAuthentication defines whether anonymous requests to the secure port
 of the API server should be allowed (flag <code>--anonymous-auth</code>).
 See: <a href="https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/">https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/</a></p>
-<p>Deprecated: This field is deprecated and will be removed in a future release.
-Please use anonymous authentication configuration instead.
-For more information see: <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration">https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration</a>
-TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.</p>
+<p>Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+This field is forbidden for clusters with Kubernetes version &gt;= 1.35.
+Please use anonymous authentication configuration instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -173,7 +173,7 @@ If you want the changes to roll out immediately, [trigger a reconciliation expli
 
 Gardener disables anonymous authentication by default for all Kubernetes versions.
 For clusters with Kubernetes version `>= 1.35`, the `.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` field is no longer available.
-If you need to enable anonymous authentication for your shoot cluster, you can configure it using [Structured Authentication Configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration) with an [anonymous authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration).
+If you need to enable anonymous authentication for your shoot cluster, you can configure it using [Structured Authentication Configuration](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration) with the [anonymous authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration).
 
 Here is an example of a `ConfigMap` that enables anonymous authentication for the `/livez` endpoint:
 

--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -9,6 +9,10 @@ Breaking changes may be introduced with new Kubernetes versions.
 This documentation describes the Gardener specific differences and requirements for upgrading to a supported Kubernetes version.
 For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [changelogs](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG) and release blogs should be considered before upgrade.
 
+## Upgrading to Kubernetes `v1.35`
+
+- The `Shoot`'s `.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` field is forbidden. Gardener continues to disable anonymous authentication by default. If you need to configure anonymous authentication, use [Structured Authentication Configuration](shoot_access.md#configuring-anonymous-authentication) with the [anonymous authenticator](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration) instead.
+
 ## Upgrading to Kubernetes `v1.34`
 
 - The `Shoot`'s `.spec.cloudProfileName` field is forbidden. `Shoot` owners must migrate their `CloudProfile` reference to the new `spec.cloudProfile.name` field.

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1541,9 +1541,9 @@ spec:
                               of the API server should be allowed (flag `--anonymous-auth`).
                               See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 
-                              Deprecated: This field is deprecated and will be removed in a future release.
+                              Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+                              This field is forbidden for clusters with Kubernetes version >= 1.35.
                               Please use anonymous authentication configuration instead.
-                              For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
                             type: boolean
                           encryptionConfig:
                             description: EncryptionConfig contains customizable encryption

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -51,7 +51,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if helper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {
-		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")
+		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")
 	}
 
 	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -51,7 +51,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if helper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {
-		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")
+		warnings = append(warnings, "you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Gardener sets this field to nil if it is set to false by the user. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")
 	}
 
 	kubernetesVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Warnings", func() {
 
 		It("should return a warning when enableAnonymousAuthentication is set", func() {
 			shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")))
 		})
 
 		DescribeTable("shoot.spec.secretBindingName",

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Warnings", func() {
 
 		It("should return a warning when enableAnonymousAuthentication is set", func() {
 			shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Gardener sets this field to nil if it is set to false by the user. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")))
 		})
 
 		DescribeTable("shoot.spec.secretBindingName",

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -733,10 +733,10 @@ type KubeAPIServerConfig struct {
 	// of the API server should be allowed (flag `--anonymous-auth`).
 	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 	//
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+	// This field is forbidden for clusters with Kubernetes version >= 1.35.
 	// Please use anonymous authentication configuration instead.
 	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
-	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
 	EnableAnonymousAuthentication *bool
 	// EventTTL controls the amount of time to retain events.
 	EventTTL *metav1.Duration

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -737,7 +737,7 @@ type KubeAPIServerConfig struct {
 	// This field is forbidden for clusters with Kubernetes version >= 1.35.
 	// Please use anonymous authentication configuration instead.
 	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
-	EnableAnonymousAuthentication *bool
+	EnableAnonymousAuthentication *bool // TODO(dimityrmirchev): Drop this field when support for Kubernetes 1.34 is dropped.
 	// EventTTL controls the amount of time to retain events.
 	EventTTL *metav1.Duration
 	// Logging contains configuration settings for the log verbosity and access logging

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1389,10 +1389,9 @@ message KubeAPIServerConfig {
   // of the API server should be allowed (flag `--anonymous-auth`).
   // See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
   //
-  // Deprecated: This field is deprecated and will be removed in a future release.
+  // Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+  // This field is forbidden for clusters with Kubernetes version >= 1.35.
   // Please use anonymous authentication configuration instead.
-  // For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
-  // TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
   // +optional
   optional bool enableAnonymousAuthentication = 11;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -975,10 +975,9 @@ type KubeAPIServerConfig struct {
 	// of the API server should be allowed (flag `--anonymous-auth`).
 	// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 	//
-	// Deprecated: This field is deprecated and will be removed in a future release.
+	// Deprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped.
+	// This field is forbidden for clusters with Kubernetes version >= 1.35.
 	// Please use anonymous authentication configuration instead.
-	// For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration
-	// TODO(marc1404): Forbid this field when the feature gate AnonymousAuthConfigurableEndpoints has graduated.
 	// +optional
 	EnableAnonymousAuthentication *bool `json:"enableAnonymousAuthentication,omitempty" protobuf:"varint,11,opt,name=enableAnonymousAuthentication"`
 	// EventTTL controls the amount of time to retain events.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -979,7 +979,7 @@ type KubeAPIServerConfig struct {
 	// This field is forbidden for clusters with Kubernetes version >= 1.35.
 	// Please use anonymous authentication configuration instead.
 	// +optional
-	EnableAnonymousAuthentication *bool `json:"enableAnonymousAuthentication,omitempty" protobuf:"varint,11,opt,name=enableAnonymousAuthentication"`
+	EnableAnonymousAuthentication *bool `json:"enableAnonymousAuthentication,omitempty" protobuf:"varint,11,opt,name=enableAnonymousAuthentication"` // TODO(dimityrmirchev): Drop this field when support for Kubernetes 1.34 is dropped.
 	// EventTTL controls the amount of time to retain events.
 	// Defaults to 1h.
 	// +optional

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1622,6 +1622,11 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, version stri
 		}
 	}
 
+	k8sGreaterEqual135, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.35")
+	if kubeAPIServer.EnableAnonymousAuthentication != nil && k8sGreaterEqual135 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("enableAnonymousAuthentication"), "for Kubernetes versions >= 1.35, enableAnonymousAuthentication field is no longer supported"))
+	}
+
 	allErrs = append(allErrs, admissionpluginsvalidation.ValidateAdmissionPlugins(kubeAPIServer.AdmissionPlugins, version, fldPath.Child("admissionPlugins"))...)
 	allErrs = append(allErrs, apigroupsvalidation.ValidateAPIGroupVersions(kubeAPIServer.RuntimeConfig, version, workerless, fldPath.Child("runtimeConfig"))...)
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2344,64 +2344,35 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(errorList).To(BeEmpty())
 				})
 
-				It("should forbid setting enableAnonymousAuthentication to true for Kubernetes version >= 1.35", func() {
-					shoot.Spec.Kubernetes.Version = "1.35.0"
-					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
-					shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(true)
-					shoot.Spec.CloudProfileName = nil
-					shoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "CloudProfile",
-						Name: "test-profile",
-					}
-					shoot.Spec.SecretBindingName = nil
-					shoot.Spec.CredentialsBindingName = ptr.To("my-secret")
+				DescribeTable("enableAnonymousAuthentication validation for Kubernetes version >= 1.35",
+					func(enableAnonymousAuth *bool, expectError bool) {
+						shoot.Spec.Kubernetes.Version = "1.35.0"
+						shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
+						shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = enableAnonymousAuth
+						shoot.Spec.CloudProfileName = nil
+						shoot.Spec.CloudProfile = &core.CloudProfileReference{
+							Kind: "CloudProfile",
+							Name: "test-profile",
+						}
+						shoot.Spec.SecretBindingName = nil
+						shoot.Spec.CredentialsBindingName = ptr.To("my-secret")
 
-					errorList := ValidateShoot(shoot)
+						errorList := ValidateShoot(shoot)
 
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication"),
-						"Detail": Equal("for Kubernetes versions >= 1.35, enableAnonymousAuthentication field is no longer supported"),
-					}))))
-				})
-
-				It("should forbid setting enableAnonymousAuthentication to false for Kubernetes version >= 1.35", func() {
-					shoot.Spec.Kubernetes.Version = "1.35.0"
-					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
-					shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = ptr.To(false)
-					shoot.Spec.CloudProfileName = nil
-					shoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "CloudProfile",
-						Name: "test-profile",
-					}
-					shoot.Spec.SecretBindingName = nil
-					shoot.Spec.CredentialsBindingName = ptr.To("my-secret")
-
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeForbidden),
-						"Field":  Equal("spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication"),
-						"Detail": Equal("for Kubernetes versions >= 1.35, enableAnonymousAuthentication field is no longer supported"),
-					}))))
-				})
-
-				It("should allow not setting enableAnonymousAuthentication for Kubernetes version >= 1.35", func() {
-					shoot.Spec.Kubernetes.Version = "1.35.0"
-					shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
-					shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = nil
-					shoot.Spec.CloudProfileName = nil
-					shoot.Spec.CloudProfile = &core.CloudProfileReference{
-						Kind: "CloudProfile",
-						Name: "test-profile",
-					}
-					shoot.Spec.SecretBindingName = nil
-					shoot.Spec.CredentialsBindingName = ptr.To("my-secret")
-
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(BeEmpty())
-				})
+						if expectError {
+							Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+								"Type":   Equal(field.ErrorTypeForbidden),
+								"Field":  Equal("spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication"),
+								"Detail": Equal("for Kubernetes versions >= 1.35, enableAnonymousAuthentication field is no longer supported"),
+							}))))
+						} else {
+							Expect(errorList).To(BeEmpty())
+						}
+					},
+					Entry("should forbid setting enableAnonymousAuthentication to true", ptr.To(true), true),
+					Entry("should forbid setting enableAnonymousAuthentication to false", ptr.To(false), true),
+					Entry("should allow not setting enableAnonymousAuthentication", nil, false),
+				)
 			})
 
 			Context("AdmissionPlugins validation", func() {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -4705,7 +4705,7 @@ func schema_pkg_apis_core_v1beta1_KubeAPIServerConfig(ref common.ReferenceCallba
 					},
 					"enableAnonymousAuthentication": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/\n\nDeprecated: This field is deprecated and will be removed in a future release. Please use anonymous authentication configuration instead. For more information see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration",
+							Description: "EnableAnonymousAuthentication defines whether anonymous requests to the secure port of the API server should be allowed (flag `--anonymous-auth`). See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/\n\nDeprecated: This field is deprecated and will be removed after support for Kubernetes v1.34 is dropped. This field is forbidden for clusters with Kubernetes version >= 1.35. Please use anonymous authentication configuration instead.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -225,6 +225,14 @@ func (shootStrategy) Canonicalize(obj runtime.Object) {
 	if shoot.Spec.Kubernetes.ClusterAutoscaler != nil && shoot.Spec.Kubernetes.ClusterAutoscaler.MaxEmptyBulkDelete != nil {
 		shoot.Spec.Kubernetes.ClusterAutoscaler.MaxEmptyBulkDelete = nil
 	}
+	// Field was previously defaulted to false.
+	// We can safely set it to nil when user had explicitly set it to false,
+	// as we treat nil as false in the codebase.
+	if kapi := shoot.Spec.Kubernetes.KubeAPIServer; kapi != nil &&
+		kapi.EnableAnonymousAuthentication != nil &&
+		!*kapi.EnableAnonymousAuthentication {
+		kapi.EnableAnonymousAuthentication = nil
+	}
 	gardenerutils.MaintainSeedNameLabels(shoot, shoot.Spec.SeedName, shoot.Status.SeedName)
 	maintainIsSelfHostedLabel(shoot)
 }

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -228,10 +228,10 @@ func (shootStrategy) Canonicalize(obj runtime.Object) {
 	// Field was previously defaulted to false.
 	// We can safely set it to nil when user had explicitly set it to false,
 	// as we treat nil as false in the codebase.
-	if kapi := shoot.Spec.Kubernetes.KubeAPIServer; kapi != nil &&
-		kapi.EnableAnonymousAuthentication != nil &&
-		!*kapi.EnableAnonymousAuthentication {
-		kapi.EnableAnonymousAuthentication = nil
+	if kubeAPIServer := shoot.Spec.Kubernetes.KubeAPIServer; kubeAPIServer != nil &&
+		kubeAPIServer.EnableAnonymousAuthentication != nil &&
+		!*kubeAPIServer.EnableAnonymousAuthentication {
+		kubeAPIServer.EnableAnonymousAuthentication = nil
 	}
 	gardenerutils.MaintainSeedNameLabels(shoot, shoot.Spec.SeedName, shoot.Status.SeedName)
 	maintainIsSelfHostedLabel(shoot)

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -712,6 +712,31 @@ var _ = Describe("Strategy", func() {
 			})
 		})
 
+		Context("enableAnonymousAuthentication", func() {
+			It("should set spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication to nil when it is false", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(false)}
+				strategy.Canonicalize(shoot)
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(BeNil())
+			})
+
+			It("should not set spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication to nil when it is true", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
+				strategy.Canonicalize(shoot)
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(Equal(ptr.To(true)))
+			})
+
+			It("should not panic when spec.kubernetes.kubeAPIServer is nil", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = nil
+				Expect(func() { strategy.Canonicalize(shoot) }).NotTo(Panic())
+			})
+
+			It("should not panic when spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication is nil", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: nil}
+				Expect(func() { strategy.Canonicalize(shoot) }).NotTo(Panic())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(BeNil())
+			})
+		})
+
 		Context("self-hosted shoots", func() {
 			It("should correctly add the self-hosted label", func() {
 				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{ControlPlane: &core.WorkerControlPlane{}})

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -133,6 +133,9 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 						{
 							Version: "1.34.0",
 						},
+						{
+							Version: "1.35.0",
+						},
 						testKubernetesVersionLowPatchLowMinor,
 						testKubernetesVersionHighestPatchLowMinor,
 						testKubernetesVersionLowPatchConsecutiveMinor,
@@ -1135,6 +1138,43 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 					g.Expect(shoot131.Spec.Kubernetes.KubeAPIServer.OIDCConfig).To(BeNil())
 					return shoot131.Spec.Kubernetes.Version
 				}).Should(Equal("1.32.0"))
+			})
+
+			It("Kubernetes version should be updated: force update minor version(>= v1.35) and set spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication to nil", func() {
+				shoot134 := shoot133.DeepCopy()
+				shoot134.Spec.Kubernetes.Version = "1.34.0"
+				shoot134.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+					EnableAnonymousAuthentication: ptr.To(true),
+				}
+				shoot134.Spec.SecretBindingName = nil
+				shoot134.Spec.CredentialsBindingName = ptr.To("credentials-binding")
+
+				By("Create k8s v1.34 Shoot")
+				Expect(testClient.Create(ctx, shoot134)).To(Succeed())
+				log.Info("Created shoot with k8s v1.34 for test", "shoot", client.ObjectKeyFromObject(shoot134))
+
+				DeferCleanup(func() {
+					By("Delete Shoot with k8s v1.34")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot134))).To(Succeed())
+				})
+
+				By("Expire Shoot's kubernetes version in the CloudProfile")
+				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot134.Spec.CloudProfile.Name, "1.34.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
+
+				By("Wait until manager has observed the CloudProfile update")
+				waitKubernetesVersionToBeExpiredInCloudProfile(shoot134.Spec.CloudProfile.Name, "1.34.0", &expirationDateInThePast)
+
+				Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot134, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				Eventually(func(g Gomega) string {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot134), shoot134)).To(Succeed())
+					g.Expect(shoot134.Status.LastMaintenance).NotTo(BeNil())
+					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring("Control Plane: Updated Kubernetes version from \"1.34.0\" to \"1.35.0\". Reason: Kubernetes version expired - force update required, .spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication is set to nil. Reason: The field is no longer supported for Shoot clusters using Kubernetes version 1.35+"))
+					g.Expect(shoot134.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+					g.Expect(shoot134.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
+					g.Expect(shoot134.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(BeNil())
+					return shoot134.Spec.Kubernetes.Version
+				}).Should(Equal("1.35.0"))
 			})
 
 			It("Kubernetes version should be updated: force update minor version", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:
Setting anonymous authentication through the `Shoot` spec is deprecated. Let's forbid it with the introduction of Kubernetes 1.35. Users should make use of Structured Authentication instead.

/cc @vpnachev @AleksandarSavchev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have followed the [additional steps for removing APIs](https://github.com/gardener/gardener/blob/5b6dbc6a3a65a34997798119beb6327b50d57ada/docs/development/changing-the-api.md#additional-steps-when-removing-a-field-from-the-shoot-api) with the difference that in the `Canonicalize` I only set the `enableAnonymousAuthentication` to `nil` if it was previously set to `false`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Setting `.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` in the `Shoot` spec is forbidden for clusters with Kubernetes version >= 1.35. Users that enable anonymous authentication should use Structured Authentication with [anonymous authenticator](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication) instead.
```

```noteworthy user
The field `.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication` in the `Shoot` spec will be automatically set to `nil` if users set it `false` as these two are equivalent across the codebase. The field is deprecated and users that enable anonymous authentication should migrate to Structured Authentication with [anonymous authenticator](https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication) instead.
```
