### PR TITLE
[GEP-30] Remove `UsesUnifiedHTTPProxyPort` constraint again, if the feature gate is disabled

### DIFF
--- a/pkg/gardenlet/operation/botanist/vpnshoot.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot.go
@@ -78,5 +78,13 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 		})
 	}
 
-	return nil
+	// in case the feature gate was previously enabled but now disabled, we need to remove the condition
+	if v1beta1helper.GetCondition(b.Shoot.GetInfo().Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort) == nil {
+		return nil
+	}
+
+	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
+		shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort)
+		return nil
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind bug

**What this PR does / why we need it**:
If an operator enables the `UsesUnifiedHTTPProxyPort` and then disables it, the shoot constraint is now removed.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:
/cc @hown3d 

Disabling this feature gate is not a "normal" operation, I think in the current implementation this would break shoot API access until a shoot is reconciled, because the seed Gateway `http-connect` is reconciled (and the new port removed) by the seed controller before the shoot is reconciled. I believe this is ok, though, because we expect this feature to be only rolled back in DEV/pre-prod environments, where this would likely be ok.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a bug in the `UsesUnifiedHTTPProxyPort` constraint, when feature gate `UseUnifiedHTTPProxyPort` was used and then disabled again
```
