### PR TITLE
[extensions] Improvement for webhook/certificate management library

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -168,7 +168,7 @@ func run(ctx context.Context, cancel context.CancelFunc, log logr.Logger, cfg *o
 		nil,
 		nil,
 		"",
-		Name,
+		Name, false,
 		v1beta1constants.GardenNamespace,
 		mode,
 		url,

--- a/extensions/pkg/webhook/certificates/add.go
+++ b/extensions/pkg/webhook/certificates/add.go
@@ -34,12 +34,13 @@ func AddCertificateManagementToManager(
 	shootNamespaceSelector map[string]string,
 	shootWebhookManagedResourceName string,
 	componentName string,
+	doNotPrefixComponentName bool,
 	namespace string,
 	mode string,
 	url string,
 ) error {
 	var (
-		identity         = webhook.PrefixedName(componentName) + "-webhook"
+		identity         = webhook.PrefixedName(componentName, doNotPrefixComponentName) + "-webhook"
 		caSecretName     = "ca-" + componentName + "-webhook"
 		serverSecretName = componentName + "-webhook-server"
 	)
@@ -57,6 +58,7 @@ func AddCertificateManagementToManager(
 		Namespace:                       namespace,
 		Identity:                        identity,
 		ComponentName:                   componentName,
+		DoNotPrefixComponentName:        doNotPrefixComponentName,
 		ShootWebhookManagedResourceName: shootWebhookManagedResourceName,
 		ShootNamespaceSelector:          shootNamespaceSelector,
 		Mode:                            mode,

--- a/extensions/pkg/webhook/certificates/certificates_test.go
+++ b/extensions/pkg/webhook/certificates/certificates_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Certificates", func() {
 		DescribeTable("should generate the expected certificate",
 			func(mode, url string, assertServerCertFn func(*x509.Certificate)) {
 				By("Validate generated CA certificate")
-				caCertPEM, err := GenerateUnmanagedCertificates(providerName, certDir, mode, url)
+				caCertPEM, err := GenerateUnmanagedCertificates(providerName, false, certDir, mode, url)
 				Expect(err).NotTo(HaveOccurred())
 
 				caCert, err := utils.DecodeCertificate(caCertPEM)

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -60,6 +60,10 @@ type reconciler struct {
 	Identity string
 	// Name of the component.
 	ComponentName string
+	// DoNotPrefixComponentName can be set if the ComponentName should not be prefixed with 'gardener-extension-'. If
+	// unset (or set to false), the ComponentName will be prefixed with 'gardener-extension-' unless it already starts
+	// with 'gardener-'.
+	DoNotPrefixComponentName bool
 	// ShootWebhookManagedResourceName is the name of the ManagedResource containing the raw shoot webhook config.
 	ShootWebhookManagedResourceName string
 	// ShootNamespaceSelector is a label selector for shoot namespaces relevant to the extension.
@@ -253,6 +257,6 @@ func (r *reconciler) generateWebhookCA(ctx context.Context, sm secretsmanager.In
 
 func (r *reconciler) generateWebhookServerCert(ctx context.Context, sm secretsmanager.Interface) (*corev1.Secret, error) {
 	// use current CA for signing server cert to prevent mismatches when dropping the old CA from the webhook config
-	return sm.Generate(ctx, getWebhookServerCertConfig(r.ServerSecretName, r.Namespace, r.ComponentName, r.Mode, r.URL),
+	return sm.Generate(ctx, getWebhookServerCertConfig(r.ServerSecretName, r.Namespace, r.ComponentName, r.DoNotPrefixComponentName, r.Mode, r.URL),
 		secretsmanager.SignedByCA(r.CASecretName, secretsmanager.UseCurrentCA))
 }

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -180,44 +180,33 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	log.Info("Generated webhook server cert", "serverSecretName", serverSecret.Name)
 
 	for _, sourceWebhookConfig := range r.SourceWebhookConfigs.GetWebhookConfigs() {
-		if err := r.reconcileWebhookConfig(ctx, sourceWebhookConfig, caBundleSecret); err != nil {
+		if err := r.reconcileSourceWebhookConfig(ctx, sourceWebhookConfig, caBundleSecret); err != nil {
 			return reconcile.Result{}, fmt.Errorf("error reconciling source webhook config %s: %w", client.ObjectKeyFromObject(sourceWebhookConfig), err)
 		}
 		log.Info("Updated source webhook config with new CA bundle", "webhookConfig", sourceWebhookConfig)
 	}
 
 	if r.ShootWebhookConfigs != nil && r.ShootWebhookConfigs.HasWebhookConfig() {
-		if r.ShootWebhookManagedResourceName == "" {
-			// Manage shoot webhooks without ManagedResource
-			for _, shootWebhookConfig := range r.ShootWebhookConfigs.GetWebhookConfigs() {
-				if err := r.reconcileWebhookConfig(ctx, shootWebhookConfig, caBundleSecret); err != nil {
-					return reconcile.Result{}, fmt.Errorf("error reconciling shoot webhook config %s: %w", client.ObjectKeyFromObject(shootWebhookConfig), err)
-				}
-				log.Info("Updated shoot webhook config with new CA bundle", "webhookConfig", shootWebhookConfig)
+		for _, shootWebhookConfig := range r.ShootWebhookConfigs.GetWebhookConfigs() {
+			// update shoot webhook config object (in memory) with the freshly created CA bundle which is also used by the
+			// ControlPlane actuator
+			if err := extensionswebhook.InjectCABundleIntoWebhookConfig(shootWebhookConfig, caBundleSecret.Data[secretsutils.DataKeyCertificateBundle]); err != nil {
+				return reconcile.Result{}, err
 			}
-		} else {
-			// Manage shoot webhooks via ManagedResource
-			for _, shootWebhookConfig := range r.ShootWebhookConfigs.GetWebhookConfigs() {
-				// update shoot webhook config object (in memory) with the freshly created CA bundle which is also used by the
-				// ControlPlane actuator
-				if err := extensionswebhook.InjectCABundleIntoWebhookConfig(shootWebhookConfig, caBundleSecret.Data[secretsutils.DataKeyCertificateBundle]); err != nil {
-					return reconcile.Result{}, err
-				}
-			}
+		}
 
-			r.AtomicShootWebhookConfigs.Store(r.ShootWebhookConfigs.DeepCopy())
+		r.AtomicShootWebhookConfigs.Store(r.ShootWebhookConfigs.DeepCopy())
 
-			// reconcile all shoot webhook configs with the freshly created CA bundle
-			if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, *r.ShootWebhookConfigs); err != nil {
-				return reconcile.Result{}, fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
-			}
+		// reconcile all shoot webhook configs with the freshly created CA bundle
+		if err := extensionsshootwebhook.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, *r.ShootWebhookConfigs); err != nil {
+			return reconcile.Result{}, fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
+		}
 
-			if r.ShootWebhookConfigs.MutatingWebhookConfig != nil {
-				log.Info("Updated all shoot mutating webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfigs.MutatingWebhookConfig)
-			}
-			if r.ShootWebhookConfigs.ValidatingWebhookConfig != nil {
-				log.Info("Updated all shoot validating webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfigs.ValidatingWebhookConfig)
-			}
+		if r.ShootWebhookConfigs.MutatingWebhookConfig != nil {
+			log.Info("Updated all shoot mutating webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfigs.MutatingWebhookConfig)
+		}
+		if r.ShootWebhookConfigs.ValidatingWebhookConfig != nil {
+			log.Info("Updated all shoot validating webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfigs.ValidatingWebhookConfig)
 		}
 	}
 
@@ -228,9 +217,9 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	return reconcile.Result{RequeueAfter: r.SyncPeriod}, nil
 }
 
-func (r *reconciler) reconcileWebhookConfig(ctx context.Context, webhookConfig client.Object, caBundleSecret *corev1.Secret) error {
+func (r *reconciler) reconcileSourceWebhookConfig(ctx context.Context, sourceWebhookConfig client.Object, caBundleSecret *corev1.Secret) error {
 	// copy object so that we don't lose its name on API/client errors
-	config := webhookConfig.DeepCopyObject().(client.Object)
+	config := sourceWebhookConfig.DeepCopyObject().(client.Object)
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(config), config); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -295,7 +295,7 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 		webhooks,
 		mgr.GetClient(),
 		c.Server.Namespace,
-		c.extensionName,
+		c.extensionName, false,
 		servicePort,
 		c.Server.Mode,
 		c.Server.URL,
@@ -318,7 +318,7 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 				path = parsedURL.Path
 			}
 
-			return extensionswebhook.BuildClientConfigFor(path, c.Server.Namespace, c.extensionName, servicePort, c.Server.Mode, c.Server.URL, nil), nil
+			return extensionswebhook.BuildClientConfigFor(path, c.Server.Namespace, c.extensionName, false, servicePort, c.Server.Mode, c.Server.URL, nil), nil
 		}
 
 		if shootWebhookConfigs.ValidatingWebhookConfig != nil {
@@ -366,7 +366,7 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 		mgr.GetLogger().Info("Running webhooks with unmanaged certificates (i.e., the webhook CA will not be rotated automatically). " +
 			"This mode is supposed to be used for development purposes only. Make sure to configure --webhook-config-namespace in production.")
 
-		caBundle, err := certificates.GenerateUnmanagedCertificates(c.extensionName, defaultServer.Options.CertDir, c.Server.Mode, c.Server.URL)
+		caBundle, err := certificates.GenerateUnmanagedCertificates(c.extensionName, false, defaultServer.Options.CertDir, c.Server.Mode, c.Server.URL)
 		if err != nil {
 			return nil, fmt.Errorf("error generating new certificates for webhook server: %w", err)
 		}
@@ -410,7 +410,7 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 		atomicShootWebhookConfigs,
 		c.shootNamespaceSelector,
 		c.shootWebhookManagedResourceName,
-		c.extensionName,
+		c.extensionName, false,
 		c.Server.Namespace,
 		c.Server.Mode,
 		c.Server.URL,

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -27,12 +27,16 @@ import (
 
 var _ = Describe("Registration", func() {
 	Describe("#PrefixedName", func() {
-		It("should return an empty string", func() {
-			Expect(PrefixedName("gardener-foo")).To(Equal("gardener-foo"))
+		It("should not prefix because name starts with 'gardener'", func() {
+			Expect(PrefixedName("gardener-foo", false)).To(Equal("gardener-foo"))
 		})
 
-		It("should return 'gardener-extension-'", func() {
-			Expect(PrefixedName("provider-bar")).To(Equal("gardener-extension-provider-bar"))
+		It("should prefix with 'gardener-extension-'", func() {
+			Expect(PrefixedName("provider-bar", false)).To(Equal("gardener-extension-provider-bar"))
+		})
+
+		It("should not prefix with 'gardener-extension-' because explicitly skipped", func() {
+			Expect(PrefixedName("provider-bar", true)).To(Equal("provider-bar"))
 		})
 	})
 
@@ -185,7 +189,7 @@ var _ = Describe("Registration", func() {
 
 		DescribeTable("it should return the expected configs",
 			func(mode, url string) {
-				seedWebhookConfig, shootWebhookConfig, err := BuildWebhookConfigs(webhooks, fakeClient, namespace, providerName, servicePort, mode, url, nil)
+				seedWebhookConfig, shootWebhookConfig, err := BuildWebhookConfigs(webhooks, fakeClient, namespace, providerName, false, servicePort, mode, url, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				var (

--- a/pkg/operator/webhook/add.go
+++ b/pkg/operator/webhook/add.go
@@ -179,7 +179,7 @@ func getClientConfig(webhookPath, mode, url string) admissionregistrationv1.Webh
 	return webhook.BuildClientConfigFor(
 		webhookPath,
 		v1beta1constants.GardenNamespace,
-		"gardener-operator",
+		"gardener-operator", false,
 		443,
 		mode,
 		url,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
1. Support skipping component name prefixing
   Previously, if the component name was not beginning with `gardener-`, we have implicitly prefixed it with `gardener-extension-`.
   However, there are usages of this library for non-native Gardener extensions. Hence, let's support that this prefix is not added automatically if desired.
2. Certificate reconciler creates webhook configs if not present
   Previously, it was only patching the CA if the webhook config was not present.
   This required custom code to initially create the webhook config (like in `gardener-operator`), with special care to prevent races.
   Now, the certificate reconciler creates the webhook config if not found.
3. ~~Support shoot webhooks without `ManagedResource`
   Typically, Gardener extensions manage their webhooks in shoot via a `ManagedResource`.
   However, if this code is used by a component responsible for the garden cluster, a "shoot webhook" is a "virtual cluster webhook". In such cases, direct management (w/o a `ManagedResource`) can be beneficial, especially if the component does not have RBAC/a kubeconfig for the runtime cluster.
   Hence, let's support this by checking if `ShootWebhookManagedResourceName` is set. If not, we just treat the shoot webhooks like "source webhooks" and manage them directly.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
The certificate library for extension webhooks now supports skipping the component name prefixing with `gardener-extension` when `DoNotPrefixComponentName` is set to `true`.
```
