### PR TITLE
Enable `includeAll` option for VPA namespace variable in the VPA Updater dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
+++ b/pkg/component/observability/plutono/dashboards/common/vpa/vpa-updater.json
@@ -1162,13 +1162,23 @@
         "useTags": false
       },
       {
-        "allValue": null,
+        "allValue": ".+",
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": "${datasource}",
         "definition": "{__name__=~\"vpa_updater_.+\", pod=~\"$pod\", vpa_namespace!=\"\"}",
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "VPA object namespace",
         "multi": true,
         "name": "vpa_namespace",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind bug

**What this PR does / why we need it**:
Right now, in the newly added VPA Updater dashboard when you select all available namespaces and they are over 400+, plutono/prometheus fails with:
> Unknown error during query transaction. Please check JS console logs.

<img width="3394" height="361" alt="Screenshot 2026-01-20 at 18 07 02" src="https://github.com/user-attachments/assets/90e89299-970d-47bf-90b7-f1e8e8e0da50" />

The issue gets fixed when adding an `includeAll` option to the dashboard variable with value `.+`.

After the  `includeAll` option, the panel gets loaded successfully:

<img width="2634" height="355" alt="Screenshot 2026-01-20 at 18 10 38" src="https://github.com/user-attachments/assets/7c880176-3460-43e1-82e6-8abeb2b1d0c3" />

<img width="1099" height="492" alt="Screenshot 2026-01-20 at 18 10 54" src="https://github.com/user-attachments/assets/91f877b4-c648-47e9-ac70-cfe429771702" />

**Which issue(s) this PR fixes**:
Follow up after https://github.com/gardener/gardener/pull/13499

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
