### PR TITLE
Allow updating a `MachineImageVersion.ExpirationDate` in `NamespacedCloudProfile`s

### DIFF
--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -300,8 +300,16 @@ func (c *validationContext) validateMachineImageOverrides(ctx context.Context, a
 						var oldMachineImageVersion gardencore.MachineImageVersion
 						oldMachineImageVersion, imageVersionAlreadyInNamespacedCloudProfile = oldVersionsSpec.GetImageVersion(image.Name, imageVersion.Version)
 
-						if imageVersionAlreadyInNamespacedCloudProfile && !reflect.DeepEqual(oldMachineImageVersion, imageVersion) {
-							allErrs = append(allErrs, field.Forbidden(imageVersionIndexPath, fmt.Sprintf("cannot update the machine image version spec of \"%s@%s\", as this version has been added to the parent CloudProfile by now", image.Name, imageVersion.Version)))
+						oldMachineImageVersionWithoutExpiration := oldMachineImageVersion.DeepCopy()
+						imageVersionWithoutExpiration := imageVersion.DeepCopy()
+						if imageVersion.ExpirationDate != nil {
+							oldMachineImageVersionWithoutExpiration.ExpirationDate = nil
+							imageVersionWithoutExpiration.ExpirationDate = nil
+						}
+						// Compare the old and new image version without considering the expiration date.
+						// If the image versions are equal except for the expiration date, then the update is allowed.
+						if imageVersionAlreadyInNamespacedCloudProfile && !reflect.DeepEqual(oldMachineImageVersionWithoutExpiration, imageVersionWithoutExpiration) {
+							allErrs = append(allErrs, field.Forbidden(imageVersionIndexPath, fmt.Sprintf("cannot update the machine image version spec (except for the expiration date) of \"%s@%s\", as this version has been added to the parent CloudProfile by now", image.Name, imageVersion.Version)))
 						}
 					}
 

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -301,14 +301,13 @@ func (c *validationContext) validateMachineImageOverrides(ctx context.Context, a
 						oldMachineImageVersion, imageVersionAlreadyInNamespacedCloudProfile = oldVersionsSpec.GetImageVersion(image.Name, imageVersion.Version)
 
 						oldMachineImageVersionWithoutExpiration := oldMachineImageVersion.DeepCopy()
-						imageVersionWithoutExpiration := imageVersion.DeepCopy()
-						if imageVersion.ExpirationDate != nil {
-							oldMachineImageVersionWithoutExpiration.ExpirationDate = nil
-							imageVersionWithoutExpiration.ExpirationDate = nil
-						}
+						machineImageVersionWithoutExpiration := imageVersion.DeepCopy()
+						oldMachineImageVersionWithoutExpiration.ExpirationDate = nil
+						machineImageVersionWithoutExpiration.ExpirationDate = nil
 						// Compare the old and new image version without considering the expiration date.
+						// The expiration date is neglected here because it is the only field allowed to change for an existing image version.
 						// If the image versions are equal except for the expiration date, then the update is allowed.
-						if imageVersionAlreadyInNamespacedCloudProfile && !reflect.DeepEqual(oldMachineImageVersionWithoutExpiration, imageVersionWithoutExpiration) {
+						if imageVersionAlreadyInNamespacedCloudProfile && !reflect.DeepEqual(oldMachineImageVersionWithoutExpiration, machineImageVersionWithoutExpiration) {
 							allErrs = append(allErrs, field.Forbidden(imageVersionIndexPath, fmt.Sprintf("cannot update the machine image version spec (except for the expiration date) of \"%s@%s\", as this version has been added to the parent CloudProfile by now", image.Name, imageVersion.Version)))
 						}
 					}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, there is a bug preventing the expiration date to be updated in `NamespacedCloudProfile`s.

The reported error is:
```console
[NamespacedCloudProfile] could not be patched: spec.machineImages[0].versions[0]: Forbidden: cannot update the machine image version spec of "gardenlinux@[version]", as this version has been added to the parent CloudProfile by now
```
indicating a bug here:
https://github.com/gardener/gardener/blob/976feb539962ad9c6b4ced721715cd5eed4e3929/plugin/pkg/namespacedcloudprofile/validator/admission.go#L303

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @adenitiu @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix a bug that prevents updating expiration dates of overridden machine image versions in `NamespacedCloudProfile`s.
```
