### PR TITLE
Deleting webhooks in make gardener-down script

### DIFF
--- a/hack/gardener-down.sh
+++ b/hack/gardener-down.sh
@@ -16,6 +16,7 @@ kubectl delete seed \
   --timeout 5m
 
 kubectl annotate project local garden confirmation.gardener.cloud/deletion=true
+kubectl delete validatingwebhookconfiguration/gardener-extension-admission-local --ignore-not-found
 skaffold delete -m provider-local,gardenlet
 
 kubectl delete validatingwebhookconfiguration/gardener-admission-controller --ignore-not-found


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Fixes the bug where when running `make gardener-down`, it didn't delete the `validatingwebhookconfiguration/gardener-extension-admission-local` webhook and later threw an error when running `make gardener-up`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
