### PR TITLE
observability: Switch metrics port for OTel collector on nodes from 8888 to 18888

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -32,7 +32,7 @@ const (
 	PathCACert = PathDirectory + "/ca.crt"
 	// MetricsPort is the port on which the OpenTelemetry collector exposes
 	// its internal metrics.
-	MetricsPort = 8888
+	MetricsPort = 18888
 
 	openTelemetryCollectorBinaryPath     = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/opentelemetry-collector"
 	openTelemetryCollectorKubeconfigPath = PathDirectory + "/kubeconfig"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -205,7 +205,7 @@ service:
             exporter:
               prometheus:
                 host: 0.0.0.0
-                port: 8888
+                port: 18888
     logs:
       level: INFO
       encoding: json

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -424,7 +424,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								{
 									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
 									Regex:        `(.+)`,
-									Replacement:  ptr.To(`/api/v1/nodes/${1}:8888/proxy/metrics`),
+									Replacement:  ptr.To(`/api/v1/nodes/${1}:18888/proxy/metrics`),
 									TargetLabel:  "__metrics_path__",
 								},
 								{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Switching the metrics port of the OTel collector running on the nodes to `18888`, in order to avoid potential conflicts with customers running their own collector or other service on the previously used port `8888`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change metrics port for OTel collector on the nodes from 8888 to 18888.
```
