### PR TITLE
HA config: Skip worker pools with `Maximum=0`

### DIFF
--- a/pkg/component/shoot/namespaces/namespaces.go
+++ b/pkg/component/shoot/namespaces/namespaces.go
@@ -79,7 +79,7 @@ func (n *namespaces) computeResourcesData() (map[string][]byte, error) {
 	zones := sets.New[string]()
 
 	for _, pool := range n.workerPools {
-		if v1beta1helper.SystemComponentsAllowed(&pool) {
+		if v1beta1helper.SystemComponentsAllowed(&pool) && pool.Maximum > 0 {
 			zones.Insert(pool.Zones...)
 		}
 	}

--- a/pkg/component/shoot/namespaces/namespaces_test.go
+++ b/pkg/component/shoot/namespaces/namespaces_test.go
@@ -37,15 +37,23 @@ var _ = Describe("Namespaces", func() {
 		namespace   = "shoot--foo--bar"
 		workerPools = []gardencorev1beta1.Worker{
 			{
-				Zones: []string{"b", "c"},
+				Maximum: 1,
+				Zones:   []string{"b", "c"},
 			},
 			{
 				SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: false},
+				Maximum:          1,
 				Zones:            []string{"a", "d"},
 			},
 			{
 				SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: true},
+				Maximum:          1,
 				Zones:            []string{"f", "e"},
+			},
+			{
+				SystemComponents: &gardencorev1beta1.WorkerSystemComponents{Allow: true},
+				Maximum:          0,
+				Zones:            []string{"g", "h"},
 			},
 		}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
We found a cluster where `kube-system` namespace was wrongly annotated with `high-availability-config.resources.gardener.cloud/zones: zone-a,zone-b` even though there was only one node (of zone `zone-a`) in the cluster:

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: kube-system
  annotations:
    high-availability-config.resources.gardener.cloud/zones: zone-a,zone-b
  labels:
    high-availability-config.resources.gardener.cloud/consider: "true"
```

```
$ k get no
NAME                                          STATUS   ROLES    AGE   VERSION
shoot--foo--bar-worker-sfgjg-z1-7bc4f-9flm2   Ready    worker   32h   v1.33.5
```

This was because the `.spec.provider.workers[]` section of the `Shoot` contained another pool with `min=max=0`:

```yaml
    workers:
      - maximum: 2
        minimum: 1
        zones:
          - zone-a
        systemComponents:
          allow: true
      - maximum: 0
        minimum: 0
        zones:
          - zone-b
        systemComponents:
          allow: true
```

For such cases, we misconfigured the HA labels on the `kube-system` namespace, effectively leading to wrong topology spread constraints (injected via `gardener-resource-manager`'s `highavailabilityconfig` webhook), hence, leading to pending/stuck pods/rollouts.

**Special notes for your reviewer**:
FYI @grolu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which was causing invalid high-availability configuration for system components in case a `Shoot` was configured with a worker pool with `maximum=0`.
```
