### PR TITLE
Improve extensions health check documentation

### DIFF
--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -133,7 +133,7 @@ The health check library will automatically transition the status to `False` if 
 It is up to the extension to decide how to conduct health checks, though it is recommended to make use of the build-in health check functionality of `ManagedResource`s for trivial checks.
 The [Gardener Resource Manager](../concepts/resource-manager.md) conducts basic checks for different API objects out-of-the-box (e.g `Deployments`, `DaemonSets`, ...) for objects deployed via `ManagedResource`s (see [example 1](https://github.com/gardener/gardener/blob/e5bd1127959f5756bfcaf0884bf00a0b2e8bd344/pkg/component/observability/opentelemetry/collector/collector.go#L157-L159), [example 2](https://github.com/gardener/gardener/blob/a7029002ef6e68b9b37df11fea934bcc80ce6f2c/pkg/component/observability/logging/fluentoperator/fluentoperator.go#L300)).
 
-We differentiate between two main scenarios.
+We differentiate between three main scenarios.
 
 ### Shoot Managed Resources
 
@@ -147,7 +147,7 @@ These checks are performed by the Gardenlet and maintained in the [Shoot Care Re
 
 ### Seed Managed Resources
 
-For the `Seed` object, health checks for `ManagedResource`s are performed by the [Seed Care Reconciler](../concepts/gardenlet.md#-care--reconciler).
+For the `Seed` object, health checks for `ManagedResource`s are performed by the [Seed Care Reconciler](../concepts/gardenlet.md#care-reconciler-1).
 The Gardenlet retrieves all `ManagedResource`s from both the `garden` namespace and the `istio-system` namespace of the seed cluster, then aggregates their status into the `Seed` conditions according to the following rule:
 
 - Health checks of `ManagedResource` with `.spec.class!=nil` are aggregated to the `SeedSystemComponentsHealthy` condition

--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -145,10 +145,17 @@ Their status will be aggregated to the `Shoot` conditions according to the follo
 
 These checks are performed by the Gardenlet and maintained in the [Shoot Care Reconciler](../concepts/gardenlet.md#care-reconciler-2).
 
+### Seed Managed Resources
+
+For the `Seed` object, health checks for `ManagedResource`s are performed by the [Seed Care Reconciler](../concepts/gardenlet.md#-care--reconciler).
+The Gardenlet retrieves all `ManagedResource`s from both the `garden` namespace and the `istio-system` namespace of the seed cluster, then aggregates their status into the `Seed` conditions according to the following rule:
+
+- Health checks of `ManagedResource` with `.spec.class!=nil` are aggregated to the `SeedSystemComponentsHealthy` condition
+
 ### Garden Managed Resources
 
 For the `Garden` object managed by the Gardener Operator, health checks for `ManagedResource`s are performed by the [Garden Care Reconciler](../concepts/operator.md#care-reconciler).
-The operator retrieves all `ManagedResource`s from both the garden namespace and the `istio-system` namespace, then aggregates their status into the `Garden` conditions according to the following rules:
+The operator retrieves all `ManagedResource`s from both the `garden` namespace and the `istio-system` namespace, then aggregates their status into the `Garden` conditions according to the following rules:
 
 - Health checks of `ManagedResource` with `.spec.class!=nil` and optionally labeled with `care.gardener.cloud/condition-type=RuntimeComponentsHealthy` are aggregated to the `RuntimeComponentsHealthy` condition
 - Health checks of `ManagedResource` with `.spec.class=nil` or labeled with `care.gardener.cloud/condition-type=VirtualComponentsHealthy` are aggregated to the `VirtualComponentsHealthy` condition


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR improves the documentation regarding managed resources health checks. Outdated links were adjusted. In addition it is mentioned that managed resource health checks are also reflected in the `Garden` status.

/cc @rfranzke 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
