### PR TITLE
local-setup: make gardenctl work with seeds

### DIFF
--- a/dev-setup/gardenlet/components/kubeconfigs/seed-local/kustomization.yaml
+++ b/dev-setup/gardenlet/components/kubeconfigs/seed-local/kustomization.yaml
@@ -9,3 +9,8 @@ secretGenerator:
   - kubeconfig
   name: seed-local
   namespace: garden
+# enables gardenctl to work
+- files:
+  - kubeconfig
+  name: local.login
+  namespace: garden

--- a/dev-setup/gardenlet/components/kubeconfigs/seed-local2/kustomization.yaml
+++ b/dev-setup/gardenlet/components/kubeconfigs/seed-local2/kustomization.yaml
@@ -9,6 +9,11 @@ secretGenerator:
   - kubeconfig
   name: seed-local2
   namespace: garden
+# enables gardenctl to work
+- files:
+  - kubeconfig
+  name: local2.login
+  namespace: garden
 # We create a second secret with the same kubeconfig for gardener-operator, since it needs it to install the gardenlet
 # into the seed cluster, but it also automatically deletes it after successful installation. However, we need the
 # kubeconfig secret for the e2e tests.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This allows to use gardenctl in the local setup for the local seeds.
```
$ bash ./hack/usage/generate-virtual-garden-admin-kubeconf.sh  > /tmp/vgarden.yaml
$ gardenctl config set-garden local --kubeconfig=/tmp/vgarden.yaml
$ gardenctl target --garden local --seed local
``` 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
gardenctl in local setup
```
