### PR TITLE
Add `.spec.dns.internal` field to `ManagedSeed` provider-local examples

### DIFF
--- a/example/provider-local/managedseeds/managedseed-ipv6.yaml
+++ b/example/provider-local/managedseeds/managedseed-ipv6.yaml
@@ -12,6 +12,15 @@ spec:
       kind: GardenletConfiguration
       seedConfig:
         spec:
+          dns:
+            internal:
+              type: local
+              domain: internal.local.gardener.cloud
+              credentialsRef:
+                apiVersion: v1
+                kind: Secret
+                name: internal-domain-internal-local-gardener-cloud
+                namespace: garden
           networks:
             ipFamilies:
             - IPv6

--- a/example/provider-local/managedseeds/managedseed.yaml
+++ b/example/provider-local/managedseeds/managedseed.yaml
@@ -12,6 +12,15 @@ spec:
       kind: GardenletConfiguration
       seedConfig:
         spec:
+          dns:
+            internal:
+              type: local
+              domain: internal.local.gardener.cloud
+              credentialsRef:
+                apiVersion: v1
+                kind: Secret
+                name: internal-domain-internal-local-gardener-cloud
+                namespace: garden
           settings:
             excessCapacityReservation:
               enabled: false


### PR DESCRIPTION
**How to categorize this PR?**

/area quality security
/kind cleanup

**What this PR does / why we need it**:

This is a follow up of

- https://github.com/gardener/gardener/pull/13529

that adds the `.spec.dns.internal` field to the `ManagedSeed` provider-local examples, so that they can be used for local development and testing.

**Special notes for your reviewer**:

/cc @dimityrmirchev 

**Release note**:

```other operator
NONE
```
