### PR TITLE
gardener-apiserver: Forbid with "ratcheting" validation `.spec.kubernetes.kubeAPIServer.eventTTL` > 24h

### DIFF
--- a/docs/development/validation-guidelines.md
+++ b/docs/development/validation-guidelines.md
@@ -233,6 +233,6 @@ Frequently used ones are:
   - When working with existing field, aim to add validation which is obvious and unlikely to break a working functionality.
   - If a breaking change is inevitable and it is likely to break a working functionality, consider the following alternatives:
     - Consider using "ratcheting" validation to incrementally tighten validation. See [Ratcheting validation](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#ratcheting-validation).
-      - An example usage of "ratcheting" validation - allow invalid field value if the value is not updated; otherwise, do not allow. Example: https://github.com/gardener/gardener/pull/10664
+      - An example usage of "ratcheting" validation - allow invalid field value if the value is not updated; otherwise, do not allow. Examples: https://github.com/gardener/gardener/pull/12902/commits/b11f10abdb8fed5a10339880b856238376365288, https://github.com/gardener/gardener/pull/13514
     - Consider using a feature gate to roll out the breaking change. The feature gate gives control when to impose the breaking change. In case of issues, it is possible to revert back to the old behavior by disabling the feature gate.
     - In case the functionality is _relevant to the majority of the end-users_, consider imposing the breaking change only with the upcoming minor Kubernetes version. This way, end-users are forced to actively adapt their manifests when performing Kubernetes upgrades.

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -86,7 +86,7 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	// TODO(ialidzhikov): Remove this in Gardener v1.142.0 when gardener-apiserver stops accepting invalid event ttl values for existing Shoots.
 	if kubeAPIServer := shoot.Spec.Kubernetes.KubeAPIServer; kubeAPIServer != nil {
 		if kubeAPIServer.EventTTL != nil && kubeAPIServer.EventTTL.Duration > time.Hour*24 {
-			warnings = append(warnings, fmt.Sprintf("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field field to an invalid value. Invalid value: '%s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825", kubeAPIServer.EventTTL.Duration))
+			warnings = append(warnings, fmt.Sprintf("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '%s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825", kubeAPIServer.EventTTL.Duration))
 		}
 	}
 

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -83,6 +83,13 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, "spec.secretBindingName is deprecated and will be disallowed starting with Kubernetes 1.34. For migration instructions, see: https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/secretbinding-to-credentialsbinding-migration.md")
 	}
 
+	// TODO(ialidzhikov): Remove this in Gardener v1.142.0 when gardener-apiserver stops accepting invalid event ttl values for existing Shoots.
+	if kubeAPIServer := shoot.Spec.Kubernetes.KubeAPIServer; kubeAPIServer != nil {
+		if kubeAPIServer.EventTTL != nil && kubeAPIServer.EventTTL.Duration > time.Hour*24 {
+			warnings = append(warnings, fmt.Sprintf("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field field to an invalid value. Invalid value: '%s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825", kubeAPIServer.EventTTL.Duration))
+		}
+	}
+
 	return warnings
 }
 

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -390,7 +390,7 @@ var _ = Describe("Warnings", func() {
 			),
 			Entry("should return a warning for invalid eventTTL duration",
 				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
-				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
+				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
 	})

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/api/core/shoot"
@@ -270,12 +271,7 @@ var _ = Describe("Warnings", func() {
 			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the operation annotation to rotate-etcd-encryption-key-complete. This annotation has been deprecated and is forbidden to be set starting from Kubernetes 1.34. Instead, use the rotate-etcd-encryption-key annotation, which performs a full rotation of the ETCD encryption key.")))
 		})
 
-		It("should return a warning when enableAnonymousAuthentication is set", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated and will be forbidden starting with Kubernetes v1.35. Gardener sets this field to nil if it is set to false by the user. Use Structured Authentication Configuration instead. See: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_access.md#configuring-anonymous-authentication")))
-		})
-
-		DescribeTable("shoot.spec.secretBindingName",
+		DescribeTable("spec.secretBindingName",
 			func(secretBindingName *string, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.SecretBindingName = secretBindingName
 				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
@@ -286,7 +282,7 @@ var _ = Describe("Warnings", func() {
 			Entry("should not return a warning when secretBindingName is not set", nil, BeEmpty()),
 		)
 
-		Context("shoot.spec.cloudProfileName", func() {
+		Context("spec.cloudProfileName", func() {
 			It("should not return a warning when cloudProfileName is set and the Kubernetes version is < v1.33", func() {
 				shoot.Spec.Kubernetes.Version = "1.32.3"
 				shoot.Spec.CloudProfileName = ptr.To("local-profile")
@@ -305,7 +301,7 @@ var _ = Describe("Warnings", func() {
 			})
 		})
 
-		Describe("shoot.spec.addons", func() {
+		Describe("spec.addons", func() {
 			It("should print a warning when addons are set", func() {
 				shoot.Spec.Addons = &core.Addons{}
 
@@ -313,7 +309,7 @@ var _ = Describe("Warnings", func() {
 			})
 		})
 
-		Describe("shoot.spec.kubernetes.kubeProxy.mode", func() {
+		Describe("spec.kubernetes.kubeProxy.mode", func() {
 			It("should print a warning when kube-proxy mode is set to 'IPVS' and the Kubernetes version is >= v1.35", func() {
 				shoot.Spec.Kubernetes.Version = "1.35.0"
 				shoot.Spec.Kubernetes.KubeProxy = &core.KubeProxyConfig{
@@ -348,7 +344,7 @@ var _ = Describe("Warnings", func() {
 			})
 		})
 
-		Describe("shoot.spec.kubernetes.kubeScheduler.kubeMaxPDVols", func() {
+		Describe("spec.kubernetes.kubeScheduler.kubeMaxPDVols", func() {
 			It("should print a warning when kubeMaxPDVols is set", func() {
 				shoot.Spec.Kubernetes.KubeScheduler = &core.KubeSchedulerConfig{
 					KubeMaxPDVols: ptr.To("20"),
@@ -358,19 +354,51 @@ var _ = Describe("Warnings", func() {
 			})
 		})
 
-		Describe("shoot.spec.kubernetes.kubeAPIServer.watchCacheSizes.default", func() {
-			It("should print a warning when default is set", func() {
-				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-					WatchCacheSizes: &core.WatchCacheSizes{
-						Default: ptr.To[int32](50),
-					},
-				}
+		DescribeTable("spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+			},
 
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you are setting the spec.kubernetes.kubeAPIServer.watchCacheSizes.default field")))
-			})
-		})
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when enableAnonymousAuthentication is nil",
+				&core.KubeAPIServerConfig{EventTTL: nil},
+				BeEmpty(),
+			),
+			Entry("should return a warning when enableAnonymousAuthentication is set",
+				&core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)},
+				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")),
+			),
+		)
 
-		DescribeTable("shoot.spec.kubernetes.kubeAPIServer.eventTTL",
+		DescribeTable("spec.kubernetes.kubeAPIServer.watchCacheSizes.default",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes.default is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: nil}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when watchCacheSizes.default is set",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: ptr.To[int32](50)}},
+				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
+			),
+		)
+
+		DescribeTable("spec.kubernetes.kubeAPIServer.eventTTL",
 			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
 				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
@@ -390,7 +418,74 @@ var _ = Describe("Warnings", func() {
 			),
 			Entry("should return a warning for invalid eventTTL duration",
 				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
-				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
+				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
+			),
+		)
+	})
+
+	Describe("#GetKubeAPIServerWarnings", func() {
+		DescribeTable("enableAnonymousAuthentication",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				Expect(GetKubeAPIServerWarnings(kubeAPIServerConfig, field.NewPath("kubeAPIServer"))).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when enableAnonymousAuthentication is nil",
+				&core.KubeAPIServerConfig{EventTTL: nil},
+				BeEmpty(),
+			),
+			Entry("should return a warning when enableAnonymousAuthentication is set",
+				&core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)},
+				ContainElement(Equal("you are setting the kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")),
+			),
+		)
+
+		DescribeTable("watchCacheSizes.default",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				Expect(GetKubeAPIServerWarnings(kubeAPIServerConfig, field.NewPath("kubeAPIServer"))).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes.default is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: nil}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when watchCacheSizes.default is set",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: ptr.To[int32](50)}},
+				ContainElement(Equal("you are setting the kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
+			),
+		)
+
+		DescribeTable("eventTTL",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				Expect(GetKubeAPIServerWarnings(kubeAPIServerConfig, field.NewPath("kubeAPIServer"))).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when eventTTL is nil",
+				&core.KubeAPIServerConfig{EventTTL: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning for valid eventTTL duration",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}},
+				BeEmpty(),
+			),
+			Entry("should return a warning for invalid eventTTL duration",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
+				ContainElement(Equal("you are setting the kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
 	})

--- a/pkg/api/seedmanagement/managedseedset/managedseedset_suite_test.go
+++ b/pkg/api/seedmanagement/managedseedset/managedseedset_suite_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package shoot_test
+package managedseedset_test
 
 import (
 	"testing"
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestShoot(t *testing.T) {
+func TestManagedSeedSet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "API Core Shoot Suite")
+	RunSpecs(t, "API Seedmanagement ManagedSeedSet Suite")
 }

--- a/pkg/api/seedmanagement/managedseedset/warnings.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedseedset
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/gardener/pkg/api/core/shoot"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+)
+
+// GetWarnings returns warnings for the given ManagedSeedSet.
+func GetWarnings(managedseedset *seedmanagement.ManagedSeedSet) []string {
+	if managedseedset == nil {
+		return nil
+	}
+
+	var warnings []string
+
+	if kubeAPIServer := managedseedset.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer; kubeAPIServer != nil {
+		path := field.NewPath("spec", "shootTemplate", "spec", "kubernetes", "kubeAPIServer")
+		warnings = append(warnings, shoot.GetKubeAPIServerWarnings(kubeAPIServer, path)...)
+	}
+
+	return warnings
+}

--- a/pkg/api/seedmanagement/managedseedset/warnings_test.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedseedset_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/gardener/gardener/pkg/api/seedmanagement/managedseedset"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+)
+
+var _ = Describe("Warnings", func() {
+	Describe("#GetWarnings", func() {
+		var managedSeedSet *seedmanagement.ManagedSeedSet
+
+		BeforeEach(func() {
+			managedSeedSet = &seedmanagement.ManagedSeedSet{}
+		})
+
+		DescribeTable("spec.shootTemplate.spec.kubernetes.kubeAPIServer",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				managedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(managedSeedSet)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when enableAnonymousAuthentication is nil",
+				&core.KubeAPIServerConfig{EnableAnonymousAuthentication: nil},
+				BeEmpty(),
+			),
+			Entry("should return a warning when enableAnonymousAuthentication is set",
+				&core.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)},
+				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")),
+			),
+		)
+
+		DescribeTable("spec.shootTemplate.spec.kubernetes.kubeAPIServer.watchCacheSizes.default",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				managedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(managedSeedSet)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes.default is nil",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: nil}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when watchCacheSizes.default is set",
+				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: ptr.To[int32](50)}},
+				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
+			),
+		)
+
+		DescribeTable("spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL",
+			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				managedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(managedSeedSet)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when eventTTL is nil",
+				&core.KubeAPIServerConfig{EventTTL: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning for valid eventTTL duration",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}},
+				BeEmpty(),
+			),
+			Entry("should return a warning for invalid eventTTL duration",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
+				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
+			),
+		)
+	})
+})

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -184,6 +184,8 @@ type KubeAPIServerValidationOptions struct {
 	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
 	AllowInvalidAcceptedIssuers bool
 	// AllowInvalidEventTTL specifies whether invalid event ttl is allowed.
+	//
+	// TODO(ialidzhikov): Stop accepting invalid event ttl values for existing Shoots in Gardener v1.142.0.
 	AllowInvalidEventTTL bool
 }
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1806,7 +1806,7 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, kubernetesVe
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("eventTTL"), *kubeAPIServer.EventTTL, "can not be negative"))
 		}
 		if kubeAPIServer.EventTTL.Duration > time.Hour*24 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("eventTTL"), *kubeAPIServer.EventTTL, "can not be longer than 1d"))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("eventTTL"), *kubeAPIServer.EventTTL, "can not be longer than 24h"))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3329,7 +3329,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should not allow to specify an event ttl duration longer than 1d", func() {
+			It("should not allow to specify an event ttl duration longer than 24h", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 2}
 
 				errorList := ValidateShoot(shoot)
@@ -3337,7 +3337,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
-					"Detail": Equal("can not be longer than 1d"),
+					"Detail": Equal("can not be longer than 24h"),
 				}))))
 			})
 
@@ -3359,7 +3359,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
-					"Detail": Equal("can not be longer than 1d"),
+					"Detail": Equal("can not be longer than 24h"),
 				}))))
 			})
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3218,11 +3218,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
 						AcceptedIssuers: []string{"http://issuer.com"},
 					}
-
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
-						AcceptedIssuers: []string{"http://issuer.com"},
-					}
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 				})
@@ -3246,6 +3242,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
+				It("should allow invalid accepted issuer URLs to be updated with valid ones on shoot update", func() {
+					shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
+						AcceptedIssuers: []string{"http://issuer.com"},
+					}
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
+						AcceptedIssuers: []string{"https://issuer.com"},
+					}
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
+				})
 			})
 
 			Context("Autoscaling validation", func() {
@@ -3315,20 +3323,53 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
+					"Detail": Equal("can not be negative"),
 				}))))
 			})
 
-			It("should not allow to specify an event ttl duration longer than 7d", func() {
-				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 8}
+			It("should not allow to specify an event ttl duration longer than 1d", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 2}
 
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
+					"Detail": Equal("can not be longer than 1d"),
 				}))))
+			})
+
+			It("should allow invalid event ttl on shoot update if it is unchanged", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
+				newShoot := prepareShootForUpdate(shoot)
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
+			})
+
+			It("should not allow invalid event ttl on shoot update if it is changed", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
+
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 42}
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
+					"Detail": Equal("can not be longer than 1d"),
+				}))))
+			})
+
+			It("should allow invalid event ttl to be updated with valid one on shoot update", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
+
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24}
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 			})
 
 			It("should not allow to specify a negative defaultNotReadyTolerationSeconds", func() {

--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -73,6 +73,7 @@ func init() {
 func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
 	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
+		AllowInvalidEventTTL:        false,
 	}
 
 	return ValidateGardenWithOps(garden, extensions, opts)
@@ -113,6 +114,8 @@ func ValidateGardenUpdate(oldGarden, newGarden *operatorv1alpha1.Garden, extensi
 		AllowInvalidAcceptedIssuers: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
 			oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
+		AllowInvalidEventTTL: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
+			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL),
 	}
 
 	allErrs = append(allErrs, validateRuntimeClusterUpdate(oldGarden, newGarden)...)

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -3202,7 +3202,7 @@ var _ = Describe("Validation Tests", func() {
 					Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL"),
-						"Detail": Equal("can not be longer than 1d"),
+						"Detail": Equal("can not be longer than 24h"),
 					}))))
 				})
 

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -29,6 +29,7 @@ import (
 func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
+		AllowInvalidEventTTL:        false,
 	}
 
 	return ValidateManagedSeedSetWithOps(ManagedSeedSet, opts)
@@ -56,6 +57,8 @@ func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmana
 		AllowInvalidAcceptedIssuers: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
 			oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
+		AllowInvalidEventTTL: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
+			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.EventTTL, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.EventTTL),
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newManagedSeedSet.ObjectMeta, &oldManagedSeedSet.ObjectMeta, field.NewPath("metadata"))...)

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -505,7 +505,7 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL"),
-				"Detail": Equal("can not be longer than 1d"),
+				"Detail": Equal("can not be longer than 24h"),
 			}))))
 		})
 

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/api/seedmanagement/managedseedset"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
@@ -115,13 +116,13 @@ func (Strategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object)
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (Strategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
-	return nil
+func (Strategy) WarningsOnCreate(_ context.Context, obj runtime.Object) []string {
+	return managedseedset.GetWarnings(obj.(*seedmanagement.ManagedSeedSet))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (Strategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
-	return nil
+func (Strategy) WarningsOnUpdate(_ context.Context, obj, _ runtime.Object) []string {
+	return managedseedset.GetWarnings(obj.(*seedmanagement.ManagedSeedSet))
 }
 
 // StatusStrategy defines the strategy for storing seeds statuses.

--- a/pkg/operator/webhook/validation/garden/handler.go
+++ b/pkg/operator/webhook/validation/garden/handler.go
@@ -107,10 +107,5 @@ func (h *Handler) ValidateDelete(_ context.Context, obj runtime.Object) (admissi
 		return nil, fmt.Errorf("expected *operatorv1alpha1.Garden but got %T", obj)
 	}
 
-	warnings, err := GetWarnings(garden)
-	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to get API warnings: %w", err))
-	}
-
-	return warnings, gardenerutils.CheckIfDeletionIsConfirmed(garden)
+	return nil, gardenerutils.CheckIfDeletionIsConfirmed(garden)
 }

--- a/pkg/operator/webhook/validation/garden/warnings.go
+++ b/pkg/operator/webhook/validation/garden/warnings.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden
+
+import (
+	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/api/core/shoot"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var gardenCoreScheme *runtime.Scheme
+
+func init() {
+	gardenCoreScheme = runtime.NewScheme()
+	utilruntime.Must(gardencoreinstall.AddToScheme(gardenCoreScheme))
+	utilruntime.Must(admissioncontrollerconfigv1alpha1.AddToScheme(gardenCoreScheme))
+}
+
+// GetWarnings returns warnings for the given Garden.
+func GetWarnings(garden *operatorv1alpha1.Garden) ([]string, error) {
+	var warnings []string
+
+	if kubeAPIServer := garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer; kubeAPIServer != nil {
+		coreKubeAPIServerConfig := &gardencore.KubeAPIServerConfig{}
+		if err := gardenCoreScheme.Convert(kubeAPIServer.KubeAPIServerConfig, coreKubeAPIServerConfig, nil); err != nil {
+			return nil, err
+		}
+
+		path := field.NewPath("spec", "virtualCluster", "kubernetes", "kubeAPIServer")
+		warnings = append(warnings, shoot.GetKubeAPIServerWarnings(coreKubeAPIServerConfig, path)...)
+	}
+
+	return warnings, nil
+}

--- a/pkg/operator/webhook/validation/garden/warnings.go
+++ b/pkg/operator/webhook/validation/garden/warnings.go
@@ -5,14 +5,15 @@
 package garden
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	admissioncontrollerconfigv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/api/core/shoot"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 var gardenCoreScheme *runtime.Scheme

--- a/pkg/operator/webhook/validation/garden/warnings_test.go
+++ b/pkg/operator/webhook/validation/garden/warnings_test.go
@@ -7,15 +7,15 @@ package garden_test
 import (
 	"time"
 
-	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
-	. "github.com/gardener/gardener/pkg/operator/webhook/validation/garden"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gomegatypes "github.com/onsi/gomega/types"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	. "github.com/gardener/gardener/pkg/operator/webhook/validation/garden"
 )
 
 var _ = Describe("Warnings", func() {

--- a/pkg/operator/webhook/validation/garden/warnings_test.go
+++ b/pkg/operator/webhook/validation/garden/warnings_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package garden_test
+
+import (
+	"time"
+
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	. "github.com/gardener/gardener/pkg/operator/webhook/validation/garden"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gomegatypes "github.com/onsi/gomega/types"
+)
+
+var _ = Describe("Warnings", func() {
+	Describe("#GetWarnings", func() {
+		var garden *operatorv1alpha1.Garden
+
+		BeforeEach(func() {
+			garden = &operatorv1alpha1.Garden{}
+		})
+
+		DescribeTable("spec.virtualCluster.kubernetes.kubeAPIServer.enableAnonymousAuthentication",
+			func(kubeAPIServerConfig *operatorv1alpha1.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(garden)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when enableAnonymousAuthentication is nil",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EnableAnonymousAuthentication: nil}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when enableAnonymousAuthentication is set",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EnableAnonymousAuthentication: ptr.To(true)}},
+				ContainElement(Equal("you are setting the spec.virtualCluster.kubernetes.kubeAPIServer.enableAnonymousAuthentication field. The field is deprecated. Using Kubernetes v1.32 and above, please use anonymous authentication configuration. See: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#anonymous-authenticator-configuration")),
+			),
+		)
+
+		DescribeTable("spec.kubernetes.kubeAPIServer.watchCacheSizes.default",
+			func(kubeAPIServerConfig *operatorv1alpha1.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(garden)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes is nil",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{WatchCacheSizes: nil}},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when watchCacheSizes.default is nil",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{WatchCacheSizes: &gardencorev1beta1.WatchCacheSizes{Default: nil}}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when watchCacheSizes.default is set",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{WatchCacheSizes: &gardencorev1beta1.WatchCacheSizes{Default: ptr.To[int32](50)}}},
+				ContainElement(Equal("you are setting the spec.virtualCluster.kubernetes.kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
+			),
+		)
+
+		DescribeTable("spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL",
+			func(kubeAPIServerConfig *operatorv1alpha1.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = kubeAPIServerConfig
+				Expect(GetWarnings(garden)).To(matcher)
+			},
+
+			Entry("should not return a warning when kubeAPIServerConfig is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when eventTTL is nil",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: nil}},
+				BeEmpty(),
+			),
+			Entry("should not return a warning for valid eventTTL duration",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}}},
+				BeEmpty(),
+			),
+			Entry("should return a warning for invalid eventTTL duration",
+				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}}},
+				ContainElement(Equal("you are setting the spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
+			),
+		)
+	})
+})

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -477,6 +477,7 @@ build:
             - pkg/api
             - pkg/api/core/shoot
             - pkg/api/extensions
+            - pkg/api/seedmanagement/managedseedset
             - pkg/apis/authentication
             - pkg/apis/authentication/install
             - pkg/apis/authentication/v1alpha1

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -26,6 +26,7 @@ build:
             - pkg/admissioncontroller/apis/config/v1alpha1/validation
             - pkg/admissioncontroller/webhook/admission
             - pkg/api
+            - pkg/api/core/shoot
             - pkg/api/extensions
             - pkg/api/indexer
             - pkg/apis/authentication

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -30,6 +30,7 @@ build:
             - pkg/api
             - pkg/api/core/shoot
             - pkg/api/extensions
+            - pkg/api/seedmanagement/managedseedset
             - pkg/apis/authentication
             - pkg/apis/authentication/install
             - pkg/apis/authentication/v1alpha1


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/13825

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13825

**Special notes for your reviewer**:
"Ratcheting" validation:  https://github.com/gardener/gardener/blob/aa82f32b8ce26c41648c80da7f230441cd62f297/docs/development/validation-guidelines.md?plain=1#L235-L236

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The Shoot's `.spec.kubernetes.kubeAPIServer.eventTTL` field's valid values range is restricted from `[0, 168h]` to `[0, 24h]`. The new range is imposed for new Shoots creations and for field value updates. Already existing Shoots which specify invalid values (more than `24h`) are not affected.
```

```breaking operator
The Garden's `.spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL` field's valid values range is restricted from `[0, 168h]` to `[0, 24h]`. The new range is imposed for new Garden creations and for field value updates. Already existing Gardens which specify invalid values (more than `24h`) are not affected.
```

```breaking operator
The ManagedSeedSet's `.spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL` field's valid values range is restricted from `[0, 168h]` to `[0, 24h]`. The new range is imposed for new ManagedSeedSet creations and for field value updates. Already existing ManagedSeedSets which specify invalid values (more than `24h`) are not affected.
```
