### PR TITLE
Add alert for Garden lastOperation error states

### DIFF
--- a/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
+++ b/pkg/component/observability/monitoring/kubestatemetrics/customresourcestate.go
@@ -166,15 +166,18 @@ func newGardenCustomResourceStateMetrics() customresourcestate.Resource {
 
 	resource.Metrics = append(resource.Metrics, customresourcestate.Generator{
 		Name: "garden_last_operation",
-		Help: "denotes the last operation performed on a Garden object",
+		Help: "state of the last operation performed on a Garden object",
 		Each: customresourcestate.Metric{
 			Type: metric.StateSet,
 			StateSet: &customresourcestate.MetricStateSet{
-				LabelName: "last_operation",
-				List:      []string{"Create", "Reconcile", "Delete", "Migrate", "Restore"},
-				ValueFrom: []string{"type"},
+				LabelName: "state",
+				List:      []string{"Processing", "Succeeded", "Error", "Failed", "Pending", "Aborted"},
+				ValueFrom: []string{"state"},
 				MetricMeta: customresourcestate.MetricMeta{
 					Path: []string{"status", "lastOperation"},
+					LabelsFromPath: map[string][]string{
+						"type": {"type"},
+					},
 				},
 			},
 		},

--- a/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-garden.expectation.yaml
+++ b/pkg/component/observability/monitoring/kubestatemetrics/testdata/custom-resource-state-garden.expectation.yaml
@@ -36,24 +36,27 @@ spec:
           labelsFromPath: {}
           errorLogV: 0
         - name: garden_last_operation
-          help: denotes the last operation performed on a Garden object
+          help: state of the last operation performed on a Garden object
           each:
             type: stateset
             gauge: null
             stateSet:
-              labelsFromPath: {}
+              labelsFromPath:
+                type:
+                  - type
               path:
                 - status
                 - lastOperation
               list:
-                - Create
-                - Reconcile
-                - Delete
-                - Migrate
-                - Restore
-              labelName: last_operation
+                - Processing
+                - Succeeded
+                - Error
+                - Failed
+                - Pending
+                - Aborted
+              labelName: state
               valueFrom:
-                - type
+                - state
             info: null
           commonLabels: {}
           labelsFromPath: {}

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -214,7 +214,7 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			For:    ptr.To(monitoringv1.Duration("10m")),
 			Labels: getLabels("critical"),
 			Annotations: map[string]string{
-			"summary": "Garden {{$labels.name}} last operation has failed",
+				"summary": "Garden {{$labels.name}} last operation has failed",
 				"description": "Garden {{$labels.name}} in landscape " +
 					"{{$externalLabels.landscape}} has last operation {{$labels.type}} in state {{$labels.state}}" +
 					" for 10 minutes.",
@@ -226,9 +226,9 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			For:    ptr.To(monitoringv1.Duration("30m")),
 			Labels: getLabels("warning"),
 			Annotations: map[string]string{
-			"summary": "Garden {{$labels.name}} last operation stuck in Processing",
-			"description": "Garden {{$labels.name}} in landscape " +
-				"{{$externalLabels.landscape}} has last operation {{$labels.type}} stuck in Processing" +
+				"summary": "Garden {{$labels.name}} last operation stuck in Processing",
+				"description": "Garden {{$labels.name}} in landscape " +
+					"{{$externalLabels.landscape}} has last operation {{$labels.type}} stuck in Processing" +
 					" for 30 minutes.",
 			},
 		},

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -221,6 +221,18 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			},
 		},
 		{
+			Alert:  "GardenLastOperationStuckProcessing",
+			Expr:   intstr.FromString(`garden_garden_last_operation{state="Processing"} == 1`),
+			For:    ptr.To(monitoringv1.Duration("30m")),
+			Labels: getLabels("warning"),
+			Annotations: map[string]string{
+				"summary": "Garden runtime last operation {{$labels.type}} stuck in Processing state",
+				"description": "Garden {{$labels.name}} in landscape " +
+					"{{$externalLabels.landscape}} has last operation {{$labels.type}} stuck in Processing state" +
+					" for 30 minutes.",
+			},
+		},
+		{
 			Alert:  "GardenKubeStateMetricsDown",
 			Expr:   intstr.FromString(`absent(up{job="kube-state-metrics"} == 1)`),
 			For:    ptr.To(monitoringv1.Duration("10m")),

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -214,7 +214,7 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			For:    ptr.To(monitoringv1.Duration("10m")),
 			Labels: getLabels("critical"),
 			Annotations: map[string]string{
-				"summary": "Garden runtime last operation {{$labels.type}} is in error state {{$labels.state}}",
+			"summary": "Garden {{$labels.name}} last operation has failed",
 				"description": "Garden {{$labels.name}} in landscape " +
 					"{{$externalLabels.landscape}} has last operation {{$labels.type}} in state {{$labels.state}}" +
 					" for 10 minutes.",
@@ -226,9 +226,9 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			For:    ptr.To(monitoringv1.Duration("30m")),
 			Labels: getLabels("warning"),
 			Annotations: map[string]string{
-				"summary": "Garden runtime last operation {{$labels.type}} stuck in Processing state",
-				"description": "Garden {{$labels.name}} in landscape " +
-					"{{$externalLabels.landscape}} has last operation {{$labels.type}} stuck in Processing state" +
+			"summary": "Garden {{$labels.name}} last operation stuck in Processing",
+			"description": "Garden {{$labels.name}} in landscape " +
+				"{{$externalLabels.landscape}} has last operation {{$labels.type}} stuck in Processing" +
 					" for 30 minutes.",
 			},
 		},

--- a/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/garden/prometheusrules.go
@@ -209,6 +209,18 @@ func gardenPrometheusRule(isGardenerDiscoveryServerEnabled bool) *monitoringv1.P
 			},
 		},
 		{
+			Alert:  "GardenLastOperationInErrorState",
+			Expr:   intstr.FromString(`garden_garden_last_operation{state=~"Error|Failed"} == 1`),
+			For:    ptr.To(monitoringv1.Duration("10m")),
+			Labels: getLabels("critical"),
+			Annotations: map[string]string{
+				"summary": "Garden runtime last operation {{$labels.type}} is in error state {{$labels.state}}",
+				"description": "Garden {{$labels.name}} in landscape " +
+					"{{$externalLabels.landscape}} has last operation {{$labels.type}} in state {{$labels.state}}" +
+					" for 10 minutes.",
+			},
+		},
+		{
 			Alert:  "GardenKubeStateMetricsDown",
 			Expr:   intstr.FromString(`absent(up{job="kube-state-metrics"} == 1)`),
 			For:    ptr.To(monitoringv1.Duration("10m")),

--- a/pkg/component/observability/plutono/dashboards/garden/garden-resource.json
+++ b/pkg/component/observability/plutono/dashboards/garden/garden-resource.json
@@ -534,7 +534,7 @@
           "exemplar": true,
           "expr": "garden_garden_last_operation",
           "interval": "",
-          "legendFormat": "{{last_operation}}",
+          "legendFormat": "{{type}} - {{state}}",
           "refId": "A"
         }
       ],
@@ -542,7 +542,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Last Operation",
+      "title": "Last Operation (Type and State)",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR extends the existing `garden_garden_last_operation` metric that is generated by kube-state-metrics using the CustomResourceState mechanism. The `last_operation` label has been renamed to `type` (breaking change), and a new `state` label has been added that exposes the operation state (Processing, Succeeded, Error, Failed, Pending, Aborted) using a StateSet. 

Two new alerts have been introduced: `GardenLastOperationInErrorState`, which fires when the Garden resource is in an `Error` or `Failed` state for 10 minutes, and `GardenLastOperationStuckProcessing`, which fires when the Garden resource remains in `Processing` state for 30 minutes. The dashboard has been updated to display both the operation type and state.

**Which issue(s) this PR fixes**:
Missing alerts in case of failed `Garden` resource reconciliation.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `garden_garden_last_operation` metric structure has changed: the `last_operation` label has been renamed to `type`, and a new `state` label has been added to expose the operation state. Existing queries and dashboards using the `last_operation` label must be updated to use `type` instead. Additionally, two new alerts have been introduced: `GardenLastOperationInErrorState` and `GardenLastOperationStuckProcessing`.
```
