### PR TITLE
Allow Project members to set ownerReference with `kind: Shoot` and `blockOwnerDeletion: true` for Secrets/ConfigMaps

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -662,6 +662,12 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.gardener.cloud
+  resources:
   - namespacedcloudprofiles
   verbs:
   - get

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -475,6 +475,11 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{"shoots/finalizers"},
+					Verbs:     []string{"update"},
+				},
+				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
 					Resources: []string{"namespacedcloudprofiles"},
 					Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},
 				},

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -494,6 +494,11 @@ var _ = Describe("Virtual", func() {
 					Verbs: []string{"create"},
 				},
 				{
+					APIGroups: []string{gardencorev1beta1.GroupName},
+					Resources: []string{"shoots/finalizers"},
+					Verbs:     []string{"update"},
+				},
+				{
 					APIGroups: []string{"core.gardener.cloud"},
 					Resources: []string{"namespacedcloudprofiles"},
 					Verbs:     []string{"get", "list", "watch", "create", "patch", "update", "delete"},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/13742

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13742

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Project admins are allowed to set ownerReference with `kind: Shoot` and `blockOwnerDeletion: true` for Secrets/ConfigMaps when the [`OwnerReferencesPermissionEnforcement`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission plugin is enabled for the virtual kube-apiserver.
```
