### PR TITLE
[flake] Ensure in-flight `operator.Gardenlet` reconciliation loops are done in integration test

### DIFF
--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -5,6 +5,8 @@
 package gardenlet_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -132,6 +134,10 @@ var _ = Describe("Gardenlet controller test", func() {
 			Eventually(func() error {
 				return mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenlet), gardenlet)
 			}).Should(BeNotFoundError())
+			// Ensure in-flight reconciliation loops are done
+			Consistently(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenlet), gardenlet)
+			}, 5*time.Second, 1*time.Second).Should(BeNotFoundError())
 
 			By("Delete and wait for Gardenlet deployment to be gone")
 			Eventually(func(g Gomega) {

--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -134,16 +134,14 @@ var _ = Describe("Gardenlet controller test", func() {
 			Eventually(func() error {
 				return mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenlet), gardenlet)
 			}).Should(BeNotFoundError())
-			// Ensure in-flight reconciliation loops are done
-			Consistently(func() error {
-				return mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenlet), gardenlet)
-			}, 5*time.Second, 1*time.Second).Should(BeNotFoundError())
 
 			By("Delete and wait for Gardenlet deployment to be gone")
-			Eventually(func(g Gomega) {
+			// Ensure gardenletDeployment from in-flight reconciliation loop is gone
+			Consistently(func(g Gomega) {
 				g.Expect(testClient.Delete(ctx, gardenletDeployment)).To(Or(Succeed(), BeNotFoundError()))
-				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenletDeployment), gardenletDeployment)).Should(BeNotFoundError())
-			}).Should(Succeed())
+			}, 2*time.Second, 200*time.Millisecond).Should(Succeed())
+
+			Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenletDeployment), gardenletDeployment)).Should(BeNotFoundError())
 		})
 	})
 

--- a/test/integration/operator/gardenlet/gardenlet_test.go
+++ b/test/integration/operator/gardenlet/gardenlet_test.go
@@ -5,8 +5,6 @@
 package gardenlet_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -139,7 +137,7 @@ var _ = Describe("Gardenlet controller test", func() {
 			// Ensure gardenletDeployment from in-flight reconciliation loop is gone
 			Consistently(func(g Gomega) {
 				g.Expect(testClient.Delete(ctx, gardenletDeployment)).To(Or(Succeed(), BeNotFoundError()))
-			}, 2*time.Second, 200*time.Millisecond).Should(Succeed())
+			}).Should(Succeed())
 
 			Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(gardenletDeployment), gardenletDeployment)).Should(BeNotFoundError())
 		})


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area flake
/kind test


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/13801

**Special notes for your reviewer**:
@rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
