### PR TITLE
Enable workload identity token expiration duration via gardenlet configuration

### DIFF
--- a/charts/gardener/gardenlet/templates/helpers.tpl
+++ b/charts/gardener/gardenlet/templates/helpers.tpl
@@ -279,6 +279,9 @@ controllers:
     concurrentSyncs: {{ required ".Values.config.controllers.tokenRequestor.concurrentSyncs is required" .Values.config.controllers.tokenRequestor.concurrentSyncs }}
   tokenRequestorWorkloadIdentity:
     concurrentSyncs: {{ required ".Values.config.controllers.tokenRequestorWorkloadIdentity.concurrentSyncs is required" .Values.config.controllers.tokenRequestorWorkloadIdentity.concurrentSyncs }}
+    {{- if .Values.config.controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration }}
+    tokenExpirationDuration: {{ .Values.config.controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration }}
+    {{- end }}
   {{- if .Values.config.controllers.vpaEvictionRequirements }}
   vpaEvictionRequirements:
     {{- if .Values.config.controllers.vpaEvictionRequirements.concurrentSyncs }}

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -768,7 +768,8 @@ func ComputeExpectedGardenletConfiguration(
 				ConcurrentSyncs: &five,
 			},
 			TokenRequestorWorkloadIdentity: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
-				ConcurrentSyncs: &five,
+				ConcurrentSyncs:         &five,
+				TokenExpirationDuration: ptr.To(6 * time.Hour),
 			},
 			VPAEvictionRequirements: &gardenletconfigv1alpha1.VPAEvictionRequirementsControllerConfiguration{
 				ConcurrentSyncs: &five,

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -135,6 +135,7 @@ config:
       concurrentSyncs: 5
     tokenRequestorWorkloadIdentity:
       concurrentSyncs: 5
+    # tokenExpirationDuration: 6h  
     vpaEvictionRequirements:
       concurrentSyncs: 5
   resources:

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -531,6 +531,12 @@ After the association is made, the `gardenlet` requests a token for the specific
 The `gardenlet` is responsible to keep this token valid by refreshing it periodically.
 The token is then used by components running in the seed cluster in order to present the said `WorkloadIdentity` before external systems, e.g. by calling cloud provider APIs.
 
+> [!NOTE]
+>
+> By default, tokens are valid for 6 hours and are renewed after 50% of their lifetime has passed (approximately 3 hours).
+> However, gardenlets cap token validity at 24 hours for renewal calculation purposes, even if tokens are issued with greater validity.
+> This means that tokens with validity longer than 24 hours will be renewed after 12 hours (50% of the 24-hour cap).
+
 Please refer to [GEP-0026: Workload Identity - Trust Based Authentication](https://github.com/gardener/enhancements/tree/main/geps/0026-workload-identity) for more details.
 
 ### [`VPAEvictionRequirements` Controller](../../pkg/gardenlet/controller/vpaevictionrequirements)

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -93,6 +93,7 @@ controllers:
     concurrentSyncs: 5
   tokenRequestorWorkloadIdentity:
     concurrentSyncs: 5
+  # tokenExpirationDuration: 6h
   vpaEvictionRequirements:
     concurrentSyncs: 5
 resources:

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -430,6 +430,10 @@ func SetDefaults_TokenRequestorWorkloadIdentityControllerConfiguration(obj *Toke
 	if obj.ConcurrentSyncs == nil {
 		obj.ConcurrentSyncs = ptr.To(5)
 	}
+
+	if obj.TokenExpirationDuration == nil {
+		obj.TokenExpirationDuration = ptr.To(DefaultWorkloadIdentityTokenExpirationDuration)
+	}
 }
 
 // SetDefaults_VPAEvictionRequirementsControllerConfiguration sets defaults for the VPAEvictionRequirements controller.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -534,15 +534,20 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(6 * time.Hour)))
 		})
 
 		It("should not overwrite already set values for the token requestor controller configuration", func() {
 			obj.Controllers = &GardenletControllerConfiguration{
-				TokenRequestorWorkloadIdentity: &TokenRequestorWorkloadIdentityControllerConfiguration{ConcurrentSyncs: ptr.To(10)},
+				TokenRequestorWorkloadIdentity: &TokenRequestorWorkloadIdentityControllerConfiguration{
+					ConcurrentSyncs:         ptr.To(10),
+					TokenExpirationDuration: ptr.To(12 * time.Hour),
+				},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(PointTo(Equal(10)))
+			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(12 * time.Hour)))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -15,6 +15,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
+const (
+	// DefaultWorkloadIdentityTokenExpirationDuration is the default duration for workload identity token expiration.
+	// It is set to 6 hours to be short enough to be secure and long enough to be resilient to disruptions.
+	// Tokens are requested with this duration, but actual expiration also depends on Gardener API Server's configuration.
+	DefaultWorkloadIdentityTokenExpirationDuration = 6 * time.Hour
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GardenletConfiguration defines the configuration for the Gardenlet.
@@ -456,6 +463,11 @@ type TokenRequestorWorkloadIdentityControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on events.
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
+	// TokenExpirationDuration is the duration for which the controller will request tokens.
+	// The Gardener API Server may still issue tokens with a shorter duration based on its configuration.
+	// Defaults to 6h.
+	// +optional
+	TokenExpirationDuration *time.Duration `json:"tokenExpirationDuration,omitempty"`
 }
 
 // VPAEvictionRequirementsControllerConfiguration defines the configuration of the VPAEvictionRequirements controller.

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -464,7 +464,7 @@ type TokenRequestorWorkloadIdentityControllerConfiguration struct {
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
 	// TokenExpirationDuration is the duration for which the controller will request tokens.
-	// The Gardener API Server may still issue tokens with a shorter duration based on its configuration.
+	// The Gardener API Server may still issue tokens with a shorter or longer duration based on its configuration.
 	// Defaults to 6h.
 	// +optional
 	TokenExpirationDuration *time.Duration `json:"tokenExpirationDuration,omitempty"`

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation.go
@@ -62,6 +62,9 @@ func ValidateGardenletConfiguration(cfg *gardenletconfigv1alpha1.GardenletConfig
 		if cfg.Controllers.NetworkPolicy != nil {
 			allErrs = append(allErrs, validateNetworkPolicyControllerConfiguration(cfg.Controllers.NetworkPolicy, fldPath.Child("controllers", "networkPolicy"))...)
 		}
+		if cfg.Controllers.TokenRequestorWorkloadIdentity != nil {
+			allErrs = append(allErrs, validateTokenRequestorWorkloadIdentityControllerConfiguration(cfg.Controllers.TokenRequestorWorkloadIdentity, fldPath.Child("controllers", "tokenRequestorWorkloadIdentity"))...)
+		}
 	}
 
 	if cfg.LogLevel != "" {
@@ -315,6 +318,16 @@ func validateBastionControllerConfiguration(cfg *gardenletconfigv1alpha1.Bastion
 
 	if cfg.ConcurrentSyncs != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*cfg.ConcurrentSyncs), fldPath.Child("concurrentSyncs"))...)
+	}
+
+	return allErrs
+}
+
+func validateTokenRequestorWorkloadIdentityControllerConfiguration(cfg *gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if cfg.TokenExpirationDuration != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*cfg.TokenExpirationDuration), fldPath.Child("tokenExpirationDuration"))...)
 	}
 
 	return allErrs

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
@@ -521,9 +521,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should allow valid configuration", func() {
 				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = ptr.To(6 * time.Hour)
 
-				errorList := ValidateGardenletConfiguration(cfg, nil)
-
-				Expect(errorList).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should allow configuration with nil tokenExpirationDuration", func() {

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
@@ -126,9 +126,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 	Describe("#ValidateGardenletConfiguration", func() {
 		It("should allow valid configurations", func() {
-			errorList := ValidateGardenletConfiguration(cfg, nil)
-
-			Expect(errorList).To(BeEmpty())
+			Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 		})
 
 		Context("client connection configuration", func() {
@@ -531,9 +529,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should allow configuration with nil tokenExpirationDuration", func() {
 				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = nil
 
-				errorList := ValidateGardenletConfiguration(cfg, nil)
-
-				Expect(errorList).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should forbid negative tokenExpirationDuration", func() {
@@ -615,8 +611,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should pass as sni config contains a valid external service ip", func() {
 				cfg.SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-				errorList := ValidateGardenletConfiguration(cfg, nil)
-				Expect(errorList).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should forbid as sni config contains an empty external service ip", func() {
@@ -654,8 +649,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should pass valid exposureClassHandler", func() {
-				errorList := ValidateGardenletConfiguration(cfg, nil)
-				Expect(errorList).To(BeEmpty())
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
 
 			It("should fail as exposureClassHandler name is no DNS1123 label with zero length", func() {
@@ -728,17 +722,13 @@ var _ = Describe("GardenletConfiguration", func() {
 				It("should allow to use an external service ip as loadbalancer ip is valid", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil)
-
-					Expect(errorList).To(BeEmpty())
+					Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 				})
 
 				It("should allow to use an external service ip", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = ptr.To("1.1.1.1")
 
-					errorList := ValidateGardenletConfiguration(cfg, nil)
-
-					Expect(errorList).To(BeEmpty())
+					Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 				})
 
 				It("should forbid to use an empty external service ip", func() {

--- a/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/validation/validation_test.go
@@ -515,6 +515,41 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 		})
 
+		Context("token requestor workload identity controller", func() {
+			BeforeEach(func() {
+				cfg.Controllers.TokenRequestorWorkloadIdentity = &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{}
+			})
+
+			It("should allow valid configuration", func() {
+				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = ptr.To(6 * time.Hour)
+
+				errorList := ValidateGardenletConfiguration(cfg, nil)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow configuration with nil tokenExpirationDuration", func() {
+				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = nil
+
+				errorList := ValidateGardenletConfiguration(cfg, nil)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should forbid negative tokenExpirationDuration", func() {
+				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = ptr.To(-1 * time.Hour)
+
+				errorList := ValidateGardenletConfiguration(cfg, nil)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration"),
+					})),
+				))
+			})
+		})
+
 		Context("seed config", func() {
 			It("should not require a seedConfig", func() {
 				cfg.SeedConfig = nil

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -10,6 +10,8 @@
 package v1alpha1
 
 import (
+	time "time"
+
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1387,6 +1389,11 @@ func (in *TokenRequestorWorkloadIdentityControllerConfiguration) DeepCopyInto(ou
 	if in.ConcurrentSyncs != nil {
 		in, out := &in.ConcurrentSyncs, &out.ConcurrentSyncs
 		*out = new(int)
+		**out = **in
+	}
+	if in.TokenExpirationDuration != nil {
+		in, out := &in.TokenExpirationDuration, &out.TokenExpirationDuration
+		*out = new(time.Duration)
 		**out = **in
 	}
 	return

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -191,7 +191,8 @@ func AddToManager(
 	}
 
 	if err := (&workloadidentity.Reconciler{
-		ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs, 0),
+		ConcurrentSyncs:         ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs, 0),
+		TokenExpirationDuration: ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration, gardenletconfigv1alpha1.DefaultWorkloadIdentityTokenExpirationDuration),
 	}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
 		return fmt.Errorf("failed adding TokenRequestorWorkloadIdentity controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -121,7 +121,7 @@ func AddToManager(
 		}
 
 		if err := (&workloadidentity.Reconciler{
-			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs, 0),
+			Config: cfg.Controllers.TokenRequestorWorkloadIdentity,
 		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
 			return fmt.Errorf("failed adding TokenRequestorWorkloadIdentity controller: %w", err)
 		}
@@ -191,8 +191,7 @@ func AddToManager(
 	}
 
 	if err := (&workloadidentity.Reconciler{
-		ConcurrentSyncs:         ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs, 0),
-		TokenExpirationDuration: ptr.Deref(cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration, gardenletconfigv1alpha1.DefaultWorkloadIdentityTokenExpirationDuration),
+		Config: cfg.Controllers.TokenRequestorWorkloadIdentity,
 	}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
 		return fmt.Errorf("failed adding TokenRequestorWorkloadIdentity controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/add.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/add.go
@@ -21,6 +21,7 @@ import (
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	securityclientset "github.com/gardener/gardener/pkg/client/security/clientset/versioned"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 // ControllerName is the name of the controller.
@@ -48,6 +49,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 		if err != nil {
 			return fmt.Errorf("could not create securityV1Alpha1Client: %w", err)
 		}
+	}
+
+	if r.TokenExpirationDuration <= 0 {
+		r.TokenExpirationDuration = gardenletconfigv1alpha1.DefaultWorkloadIdentityTokenExpirationDuration
 	}
 
 	return builder.

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler.go
@@ -142,5 +142,5 @@ func (r *Reconciler) renewDuration(expirationTimestamp time.Time) time.Duration 
 		maxExpirationDuration,
 	)
 
-	return r.JitterFunc(expirationDuration*80/100, 0.05)
+	return r.JitterFunc(expirationDuration*50/100, 0.05)
 }

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -27,6 +27,7 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	securityfake "github.com/gardener/gardener/pkg/client/security/clientset/versioned/fake"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/tokenrequestor/workloadidentity"
 )
 
@@ -95,12 +96,14 @@ var _ = Describe("Reconciler", func() {
 			securityClient = &securityfake.Clientset{Fake: testing.Fake{}}
 
 			ctrl = &workloadidentity.Reconciler{
-				SeedClient:              seedClient,
-				GardenClient:            gardenClient,
-				GardenSecurityClient:    securityClient,
-				Clock:                   fakeClock,
-				JitterFunc:              fakeJitter,
-				TokenExpirationDuration: 6 * time.Hour,
+				SeedClient:           seedClient,
+				GardenClient:         gardenClient,
+				GardenSecurityClient: securityClient,
+				Clock:                fakeClock,
+				JitterFunc:           fakeJitter,
+				Config: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
+					TokenExpirationDuration: ptr.To(6 * time.Hour),
+				},
 			}
 
 			secretName = "cloudsecret"

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Reconciler", func() {
 			secretName = "cloudsecret"
 			workloadIdentityName = "foo-cloud"
 			workloadIdentityNamespace = "garden-foo"
-			expectedRenewDuration = 6 * time.Hour * 80 / 100
+			expectedRenewDuration = 6 * time.Hour * 50 / 100
 			token = "foo"
 
 			secret = &corev1.Secret{
@@ -216,7 +216,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should always renew the token after 24h", func() {
-			expectedRenewDuration = 24 * time.Hour * 80 / 100
+			expectedRenewDuration = 24 * time.Hour * 50 / 100
 			fakeCreateWorkloadIdentityToken(ptr.To[int64](3600 * 100))
 
 			Expect(seedClient.Create(ctx, secret)).To(Succeed())

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -95,11 +95,12 @@ var _ = Describe("Reconciler", func() {
 			securityClient = &securityfake.Clientset{Fake: testing.Fake{}}
 
 			ctrl = &workloadidentity.Reconciler{
-				SeedClient:           seedClient,
-				GardenClient:         gardenClient,
-				GardenSecurityClient: securityClient,
-				Clock:                fakeClock,
-				JitterFunc:           fakeJitter,
+				SeedClient:              seedClient,
+				GardenClient:            gardenClient,
+				GardenSecurityClient:    securityClient,
+				Clock:                   fakeClock,
+				JitterFunc:              fakeJitter,
+				TokenExpirationDuration: 6 * time.Hour,
 			}
 
 			secretName = "cloudsecret"

--- a/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_suite_test.go
+++ b/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -35,6 +36,7 @@ import (
 
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/tokenrequestor/workloadidentity"
 	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -157,9 +159,12 @@ var _ = BeforeSuite(func() {
 	By("Register controller")
 	fakeClock = testclock.NewFakeClock(time.Now())
 	Expect((&workloadidentity.Reconciler{
-		Clock:           fakeClock,
-		JitterFunc:      func(_ time.Duration, _ float64) time.Duration { return time.Second },
-		ConcurrentSyncs: 5,
+		Clock:      fakeClock,
+		JitterFunc: func(_ time.Duration, _ float64) time.Duration { return time.Second },
+		Config: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
+			ConcurrentSyncs:         ptr.To(5),
+			TokenExpirationDuration: ptr.To(6 * time.Hour),
+		},
 	}).AddToManager(mgr, mgr, mgr)).To(Succeed())
 
 	By("Start manager")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
- allows configuring workload identity token expiration duration via gardenlet configuration
- reduces the token renewal duration to use the min of 50% of the token's lifespan and 24h

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13669

**Special notes for your reviewer**:

/cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Operators can configure workload identity token expiration duration via gardenlet's configuration by setting `.controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration`.
```
