### PR TITLE
Changing metric names and making mcm-dashboard panels editable

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
@@ -1,6 +1,6 @@
 {
   "description": "Information about the operations of the Machine Controller Manager",
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 16,
@@ -446,14 +446,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_cloud_api_requests_total[1m])",
+          "expr": "rate(mcm_cloud_api_requests_total{name=\"${controlloop}\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{provider}} / {{service}} ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "rate(mcm_cloud_api_requests_failed_total[1m])",
+          "expr": "rate(mcm_cloud_api_requests_failed_total{name=\"${controlloop}\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Error: {{provider}} / {{service}} ({{pod}})",
@@ -653,7 +653,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mcm_workqueue_queue_duration_seconds_sum / mcm_workqueue_queue_duration_seconds_count",
+          "expr": "mcm_workqueue_queue_duration_seconds_sum{name=\"${controlloop}\"} / mcm_workqueue_queue_duration_seconds_count{name=\"${controlloop}\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}",
@@ -738,7 +738,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mcm_workqueue_queue_duration_seconds_sum",
+          "expr": "mcm_workqueue_queue_duration_seconds_sum{name=\"${controlloop}\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}",
@@ -823,7 +823,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mcm_workqueue_depth",
+          "expr": "mcm_workqueue_depth{name=\"${controlloop}\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",
@@ -908,7 +908,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_workqueue_adds_total[5m])",
+          "expr": "rate(mcm_workqueue_adds_total{name=\"${controlloop}\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",
@@ -993,7 +993,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_workqueue_retries_total[5m])",
+          "expr": "rate(mcm_workqueue_retries_total{name=\"${controlloop}\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
@@ -1,6 +1,6 @@
 {
   "description": "Information about the operations of the Machine Controller Manager",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 16,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
@@ -1,6 +1,6 @@
 {
   "description": "Information about the operations of the Machine Controller Manager",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 16,
@@ -653,25 +653,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "${controlloop}_work_duration{quantile=\"0.5\"}",
+          "expr": "mcm_workqueue_queue_duration_seconds_sum / mcm_workqueue_queue_duration_seconds_count",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 ({{pod}})",
+          "legendFormat": "{{pod}}",
           "refId": "A"
-        },
-        {
-          "expr": "${controlloop}_work_duration{quantile=\"0.9\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "p90 ({{pod}})",
-          "refId": "B"
-        },
-        {
-          "expr": "${controlloop}_work_duration{quantile=\"0.99\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "p99 ({{pod}})",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -752,25 +738,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "${controlloop}_queue_latency{quantile=\"0.5\"}",
+          "expr": "mcm_workqueue_queue_duration_seconds_sum",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "p50 ({{pod}})",
+          "legendFormat": "{{pod}}",
           "refId": "A"
-        },
-        {
-          "expr": "${controlloop}_queue_latency{quantile=\"0.9\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "p90 ({{pod}})",
-          "refId": "B"
-        },
-        {
-          "expr": "${controlloop}_queue_latency{quantile=\"0.99\"}",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "p99 ({{pod}})",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -851,7 +823,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "${controlloop}_depth",
+          "expr": "mcm_workqueue_depth",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",
@@ -936,7 +908,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(${controlloop}_adds[5m])",
+          "expr": "rate(mcm_workqueue_adds_total[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",
@@ -1021,7 +993,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(${controlloop}_retries[5m])",
+          "expr": "rate(mcm_workqueue_retries_total[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR changes the names of the metric to be displayed on plutono dashboards. Earlier the names had mismatch which resulted in metrics not being displayed on mcm-dashboard. Also, the `editable` flag is set to allow metric panels to be edited for easy debugging.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
