### PR TITLE
New RBAC Permissions for Gardener Metrics Exporter

### DIFF
--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -171,6 +171,7 @@ var _ = Describe("GardenerMetricsExporter", func() {
 					APIGroups: []string{seedmanagementv1alpha1.GroupName},
 					Resources: []string{
 						"managedseeds",
+						"gardenlets",
 					},
 					Verbs: []string{"get", "list", "watch"},
 				},

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/rbac.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/rbac.go
@@ -39,6 +39,7 @@ func (g *gardenerMetricsExporter) clusterRole() *rbacv1.ClusterRole {
 				APIGroups: []string{seedmanagementv1alpha1.GroupName},
 				Resources: []string{
 					"managedseeds",
+					"gardenlets",
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},


### PR DESCRIPTION
If I forgot something to add, please don't hesitate to tell me. Thank you very much.

**How to categorize this PR?**
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In this [discussion](https://github.com/gardener/gardener/pull/13760#discussion_r2689284268), we have noticed that the Gardener Metrics Exporter is not able to list "gardenlets" resources in the API group "seedmanagement.gardener.cloud".

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other operator
Extended RBAC rules for `gardener-metrics-exporter` to cover `Gardenlet` resources as well.
```
