### PR TITLE
Support garden extension class in extensions healthcheck controller

### DIFF
--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -62,33 +62,38 @@ type HealthCheck interface {
 Health check implementations can optionally implement one or both of the following interfaces to receive the appropriate Kubernetes clients:
 
 ```go
-type ShootClient interface {
-    // InjectShootClient injects the shoot client
-    InjectShootClient(client.Client)
+type TargetClient interface {
+    // InjectTargetClient injects the target client
+    InjectTargetClient(client.Client)
 }
 
-type SeedClient interface {
-    // InjectSeedClient injects the seed client
-    InjectSeedClient(client.Client)
+type SourceClient interface {
+    // InjectSourceClient injects the source client
+    InjectSourceClient(client.Client)
 }
 ```
 
 The health check controller automatically detects if a health checker implements these interfaces and injects the corresponding clients before executing the health checks.
-This allows health checks to interact with resources in the shoot cluster (via `ShootClient`) or the seed cluster (via `SeedClient`) as needed.
 
-For example, a health check that needs to verify resources in the shoot cluster would implement the `ShootClient` interface:
+For shoot extensions (extension class `shoot`):
+- `SourceClient` refers to the seed cluster client
+- `TargetClient` refers to the shoot cluster client
 
+For garden extensions (extension class `garden`):
+- `SourceClient` refers to the garden cluster client
+
+For example, a health check that needs to verify resources in the shoot cluster would implement the `TargetClient` interface:
 ```go
 type MyShootHealthCheck struct {
-    shootClient client.Client
+    targetClient client.Client
 }
 
-func (h *MyShootHealthCheck) InjectShootClient(c client.Client) {
-    h.shootClient = c
+func (h *MyShootHealthCheck) InjectTargetClient(c client.Client) {
+    h.targetClient = c
 }
 
 func (h *MyShootHealthCheck) Check(ctx context.Context, request types.NamespacedName) (*SingleCheckResult, error) {
-    // Use h.shootClient to check resources in the shoot cluster
+    // Use h.targetClient to check resources in the shoot cluster
     // ...
 }
 ```

--- a/docs/extensions/healthcheck-library.md
+++ b/docs/extensions/healthcheck-library.md
@@ -80,7 +80,7 @@ For shoot extensions (extension class `shoot`):
 - `TargetClient` refers to the shoot cluster client
 
 For garden extensions (extension class `garden`):
-- `SourceClient` refers to the garden cluster client
+- `SourceClient` refers to the garden runtime cluster client
 
 For example, a health check that needs to verify resources in the shoot cluster would implement the `TargetClient` interface:
 ```go

--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -47,7 +47,7 @@ type GetExtensionObjectListFunc = func() client.ObjectList
 // PreCheckFunc checks whether the health check shall be performed based on the given object.
 // For shoot extensions, the object is a cluster resource *extensions.Cluster.
 // For garden extensions, the object is *operatorv1alpha1.Garden.
-type PreCheckFunc = func(any) bool
+type PreCheckFunc = func(context.Context, client.Client, client.Object, any) bool
 
 // ErrorCodeCheckFunc checks if the given error is user specific and return respective Gardener ErrorCodes.
 type ErrorCodeCheckFunc = func(error) []gardencorev1beta1.ErrorCode

--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
@@ -45,8 +44,10 @@ type GetExtensionObjectFunc = func() extensionsv1alpha1.Object
 // For example: func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} }
 type GetExtensionObjectListFunc = func() client.ObjectList
 
-// PreCheckFunc checks whether the health check shall be performed based on the given object and cluster.
-type PreCheckFunc = func(context.Context, client.Client, client.Object, *extensionscontroller.Cluster) bool
+// PreCheckFunc checks whether the health check shall be performed based on the given object.
+// For shoot extensions, the object is a cluster resource *extensions.Cluster.
+// For garden extensions, the object is *operatorv1alpha1.Garden.
+type PreCheckFunc = func(any) bool
 
 // ErrorCodeCheckFunc checks if the given error is user specific and return respective Gardener ErrorCodes.
 type ErrorCodeCheckFunc = func(error) []gardencorev1beta1.ErrorCode
@@ -107,7 +108,7 @@ func (h *Result) GetDetails() string {
 }
 
 // HealthCheck represents a single health check
-// Each health check gets the shoot and seed clients injected
+// Each health check gets the target (i.e. shoot) and source (i.e. seed) clients injected
 // returns isHealthy, conditionReason, conditionDetail and error
 // returning an error means the health check could not be conducted and will result in a condition with with type "Unknown" and reason "ConditionCheckError"
 type HealthCheck interface {

--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -38,10 +38,10 @@ type ShootDaemonSetHealthChecker struct {
 }
 
 var (
-	_ healthcheck.HealthCheck = (*SeedDaemonSetHealthChecker)(nil)
-	_ healthcheck.SeedClient  = (*SeedDaemonSetHealthChecker)(nil)
-	_ healthcheck.HealthCheck = (*ShootDaemonSetHealthChecker)(nil)
-	_ healthcheck.ShootClient = (*ShootDaemonSetHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*SeedDaemonSetHealthChecker)(nil)
+	_ healthcheck.SourceClient = (*SeedDaemonSetHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*ShootDaemonSetHealthChecker)(nil)
+	_ healthcheck.TargetClient = (*ShootDaemonSetHealthChecker)(nil)
 )
 
 // NewSeedDaemonSetHealthChecker is a healthCheck function to check DaemonSets in the Seed cluster
@@ -62,14 +62,14 @@ func NewShootDaemonSetHealthChecker(name string) *ShootDaemonSetHealthChecker {
 	}
 }
 
-// InjectSeedClient injects the seed client
-func (h *SeedDaemonSetHealthChecker) InjectSeedClient(seedClient client.Client) {
-	h.client = seedClient
+// InjectSourceClient injects the seed client
+func (h *SeedDaemonSetHealthChecker) InjectSourceClient(sourceClient client.Client) {
+	h.client = sourceClient
 }
 
-// InjectShootClient injects the shoot client
-func (h *ShootDaemonSetHealthChecker) InjectShootClient(shootClient client.Client) {
-	h.client = shootClient
+// InjectTargetClient injects the shoot client
+func (h *ShootDaemonSetHealthChecker) InjectTargetClient(targetClient client.Client) {
+	h.client = targetClient
 }
 
 // SetLoggerSuffix injects the logger

--- a/extensions/pkg/controller/healthcheck/general/deployment.go
+++ b/extensions/pkg/controller/healthcheck/general/deployment.go
@@ -38,10 +38,10 @@ type ShootDeploymentHealthChecker struct {
 }
 
 var (
-	_ healthcheck.HealthCheck = (*SeedDeploymentHealthChecker)(nil)
-	_ healthcheck.SeedClient  = (*SeedDeploymentHealthChecker)(nil)
-	_ healthcheck.HealthCheck = (*ShootDeploymentHealthChecker)(nil)
-	_ healthcheck.ShootClient = (*ShootDeploymentHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*SeedDeploymentHealthChecker)(nil)
+	_ healthcheck.SourceClient = (*SeedDeploymentHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*ShootDeploymentHealthChecker)(nil)
+	_ healthcheck.TargetClient = (*ShootDeploymentHealthChecker)(nil)
 )
 
 // NewSeedDeploymentHealthChecker is a healthCheck function to check Deployments in the Seed cluster
@@ -62,14 +62,14 @@ func NewShootDeploymentHealthChecker(deploymentName string) *ShootDeploymentHeal
 	}
 }
 
-// InjectSeedClient injects the seed client
-func (h *SeedDeploymentHealthChecker) InjectSeedClient(seedClient client.Client) {
-	h.client = seedClient
+// InjectSourceClient injects the seed client
+func (h *SeedDeploymentHealthChecker) InjectSourceClient(sourceClient client.Client) {
+	h.client = sourceClient
 }
 
-// InjectShootClient injects the shoot client
-func (h *ShootDeploymentHealthChecker) InjectShootClient(shootClient client.Client) {
-	h.client = shootClient
+// InjectTargetClient injects the shoot client
+func (h *ShootDeploymentHealthChecker) InjectTargetClient(targetClient client.Client) {
+	h.client = targetClient
 }
 
 // SetLoggerSuffix injects the logger

--- a/extensions/pkg/controller/healthcheck/general/statefulsets.go
+++ b/extensions/pkg/controller/healthcheck/general/statefulsets.go
@@ -38,10 +38,10 @@ type ShootStatefulSetHealthChecker struct {
 }
 
 var (
-	_ healthcheck.HealthCheck = (*SeedStatefulSetHealthChecker)(nil)
-	_ healthcheck.SeedClient  = (*SeedStatefulSetHealthChecker)(nil)
-	_ healthcheck.HealthCheck = (*ShootStatefulSetHealthChecker)(nil)
-	_ healthcheck.ShootClient = (*ShootStatefulSetHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*SeedStatefulSetHealthChecker)(nil)
+	_ healthcheck.SourceClient = (*SeedStatefulSetHealthChecker)(nil)
+	_ healthcheck.HealthCheck  = (*ShootStatefulSetHealthChecker)(nil)
+	_ healthcheck.TargetClient = (*ShootStatefulSetHealthChecker)(nil)
 )
 
 // NewSeedStatefulSetChecker is a healthCheck function to check StatefulSets in the Seed cluster
@@ -62,14 +62,14 @@ func NewShootStatefulSetChecker(name string) *ShootStatefulSetHealthChecker {
 	}
 }
 
-// InjectSeedClient injects the seed client
-func (h *SeedStatefulSetHealthChecker) InjectSeedClient(seedClient client.Client) {
-	h.client = seedClient
+// InjectSourceClient injects the seed client
+func (h *SeedStatefulSetHealthChecker) InjectSourceClient(sourceClient client.Client) {
+	h.client = sourceClient
 }
 
-// InjectShootClient injects the shoot client
-func (h *ShootStatefulSetHealthChecker) InjectShootClient(shootClient client.Client) {
-	h.client = shootClient
+// InjectTargetClient injects the shoot client
+func (h *ShootStatefulSetHealthChecker) InjectTargetClient(targetClient client.Client) {
+	h.client = targetClient
 }
 
 // SetLoggerSuffix injects the logger

--- a/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
@@ -142,7 +142,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 					return
 				}
 
-				if !preCheckFunc(preCheckObj) {
+				if !preCheckFunc(ctx, a.sourceClient, obj, preCheckObj) {
 					log.V(1).Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{

--- a/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
@@ -22,31 +22,35 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
 
 // Actuator contains all the health checks and the means to execute them
 type Actuator struct {
-	restConfig *rest.Config
-	seedClient client.Client
+	restConfig   *rest.Config
+	sourceClient client.Client
 
 	provider            string
 	extensionKind       string
+	extensionClasses    []extensionsv1alpha1.ExtensionClass
 	getExtensionObjFunc GetExtensionObjectFunc
 	healthChecks        []ConditionTypeToHealthCheck
-	shootRESTOptions    extensionsconfigv1alpha1.RESTOptions
+	targetRESTOptions   extensionsconfigv1alpha1.RESTOptions
 }
 
 // NewActuator creates a new Actuator.
-func NewActuator(mgr manager.Manager, provider, extensionKind string, getExtensionObjFunc GetExtensionObjectFunc, healthChecks []ConditionTypeToHealthCheck, shootRESTOptions extensionsconfigv1alpha1.RESTOptions) HealthCheckActuator {
+func NewActuator(mgr manager.Manager, provider, extensionKind string, getExtensionObjFunc GetExtensionObjectFunc, healthChecks []ConditionTypeToHealthCheck, targetRESTOptions extensionsconfigv1alpha1.RESTOptions, extensionClasses []extensionsv1alpha1.ExtensionClass) HealthCheckActuator {
 	return &Actuator{
-		restConfig: mgr.GetConfig(),
-		seedClient: mgr.GetClient(),
+		restConfig:   mgr.GetConfig(),
+		sourceClient: mgr.GetClient(),
 
 		healthChecks:        healthChecks,
 		getExtensionObjFunc: getExtensionObjFunc,
 		provider:            provider,
 		extensionKind:       extensionKind,
-		shootRESTOptions:    shootRESTOptions,
+		extensionClasses:    extensionClasses,
+		targetRESTOptions:   targetRESTOptions,
 	}
 }
 
@@ -77,18 +81,18 @@ type checkResultForConditionType struct {
 // returns an Result for each HealthConditionType (e.g  ControlPlaneHealthy)
 func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Logger, request types.NamespacedName) (*[]Result, error) {
 	var (
-		shootClient client.Client
-		channel     = make(chan channelResult, len(a.healthChecks))
-		wg          sync.WaitGroup
+		targetClient client.Client
+		channel      = make(chan channelResult, len(a.healthChecks))
+		wg           sync.WaitGroup
 	)
 
 	for _, hc := range a.healthChecks {
 		check := hc.HealthCheck
-		SeedClientInto(a.seedClient, check)
-		if _, ok := check.(ShootClient); ok {
-			if shootClient == nil {
+		SourceClientInfo(a.sourceClient, check)
+		if _, ok := check.(TargetClient); ok {
+			if targetClient == nil {
 				var err error
-				_, shootClient, err = util.NewClientForShoot(ctx, a.seedClient, request.Namespace, client.Options{}, a.shootRESTOptions)
+				_, targetClient, err = util.NewClientForShoot(ctx, a.sourceClient, request.Namespace, client.Options{}, a.targetRESTOptions)
 				if err != nil {
 					// don't return here, as we might have started some goroutines already to prevent leakage
 					channel <- channelResult{
@@ -102,7 +106,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 					continue
 				}
 			}
-			ShootClientInto(shootClient, check)
+			TargetClientInfo(targetClient, check)
 		}
 
 		check.SetLoggerSuffix(a.provider, a.extensionKind)
@@ -113,7 +117,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 
 			if preCheckFunc != nil {
 				obj := a.getExtensionObjFunc()
-				if err := a.seedClient.Get(ctx, request, obj); err != nil {
+				if err := a.sourceClient.Get(ctx, request, obj); err != nil {
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
 							Status: gardencorev1beta1.ConditionFalse,
@@ -125,12 +129,12 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 					return
 				}
 
-				cluster, err := extensionscontroller.GetCluster(ctx, a.seedClient, request.Namespace)
+				preCheckObj, err := a.getPreCheckFuncObject(ctx, request)
 				if err != nil {
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
 							Status: gardencorev1beta1.ConditionFalse,
-							Detail: fmt.Sprintf("failed to read the cluster resource: %v", err),
+							Detail: fmt.Sprintf("failed to read the resource: %v", err),
 						},
 						error:               err,
 						healthConditionType: healthConditionType,
@@ -138,7 +142,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 					return
 				}
 
-				if !preCheckFunc(ctx, a.seedClient, obj, cluster) {
+				if !preCheckFunc(preCheckObj) {
 					log.V(1).Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
@@ -260,4 +264,37 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, log logr.Log
 	}
 
 	return &checkResults, nil
+}
+
+func (a *Actuator) getPreCheckFuncObject(ctx context.Context, request types.NamespacedName) (any, error) {
+	if isGardenExtensionClass(a.extensionClasses) {
+		garden, err := getGarden(ctx, a.sourceClient)
+		if err != nil {
+			return nil, err
+		}
+		return garden, nil
+	}
+	cluster, err := extensionscontroller.GetCluster(ctx, a.sourceClient, request.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// getGarden retrieves the Garden resource from the garden cluster.
+func getGarden(ctx context.Context, c client.Client) (*operatorv1alpha1.Garden, error) {
+	gardenList := &operatorv1alpha1.GardenList{}
+	if err := c.List(ctx, gardenList); err != nil {
+		return nil, fmt.Errorf("failed to list Garden resources: %w", err)
+	}
+
+	if len(gardenList.Items) == 0 {
+		return nil, fmt.Errorf("no Garden resource found")
+	}
+
+	if len(gardenList.Items) > 1 {
+		return nil, fmt.Errorf("multiple Garden resources found, expected exactly one")
+	}
+
+	return &gardenList.Items[0], nil
 }

--- a/extensions/pkg/controller/healthcheck/inject.go
+++ b/extensions/pkg/controller/healthcheck/inject.go
@@ -8,31 +8,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ShootClient is an interface to be used to receive a shoot client.
-type ShootClient interface {
-	// InjectShootClient injects the shoot client
-	InjectShootClient(client.Client)
+// TargetClient is an interface to be used to receive a target/shoot client.
+type TargetClient interface {
+	// InjectTargetClient injects the shoot client
+	InjectTargetClient(client.Client)
 }
 
-// SeedClient is an interface to be used to receive a seed client.
-type SeedClient interface {
-	// InjectSeedClient injects the seed client
-	InjectSeedClient(client.Client)
+// SourceClient is an interface to be used to receive a source/seed client.
+type SourceClient interface {
+	// InjectSourceClient injects the source client
+	InjectSourceClient(client.Client)
 }
 
-// ShootClientInto will set the shoot client on i if i implements ShootClient.
-func ShootClientInto(client client.Client, i any) bool {
-	if s, ok := i.(ShootClient); ok {
-		s.InjectShootClient(client)
+// TargetClientInfo will set the target client on i if i implements TargetClient.
+func TargetClientInfo(client client.Client, i any) bool {
+	if s, ok := i.(TargetClient); ok {
+		s.InjectTargetClient(client)
 		return true
 	}
 	return false
 }
 
-// SeedClientInto will set the seed client on i if i implements SeedClient.
-func SeedClientInto(client client.Client, i any) bool {
-	if s, ok := i.(SeedClient); ok {
-		s.InjectSeedClient(client)
+// SourceClientInfo will set the source client on i if i implements SourceClient.
+func SourceClientInfo(client client.Client, i any) bool {
+	if s, ok := i.(SourceClient); ok {
+		s.InjectSourceClient(client)
 		return true
 	}
 	return false

--- a/extensions/pkg/controller/healthcheck/worker/nodes.go
+++ b/extensions/pkg/controller/healthcheck/worker/nodes.go
@@ -77,7 +77,7 @@ func (h *DefaultHealthChecker) InjectSourceClient(sourceClient client.Client) {
 	h.sourceClient = sourceClient
 }
 
-// InjectTargetClient injects the target/shoot client.
+// InjectTargetClient injects the shoot client.
 func (h *DefaultHealthChecker) InjectTargetClient(targetClient client.Client) {
 	h.targetClient = targetClient
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

Extend the healthcheck controller to support the`garden` extension class in addition to shoot extensions. Garden extensions don't require cluster resources or hibernation checks.

Changes:
- support (garden) extension class in the actuator and reconciler
- rename `SeedClient` -> `SourceClient` and `InjectSeedClient()` -> `InjectSourceClient()`
- rename `ShootClient` -> `TargetClient` and `InjectShootClient()` -> `InjectTargetClient()`  
- change `PreCheckFunc` from `func(ctx, client, obj, cluster)` to `func(ctx, client, obj, any)`. The `PreCheckFunc` is used in four places: [ref](https://github.com/search?q=org%3Agardener+%22preCheckFunc+%3A%22&type=code). Those need to be refactored with additional cast of any -> cluster object.
- add `extensionClasses` parameter to `NewActuator()` and `NewReconciler()`

**Which issue(s) this PR fixes**:
Relates to https://github.com/gardener/gardener-extension-shoot-oidc-service/issues/388 

**Special notes for your reviewer**:
CC: @timuthy 

Verified locally with `shoot-oidc-service` extension, deployed with extension class `garden` and healthcheck enabled. Additionally, fot testing purposes, a custom health check was added to verify that the Source + Target clients for the garden case work as expected.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The healthcheck controller now supports the `garden` extension class. Health check client interfaces have been renamed from `SeedClient/ShootClient` to `SourceClient/TargetClient` for better abstraction across extension classes. The `PreCheckFunc` method signature has been changed to accept `any` for cluster or garden object.
```
