### PR TITLE
Set static cpu requests for node-exporter

### DIFF
--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -424,7 +424,6 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("50m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
 								},

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -424,6 +424,7 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("3m"),
 										corev1.ResourceMemory: resource.MustParse("50Mi"),
 									},
 								},

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -483,7 +483,8 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ContainerName:       vpaautoscalingv1.DefaultContainerResourcePolicy,
+							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("50Mi"),
 							},

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -364,6 +364,7 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
+            cpu: 3m
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -364,7 +364,6 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            cpu: 50m
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -412,6 +412,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: '*'
+      controlledResources:
+      - memory
       controlledValues: RequestsOnly
       minAllowed:
         memory: 50Mi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR sets small static CPU requests for the node-exporter Container as we found it to consume far less than the minimal value which the VPA can recommend (`10m` cores CPU).
It also sets the VPA to scale memory only, as otherwise the first VPA scaling would bring back CPU requests of `10m`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set static cpu requests for node-exporter
```
