### PR TITLE
Add integration test for auto credential rotations in maintenance window

### DIFF
--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -2012,14 +2012,18 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 				g.Expect(shoot.Status.LastMaintenance).NotTo(BeNil())
-				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-ssh-keypair\": SSH keypair rotation started"))
-				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-observability-credentials\": Observability passwords rotation started"))
-				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started"))
+				g.Expect(shoot.Status.LastMaintenance.Description).To(And(
+					ContainSubstring("Credentials \"rotate-ssh-keypair\": SSH keypair rotation started"),
+					ContainSubstring("Credentials \"rotate-observability-credentials\": Observability passwords rotation started"),
+					ContainSubstring("Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started"),
+				))
 				g.Expect(shoot.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
 				g.Expect(shoot.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
-				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-ssh-keypair"))
-				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-observability-credentials"))
-				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-etcd-encryption-key"))
+				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(And(
+					ContainSubstring("rotate-ssh-keypair"),
+					ContainSubstring("rotate-observability-credentials"),
+					ContainSubstring("rotate-etcd-encryption-key"),
+				))
 			}).Should(Succeed())
 		})
 	})

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -1942,9 +1942,14 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 			Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
 		})
 
-		DescribeTable("Auto rotate credentials",
-			func(credentialsAutoRotation gardencorev1beta1.MaintenanceCredentialsAutoRotation, descriptionSubstring, operation string) {
+		DescribeTable("should auto rotate credentials",
+			func(credentialsAutoRotation gardencorev1beta1.MaintenanceCredentialsAutoRotation, maintenanceOperation, descriptionSubstring, operation string) {
 				patch := client.MergeFrom(shoot.DeepCopy())
+				if len(maintenanceOperation) > 0 {
+					shoot.Annotations = map[string]string{
+						"maintenance.gardener.cloud/operation": maintenanceOperation,
+					}
+				}
 				shoot.Spec.Maintenance.AutoRotation = &gardencorev1beta1.MaintenanceAutoRotation{
 					Credentials: &credentialsAutoRotation,
 				}
@@ -1962,22 +1967,61 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 					return shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]
 				}).Should(Equal(operation))
 			},
-			Entry("sshKeypair", gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+			Entry("ssh key pair", gardencorev1beta1.MaintenanceCredentialsAutoRotation{
 				SSHKeypair: &gardencorev1beta1.MaintenanceRotationConfig{
 					RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
 				},
-			}, "Credentials \"rotate-ssh-keypair\": SSH keypair rotation started", "rotate-ssh-keypair"),
+			}, "", "Credentials \"rotate-ssh-keypair\": SSH keypair rotation started", "rotate-ssh-keypair"),
 			Entry("observability credentials", gardencorev1beta1.MaintenanceCredentialsAutoRotation{
 				Observability: &gardencorev1beta1.MaintenanceRotationConfig{
 					RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
 				},
-			}, "Credentials \"rotate-observability-credentials\": Observability passwords rotation started", "rotate-observability-credentials"),
+			}, "", "Credentials \"rotate-observability-credentials\": Observability passwords rotation started", "rotate-observability-credentials"),
 			Entry("etcd encryption key", gardencorev1beta1.MaintenanceCredentialsAutoRotation{
 				ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
 					RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
 				},
-			}, "Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started", "rotate-etcd-encryption-key"),
+			}, "", "Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started", "rotate-etcd-encryption-key"),
+			Entry("etcd encryption key when encryption key rotation start maintenance operation is set", gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+				ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
+					RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
+				},
+			}, "rotate-etcd-encryption-key-start", "Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started", "rotate-etcd-encryption-key-start"),
 		)
+
+		It("should auto rotate multiple credentials", func() {
+			patch := client.MergeFrom(shoot.DeepCopy())
+			shoot.Spec.Maintenance.AutoRotation = &gardencorev1beta1.MaintenanceAutoRotation{
+				Credentials: &gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+					SSHKeypair: &gardencorev1beta1.MaintenanceRotationConfig{
+						RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
+					},
+					Observability: &gardencorev1beta1.MaintenanceRotationConfig{
+						RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
+					},
+					ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
+						RotationPeriod: ptr.To(metav1.Duration{Duration: time.Hour}),
+					},
+				},
+			}
+			Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+			fakeClock.SetTime(fakeClock.Now().Add(2 * time.Hour))
+
+			Expect(kubernetesutils.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.Status.LastMaintenance).NotTo(BeNil())
+				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-ssh-keypair\": SSH keypair rotation started"))
+				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-observability-credentials\": Observability passwords rotation started"))
+				g.Expect(shoot.Status.LastMaintenance.Description).To(ContainSubstring("Credentials \"rotate-etcd-encryption-key\": ETCD Encryption key rotation started"))
+				g.Expect(shoot.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+				g.Expect(shoot.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
+				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-ssh-keypair"))
+				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-observability-credentials"))
+				g.Expect(shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]).To(ContainSubstring("rotate-etcd-encryption-key"))
+			}).Should(Succeed())
+		})
 	})
 },
 	Entry("with capabilities in CloudProfile", true),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind test

**What this PR does / why we need it**:
This PR add an integration tests for the auto credential rotations in the maintenance window added with: https://github.com/gardener/gardener/pull/13493

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
