### PR TITLE
Federate shoot OS image metrics from garden to longterm Prometheus

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs.go
@@ -63,6 +63,7 @@ func CentralScrapeConfigs() []*monitoringv1alpha1.ScrapeConfig {
 						`{__name__="garden_seed_capacity"}`,
 						`{__name__="etcdbr_snapshot_duration_seconds_count"}`,
 						`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
+						`{__name__="shoot:node_operating_system:sum"}`,
 					},
 				},
 				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{

--- a/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/longterm/scrapeconfigs_test.go
@@ -64,6 +64,7 @@ var _ = Describe("PrometheusRules", func() {
 								`{__name__="garden_seed_capacity"}`,
 								`{__name__="etcdbr_snapshot_duration_seconds_count"}`,
 								`{__name__="apiserver_request_total", job="virtual-garden-kube-apiserver"}`,
+								`{__name__="shoot:node_operating_system:sum"}`,
 							},
 						},
 						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This federates the `shoot:node_operating_system:sum` metric from the garden to the longterm Prometheus. This way, the metric is retained for longer and can be used for retroactive analysis of OS image updates.

**Special notes for your reviewer**:

/cc @istvanballok @rickardsjp @chrkl

**Release note**:

```other operator
Federate `shoot:node_operating_system:sum` time series from the garden to the longterm Prometheus.
```
