### PR TITLE
Enhance manifest generation

### DIFF
--- a/hack/format.sh
+++ b/hack/format.sh
@@ -15,6 +15,4 @@ echo "> Format Import Order"
 
 goimports_reviser_opts=${GOIMPORTS_REVISER_OPTIONS:-""}
 
-for p in "$@" ; do
-  goimports-reviser $goimports_reviser_opts -recursive $p
-done
+printf '%s\n' "$@" | parallel --will-cite goimports-reviser ${goimports_reviser_opts} -recursive {}

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -15,16 +15,144 @@ if [ "${PROJECT_ROOT#/}" == "${PROJECT_ROOT}" ]; then
 fi
 
 pushd "$PROJECT_ROOT" > /dev/null
+
+extract_mockgen_packages() {
+  local file=$1
+
+  grep -E '//go:generate.*mockgen' "$file" | while read -r line; do
+    # Strip everything before mockgen
+    line="${line#*mockgen}"
+
+    # Tokenize
+    read -ra args <<< "$line"
+
+    skip_next=false
+    for arg in "${args[@]}"; do
+      if $skip_next; then
+        skip_next=false
+        continue
+      fi
+
+      case "$arg" in
+        -package|-destination|-source)
+          skip_next=true
+          ;;
+        -package=*|-destination=*|-source=*)
+          ;;
+        -*)
+          ;;
+        *)
+          # First non-flag token → source package
+          echo "$arg"
+          break
+          ;;
+      esac
+    done
+  done | sort -u
+}
+
+should_generate_mocks() {
+  local dir=$1
+  local file=$2
+
+  local packages
+  packages=$(extract_mockgen_packages "$file")
+
+  # No detectable package → be safe
+  if [ -z "$packages" ]; then
+    return 0
+  fi
+
+  for pkg in $packages; do
+    # If dependency is NOT a gardener package → always generate
+    if [[ "$pkg" != github.com/gardener/gardener/* ]]; then
+      return 0
+    fi
+
+    # Strip module prefix to get repo-relative path
+    local pkg_path="${pkg#github.com/gardener/gardener/}"
+
+    # If source package changed → regenerate
+    if ! git diff --quiet HEAD -- "$pkg_path" 2>/dev/null; then
+      return 0
+    fi
+  done
+
+  # Check destination files exist
+  local generated
+  generated=$(grep -E '//go:generate.*mockgen' "$file" |
+    sed -n 's/.*-destination=\([^ ]*\).*/\1/p')
+
+  for gen_file in $generated; do
+    if [ ! -f "$dir/$gen_file" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# Collect directories that need generation
 ROOTS=${ROOTS:-$(
   git grep -l '//go:generate' "$@" | awk '
     {
       if (/\//) { sub(/\/[^\/]+$/, ""); } else { $0 = "."; }
       if (!seen[$0]++) {
-        print "github.com/gardener/gardener/" $0
+        print $0
       }
     }
   '
 )}
 popd > /dev/null
 
-echo "${ROOTS}" | parallel --tag --will-cite 'echo "Generate {}"; go generate {}'
+# Filter mockgen-only directories
+echo "$ROOTS" | while IFS= read -r dir; do
+  if [ -z "$dir" ]; then
+    continue
+  fi
+  
+  # Check if directory has only mockgen directives
+  has_only_mockgen=true
+  has_mockgen=false
+  
+  for file in "$dir"/*.go; do
+    if [ ! -f "$file" ]; then
+      continue
+    fi
+    
+    if grep -q '//go:generate' "$file"; then
+      if grep -q '//go:generate.*mockgen' "$file"; then
+        has_mockgen=true
+        # Check if there are non-mockgen directives
+        if grep '//go:generate' "$file" | grep -qv 'mockgen'; then
+          has_only_mockgen=false
+          break
+        fi
+      else
+        has_only_mockgen=false
+        break
+      fi
+    fi
+  done
+  
+  # If directory has only mockgen directives, check if generation is needed
+  if [ "$has_only_mockgen" = true ] && [ "$has_mockgen" = true ]; then
+    needs_gen=false
+    for file in "$dir"/*.go; do
+      if [ ! -f "$file" ]; then
+        continue
+      fi
+      if grep -q '//go:generate.*mockgen' "$file" && should_generate_mocks "$dir" "$file"; then
+        needs_gen=true
+        break
+      fi
+    done
+    
+    if [ "$needs_gen" = true ]; then
+      echo "github.com/gardener/gardener/$dir"
+    fi
+  else
+    # Directory has non-mockgen directives or no mockgen, always generate
+    echo "github.com/gardener/gardener/$dir"
+  fi
+done | parallel --will-cite 'echo "Generate {}"; go generate {}'

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -51,6 +51,57 @@ extract_mockgen_packages() {
   done | sort -u
 }
 
+extract_api_dir_packages() {
+  local file=$1
+
+  grep -E '//go:generate.*gen-crd-api-reference-docs' "$file" | while read -r line; do
+    # Extract -api-dir argument
+    if [[ "$line" =~ -api-dir[[:space:]]+([^[:space:]]+) ]]; then
+      echo "${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ -api-dir=([^[:space:]]+) ]]; then
+      echo "${BASH_REMATCH[1]}"
+    fi
+  done | sort -u
+}
+
+should_generate_api_docs() {
+  local dir=$1
+  local file=$2
+
+  local packages
+  packages=$(extract_api_dir_packages "$file")
+
+  # No detectable package → be safe
+  if [ -z "$packages" ]; then
+    return 0
+  fi
+
+  for pkg in $packages; do
+    # Strip module prefix to get repo-relative path
+    local pkg_path="${pkg#github.com/gardener/gardener/}"
+
+    # If API directory changed → regenerate
+    if ! git diff --quiet HEAD -- "$pkg_path" 2>/dev/null; then
+      return 0
+    fi
+  done
+
+  # Check if output files exist
+  local generated
+  generated=$(grep -E '//go:generate.*gen-crd-api-reference-docs' "$file" |
+    sed -n 's/.*-out-file[[:space:]]*\([^[:space:]]*\).*/\1/p')
+
+  for gen_file in $generated; do
+    # Resolve relative path from directory
+    local full_path="$dir/$gen_file"
+    if [ ! -f "$full_path" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 should_generate_mocks() {
   local dir=$1
   local file=$2
@@ -111,9 +162,9 @@ echo "$ROOTS" | while IFS= read -r dir; do
     continue
   fi
   
-  # Check if directory has only mockgen directives
-  has_only_mockgen=true
-  has_mockgen=false
+  # Check if directory has only mockgen or api-docs directives
+  has_only_skippable=true
+  has_skippable=false
   
   for file in "$dir"/*.go; do
     if [ ! -f "$file" ]; then
@@ -121,22 +172,23 @@ echo "$ROOTS" | while IFS= read -r dir; do
     fi
     
     if grep -q '//go:generate' "$file"; then
-      if grep -q '//go:generate.*mockgen' "$file"; then
-        has_mockgen=true
-        # Check if there are non-mockgen directives
-        if grep '//go:generate' "$file" | grep -qv 'mockgen'; then
-          has_only_mockgen=false
+      # Check if file has mockgen or gen-crd-api-reference-docs
+      if grep -q '//go:generate.*mockgen' "$file" || grep -q '//go:generate.*gen-crd-api-reference-docs' "$file"; then
+        has_skippable=true
+        # Check if there are other non-skippable directives
+        if grep '//go:generate' "$file" | grep -v 'mockgen' | grep -qv 'gen-crd-api-reference-docs'; then
+          has_only_skippable=false
           break
         fi
       else
-        has_only_mockgen=false
+        has_only_skippable=false
         break
       fi
     fi
   done
   
-  # If directory has only mockgen directives, check if generation is needed
-  if [ "$has_only_mockgen" = true ] && [ "$has_mockgen" = true ]; then
+  # If directory has only skippable directives, check if generation is needed
+  if [ "$has_only_skippable" = true ] && [ "$has_skippable" = true ]; then
     needs_gen=false
     for file in "$dir"/*.go; do
       if [ ! -f "$file" ]; then
@@ -146,13 +198,19 @@ echo "$ROOTS" | while IFS= read -r dir; do
         needs_gen=true
         break
       fi
+      if grep -q '//go:generate.*gen-crd-api-reference-docs' "$file" && should_generate_api_docs "$dir" "$file"; then
+        needs_gen=true
+        break
+      fi
     done
     
     if [ "$needs_gen" = true ]; then
       echo "github.com/gardener/gardener/$dir"
+    else
+      echo "Skipping github.com/gardener/gardener/$dir (no changes detected)" >&2
     fi
   else
-    # Directory has non-mockgen directives or no mockgen, always generate
+    # Directory has non-skippable directives, always generate
     echo "github.com/gardener/gardener/$dir"
   fi
 done | parallel --will-cite 'echo "Generate {}"; go generate {}'

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -198,13 +198,7 @@ should_generate_mocks() {
 
   # Check if any package changed
   for pkg in $packages; do
-    # If dependency is NOT a gardener package → always generate
-    if [[ "$pkg" != github.com/gardener/gardener/* ]]; then
-      return 0
-    fi
-
-    local pkg_path="${pkg#github.com/gardener/gardener/}"
-    if ! git diff --quiet master -- "$pkg_path" 2>/dev/null; then
+    if ! package_changed "$pkg"; then
       return 0
     fi
   done

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -81,7 +81,7 @@ should_generate_api_docs() {
     local pkg_path="${pkg#github.com/gardener/gardener/}"
 
     # If API directory changed → regenerate
-    if ! git diff --quiet HEAD -- "$pkg_path" 2>/dev/null; then
+    if ! git diff --quiet master -- "$pkg_path" 2>/dev/null; then
       return 0
     fi
   done
@@ -124,7 +124,7 @@ should_generate_mocks() {
     local pkg_path="${pkg#github.com/gardener/gardener/}"
 
     # If source package changed → regenerate
-    if ! git diff --quiet HEAD -- "$pkg_path" 2>/dev/null; then
+    if ! git diff --quiet master -- "$pkg_path" 2>/dev/null; then
       return 0
     fi
   done


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enhances manifest generation to make it conditional, so that it only generates stuff when there are changes in the packages or go.mod.

When everything is cached i.e.  make generate was executed already, on that

Before
`make generate WHAT="manifests"` takes 3 min 20 seconds.

After 
`make generate WHAT="manifests"` takes around 30 seconds only.


Probably, later point codgen generation can also be improved to decrease the overall time to run `make generate` even more.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
