### PR TITLE
Make MCM (cluster-autoscaler) work in provider-local setup

### DIFF
--- a/pkg/provider-local/webhook/node/add.go
+++ b/pkg/provider-local/webhook/node/add.go
@@ -37,7 +37,7 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 
 	var (
 		provider = local.Type
-		types    = []extensionswebhook.Type{{Obj: &corev1.Node{}, Subresource: ptr.To("status")}}
+		types    = []extensionswebhook.Type{{Obj: &corev1.Node{}, Subresource: ptr.To("*")}}
 	)
 
 	logger = logger.WithValues("provider", provider)

--- a/pkg/provider-local/webhook/node/mutator.go
+++ b/pkg/provider-local/webhook/node/mutator.go
@@ -27,5 +27,9 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 		resourceList[corev1.ResourceMemory] = local.NodeResourceMemory
 	}
 
+	if len(node.Spec.ProviderID) == 0 {
+		node.Spec.ProviderID = node.Name // MCM requires ProviderID to be set to act on the NodeGroup.
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Formerly, MCM was not able to auto-scale nodes in a `provider-local` cluster, as there was [no `nodeTemplate`](https://github.com/gardener/autoscaler/blob/c37551c32f565b05c382ca1b226fe064297faf9c/cluster-autoscaler/clusterstate/clusterstate.go#L446) in the `MachineClass` and the `Node`s did not have a [`providerID`](https://github.com/gardener/autoscaler/blob/c37551c32f565b05c382ca1b226fe064297faf9c/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go#L138) set.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Enable MCM (cluster-autoscaler) to scale `provider-local` `Node`s.
```
