### PR TITLE
Make `NamespacedCloudProfile` status entries order stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/distribution/distribution/v3 v3.0.0
 	github.com/docker/cli v29.1.4+incompatible
+	github.com/elliotchance/orderedmap/v3 v3.1.0
 	github.com/fluent/fluent-operator/v3 v3.5.0
 	github.com/gardener/cert-management v0.19.0
 	github.com/gardener/dependency-watchdog v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elliotchance/orderedmap/v3 v3.1.0 h1:j4DJ5ObEmMBt/lcwIecKcoRxIQUEnw0L804lXYDt/pg=
+github.com/elliotchance/orderedmap/v3 v3.1.0/go.mod h1:G+Hc2RwaZvJMcS4JpGCOyViCnGeKf0bTYCGTO4uhjSo=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -133,7 +133,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"machineImages":[],"machineTypes":[],"providerConfig":{"key":"value"}}}}`))
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"providerConfig":{"key":"value"}}}}`))
 					return nil
 				}),
 			)
@@ -163,7 +163,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"machineImages":[],"machineTypes":[],"providerConfig":{"key2":null}}}}`))
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"providerConfig":{"key2":null}}}}`))
 					return nil
 				}),
 			)
@@ -252,7 +252,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]},"machineImages":[],"machineTypes":[]}}}`))
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]}}}}`))
 					return nil
 				}),
 			)
@@ -282,7 +282,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"expirationDate":"%s","version":"1.0.0"}]},"machineImages":[],"machineTypes":[]}}}`, newExpiryDate.UTC().Format(time.RFC3339))))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"expirationDate":"%s","version":"1.0.0"}]}}}}`, newExpiryDate.UTC().Format(time.RFC3339))))
 					return nil
 				}),
 			)
@@ -310,7 +310,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]},"machineImages":[],"machineTypes":[]},"observedGeneration":7}}`))
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]}},"observedGeneration":7}}`))
 					return nil
 				}),
 			)
@@ -491,7 +491,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[`),
 						ContainSubstring(machineImageParent),
 						ContainSubstring(machineImageNamespacedCloudProfile),
-						ContainSubstring(`],"machineTypes":[]}}}`),
+						ContainSubstring(`]}}}`),
 					))
 					return nil
 				}),
@@ -538,7 +538,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[{"name":"test-image","updateStrategy":"major","versions":[`),
 						ContainSubstring(versionOverride),
 						ContainSubstring(versionAdded),
-						ContainSubstring(`]}],"machineTypes":[]}}}`),
+						ContainSubstring(`]}]}}}`),
 					))
 					return nil
 				}),
@@ -575,7 +575,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 					Expect(patch.Data(o)).To(And(
 						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[{"name":"test-image","updateStrategy":"minor","versions":[`),
 						ContainSubstring(`{"architectures":["amd64"],"cri":[{"name":"containerd"}],"kubeletVersionConstraint":"==1.30.0","version":"1.0.0"}`),
-						ContainSubstring(`]}],"machineTypes":[]}}}`),
+						ContainSubstring(`]}]}}}`),
 					))
 					return nil
 				}),
@@ -628,7 +628,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			gomock.InOrder(
 				c.EXPECT().Status().Return(sw),
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"machineImages":[],"machineTypes":[{"architecture":"amd64","cpu":"1","gpu":"5","memory":"3Gi","name":"test-type-namespaced"}]}}}`))
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"machineTypes":[{"architecture":"amd64","cpu":"1","gpu":"5","memory":"3Gi","name":"test-type-namespaced"}]}}}`))
 					return nil
 				}),
 			)
@@ -665,7 +665,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
 					// Order of machine type array in patch is not guaranteed
 					Expect(patch.Data(o)).To(And(
-						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[],"machineTypes":[`),
+						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineTypes":[`),
 						ContainSubstring(`{"architecture":"amd64","cpu":"1","gpu":"5","memory":"3Gi","name":"test-type-namespaced"}`),
 						ContainSubstring(`{"architecture":"amd64","cpu":"2","gpu":"7","memory":"10Gi","name":"test-type"}`),
 					))
@@ -870,6 +870,115 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 		})
 
 		Describe("#MergeCloudProfiles", func() {
+			Describe("retain order of parent CloudProfile when merging", func() {
+				var (
+					cloudProfile           *gardencorev1beta1.CloudProfile
+					namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
+				)
+
+				BeforeEach(func() {
+					cloudProfile = &gardencorev1beta1.CloudProfile{
+						Spec: gardencorev1beta1.CloudProfileSpec{
+							MachineCapabilities: []gardencorev1beta1.CapabilityDefinition{
+								{Name: "architecture", Values: []string{"amd64", "arm64"}},
+								{Name: "cap-a", Values: []string{"featured", "standard"}},
+								{Name: "cap-b", Values: []string{"one", "two", "three"}},
+							},
+							MachineImages: []gardencorev1beta1.MachineImage{
+								{Name: "image-a"},
+								{
+									Name: "image-b",
+									Versions: []gardencorev1beta1.MachineImageVersion{
+										{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0"}, Architectures: []string{"amd64"}, CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{{Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+											"architecture": {"amd64"},
+											"cap-b":        {"three", "two", "one"},
+											"cap-a":        {"standard"},
+										}}}},
+										{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "2.0"}, Architectures: []string{"amd64"}, CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{{Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+											"architecture": {"amd64"},
+										}}}},
+										{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "3.0"}, Architectures: []string{"arm64"}, CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{{Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+											"architecture": {"arm64"},
+											"cap-a":        {"featured"},
+										}}}},
+									},
+								},
+								{Name: "image-c"},
+							},
+							MachineTypes: []gardencorev1beta1.MachineType{
+								{Name: "type-a", Architecture: ptr.To("amd64")},
+								{Name: "type-b", Architecture: ptr.To("amd64")},
+								{Name: "type-c", Architecture: ptr.To("amd64")},
+							},
+							VolumeTypes: []gardencorev1beta1.VolumeType{
+								{Name: "volume-a"},
+								{Name: "volume-b"},
+								{Name: "volume-c"},
+							},
+							Kubernetes: gardencorev1beta1.KubernetesSettings{Versions: []gardencorev1beta1.ExpirableVersion{
+								{Version: "1.35.0"},
+								{Version: "1.34.1"},
+								{Version: "1.34.0"},
+							}},
+						},
+					}
+					namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{}
+				})
+
+				It("should match the CloudProfile for no overrides", func() {
+					namespacedcloudprofilecontroller.MergeCloudProfiles(namespacedCloudProfile, cloudProfile)
+
+					Expect(namespacedCloudProfile.Status.CloudProfileSpec).To(Equal(cloudProfile.Spec))
+				})
+
+				It("should add new elements and apply overrides consistently while keeping the existing elements ordered", func() {
+					expirationDate := metav1.NewTime(time.Now().Add(time.Hour))
+
+					namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+						{
+							Name: "image-b",
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "2.0", ExpirationDate: &expirationDate}},
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.0"}, Architectures: []string{"amd64"}, CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{{Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+									"architecture": {"amd64"},
+								}}}},
+							},
+						},
+					}
+					namespacedCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{
+						{Name: "type-d", Architecture: ptr.To("amd64")},
+					}
+					namespacedCloudProfile.Spec.VolumeTypes = []gardencorev1beta1.VolumeType{
+						{Name: "volume-d"},
+					}
+					namespacedCloudProfile.Spec.Kubernetes = ptr.To(gardencorev1beta1.KubernetesSettings{
+						Versions: []gardencorev1beta1.ExpirableVersion{
+							{Version: "1.34.1", ExpirationDate: &expirationDate},
+						},
+					})
+
+					namespacedcloudprofilecontroller.MergeCloudProfiles(namespacedCloudProfile, cloudProfile)
+
+					expectedSpec := cloudProfile.Spec.DeepCopy()
+
+					expectedSpec.MachineImages[1].Versions[1].ExpirationDate = &expirationDate
+					expectedSpec.MachineImages[1].Versions = append(expectedSpec.MachineImages[1].Versions, gardencorev1beta1.MachineImageVersion{
+						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.0"},
+						Architectures:    []string{"amd64"},
+						CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{{Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+							"architecture": {"amd64"},
+						}}},
+					})
+					expectedSpec.MachineTypes = append(expectedSpec.MachineTypes, gardencorev1beta1.MachineType{Name: "type-d", Architecture: ptr.To("amd64"), Capabilities: map[string]gardencorev1beta1.CapabilityValues{
+						"architecture": {"amd64"},
+					}})
+					expectedSpec.VolumeTypes = append(expectedSpec.VolumeTypes, gardencorev1beta1.VolumeType{Name: "volume-d"})
+					expectedSpec.Kubernetes.Versions[1].ExpirationDate = &expirationDate
+
+					Expect(namespacedCloudProfile.Status.CloudProfileSpec).To(Equal(*expectedSpec))
+				})
+			})
+
 			Describe("merge limits.maxNodesTotal correctly", func() {
 				var (
 					cloudProfile           *gardencorev1beta1.CloudProfile

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elliotchance/orderedmap/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -70,12 +71,17 @@ func MergeStringMaps[T any](oldMap map[string]T, newMaps ...map[string]T) map[st
 
 // CreateMapFromSlice converts the values of an array to a map using a key function.
 func CreateMapFromSlice[K comparable, T any](arr []T, keyFunc func(T) K) map[K]T {
-	mapped := make(map[K]T, len(arr))
+	return maps.Collect(CreateOrderedMapFromSlice(arr, keyFunc).AllFromFront())
+}
+
+// CreateOrderedMapFromSlice converts the values of an array to an ordered map using a key function.
+func CreateOrderedMapFromSlice[K comparable, T any](arr []T, keyFunc func(T) K) *orderedmap.OrderedMap[K, T] {
+	mapped := orderedmap.NewOrderedMapWithCapacity[K, T](len(arr))
 	if keyFunc == nil {
 		return mapped
 	}
 	for _, value := range arr {
-		mapped[keyFunc(value)] = value
+		mapped.Set(keyFunc(value), value)
 	}
 	return mapped
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This makes comparing the `NamespacedCloudProfile` to its parent `CloudProfile` easier. Also, it opens up for future dashboard enhancements, e.g. for sending diffs to the frontend instead of transmitting the whole status body.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
FYI @klocke-io

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The order of entries in the `NamespacedCloudProfile.Status.CloudProfileSpec` is now the same as in the parent `CloudProfile.Spec`.
```
