### PR TITLE
fix(dashboards/vpa-updater): Remove `vpa_namespace` variable from panel titles

### DIFF
--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -887,7 +887,7 @@
       },
       "id": 22,
       "panels": [],
-      "title": "Pod evictions by namespace",
+      "title": "Pod evictions",
       "type": "row"
     },
     {

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -653,7 +653,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Pod in-place resource updates within \"$vpa_namespace\" namespace",
+      "title": "Pod in-place resource updates by namespace",
       "type": "row"
     },
     {
@@ -887,7 +887,7 @@
       },
       "id": 22,
       "panels": [],
-      "title": "Pod evictions within \"$vpa_namespace\" namespace",
+      "title": "Pod evictions by namespace",
       "type": "row"
     },
     {

--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -653,7 +653,7 @@
       },
       "id": 14,
       "panels": [],
-      "title": "Pod in-place resource updates by namespace",
+      "title": "Pod in-place resource updates",
       "type": "row"
     },
     {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

This PR removes the `vpa_namespace` variable value from the _success_/_failure_ panels titles. Since the variable allows multi-select, clusters with large amount of namespaces overflow the panel title length, which causes Grafana to display an error without updating the charts.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
