### PR TITLE
Allow specifying short machine image versions in the `Shoot` workers

### DIFF
--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -535,8 +535,16 @@ func getDefaultMachineImage(
 				break
 			}
 		}
+
 		if defaultImage == nil {
 			return nil, field.Invalid(fldPath, image.Name, "image is not supported")
+		}
+
+		// check for an exact image version match. In that case, do no apply version defaulting.
+		if slices.ContainsFunc(defaultImage.Versions, func(version gardencorev1beta1.MachineImageVersion) bool {
+			return version.Version == image.Version
+		}) {
+			return image, nil
 		}
 	} else {
 		// select the first image which supports the required architecture type


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

This PR allows specifying short worker image versions in the `Shoot` when the short version is explicitly contained in the `CloudProfile`. This allows short images being evaluated by the provider as described in #13758.

The idea is to not default to the long version in case there is an exact match in the `CloudProfile`'s worker images.

**Which issue(s) this PR fixes**:

Fixes #13758.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
It is now explicitly supported to use short worker OS image versions in the `CloudProfile`, which are not defaulted when creating or updating the `Shoot` spec. 
```
