### PR TITLE
[extensions] Improvement for webhook/certificate management library II

### DIFF
--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -62,6 +62,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			AdmissionName,
 			"",
 			nil,
+			nil,
 			webhookServerOptions,
 			webhookSwitches,
 		)
@@ -154,7 +155,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Setting up webhook server")
-			if _, err := webhookOptions.Completed().AddToManager(ctx, mgr, sourceCluster, false); err != nil {
+			if _, err := webhookOptions.Completed().AddToManager(ctx, mgr, sourceCluster); err != nil {
 				return err
 			}
 

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -170,6 +170,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			local.Name,
 			genericactuator.ShootWebhooksResourceName,
 			genericactuator.ShootWebhookNamespaceSelector(local.Type),
+			generalOpts,
 			webhookServerOptions,
 			webhookSwitches,
 		)
@@ -319,7 +320,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not add readycheck of webhook to manager: %w", err)
 			}
 
-			atomicShootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil, generalOpts.Completed().SelfHostedShootCluster)
+			atomicShootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil)
 			if err != nil {
 				return fmt.Errorf("could not add webhooks to manager: %w", err)
 			}

--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -495,7 +495,10 @@ type GeneralConfig struct {
 
 // Complete implements Complete.
 func (r *GeneralOptions) Complete() error {
-	r.config = &GeneralConfig{r.GardenerVersion, r.SelfHostedShootCluster}
+	r.config = &GeneralConfig{
+		GardenerVersion:        r.GardenerVersion,
+		SelfHostedShootCluster: r.SelfHostedShootCluster,
+	}
 	return nil
 }
 
@@ -506,6 +509,12 @@ func (r *GeneralOptions) Completed() *GeneralConfig {
 
 // AddFlags implements Flagger.AddFlags.
 func (r *GeneralOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&r.GardenerVersion, GardenerVersionFlag, "", "Version of the gardenlet.")
-	fs.BoolVar(&r.SelfHostedShootCluster, SelfHostedShootClusterFlag, false, "Does the extension run in a self-hosted shoot cluster?")
+	// GeneralOptions is used in various places and AddFlags might be called multiple times.
+	// Hence, flag registration must only happen once.
+	if fs.Lookup(GardenerVersionFlag) == nil {
+		fs.StringVar(&r.GardenerVersion, GardenerVersionFlag, "", "Version of the gardenlet / gardener-operator.")
+	}
+	if fs.Lookup(SelfHostedShootClusterFlag) == nil {
+		fs.BoolVar(&r.SelfHostedShootCluster, SelfHostedShootClusterFlag, false, "Does the extension run in a self-hosted shoot cluster?")
+	}
 }

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -94,6 +94,7 @@ func BuildWebhookConfigs(
 	servicePort int,
 	mode, url string,
 	caBundle []byte,
+	mergeShootWebhooksIntoSeedWebhooks bool,
 ) (
 	seedWebhookConfigs Configs,
 	shootWebhookConfigs Configs,
@@ -123,7 +124,18 @@ func BuildWebhookConfigs(
 			rules = append(rules, *rule)
 		}
 
-		switch webhook.Target {
+		target := webhook.Target
+		webhookCABundle := caBundle
+		failurePolicy := getFailurePolicy(admissionregistrationv1.Fail, webhook.FailurePolicy)
+
+		// Handle extra settings when shoot webhooks are merged into seed webhooks (self-hosted shoot case).
+		if mergeShootWebhooksIntoSeedWebhooks && target == TargetShoot {
+			target = TargetSeed
+			webhookCABundle = nil
+			failurePolicy = getFailurePolicy(admissionregistrationv1.Ignore, webhook.FailurePolicy)
+		}
+
+		switch target {
 		case TargetSeed:
 			// if all webhooks for one target are removed in a new version, extensions need to explicitly delete the respective
 			// webhook config
@@ -133,9 +145,9 @@ func BuildWebhookConfigs(
 				*webhook,
 				providerName,
 				rules,
-				getFailurePolicy(admissionregistrationv1.Fail, webhook.FailurePolicy),
+				failurePolicy,
 				&exact,
-				BuildClientConfigFor(webhook.Path, namespace, providerName, doNotPrefixComponentName, servicePort, mode, url, caBundle),
+				BuildClientConfigFor(webhook.Path, namespace, providerName, doNotPrefixComponentName, servicePort, mode, url, webhookCABundle),
 				&sideEffects,
 			)
 

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -111,7 +111,7 @@ func BuildWebhookConfigs(
 
 	for _, webhook := range webhooks {
 		var (
-			name  = NamePrefix + providerName
+			name  = PrefixedName(providerName, doNotPrefixComponentName)
 			rules []admissionregistrationv1.RuleWithOperations
 		)
 

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -226,14 +226,14 @@ var _ = Describe("Certificates tests", func() {
 				switchOptions = extensionscmdwebhook.NewSwitchOptions(
 					extensionscmdwebhook.Switch(shootMutatingWebhookName, newShootMutatingWebhook),
 				)
-				webhookOptions = extensionscmdwebhook.NewAddToManagerOptions(extensionName, shootWebhookManagedResourceName, shootNamespaceSelector, serverOptions, switchOptions)
+				webhookOptions = extensionscmdwebhook.NewAddToManagerOptions(extensionName, shootWebhookManagedResourceName, shootNamespaceSelector, nil, serverOptions, switchOptions)
 			)
 
 			shootWebhookConfig.ValidatingWebhookConfig = nil
 			Expect(webhookOptions.Complete()).To(Succeed())
 			webhookConfig := webhookOptions.Completed()
 			webhookConfig.Clock = fakeClock
-			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil, false)
+			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultServer, ok = mgr.GetWebhookServer().(*webhook.DefaultServer)
@@ -422,13 +422,13 @@ var _ = Describe("Certificates tests", func() {
 					extensionscmdwebhook.Switch(shootMutatingWebhookName, newShootMutatingWebhook),
 					extensionscmdwebhook.Switch(shootValidatingWebhookName, newShootValidatingWebhook),
 				)
-				webhookOptions = extensionscmdwebhook.NewAddToManagerOptions(extensionName, shootWebhookManagedResourceName, shootNamespaceSelector, serverOptions, switchOptions)
+				webhookOptions = extensionscmdwebhook.NewAddToManagerOptions(extensionName, shootWebhookManagedResourceName, shootNamespaceSelector, nil, serverOptions, switchOptions)
 			)
 
 			Expect(webhookOptions.Complete()).To(Succeed())
 			webhookConfig := webhookOptions.Completed()
 			webhookConfig.Clock = fakeClock
-			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil, false)
+			atomicShootWebhookConfig, err = webhookConfig.AddToManager(ctx, mgr, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultServer, ok = mgr.GetWebhookServer().(*webhook.DefaultServer)

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
@@ -172,7 +172,7 @@ func addTestWebhookToManager(mgr manager.Manager) error {
 		}),
 	)
 
-	addToManagerOptions := extensionscmdwebhook.NewAddToManagerOptions(providerName, "", nil, &extensionscmdwebhook.ServerOptions{
+	addToManagerOptions := extensionscmdwebhook.NewAddToManagerOptions(providerName, "", nil, nil, &extensionscmdwebhook.ServerOptions{
 		Mode: extensionswebhook.ModeURL,
 		URL:  fmt.Sprintf("%s:%d", testEnv.WebhookInstallOptions.LocalServingHost, testEnv.WebhookInstallOptions.LocalServingPort),
 	}, switchOptions)
@@ -181,6 +181,6 @@ func addTestWebhookToManager(mgr manager.Manager) error {
 		return err
 	}
 
-	_, err := addToManagerOptions.Completed().AddToManager(ctx, mgr, nil, false)
+	_, err := addToManagerOptions.Completed().AddToManager(ctx, mgr, nil)
 	return err
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Improvements and cleanups for webhook/certificate management library:

- Use `PrefixedName` for webhooks for naming consistency.
- Cleanup or consolidate webhook registration for self-hosted shoots.
- Introduce shared options (`GeneralOptions`) for controllers and webhooks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The naming logic for automatically generated webhooks has changed. If the extension name passed to [`extensionscmdwebhook.NewAddToManagerOptions`](https://github.com/gardener/gardener/blob/aae8c452607280e1008393519651bb66c282264c/extensions/pkg/webhook/cmd/options.go#L203) starts with `gardener-`, the extension's webhook names are no longer prefixed with `gardener-extension-`.
```
```feature dependency
[`extensionscmdcontroller.GeneralOptions`](https://github.com/gardener/gardener/blob/aae8c452607280e1008393519651bb66c282264c/extensions/pkg/controller/cmd/options.go#L479) can now be shared between controllers and webhooks. It contains general deployment information that are relevant to both.
```

```breaking dependency
The signature of the `github.com/gardener/gardener/extensions/pkg/webhook/cmd.NewAddToManagerOptions` function has been changed. It now accepts a new `github.com/gardener/gardener/extensions/pkg/controller/cmd.GeneralOptions` parameter at 4th position.
```
