### PR TITLE
Delete `ManagedResource`s even if shoot resources don't need cleanup

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -503,7 +503,6 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		waitUntilManagedResourcesDeleted = g.Add(flow.Task{
 			Name:         "Waiting until managed resources have been deleted",
 			Fn:           flow.TaskFn(botanist.WaitUntilManagedResourcesDeleted).Timeout(10 * time.Minute),
-			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deleteDWDResources),
 		})
 		deleteExtensionResourcesBeforeKubeAPIServer = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -490,7 +490,6 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		deleteManagedResources = g.Add(flow.Task{
 			Name:         "Deleting managed resources",
 			Fn:           flow.TaskFn(botanist.DeleteManagedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(syncPointCleanedKubernetesResources, waitUntilWorkerDeleted),
 		})
 		deleteDWDResources = g.Add(flow.Task{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
We saw `Shoot`s stuck in deletion because of pending `ManagedResource`s. However, the `Infrastructure` object was already gone, hence, `cleanupShootResources` was `false`. This prevented the `ManagedResource` deletion in a subsequent deletion flow attempt – and eventually led to a deadlock:

```
$ k get mr -L origin
NAME                                                CLASS   APPLIED   HEALTHY   PROGRESSING   AGE     ORIGIN
referenced-resources                                seed    True      True      False         7d2h
shoot-core-blackbox-exporter-monitoring-resources   seed    True      True      False         7d2h
shoot-core-gardener-resource-manager                        True      True      False         6d20h   gardener
shoot-core-gardeneraccess                                   True      True      False         6d20h   gardener
shoot-core-kube-apiserver                                   True      True      False         6d20h   gardener
shoot-core-kube-controller-manager                          True      True      False         6d20h   gardener
shoot-core-kube-state-metrics                       seed    True      True      False         7d1h

$ k get infra
No resources found in shoot--foo--bar namespace.
```

The removed `SkipIf: !cleanupShootResources` is an artifact from initial introducing of `gardener-resource-manager` seven or more years ago. Back then, we haven't used `ManagedResource`s the same way as we do today. There is no good reason to skip this task.

**Special notes for your reviewer**:
FYI @petersutter @grolu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fix which could lead to pending `ManagedResource`s in the shoot's control plane namespace (effectively, blocking `Shoot` deletion).
```
