### PR TITLE
feat: Add health/readiness checks for vpn-server

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -168,7 +168,7 @@ images:
   - name: vpn-server
     sourceRepository: github.com/gardener/vpn2
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-server
-    tag: "0.45.0"
+    tag: "0.46.1"
   # OpenTelemetry
   - name: opentelemetry-operator
     sourceRepository: github.com/open-telemetry/opentelemetry-operator
@@ -443,7 +443,7 @@ images:
   - name: vpn-client
     sourceRepository: github.com/gardener/vpn2
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-client
-    tag: "0.45.0"
+    tag: "0.46.1"
   - name: coredns
     sourceRepository: github.com/coredns/coredns
     repository: registry.k8s.io/coredns/coredns


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
- Replaces the port-based liveness/readiness checks with exec-based readiness checks that decides if VPN server is alive and ready based on its status file instead of an open port.
- This removes these annoying log messages from vpn-server:
```
vpn-seed-server 2025-07-28 07:14:05 TCP connection established with [AF_INET6]::ffff:240.123.28.179:51606
vpn-seed-server 2025-07-28 07:14:05 240.123.28.179:51606 Connection reset, restarting [0]
vpn-seed-server 2025-07-28 07:14:08 TCP connection established with [AF_INET6]::ffff:240.123.28.179:41662
vpn-seed-server 2025-07-28 07:14:08 240.123.28.179:41662 Connection reset, restarting [0]
vpn-seed-server 2025-07-28 07:14:15 TCP connection established with [AF_INET6]::ffff:240.123.28.179:41676
vpn-seed-server 2025-07-28 07:14:15 240.123.28.179:41676 Connection reset, restarting [0]
vpn-seed-server 2025-07-28 07:14:18 TCP connection established with [AF_INET6]::ffff:240.123.28.179:57932
vpn-seed-server 2025-07-28 07:14:18 240.123.28.179:57932 Connection reset, restarting [0]
vpn-seed-server 2025-07-28 07:14:25 TCP connection established with [AF_INET6]::ffff:240.123.28.179:57946
vpn-seed-server 2025-07-28 07:14:25 240.123.28.179:57946 Connection reset, restarting [0]
vpn-seed-server 2025-07-28 07:14:28 TCP connection established with [AF_INET6]::ffff:240.123.28.179:52884
vpn-seed-server 2025-07-28 07:14:28 240.123.28.179:52884 Connection reset, restarting [0]

(...)
```
- The new readiness check also handles the VPN server restart more gracefully by waiting for seed->shoot connectivity on the first instance before tearing down the second one, removing a brief outage moment during the restart.



**Special notes for your reviewer**:
Companion PR to [this VPN PR](https://github.com/gardener/vpn2/pull/195). Once VPN is merged, the new VPN release should be added to this PR to merge them together.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
New health and readiness checks have been added to vpn-seed-server to improve availability and reduce log clutter.
```
