### PR TITLE
GNA support CNI bin_dirs with containerd 2.2

### DIFF
--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -130,7 +130,7 @@ func (b *GardenadmBotanist) ApplyOperatingSystemConfig(ctx context.Context) erro
 		return fmt.Errorf("failed fetching node object by hostname %q: %w", b.HostName, err)
 	}
 
-	containerdclient, err := nodeagentcontainerd.NewContainerdClient()
+	containerdclient, err := nodeagentcontainerd.NewClient()
 	if err != nil {
 		return fmt.Errorf("failed connecting to containerd: %w", err)
 	}

--- a/pkg/nodeagent/containerd/containerdclient.go
+++ b/pkg/nodeagent/containerd/containerdclient.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+)
+
+// ContainerdClient defines the containerd client Interface exported for testing.
+type ContainerdClient interface {
+	Version(context.Context) (containerd.Version, error)
+}
+
+const (
+	// envContainerdAddress is the name of the environment variable holding the containerd address
+	envContainerdAddress = "CONTAINERD_ADDRESS"
+)
+
+var (
+	version2dot2 *semver.Version
+)
+
+func init() {
+	version2dot2 = semver.MustParse("2.2")
+}
+
+// NewContainerdClient returns a new client to connect to containerd
+func NewContainerdClient() (*containerd.Client, error) {
+	address := os.Getenv(envContainerdAddress)
+	if address == "" {
+		address = defaults.DefaultAddress
+	}
+
+	namespace := os.Getenv(namespaces.NamespaceEnvVar)
+	if namespace == "" {
+		namespace = namespaces.Default
+	}
+
+	client, err := containerd.New(address, containerd.WithDefaultNamespace(namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error creating containerd client: %w", err)
+	}
+
+	return client, err
+}
+
+// VersionGreaterThanEqual22 checks if the running containerd version is greater or equal to 2.2
+func VersionGreaterThanEqual22(ctx context.Context, client ContainerdClient) (bool, error) {
+	return versionGreaterThanEqual(ctx, client, version2dot2)
+}
+
+func versionGreaterThanEqual(ctx context.Context, client ContainerdClient, s *semver.Version) (bool, error) {
+	containerdVersion, err := client.Version(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	v, err := semver.NewVersion(containerdVersion.Version)
+	if err != nil {
+		return false, err
+	}
+
+	return v.GreaterThanEqual(s), nil
+}

--- a/pkg/nodeagent/containerd/containerdclient.go
+++ b/pkg/nodeagent/containerd/containerdclient.go
@@ -15,26 +15,22 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 )
 
-// ContainerdClient defines the containerd client Interface exported for testing.
-type ContainerdClient interface {
+// Client defines the containerd client Interface exported for testing.
+type Client interface {
 	Version(context.Context) (containerd.Version, error)
 }
 
-const (
-	// envContainerdAddress is the name of the environment variable holding the containerd address
-	envContainerdAddress = "CONTAINERD_ADDRESS"
-)
+// envContainerdAddress is the name of the environment variable holding the containerd address
+const envContainerdAddress = "CONTAINERD_ADDRESS"
 
-var (
-	version2dot2 *semver.Version
-)
+var version2dot2 *semver.Version
 
 func init() {
 	version2dot2 = semver.MustParse("2.2")
 }
 
-// NewContainerdClient returns a new client to connect to containerd
-func NewContainerdClient() (*containerd.Client, error) {
+// NewClient returns a new client to connect to containerd
+func NewClient() (*containerd.Client, error) {
 	address := os.Getenv(envContainerdAddress)
 	if address == "" {
 		address = defaults.DefaultAddress
@@ -54,11 +50,11 @@ func NewContainerdClient() (*containerd.Client, error) {
 }
 
 // VersionGreaterThanEqual22 checks if the running containerd version is greater or equal to 2.2
-func VersionGreaterThanEqual22(ctx context.Context, client ContainerdClient) (bool, error) {
+func VersionGreaterThanEqual22(ctx context.Context, client Client) (bool, error) {
 	return versionGreaterThanEqual(ctx, client, version2dot2)
 }
 
-func versionGreaterThanEqual(ctx context.Context, client ContainerdClient, s *semver.Version) (bool, error) {
+func versionGreaterThanEqual(ctx context.Context, client Client, s *semver.Version) (bool, error) {
 	containerdVersion, err := client.Version(ctx)
 	if err != nil {
 		return false, err

--- a/pkg/nodeagent/containerd/fake/containerdclient.go
+++ b/pkg/nodeagent/containerd/fake/containerdclient.go
@@ -12,26 +12,24 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 )
 
-const (
-	defaultContainerdVersion = "2.1.2"
-)
+const defaultContainerdVersion = "2.1.2"
 
-// FakeContainerdClient is a fake containerd client used for testing
-type FakeContainerdClient struct {
+// Client is a fake containerd client used for testing
+type Client struct {
 	returnError bool
 	version     string
 }
 
-// NewFakeClient returns a new fake containerd client
-func NewFakeClient() *FakeContainerdClient {
-	return &FakeContainerdClient{
+// NewClient returns a new fake containerd client
+func NewClient() *Client {
+	return &Client{
 		returnError: false,
 		version:     defaultContainerdVersion,
 	}
 }
 
 // Version returns the version of the (fake) containerd represented by the FakeContainerdClient
-func (f FakeContainerdClient) Version(_ context.Context) (containerd.Version, error) {
+func (f Client) Version(_ context.Context) (containerd.Version, error) {
 	if f.returnError {
 		return containerd.Version{}, errors.New("calling fake containerd socket error")
 	}
@@ -42,12 +40,12 @@ func (f FakeContainerdClient) Version(_ context.Context) (containerd.Version, er
 }
 
 // SetFakeContainerdVersion sets the version of the (fake) containerd to the desired value
-func (f *FakeContainerdClient) SetFakeContainerdVersion(version string) {
+func (f *Client) SetFakeContainerdVersion(version string) {
 	semver.MustParse(version)
 	f.version = version
 }
 
 // SetReturnError sets whether or not the fake containerd client returns an error
-func (f *FakeContainerdClient) SetReturnError(returnError bool) {
+func (f *Client) SetReturnError(returnError bool) {
 	f.returnError = returnError
 }

--- a/pkg/nodeagent/containerd/fake/fake_containerdclient.go
+++ b/pkg/nodeagent/containerd/fake/fake_containerdclient.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultContainerdVersion = "1.7.2"
+	defaultContainerdVersion = "2.1.2"
 )
 
 // FakeContainerdClient is a fake containerd client used for testing

--- a/pkg/nodeagent/containerd/fake/fake_containerdclient.go
+++ b/pkg/nodeagent/containerd/fake/fake_containerdclient.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	"context"
+	"errors"
+
+	"github.com/Masterminds/semver/v3"
+	containerd "github.com/containerd/containerd/v2/client"
+)
+
+const (
+	defaultContainerdVersion = "1.7.2"
+)
+
+// FakeContainerdClient is a fake containerd client used for testing
+type FakeContainerdClient struct {
+	returnError bool
+	version     string
+}
+
+// NewFakeClient returns a new fake containerd client
+func NewFakeClient() *FakeContainerdClient {
+	return &FakeContainerdClient{
+		returnError: false,
+		version:     defaultContainerdVersion,
+	}
+}
+
+// Version returns the version of the (fake) containerd represented by the FakeContainerdClient
+func (f FakeContainerdClient) Version(_ context.Context) (containerd.Version, error) {
+	if f.returnError {
+		return containerd.Version{}, errors.New("calling fake containerd socket error")
+	}
+	return containerd.Version{
+		Version:  f.version,
+		Revision: f.version + "-fake",
+	}, nil
+}
+
+// SetFakeContainerdVersion sets the version of the (fake) containerd to the desired value
+func (f *FakeContainerdClient) SetFakeContainerdVersion(version string) {
+	semver.MustParse(version)
+	f.version = version
+}
+
+// SetReturnError sets whether or not the fake containerd client returns an error
+func (f *FakeContainerdClient) SetReturnError(returnError bool) {
+	f.returnError = returnError
+}

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/nodeagent/containerd"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/certificate"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/hostnamecheck"
@@ -43,6 +44,11 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 		return fmt.Errorf("failed adding node controller: %w", err)
 	}
 
+	containerdClient, err := containerd.NewContainerdClient()
+	if err != nil {
+		return fmt.Errorf("failed obtaining containerd client: %w", err)
+	}
+
 	var channel = make(chan event.TypedGenericEvent[*corev1.Secret])
 
 	if err := (&operatingsystemconfig.Reconciler{
@@ -54,6 +60,7 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 		NodeName:               nodeName,
 		MachineName:            machineName,
 		CancelContext:          cancel,
+		ContainerdClient:       containerdClient,
 	}).AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed adding operating system config controller: %w", err)
 	}

--- a/pkg/nodeagent/controller/add.go
+++ b/pkg/nodeagent/controller/add.go
@@ -44,7 +44,7 @@ func AddToManager(ctx context.Context, cancel context.CancelFunc, mgr manager.Ma
 		return fmt.Errorf("failed adding node controller: %w", err)
 	}
 
-	containerdClient, err := containerd.NewContainerdClient()
+	containerdClient, err := containerd.NewClient()
 	if err != nil {
 		return fmt.Errorf("failed obtaining containerd client: %w", err)
 	}

--- a/pkg/nodeagent/controller/healthcheck/add.go
+++ b/pkg/nodeagent/controller/healthcheck/add.go
@@ -61,7 +61,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 func (r *Reconciler) setDefaultHealthChecks() error {
 	clock := clock.RealClock{}
 
-	client, err := containerd.NewContainerdClient()
+	client, err := containerd.NewClient()
 	if err != nil {
 		return fmt.Errorf("error creating containerd client: %w", err)
 	}

--- a/pkg/nodeagent/controller/healthcheck/add.go
+++ b/pkg/nodeagent/controller/healthcheck/add.go
@@ -7,11 +7,7 @@ package healthcheck
 import (
 	"fmt"
 	"net"
-	"os"
 
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -19,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/gardener/gardener/pkg/nodeagent/containerd"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 )
 
@@ -64,17 +61,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, nodePredicate predicate.P
 func (r *Reconciler) setDefaultHealthChecks() error {
 	clock := clock.RealClock{}
 
-	address := os.Getenv("CONTAINERD_ADDRESS")
-	if address == "" {
-		address = defaults.DefaultAddress
-	}
-
-	namespace := os.Getenv(namespaces.NamespaceEnvVar)
-	if namespace == "" {
-		namespace = namespaces.Default
-	}
-
-	client, err := containerd.New(address, containerd.WithDefaultNamespace(namespace))
+	client, err := containerd.NewContainerdClient()
 	if err != nil {
 		return fmt.Errorf("error creating containerd client: %w", err)
 	}

--- a/pkg/nodeagent/controller/healthcheck/containerd.go
+++ b/pkg/nodeagent/controller/healthcheck/containerd.go
@@ -23,7 +23,7 @@ import (
 type containerdHealthChecker struct {
 	client client.Client
 
-	containerdClient containerd.ContainerdClient
+	containerdClient containerd.Client
 	firstFailure     *time.Time
 	clock            clock.Clock
 	dbus             dbus.DBus
@@ -31,7 +31,7 @@ type containerdHealthChecker struct {
 }
 
 // NewContainerdHealthChecker creates a new instance of a containerd health check.
-func NewContainerdHealthChecker(client client.Client, containerdClient containerd.ContainerdClient, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder) HealthChecker {
+func NewContainerdHealthChecker(client client.Client, containerdClient containerd.Client, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder) HealthChecker {
 	return &containerdHealthChecker{
 		client:           client,
 		containerdClient: containerdClient,

--- a/pkg/nodeagent/controller/healthcheck/containerd.go
+++ b/pkg/nodeagent/controller/healthcheck/containerd.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
@@ -17,18 +16,14 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/nodeagent/containerd"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 )
-
-// ContainerdClient defines the containerd client Interface exported for testing.
-type ContainerdClient interface {
-	Version(context.Context) (containerd.Version, error)
-}
 
 type containerdHealthChecker struct {
 	client client.Client
 
-	containerdClient ContainerdClient
+	containerdClient containerd.ContainerdClient
 	firstFailure     *time.Time
 	clock            clock.Clock
 	dbus             dbus.DBus
@@ -36,7 +31,7 @@ type containerdHealthChecker struct {
 }
 
 // NewContainerdHealthChecker creates a new instance of a containerd health check.
-func NewContainerdHealthChecker(client client.Client, containerdClient ContainerdClient, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder) HealthChecker {
+func NewContainerdHealthChecker(client client.Client, containerdClient containerd.ContainerdClient, clock clock.Clock, dbus dbus.DBus, recorder record.EventRecorder) HealthChecker {
 	return &containerdHealthChecker{
 		client:           client,
 		containerdClient: containerdClient,

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd.go
@@ -45,7 +45,7 @@ func (r *Reconciler) ReconcileContainerdConfig(ctx context.Context, log logr.Log
 		return fmt.Errorf("failed to ensure containerd default config: %w", err)
 	}
 
-	if err := r.ensureContainerdConfiguration(log, osc.Spec.CRIConfig); err != nil {
+	if err := r.ensureContainerdConfiguration(ctx, log, osc.Spec.CRIConfig); err != nil {
 		return fmt.Errorf("failed to ensure containerd config: %w", err)
 	}
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -184,7 +184,7 @@ func (r *Reconciler) ensureContainerdConfiguration(ctx context.Context, log logr
 	// and hence takes an array of strings
 	containerdGreaterThanEqual22, err := nodeagentcontainerd.VersionGreaterThanEqual22(ctx, r.ContainerdClient)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to determine containerd version: %w", err)
 	}
 
 	if configFileVersion >= 3 && containerdGreaterThanEqual22 {

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	nodeagentcontainerd "github.com/gardener/gardener/pkg/nodeagent/containerd"
 	"github.com/gardener/gardener/pkg/utils/structuredmap"
 )
 
@@ -36,6 +37,7 @@ const (
 	sandboxImagePath
 	cgroupDriverPath
 	cniPluginPath
+	cniPluginsPaths
 )
 
 var (
@@ -58,6 +60,7 @@ var (
 			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"},
 			cgroupDriverPath:   {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
+			cniPluginsPaths:    {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"},
 		},
 	}
 
@@ -108,7 +111,7 @@ func (r *Reconciler) ensureContainerdDefaultConfig(ctx context.Context) error {
 }
 
 // ensureContainerdConfiguration sets the configuration for containerd.
-func (r *Reconciler) ensureContainerdConfiguration(log logr.Logger, criConfig *extensionsv1alpha1.CRIConfig) error {
+func (r *Reconciler) ensureContainerdConfiguration(ctx context.Context, log logr.Logger, criConfig *extensionsv1alpha1.CRIConfig) error {
 	config, err := r.FS.ReadFile(configFile)
 	if err != nil {
 		return fmt.Errorf("unable to read containerd config.toml: %w", err)
@@ -175,14 +178,32 @@ func (r *Reconciler) ensureContainerdConfiguration(log logr.Logger, criConfig *e
 				return criConfig.Containerd.SandboxImage, nil
 			},
 		},
-		{
-			name: "CNI plugin dir",
-			path: containerdConfigPaths[configFileVersion][cniPluginPath],
-			setFn: func(_ any) (any, error) {
-				return cniPluginDir, nil
-			},
-		},
 	}
+
+	// containerd 2.2 is using config file version 3 but the CNI plugin path now ends in "bin_dirs" (note plural)
+	// and hence takes an array of strings
+	cniPluginPath := containerdConfigPaths[configFileVersion][cniPluginPath]
+
+	containerdGreaterThanEqual22, err := nodeagentcontainerd.VersionGreaterThanEqual22(ctx, r.ContainerdClient)
+	if err != nil {
+		return err
+	}
+
+	if configFileVersion >= 3 && containerdGreaterThanEqual22 {
+		cniPluginPath = containerdConfigPaths[configFileVersion][cniPluginsPaths]
+	}
+
+	patches = append(patches, patch{
+		name: "CNI plugin dir",
+		path: cniPluginPath,
+		setFn: func(_ any) (any, error) {
+			if configFileVersion >= 3 && containerdGreaterThanEqual22 {
+				return []string{cniPluginDir}, nil
+			} else {
+				return cniPluginDir, nil
+			}
+		},
+	})
 
 	if criConfig.CgroupDriver != nil {
 		patches = append(patches, patch{

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -204,19 +204,26 @@ var _ = Describe("containerd configuration file tests", func() {
 	)
 
 	It("should configure CNI plugin dirs as array at corresponding path for containerd >= 2.2", func() {
-		cniPluginDirs := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"}
+		var (
+			cniPluginDirPath  = structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"}
+			cniPluginDirsPath = structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"}
+		)
 
 		containerdClient.SetFakeContainerdVersion("2.2.1")
 
 		Expect(loadContainerdConfig("testfiles/containerd-config.toml-v3", r.FS)).To(Succeed())
 		Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
 
-		configValue, err := getContainerdConfigValue(r.FS, cniPluginDirs)
+		pluginDirValue, err := getContainerdConfigValue(r.FS, cniPluginDirPath)
 		Expect(err).ToNot(HaveOccurred())
-		pluginDirs, ok := configValue.([]any)
+		Expect(pluginDirValue).To(BeNil())
+
+		configValue, err := getContainerdConfigValue(r.FS, cniPluginDirsPath)
+		Expect(err).ToNot(HaveOccurred())
+		pluginDirsValue, ok := configValue.([]any)
 		Expect(ok).To(BeTrue())
-		Expect(pluginDirs).To(HaveLen(1))
-		Expect(pluginDirs).To(ContainElements("/opt/cni/bin"))
+		Expect(pluginDirsValue).To(HaveLen(1))
+		Expect(pluginDirsValue).To(ContainElements("/opt/cni/bin"))
 	})
 
 	Describe("plugin configuration paths inserted by osc plugin config", func() {

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	fakecontainerdclient "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/utils/structuredmap"
 )
@@ -28,6 +29,8 @@ var (
 
 	ctx context.Context
 	log logr.Logger
+
+	containerdClient *fakecontainerdclient.FakeContainerdClient
 )
 
 const (
@@ -43,7 +46,11 @@ func init() {
 	ctx = context.Background()
 	log = logr.Discard()
 
-	r = operatingsystemconfig.Reconciler{}
+	containerdClient = fakecontainerdclient.NewFakeClient()
+
+	r = operatingsystemconfig.Reconciler{
+		ContainerdClient: containerdClient,
+	}
 
 	osc = &extensionsv1alpha1.OperatingSystemConfig{
 		Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
@@ -195,6 +202,22 @@ var _ = Describe("containerd configuration file tests", func() {
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
 		),
 	)
+
+	It("should configure CNI plugin dirs as array at corresponding path for containerd >= 2.2", func() {
+		cniPluginDirs := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"}
+
+		containerdClient.SetFakeContainerdVersion("2.2.1")
+
+		Expect(loadContainerdConfig("testfiles/containerd-config.toml-v3", r.FS)).To(Succeed())
+		Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+		configValue, err := getContainerdConfigValue(r.FS, cniPluginDirs)
+		Expect(err).ToNot(HaveOccurred())
+		pluginDirs, ok := configValue.([]any)
+		Expect(ok).To(BeTrue())
+		Expect(pluginDirs).To(HaveLen(1))
+		Expect(pluginDirs).To(ContainElements("/opt/cni/bin"))
+	})
 
 	Describe("plugin configuration paths inserted by osc plugin config", func() {
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	fakecontainerdclient "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
+	fakecontainerd "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/utils/structuredmap"
 )
@@ -30,7 +30,7 @@ var (
 	ctx context.Context
 	log logr.Logger
 
-	containerdClient *fakecontainerdclient.FakeContainerdClient
+	containerdClient *fakecontainerd.Client
 )
 
 const (
@@ -46,7 +46,7 @@ func init() {
 	ctx = context.Background()
 	log = logr.Discard()
 
-	containerdClient = fakecontainerdclient.NewFakeClient()
+	containerdClient = fakecontainerd.NewClient()
 
 	r = operatingsystemconfig.Reconciler{
 		ContainerdClient: containerdClient,

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -48,6 +48,7 @@ import (
 	kubeletcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/nodeagent"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	nodeagentcontainerd "github.com/gardener/gardener/pkg/nodeagent/containerd"
 	healthcheckcontroller "github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
 	"github.com/gardener/gardener/pkg/nodeagent/dbus"
 	filespkg "github.com/gardener/gardener/pkg/nodeagent/files"
@@ -95,17 +96,18 @@ func init() {
 // Reconciler decodes the OperatingSystemConfig resources from secrets and applies the systemd units and files to the
 // node.
 type Reconciler struct {
-	Client        client.Client
-	Config        nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig
-	ConfigDir     string
-	Recorder      record.EventRecorder
-	DBus          dbus.DBus
-	FS            afero.Afero
-	Extractor     registry.Extractor
-	CancelContext context.CancelFunc
-	HostName      string
-	NodeName      string
-	MachineName   string
+	Client           client.Client
+	ContainerdClient nodeagentcontainerd.ContainerdClient
+	Config           nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig
+	ConfigDir        string
+	Recorder         record.EventRecorder
+	DBus             dbus.DBus
+	FS               afero.Afero
+	Extractor        registry.Extractor
+	CancelContext    context.CancelFunc
+	HostName         string
+	NodeName         string
+	MachineName      string
 	// SkipWritingStateFiles is used by gardenadm when it deploys the provision OSC. In this case, both the "last
 	// applied configuration" and the "last computed changes" files should not be written. Otherwise,
 	// gardener-node-agent might delete files which exist in the provision OSC only after it comes up and reconciles the

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -97,7 +97,7 @@ func init() {
 // node.
 type Reconciler struct {
 	Client           client.Client
-	ContainerdClient nodeagentcontainerd.ContainerdClient
+	ContainerdClient nodeagentcontainerd.Client
 	Config           nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig
 	ConfigDir        string
 	Recorder         record.EventRecorder

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -301,6 +301,7 @@ build:
             - pkg/nodeagent/apis/config/v1alpha1
             - pkg/nodeagent/apis/config/v1alpha1/helper
             - pkg/nodeagent/bootstrappers
+            - pkg/nodeagent/containerd
             - pkg/nodeagent/controller/healthcheck
             - pkg/nodeagent/controller/operatingsystemconfig
             - pkg/nodeagent/controller/operatingsystemconfig/templates/containerd-hosts.toml.tpl
@@ -452,6 +453,7 @@ build:
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh
             - pkg/nodeagent/bootstrappers
+            - pkg/nodeagent/containerd
             - pkg/nodeagent/controller
             - pkg/nodeagent/controller/certificate
             - pkg/nodeagent/controller/healthcheck

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -619,6 +619,7 @@ build:
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh
             - pkg/nodeagent/bootstrappers
+            - pkg/nodeagent/containerd
             - pkg/nodeagent/controller
             - pkg/nodeagent/controller/certificate
             - pkg/nodeagent/controller/healthcheck

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1590,6 +1590,7 @@ build:
             - pkg/nodeagent/bootstrap
             - pkg/nodeagent/bootstrap/templates/scripts/format-kubelet-data-volume.tpl.sh
             - pkg/nodeagent/bootstrappers
+            - pkg/nodeagent/containerd
             - pkg/nodeagent/controller
             - pkg/nodeagent/controller/certificate
             - pkg/nodeagent/controller/healthcheck

--- a/test/integration/nodeagent/healthcheck/healthcheck_test.go
+++ b/test/integration/nodeagent/healthcheck/healthcheck_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Healthcheck controller tests", func() {
 		node               *corev1.Node
 		fakeDBus           *fakedbus.DBus
 		interfaceAddresses []string
-		containerdClient   *fakecontainerdclient.FakeContainerdClient
+		containerdClient   *fakecontainerdclient.Client
 		kubeletHealthcheck *healthcheck.KubeletHealthChecker
 		ts                 *httptest.Server
 	)
@@ -72,7 +72,7 @@ var _ = Describe("Healthcheck controller tests", func() {
 			}
 			return result, nil
 		}
-		containerdClient = fakecontainerdclient.NewFakeClient()
+		containerdClient = fakecontainerdclient.NewClient()
 
 		nodeName = testRunID
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -182,7 +182,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				{SecretName: secretName2},
 			},
 			CancelContext:    cancelFunc.cancel,
-			ContainerdClient: fakecontainerdclient.NewFakeClient(),
+			ContainerdClient: fakecontainerdclient.NewClient(),
 		}).AddToManager(ctx, mgr)).To(Succeed())
 
 		By("Start manager")

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -42,6 +42,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/kubelet"
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/nodeagent/apis/config/v1alpha1"
+	fakecontainerdclient "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
 	healthcheckcontroller "github.com/gardener/gardener/pkg/nodeagent/controller/healthcheck"
 	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
 	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
@@ -180,7 +181,8 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				{SecretName: secretName1},
 				{SecretName: secretName2},
 			},
-			CancelContext: cancelFunc.cancel,
+			CancelContext:    cancelFunc.cancel,
+			ContainerdClient: fakecontainerdclient.NewFakeClient(),
 		}).AddToManager(ctx, mgr)).To(Succeed())
 
 		By("Start manager")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/kind technical-debt

**What this PR does / why we need it**:

With containerd 2.1 and above, CNI plugins can reside in multiple locations. As a result, the CNI plugin path which used to be single string at `bin_dir` in containerd's config.toml is now an array of strings at `bin_dirs`(note plural).

When configuring a custom CNI path for containerd, GNA will now - in addition to checking the version of the config.toml config file - query containerd for its version and use the `bin_dirs` path with a string array if the config file version is 3 and containerd >= 2.2 is detected.

This addresses the following containerd deprecation warning:
> The "bin_dir" property of [plugins."io.containerd.cri.v1.runtime".cni] is deprecated since containerd v2.1 and will be removed in containerd v2.3. Use "bin_dirs" in the same section instead.

Note: containerd initially planned to deprecate `bin_dir` with version 2.2 but postponed that to version 2.3 in https://github.com/containerd/containerd/pull/12417. Still, this PR will enforce the change to `bin_dirs` for containerd 2.2.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
When configuring a custom CNI path for containerd, GNA will now - in addition to checking the version of the config.toml config file - query containerd for its version and use the `bin_dirs` path with a string array if the config file version is 3 and containerd >= 2.2 is detected.
```
