### PR TITLE
Fix namespace handling for `SecretsManagerForGarden`

### DIFF
--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -77,6 +77,7 @@ func SecretsManagerForGarden(
 	garden *operatorv1alpha1.Garden,
 	identity string,
 	secretConfigs []SecretConfigWithOptions,
+	namespaces ...string,
 ) (
 	secretsmanager.Interface,
 	error,
@@ -84,7 +85,7 @@ func SecretsManagerForGarden(
 	sm, err := secretsmanager.New(ctx, logger, clock, c, identity, secretsmanager.Config{
 		CASecretAutoRotation: false,
 		SecretNamesToTimes:   lastSecretRotationStartTimesFromGarden(garden, secretConfigs),
-	}, garden.Name)
+	}, namespaces...)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -328,7 +328,7 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 			// This means, these tests might fail if the core logic is changed. This is good, because technically both packages
 			// belong together, and we want to make sure that extensions using the wrapped SecretsManager do exactly the right
 			// thing during CA rotation, otherwise things will be messed up.
-			sm, err = SecretsManagerForGarden(ctx, logr.Discard(), fakeClock, fakeClient, garden, testIdentity, secretConfigs)
+			sm, err = SecretsManagerForGarden(ctx, logr.Discard(), fakeClock, fakeClient, garden, testIdentity, secretConfigs, garden.Name)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Fixes a namespace handling issue in `SecretsManagerForGarden`, introduced with #13662. Earlier, the garden name was used as the namespace parameter which is semantically wrong.

/cc @vpnachev @theoddora

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Release note is left out since #13662 has not been released yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
