### PR TITLE
gardener-operator: Run renew Seed Secrets tasks sequentially

### DIFF
--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -467,9 +467,9 @@ func (r *Reconciler) reconcile(
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeWorkloadIdentity), virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       helper.GetWorkloadIdentityKeyRotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
-			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient, waitUntilGardenerAPIServerReady),
+			Dependencies: flow.NewTaskIDs(initializeVirtualClusterClient, waitUntilGardenerAPIServerReady, checkIfGardenAccessSecretsRenewalCompletedInAllSeeds),
 		})
-		_ = g.Add(flow.Task{
+		checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds = g.Add(flow.Task{
 			Name: "Check if all seeds finished the renewal of their workload identity tokens",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.CheckIfGardenSecretsRenewalCompletedInAllSeeds(ctx, virtualClusterClient, v1beta1constants.SeedOperationRenewWorkloadIdentityTokens, secretsTypeWorkloadIdentity)
@@ -483,7 +483,7 @@ func (r *Reconciler) reconcile(
 				return secretsrotation.RenewGardenSecretsInAllSeeds(ctx, log.WithValues(secretsTypeKey, secretsTypeGardenletKubeconfig), virtualClusterClient, v1beta1constants.GardenerOperationRenewKubeconfig)
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
-			Dependencies: flow.NewTaskIDs(checkIfGardenAccessSecretsRenewalCompletedInAllSeeds),
+			Dependencies: flow.NewTaskIDs(checkIfWorkloadIdentityTokensRenewalCompletedInAllSeeds),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Check if all seeds finished the renewal of their gardenlet kubeconfig",
@@ -493,6 +493,7 @@ func (r *Reconciler) reconcile(
 			SkipIf:       helper.GetCARotationPhase(garden.Status.Credentials) != gardencorev1beta1.RotationPreparing,
 			Dependencies: flow.NewTaskIDs(renewGardenletKubeconfigInAllSeeds),
 		})
+
 		rewriteResourcesAddLabel = g.Add(flow.Task{
 			Name: "Labeling encrypted resources after modification of encryption config or to re-encrypt them with new ETCD encryption key",
 			Fn: flow.TaskFn(func(ctx context.Context) error {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality ops-productivity
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/blob/4262e4030b1d67ed4e55b61fe0ada8671e71ddd0/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L447 explains that the renew Seed Secrets tasks must run sequentially.

https://github.com/gardener/gardener/pull/10313 introduces a new renew Seed Secrets tasks which in not sequential with the other two existing tasks.

in the current HEAD (9be929bda5e33324f5114aaecb792c732162fa5e), the renew Seed Secrets tasks are:
1. Renew garden-access Secrets: https://github.com/gardener/gardener/blob/9be929bda5e33324f5114aaecb792c732162fa5e/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L448-L463
1. Renew WorkloadIdentity tokens: https://github.com/gardener/gardener/blob/9be929bda5e33324f5114aaecb792c732162fa5e/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L464-L479
1. Renew gardenlet kubeconfigs: https://github.com/gardener/gardener/blob/9be929bda5e33324f5114aaecb792c732162fa5e/pkg/operator/controller/garden/garden/reconciler_reconcile.go#L480-L495

Before https://github.com/gardener/gardener/pull/10313 `1. Renew garden-access Secrets` was depending on `3. Renew gardenlet kubeconfigs`. After the introduction of `2. Renew WorkloadIdentity tokens`, it can run in parallel with  `1. Renew garden-access Secrets` and fail with `error annotating seed foo: already annotated with "gardener.cloud/operation: renew-garden-access-secrets"` as described in https://github.com/gardener/gardener/issues/13734.

With this PR we make the tasks to depend on each other.
The flow should be `1. Renew garden-access Secrets` -> `2. Renew WorkloadIdentity tokens` -> `3. Renew gardenlet kubeconfigs`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13734

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing credentials rotation for the Garden resource to fail is now fixed.
```
