### PR TITLE
Machines of MachineDeployments of deleted Worker Pools are able to join cluster

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"go.yaml.in/yaml/v4"
 	corev1 "k8s.io/api/core/v1"
@@ -594,7 +594,7 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 		}
 	}
 
-	machineList := &v1alpha1.MachineList{}
+	machineList := &machinev1alpha1.MachineList{}
 	if err := o.client.List(ctx, machineList, client.InNamespace(o.values.Namespace)); err != nil {
 		return nil, fmt.Errorf("failed to list Machines: %w", err)
 	}
@@ -611,7 +611,6 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 				extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			)
 
-			o.log.V(1).Info("Found wanted OSC name from existing machine", "init", initVal, "original", originalVal, "machine", machine.Name)
 			wantedOSCNames.Insert(originalVal, initVal)
 			continue
 		}
@@ -1146,9 +1145,9 @@ func KeyV2(
 func oscPurposeSuffix(purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {
 	switch purpose {
 	case extensionsv1alpha1.OperatingSystemConfigPurposeProvision:
-		return "init"
+		return "-init"
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
-		return "original"
+		return "-original"
 	default:
 		return ""
 	}
@@ -1169,7 +1168,7 @@ func keySuffix(
 		return ""
 	}
 
-	return imagePrefix + "-" + suffix
+	return imagePrefix + suffix
 }
 
 func generateOSCName(
@@ -1180,5 +1179,5 @@ func generateOSCName(
 	if suffix == "" {
 		return val
 	}
-	return fmt.Sprintf("%s-%s", val, suffix)
+	return fmt.Sprintf("%s%s", val, suffix)
 }

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -597,18 +597,20 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 		}
 	}
 
-	mdList := &v1alpha1.MachineDeploymentList{}
+	mdList := &v1alpha1.MachineList{}
 	if err := o.client.List(ctx, mdList, client.InNamespace(o.values.Namespace), client.HasLabels{}); err != nil {
-		return nil, fmt.Errorf("failed to list MachineDeployments: %w", err)
+		return nil, fmt.Errorf("failed to list Machines: %w", err)
 	}
 
-	for _, md := range mdList.Items {
-		_, ok := md.Labels[gardencorev1beta1constants.LabelWorkerPool]
-		if !ok {
-			continue // Skip MDs that don't have the worker pool label
-		}
+	for _, machine := range mdList.Items {
+		o.log.Info("machine name", "name", machine.Name)
+		//_, ok := machine.Labels[gardencorev1beta1constants.LabelWorkerPool]
+		//if !ok {
+		//	continue // Skip MDs that don't have the worker pool label
+		//}
 
-		if val, ok := md.Spec.Template.Spec.NodeTemplateSpec.ObjectMeta.Labels[gardencorev1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
+		if val, ok := machine.Spec.NodeTemplateSpec.ObjectMeta.Labels[gardencorev1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
+			o.log.Info("found wanted OSC name from existing machine", "oscName", val, "machineName", machine.Name)
 			wantedOSCNames.Insert(val)
 			continue
 		}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -594,15 +594,15 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 		}
 	}
 
-	mdList := &v1alpha1.MachineList{}
-	if err := o.client.List(ctx, mdList, client.InNamespace(o.values.Namespace)); err != nil {
+	machineList := &v1alpha1.MachineList{}
+	if err := o.client.List(ctx, machineList, client.InNamespace(o.values.Namespace)); err != nil {
 		return nil, fmt.Errorf("failed to list Machines: %w", err)
 	}
 
-	for _, machine := range mdList.Items {
+	for _, machine := range machineList.Items {
 		if val, ok := machine.Spec.NodeTemplateSpec.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
-			originalVal := val + "-original"
-			initVal := val + "-init"
+			originalVal := generateOSCName(val, "original")
+			initVal := generateOSCName(val, "init")
 
 			o.log.V(1).Info("Found wanted OSC name from existing machine", "init", initVal, "original", originalVal, "machine", machine.Name)
 			wantedOSCNames.Insert(originalVal, initVal)
@@ -1149,4 +1149,8 @@ func keySuffix(version int, machineImage *gardencorev1beta1.ShootMachineImage, p
 		return imagePrefix + "-original"
 	}
 	return ""
+}
+
+func generateOSCName(val, suffix string) string {
+	return fmt.Sprintf("%s-%s", val, suffix)
 }

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -592,24 +592,22 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 			if err != nil {
 				return nil, err
 			}
-			o.log.Info("inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose)) // gardener-node-agent-worker-kaputt-15050ccbf2cd566b-init || gardener-node-agent-worker-kaputt-15050ccbf2cd566b-original
+			o.log.V(1).Info("inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose))
 			wantedOSCNames.Insert(oscKey + keySuffix(version, worker.Machine.Image, purpose))
 		}
 	}
 
 	mdList := &v1alpha1.MachineList{}
-	if err := o.client.List(ctx, mdList, client.InNamespace(o.values.Namespace), client.HasLabels{}); err != nil {
+	if err := o.client.List(ctx, mdList, client.InNamespace(o.values.Namespace)); err != nil {
 		return nil, fmt.Errorf("failed to list Machines: %w", err)
 	}
 
 	for _, machine := range mdList.Items {
-		o.log.Info("machine name", "name", machine.Name)
-
 		if val, ok := machine.Spec.NodeTemplateSpec.ObjectMeta.Labels[gardencorev1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
 			originalVal := val + "-original"
 			initVal := val + "-init"
 
-			o.log.Info("found wanted OSC name from existing machine", "oscName-originalVal", originalVal, "oscName-initVal", initVal, "machineName", machine.Name)
+			o.log.V(1).Info("found wanted OSC name from existing machine", "init", initVal, "original", originalVal, "machine", machine.Name)
 			wantedOSCNames.Insert(originalVal, initVal)
 			continue
 		}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -1179,5 +1179,5 @@ func generateOSCName(
 	if suffix == "" {
 		return val
 	}
-	return fmt.Sprintf("%s%s", val, suffix)
+	return val + suffix
 }

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -589,7 +589,6 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 			if err != nil {
 				return nil, err
 			}
-			o.log.V(1).Info("Inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose))
 			wantedOSCNames.Insert(oscKey + keySuffix(version, worker.Machine.Image, purpose))
 		}
 	}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"go.yaml.in/yaml/v4"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,6 @@ import (
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/version"
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 )
 
 const (

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gardener/gardener/imagevector"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -576,8 +575,6 @@ func (o *operatingSystemConfig) waitCleanup(ctx context.Context, wantedOSCNames 
 func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set[string], error) {
 	wantedOSCNames := sets.New[string]()
 
-	o.log.Info("number of workers", "number", len(o.values.Workers))
-
 	for _, worker := range o.values.Workers {
 		version, err := o.hashVersion(worker)
 		if err != nil {
@@ -592,7 +589,7 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 			if err != nil {
 				return nil, err
 			}
-			o.log.V(1).Info("inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose))
+			o.log.V(1).Info("Inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose))
 			wantedOSCNames.Insert(oscKey + keySuffix(version, worker.Machine.Image, purpose))
 		}
 	}
@@ -603,11 +600,11 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 	}
 
 	for _, machine := range mdList.Items {
-		if val, ok := machine.Spec.NodeTemplateSpec.ObjectMeta.Labels[gardencorev1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
+		if val, ok := machine.Spec.NodeTemplateSpec.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
 			originalVal := val + "-original"
 			initVal := val + "-init"
 
-			o.log.V(1).Info("found wanted OSC name from existing machine", "init", initVal, "original", originalVal, "machine", machine.Name)
+			o.log.V(1).Info("Found wanted OSC name from existing machine", "init", initVal, "original", originalVal, "machine", machine.Name)
 			wantedOSCNames.Insert(originalVal, initVal)
 			continue
 		}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -592,7 +592,7 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 			if err != nil {
 				return nil, err
 			}
-			o.log.Info("inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose))
+			o.log.Info("inserted osc data from worker", "data", oscKey+keySuffix(version, worker.Machine.Image, purpose)) // gardener-node-agent-worker-kaputt-15050ccbf2cd566b-init || gardener-node-agent-worker-kaputt-15050ccbf2cd566b-original
 			wantedOSCNames.Insert(oscKey + keySuffix(version, worker.Machine.Image, purpose))
 		}
 	}
@@ -604,14 +604,13 @@ func (o *operatingSystemConfig) getWantedOSCNames(ctx context.Context) (sets.Set
 
 	for _, machine := range mdList.Items {
 		o.log.Info("machine name", "name", machine.Name)
-		//_, ok := machine.Labels[gardencorev1beta1constants.LabelWorkerPool]
-		//if !ok {
-		//	continue // Skip MDs that don't have the worker pool label
-		//}
 
 		if val, ok := machine.Spec.NodeTemplateSpec.ObjectMeta.Labels[gardencorev1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]; ok {
-			o.log.Info("found wanted OSC name from existing machine", "oscName", val, "machineName", machine.Name)
-			wantedOSCNames.Insert(val)
+			originalVal := val + "-original"
+			initVal := val + "-init"
+
+			o.log.Info("found wanted OSC name from existing machine", "oscName-originalVal", originalVal, "oscName-initVal", initVal, "machineName", machine.Name)
+			wantedOSCNames.Insert(originalVal, initVal)
 			continue
 		}
 	}

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
@@ -355,7 +355,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			s := runtime.NewScheme()
 			Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())
 			Expect(fakekubernetes.AddToScheme(s)).To(Succeed())
-			Expect(v1alpha1.AddToScheme(s)).To(Succeed())
+			Expect(machinev1alpha1.AddToScheme(s)).To(Succeed())
 			c = fakeclient.NewClientBuilder().WithScheme(s).Build()
 
 			fakeClient = fakeclient.NewClientBuilder().WithScheme(s).Build()

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,7 +51,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/version"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/third_party/mock/go/time"
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 )
 
 var _ = Describe("OperatingSystemConfig", func() {

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/version"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/third_party/mock/go/time"
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 )
 
 var _ = Describe("OperatingSystemConfig", func() {
@@ -354,6 +355,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			s := runtime.NewScheme()
 			Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())
 			Expect(fakekubernetes.AddToScheme(s)).To(Succeed())
+			Expect(v1alpha1.AddToScheme(s)).To(Succeed())
 			c = fakeclient.NewClientBuilder().WithScheme(s).Build()
 
 			fakeClient = fakeclient.NewClientBuilder().WithScheme(s).Build()


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area auto-scaling
/kind bug

**What this PR does / why we need it**:

The OperatingSystemConfig cleanup holds the secrets for the existing machines if if the worker pool is deleted, so they can join back the cluster when the worker pool is again created.

**Which issue(s) this PR fixes**:
Fixes #13431

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The machines of a deleted worker pool are able to join back cluster in healthy state.
```
