### PR TITLE
Set static cpu requests for fluent-operator

### DIFF
--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -226,6 +226,7 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("4m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
 								},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -270,7 +270,8 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ContainerName:       vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -226,7 +226,6 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("20m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
 								},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -299,7 +299,8 @@ var _ = Describe("Fluent Operator", func() {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ContainerName:       vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -255,6 +255,7 @@ var _ = Describe("Fluent Operator", func() {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4m"),
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -255,7 +255,6 @@ var _ = Describe("Fluent Operator", func() {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR sets small static CPU requests for the fluent-operator Container as we found it to consume far less than the minimal value which the VPA can recommend (`10m` cores CPU).
It also sets the VPA to scale memory only, as otherwise the first VPA scaling would bring back CPU requests of `10m`.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set static cpu requests for fluent-operator.
```
