### PR TITLE
Split the `ShootDNS` admission plugin into mutating and validating admission plugin (part 1)

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -99,10 +99,10 @@ This prevents misconfigurations that would otherwise allow users to create such 
 
 **Type**: Validating. **Enabled by default**: Yes.
 
-This admission controller reacts on `UPDATE` operations for `CredentialsBinding`s, `SecretBinding`s, `Shoot`s. 
+This admission controller reacts on `UPDATE` operations for `CredentialsBinding`s, `SecretBinding`s, `Shoot`s.
 It ensures that the finalizers of these resources are not removed by users, as long as the affected resource is still in use.
 For `CredentialsBinding`s and `SecretBinding`s this means, that the `gardener` finalizer can only be removed if the binding is not referenced by any `Shoot`.
-In case of `Shoot`s, the `gardener` finalizer can only be removed if the last operation of the `Shoot` indicates a successful deletion. 
+In case of `Shoot`s, the `gardener` finalizer can only be removed if the last operation of the `Shoot` indicates a successful deletion.
 
 ## `ManagedSeed`
 
@@ -197,7 +197,7 @@ When the seed is using `WorkloadIdentity` as backup credentials, the plugin ensu
 
 ## `ShootDNS`
 
-**Type**: Mutating. **Enabled by default**: Yes.
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It tries to assign a default domain to the `Shoot`.

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -222,19 +222,6 @@ func (d *DNS) Admit(_ context.Context, a admission.Attributes, _ admission.Objec
 	return nil
 }
 
-// checkFunctionlessDNSProviders returns an error if a non-primary provider isn't configured correctly.
-func checkFunctionlessDNSProviders(a admission.Attributes, shoot *core.Shoot) error {
-	dns := shoot.Spec.DNS
-	fldPath := field.NewPath("spec", "dns", "providers")
-	for idx, provider := range dns.Providers {
-		if !ptr.Deref(provider.Primary, false) && (provider.Type == nil || provider.CredentialsRef == nil) {
-			fieldErr := field.Required(fldPath.Index(idx), "non-primary DNS providers must specify `type` and `credentialsRef`")
-			return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
-		}
-	}
-	return nil
-}
-
 // checkPrimaryDNSProvider checks if the shoot uses a default domain and returns an error
 // if a primary provider is used at the same time.
 func checkPrimaryDNSProvider(a admission.Attributes, shoot *core.Shoot, defaultDomains []string) error {
@@ -464,5 +451,18 @@ func (d *DNS) Validate(_ context.Context, a admission.Attributes, _ admission.Ob
 		}
 	}
 
+	return nil
+}
+
+// checkFunctionlessDNSProviders returns an error if a non-primary provider isn't configured correctly.
+func checkFunctionlessDNSProviders(a admission.Attributes, shoot *core.Shoot) error {
+	dns := shoot.Spec.DNS
+	fldPath := field.NewPath("spec", "dns", "providers")
+	for idx, provider := range dns.Providers {
+		if !ptr.Deref(provider.Primary, false) && (provider.Type == nil || provider.CredentialsRef == nil) {
+			fieldErr := field.Required(fldPath.Index(idx), "non-primary DNS providers must specify `type` and `credentialsRef`")
+			return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
+		}
+	}
 	return nil
 }

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -823,44 +823,33 @@ var _ = Describe("dns", func() {
 
 	Describe("#Validate", func() {
 		var (
-			ctx                 context.Context
-			admissionHandler    *DNS
-			kubeInformerFactory kubeinformers.SharedInformerFactory
-			coreInformerFactory gardencoreinformers.SharedInformerFactory
+			ctx              context.Context
+			admissionHandler *DNS
 
-			shoot     core.Shoot
-			provider  = core.DNSUnmanaged
-			shootBase = core.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      shootName,
-					Namespace: namespace,
-				},
-				Spec: core.ShootSpec{
-					DNS:      &core.DNS{},
-					SeedName: ptr.To(seedName),
-				},
-			}
+			shoot    core.Shoot
+			provider = core.DNSUnmanaged
 		)
 
 		BeforeEach(func() {
-			ctx = context.TODO()
+			ctx = context.Background()
 			var err error
 			admissionHandler, err = New()
 			Expect(err).ToNot(HaveOccurred())
 
 			admissionHandler.AssignReadyFunc(func() bool { return true })
-			kubeInformerFactory = kubeinformers.NewSharedInformerFactory(nil, 0)
-			admissionHandler.SetKubeInformerFactory(kubeInformerFactory)
-			coreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-			admissionHandler.SetCoreInformerFactory(coreInformerFactory)
-
-			shootBase.Spec.DNS.Domain = nil
-			shootBase.Spec.DNS.Providers = []core.DNSProvider{
-				{
-					Type: &provider,
+			shoot = core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: namespace,
+				},
+				Spec: core.ShootSpec{
+					DNS: &core.DNS{
+						Domain:    nil,
+						Providers: []core.DNSProvider{{Type: &provider}},
+					},
+					SeedName: ptr.To(seedName),
 				},
 			}
-			shoot = shootBase
 		})
 
 		It("should skip validation when resource is not Shoot", func() {

--- a/test/integration/apiserver/admissionplugins/shootdns/shootdns_suite_test.go
+++ b/test/integration/apiserver/admissionplugins/shootdns/shootdns_suite_test.go
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootdns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	gardenerenvtest "github.com/gardener/gardener/test/envtest"
+)
+
+func TestShootDNS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration APIServer AdmissionPlugins ShootDNS Suite")
+}
+
+// testID is used for generating test namespace names and other IDs
+const testID = "shootdns-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+
+	testNamespace          *corev1.Namespace
+	cloudProfile           *gardencorev1beta1.CloudProfile
+	testSecret             *corev1.Secret
+	testCredentialsBinding *securityv1alpha1.CredentialsBinding
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootValidator,SeedValidator,ShootMutator",
+			},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test clients")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Create test Namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			GenerateName: "garden-",
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("Delete test Namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("Create Project")
+	project := &gardencorev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+		},
+		Spec: gardencorev1beta1.ProjectSpec{
+			Namespace: &testNamespace.Name,
+		},
+	}
+	Expect(testClient.Create(ctx, project)).To(Succeed())
+	log.Info("Created Project for test", "project", client.ObjectKeyFromObject(project))
+
+	DeferCleanup(func() {
+		By("Delete Project")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, project))).To(Succeed())
+	})
+
+	By("Create CloudProfile")
+	cloudProfile = &gardencorev1beta1.CloudProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: testID + "-",
+		},
+		Spec: gardencorev1beta1.CloudProfileSpec{
+			Kubernetes: gardencorev1beta1.KubernetesSettings{
+				Versions: []gardencorev1beta1.ExpirableVersion{{Version: "1.31.1"}},
+			},
+			MachineImages: []gardencorev1beta1.MachineImage{
+				{
+					Name: "some-OS",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.1"},
+							CRI: []gardencorev1beta1.CRI{
+								{
+									Name: gardencorev1beta1.CRINameContainerD,
+								},
+							},
+						},
+					},
+				},
+			},
+			MachineTypes: []gardencorev1beta1.MachineType{{Name: "large"}},
+			Regions:      []gardencorev1beta1.Region{{Name: "region"}},
+			Type:         "provider-type",
+		},
+	}
+	Expect(testClient.Create(ctx, cloudProfile)).To(Succeed())
+	log.Info("Created CloudProfile for test", "cloudProfile", client.ObjectKeyFromObject(cloudProfile))
+
+	DeferCleanup(func() {
+		By("Delete CloudProfile")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, cloudProfile))).To(Succeed())
+	})
+
+	By("Create CredentialsBinding")
+	testSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    testNamespace.Name,
+		},
+	}
+	Expect(testClient.Create(ctx, testSecret)).To(Succeed())
+	log.Info("Created Secret for test", "secret", client.ObjectKeyFromObject(testSecret))
+
+	DeferCleanup(func() {
+		By("Delete Secret")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, testSecret))).To(Succeed())
+	})
+
+	testCredentialsBinding = &securityv1alpha1.CredentialsBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-",
+			Namespace:    testNamespace.Name,
+		},
+		Provider: securityv1alpha1.CredentialsBindingProvider{
+			Type: "provider-type",
+		},
+		CredentialsRef: corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       testSecret.Name,
+			Namespace:  testSecret.Namespace,
+		},
+	}
+	Expect(testClient.Create(ctx, testCredentialsBinding)).To(Succeed())
+	log.Info("Created CredentialsBinding for test", "credentialsBinding", client.ObjectKeyFromObject(testCredentialsBinding))
+
+	DeferCleanup(func() {
+		By("Delete CredentialsBinding")
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, testCredentialsBinding))).To(Succeed())
+	})
+})

--- a/test/integration/apiserver/admissionplugins/shootdns/shootdns_test.go
+++ b/test/integration/apiserver/admissionplugins/shootdns/shootdns_test.go
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootdns_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("ShootDNS tests", func() {
+	var (
+		shoot *gardencorev1beta1.Shoot
+	)
+
+	BeforeEach(func() {
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    testNamespace.Name,
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				CloudProfileName:       &cloudProfile.Name,
+				CredentialsBindingName: ptr.To(testCredentialsBinding.Name),
+				DNS: &gardencorev1beta1.DNS{
+					Domain: ptr.To("test.local.gardener.cloud"),
+					Providers: []gardencorev1beta1.DNSProvider{
+						{
+							Type:       ptr.To("provider-type"),
+							Primary:    ptr.To(false),
+							SecretName: &testSecret.Name,
+							CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+								APIVersion: "v1",
+								Kind:       "Secret",
+								Name:       testSecret.Name,
+							},
+						},
+					},
+				},
+				Region: "region",
+				Provider: gardencorev1beta1.Provider{
+					Type: "provider-type",
+					Workers: []gardencorev1beta1.Worker{
+						{
+							Name:    "cpu-worker",
+							Minimum: 2,
+							Maximum: 2,
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    "some-OS",
+									Version: ptr.To("1.1.1"),
+								},
+							},
+						},
+					},
+				},
+				Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.31.1"},
+				Networking: &gardencorev1beta1.Networking{
+					Type:     ptr.To("foo-networking"),
+					Pods:     ptr.To("100.128.0.0/11"),
+					Services: ptr.To("100.72.0.0/13"),
+				},
+			},
+		}
+	})
+
+	Context("checkFunctionlessDNSProviders", func() {
+		Context("Create", func() {
+			It("should allow shoot creation with non-primary DNS provider and configured credentials", func() {
+				By("Create Shoot")
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete Shoot")
+					Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("should allow shoot creation when shoot.spec.dns is not set", func() {
+				shoot.Spec.DNS = nil
+				By("Create Shoot")
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete Shoot")
+					Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("should allow shoot creation when dnsProvider has secretName set and credentialsRef unset", func() {
+				shoot.Spec.DNS.Providers[0].CredentialsRef = nil
+				By("Create Shoot")
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(Succeed())
+
+				By("Ensure credentialsRef has been synced with secretName")
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+				}).Should(Succeed())
+
+				Expect(shoot.Spec.DNS.Providers[0].CredentialsRef).To(Equal(&autoscalingv1.CrossVersionObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       testSecret.Name,
+				}))
+
+				DeferCleanup(func() {
+					By("Delete Shoot")
+					Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("should allow shoot creation when dnsProvider has secretName unset and credentialsRef set", func() {
+				shoot.Spec.DNS.Providers[0].SecretName = nil
+				By("Create Shoot")
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(Succeed())
+
+				By("Ensure credentialsRef has been synced with secretName")
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+				}).Should(Succeed())
+
+				Expect(shoot.Spec.DNS.Providers[0].SecretName).To(Equal(&testSecret.Name))
+
+				DeferCleanup(func() {
+					By("Delete Shoot")
+					Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+					Eventually(func() error {
+						return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+					}).Should(BeNotFoundError())
+				})
+			})
+
+			It("should forbid shoot creation when dnsProvider is not primary and has no credentials configured", func() {
+				shoot.Spec.DNS.Providers[0] = gardencorev1beta1.DNSProvider{
+					Primary: ptr.To(false),
+					Type:    ptr.To("provider-type"),
+				}
+				By("Create Shoot")
+				Expect(testClient.Create(ctx, shoot)).To(And(
+					HaveOccurred(),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"ErrStatus": MatchFields(IgnoreExtras, Fields{
+							"Code":    Equal(int32(http.StatusUnprocessableEntity)),
+							"Message": ContainSubstring("Required value: non-primary DNS providers must specify `type` and `credentialsRef`"),
+						})},
+					)),
+				))
+
+				DeferCleanup(func() {
+					// Only when the shoot is created the name is set and it should be deleted.
+					if shoot.Name != "" {
+						By("Delete Shoot")
+						Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+						Eventually(func() error {
+							return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+						}).Should(BeNotFoundError())
+					}
+				})
+			})
+
+			It("should forbid shoot creation when dnsProvider is not primary, has no type, credentialsRef is unset but secretName is set", func() {
+				shoot.Spec.DNS.Providers[0] = gardencorev1beta1.DNSProvider{
+					Primary:    ptr.To(false),
+					Type:       nil,
+					SecretName: &testSecret.Name,
+				}
+				By("Create Shoot")
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).Should(And(
+					HaveOccurred(),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"ErrStatus": MatchFields(IgnoreExtras, Fields{
+							"Code":    Equal(int32(http.StatusUnprocessableEntity)),
+							"Message": ContainSubstring("Required value: type must be set when credentialsRef is set"),
+						})},
+					)),
+				))
+
+				DeferCleanup(func() {
+					// Only when the shoot is created the name is set and it should be deleted.
+					if shoot.Name != "" {
+						By("Delete Shoot")
+						Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+						Eventually(func() error {
+							return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+						}).Should(BeNotFoundError())
+					}
+				})
+			})
+		})
+
+		Context("Update", func() {
+			BeforeEach(func() {
+				By("Create Seed")
+				seed := &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: testID + "-",
+					},
+					Spec: gardencorev1beta1.SeedSpec{
+						Provider: gardencorev1beta1.SeedProvider{
+							Region: "region",
+							Type:   "provider-type",
+						},
+						Ingress: &gardencorev1beta1.Ingress{
+							Domain: "seed.example.com",
+							Controller: gardencorev1beta1.IngressController{
+								Kind: "nginx",
+							},
+						},
+						DNS: gardencorev1beta1.SeedDNS{
+							Provider: &gardencorev1beta1.SeedDNSProvider{
+								Type: "provider",
+								CredentialsRef: &corev1.ObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "some-secret",
+									Namespace:  "some-namespace",
+								},
+							},
+							Internal: &gardencorev1beta1.SeedDNSProviderConfig{
+								Type:   "provider",
+								Domain: "local.example.com",
+								CredentialsRef: corev1.ObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "some-secret",
+									Namespace:  "some-namespace",
+								},
+							},
+						},
+						Settings: &gardencorev1beta1.SeedSettings{
+							Scheduling: &gardencorev1beta1.SeedSettingScheduling{Visible: true},
+						},
+						Networks: gardencorev1beta1.SeedNetworks{
+							Pods:     "10.0.0.0/16",
+							Services: "10.1.0.0/16",
+							Nodes:    ptr.To("10.2.0.0/16"),
+						},
+					},
+				}
+				Expect(testClient.Create(ctx, seed)).To(Succeed())
+				log.Info("Created Seed for test", "seed", client.ObjectKeyFromObject(seed))
+
+				DeferCleanup(func() {
+					By("Delete Seed")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, seed))).To(Succeed())
+				})
+
+				By("Pre-create the shoot with spec.seedName set otherwise the validation would be skipped")
+				shoot.Spec.SeedName = &seed.Name
+				Eventually(func() error {
+					return testClient.Create(ctx, shoot)
+				}).To(Succeed())
+
+				DeferCleanup(func() {
+					By("Delete Shoot")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
+				})
+			})
+
+			It("should allow shoot update with non-primary DNS provider and configured credentials", func() {
+				shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: ptr.To(false)}
+				By("Update Shoot")
+				Eventually(func() error {
+					return testClient.Update(ctx, shoot)
+				}).Should(Succeed())
+
+			})
+
+			It("should forbid shoot update with non-primary DNS provider and not configured credentials", func() {
+				shoot.Spec.DNS.Providers = append(shoot.Spec.DNS.Providers, gardencorev1beta1.DNSProvider{
+					Primary: ptr.To(false),
+					Type:    ptr.To("another-provider-type"),
+				})
+				By("Update Shoot")
+				Eventually(func() error {
+					return testClient.Update(ctx, shoot)
+				}).Should(And(
+					HaveOccurred(),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"ErrStatus": MatchFields(IgnoreExtras, Fields{
+							"Code":    Equal(int32(http.StatusUnprocessableEntity)),
+							"Message": ContainSubstring("Required value: non-primary DNS providers must specify `type` and `credentialsRef`"),
+						})},
+					)),
+				))
+			})
+
+			It("should allow shoot update with non-primary DNS provider and only secretName set", func() {
+				shoot.Spec.DNS.Providers = append(shoot.Spec.DNS.Providers, gardencorev1beta1.DNSProvider{
+					Primary:    ptr.To(false),
+					Type:       ptr.To("another-provider-type"),
+					SecretName: &testSecret.Name,
+				})
+				By("Update Shoot")
+				Eventually(func() error {
+					return testClient.Update(ctx, shoot)
+				}).Should(Succeed())
+			})
+
+			It("should allow shoot update with non-primary DNS provider and only credentialsRef set", func() {
+				shoot.Spec.DNS.Providers = append(shoot.Spec.DNS.Providers, gardencorev1beta1.DNSProvider{
+					Primary: ptr.To(false),
+					Type:    ptr.To("another-provider-type"),
+					CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+						APIVersion: "v1",
+						Kind:       "Secret",
+						Name:       testSecret.Name,
+					},
+				})
+				By("Update Shoot")
+				Eventually(func() error {
+					return testClient.Update(ctx, shoot)
+				}).Should(Succeed())
+			})
+
+			It("should allow shoot patch to try to unset credentialsRef", func() {
+				patch := client.MergeFrom(shoot.DeepCopy())
+				shoot.Spec.DNS.Providers[0].CredentialsRef = nil
+
+				By("Patch Shoot")
+				Eventually(func() error {
+					return testClient.Patch(ctx, shoot, patch)
+				}).Should(Succeed())
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind enhancement


**What this PR does / why we need it**:
Start splitting ShootDNS admission plugin into Mutating and Validating

- Move `checkFunctionlessDNSProviders` to validating plugin

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13618
Part of #9586 
Follow-up on https://github.com/gardener/gardener/pull/13552

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The mutating `ShootDNS` admission plugin is now also a validating one. Validations which are executed by this admission plugin during the mutation phase will be gradually moved to the validating `ShootDNS` admission plugin.
```
