### PR TITLE
Forbid downgrading machine image version in case of in-place update strategy

### DIFF
--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -154,6 +154,11 @@ machineImages:
 
 The `inPlaceUpdates` field in the Shoot status provides details about in-place updates for the Shoot workers. It includes the `pendingWorkerUpdates` field, which lists the worker pools that are awaiting in-place updates.
 
+For worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, the following actions are not allowed (they are allowed with `AutoRollingUpdate`):
+
+- Skipping a minor version when upgrading the worker pool Kubernetes version (`.spec.provider.workers[].kubernetes.version`).
+- Downgrading the machine image version (`.spec.provider.workers[].machine.image.version`).
+
 #### Customize In-Place Update Behaviour of Shoot Worker Nodes
 
 In addition to customisable fields mentioned in [](#customize-rolling-update-behaviour-of-shoot-worker-nodes) section, you can configure the following fields in `.spec.provider.worker[].machineControllerManager`:
@@ -171,7 +176,7 @@ An in-place update of the shoot worker nodes is triggered for rolling update tri
 * `.spec.provider.workers[].cri.name`
 * `.spec.systemComponents.nodeLocalDNS.enabled` (for Kubernetes version < 1.34 or if `kube-proxy` runs in `IPVS` mode)
 
-> There are validations which restricts changing the above mentioned exception fields when `in-place` updates strategy is configured.
+> There are validations which restricts changing the above mentioned exception fields when an `in-place` update strategy is configured.
 
 When a worker pool is undergoing an in-place update, applying subsequent updates to the same worker pool is restricted.
 If an in-place update fails and nodes are left in a problematic state, user intervention is required to manually fix the nodes. In cases where a subsequent update is necessary to resolve the issue, users can update the worker pool after adding the force update annotation `gardener.cloud/operation=force-in-place-update` on the Shoot. Refer to [Force-update a worker pool with InPlace update strategy](shoot_operations.md#force-update-a-worker-pool-with-inplace-update-strategy) for more details.

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -156,8 +156,8 @@ The `inPlaceUpdates` field in the Shoot status provides details about in-place u
 
 ⚠️ For worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, the following actions are not allowed (they are allowed with `AutoRollingUpdate`):
 
-- Skipping a minor version when upgrading the worker pool Kubernetes version (`.spec.provider.workers[].kubernetes.version`).
-- Downgrading the machine image version (`.spec.provider.workers[].machine.image.version`).
+* Skipping a minor version when upgrading the worker pool Kubernetes version (`.spec.provider.workers[].kubernetes.version`).
+* Downgrading the machine image version of the worker pool (`.spec.provider.workers[].machine.image.version`).
 
 #### Customize In-Place Update Behaviour of Shoot Worker Nodes
 

--- a/docs/usage/shoot-operations/shoot_updates.md
+++ b/docs/usage/shoot-operations/shoot_updates.md
@@ -154,7 +154,7 @@ machineImages:
 
 The `inPlaceUpdates` field in the Shoot status provides details about in-place updates for the Shoot workers. It includes the `pendingWorkerUpdates` field, which lists the worker pools that are awaiting in-place updates.
 
-For worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, the following actions are not allowed (they are allowed with `AutoRollingUpdate`):
+⚠️ For worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, the following actions are not allowed (they are allowed with `AutoRollingUpdate`):
 
 - Skipping a minor version when upgrading the worker pool Kubernetes version (`.spec.provider.workers[].kubernetes.version`).
 - Downgrading the machine image version (`.spec.provider.workers[].machine.image.version`).


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR forbids downgrading machine image version in case of in-place update strategy which is allowed for rolling update strategies.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
 Downgrading the machine image version (`.spec.provider.workers[].machine.image.version`) is not allowed for worker pools using the `AutoInPlaceUpdate` or `ManualInPlaceUpdate` strategy, as Gardener does not support machine image downgrades for any operating system currently.  For `AutoRollingUpdate`, the entire node is replaced, so this limitation does not apply.
```
