### PR TITLE
Relax pattern for recognising local registry

### DIFF
--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -25,7 +25,7 @@ import (
 const (
 	mediaTypeHelm = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
-	localRegistry = "registry.local.gardener.cloud:5001"
+	localRegistryPattern = "registry.local.gardener.cloud:"
 )
 
 type pullSecretNamespace struct{}
@@ -122,7 +122,7 @@ func buildRef(oci *gardencorev1.OCIRepository) (name.Reference, error) {
 	}
 
 	// in the local setup we don't want to use TLS
-	if strings.Contains(ref, localRegistry) {
+	if strings.Contains(ref, localRegistryPattern) {
 		opts = append(opts, name.Insecure)
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Relax pattern for recognising local registry to allow reuse for additional local registries on other ports.
This is useful for example for the garden-landscape-kit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
