### PR TITLE
Let shoots switch exposure classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ test-e2e-local-migration-ha-multi-node: $(GINKGO)
 test-e2e-local-ha-multi-node: $(GINKGO)
 	SHOOT_FAILURE_TOLERANCE_TYPE=node ./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter "basic || (high-availability && update-to-node)" ./test/e2e/gardener/...
 test-e2e-local-ha-multi-zone: $(GINKGO)
-	SHOOT_FAILURE_TOLERANCE_TYPE=zone USE_PROVIDER_LOCAL_COREDNS_SERVER=true ./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter "basic || (high-availability && update-to-zone)" ./test/e2e/gardener/...
+	SHOOT_FAILURE_TOLERANCE_TYPE=zone ./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter "basic || (high-availability && update-to-zone)" ./test/e2e/gardener/...
 test-e2e-local-operator: $(GINKGO)
 	./hack/test-e2e-local.sh operator --procs=1 --label-filter="default" ./test/e2e/operator/...
 test-e2e-local-gardenadm-managed-infra: $(GINKGO)
@@ -488,4 +488,4 @@ ci-e2e-kind-upgrade: $(KIND) $(YQ)
 ci-e2e-kind-ha-multi-node-upgrade: $(KIND) $(YQ)
 	SHOOT_FAILURE_TOLERANCE_TYPE=node GARDENER_PREVIOUS_RELEASE=$(GARDENER_PREVIOUS_RELEASE) GARDENER_RELEASE_DOWNLOAD_PATH=$(GARDENER_RELEASE_DOWNLOAD_PATH) GARDENER_NEXT_RELEASE=$(GARDENER_NEXT_RELEASE) ./hack/ci-e2e-kind-upgrade.sh
 ci-e2e-kind-ha-multi-zone-upgrade: $(KIND) $(YQ)
-	SHOOT_FAILURE_TOLERANCE_TYPE=zone USE_PROVIDER_LOCAL_COREDNS_SERVER=true GARDENER_PREVIOUS_RELEASE=$(GARDENER_PREVIOUS_RELEASE) GARDENER_RELEASE_DOWNLOAD_PATH=$(GARDENER_RELEASE_DOWNLOAD_PATH) GARDENER_NEXT_RELEASE=$(GARDENER_NEXT_RELEASE) ./hack/ci-e2e-kind-upgrade.sh
+	SHOOT_FAILURE_TOLERANCE_TYPE=zone GARDENER_PREVIOUS_RELEASE=$(GARDENER_PREVIOUS_RELEASE) GARDENER_RELEASE_DOWNLOAD_PATH=$(GARDENER_RELEASE_DOWNLOAD_PATH) GARDENER_NEXT_RELEASE=$(GARDENER_NEXT_RELEASE) ./hack/ci-e2e-kind-upgrade.sh

--- a/charts/gardener/provider-local/templates/coredns/configmap.yaml
+++ b/charts/gardener/provider-local/templates/coredns/configmap.yaml
@@ -22,10 +22,10 @@ data:
           {{ .Values.controllers.service.zone0IP }} istio-ingressgateway.istio-ingress--0.svc.cluster.local
           {{ .Values.controllers.service.zone1IP }} istio-ingressgateway.istio-ingress--1.svc.cluster.local
           {{ .Values.controllers.service.zone2IP }} istio-ingressgateway.istio-ingress--2.svc.cluster.local
-          {{ .Values.controllers.service.exposureclassIP }} istio-ingressgateway.istio-ingress-exposureclass.svc.cluster.local
-          {{ .Values.controllers.service.exposureclassZone0IP }} istio-ingressgateway.istio-ingress-exposureclass--0.svc.cluster.local
-          {{ .Values.controllers.service.exposureclassZone1IP }} istio-ingressgateway.istio-ingress-exposureclass--1.svc.cluster.local
-          {{ .Values.controllers.service.exposureclassZone2IP }} istio-ingressgateway.istio-ingress-exposureclass--2.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassIP }} istio-ingressgateway.istio-ingress-local.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone0IP }} istio-ingressgateway.istio-ingress-local--0.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone1IP }} istio-ingressgateway.istio-ingress-local--1.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone2IP }} istio-ingressgateway.istio-ingress-local--2.svc.cluster.local
           fallthrough
         }
         forward . /etc/resolv.conf {

--- a/charts/gardener/provider-local/templates/coredns/configmap.yaml
+++ b/charts/gardener/provider-local/templates/coredns/configmap.yaml
@@ -22,6 +22,7 @@ data:
           {{ .Values.controllers.service.zone0IP }} istio-ingressgateway.istio-ingress--0.svc.cluster.local
           {{ .Values.controllers.service.zone1IP }} istio-ingressgateway.istio-ingress--1.svc.cluster.local
           {{ .Values.controllers.service.zone2IP }} istio-ingressgateway.istio-ingress--2.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassIP }} istio-ingressgateway.istio-ingress-exposureclass.svc.cluster.local
           fallthrough
         }
         forward . /etc/resolv.conf {

--- a/charts/gardener/provider-local/templates/coredns/configmap.yaml
+++ b/charts/gardener/provider-local/templates/coredns/configmap.yaml
@@ -23,6 +23,9 @@ data:
           {{ .Values.controllers.service.zone1IP }} istio-ingressgateway.istio-ingress--1.svc.cluster.local
           {{ .Values.controllers.service.zone2IP }} istio-ingressgateway.istio-ingress--2.svc.cluster.local
           {{ .Values.controllers.service.exposureclassIP }} istio-ingressgateway.istio-ingress-exposureclass.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone0IP }} istio-ingressgateway.istio-ingress-exposureclass--0.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone1IP }} istio-ingressgateway.istio-ingress-exposureclass--1.svc.cluster.local
+          {{ .Values.controllers.service.exposureclassZone2IP }} istio-ingressgateway.istio-ingress-exposureclass--2.svc.cluster.local
           fallthrough
         }
         forward . /etc/resolv.conf {

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
         - --service-zone-1-ip={{ .Values.controllers.service.zone1IP }}
         - --service-zone-2-ip={{ .Values.controllers.service.zone2IP }}
         - --service-bastion-ip={{ .Values.controllers.service.bastionIP }}
+        - --service-exposureclass-ip={{ .Values.controllers.service.exposureclassIP }}
         - --backupbucket-local-dir={{ .Values.controllers.backupbucket.localDir }}
         - --backupbucket-container-mount-path={{ .Values.controllers.backupbucket.containerMountPath }}
         - --heartbeat-namespace={{ .Release.Namespace }}

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
         - --service-zone-2-ip={{ .Values.controllers.service.zone2IP }}
         - --service-bastion-ip={{ .Values.controllers.service.bastionIP }}
         - --service-exposureclass-ip={{ .Values.controllers.service.exposureclassIP }}
+        - --service-exposureclass-zone-0-ip={{ .Values.controllers.service.exposureclassZone0IP }}
+        - --service-exposureclass-zone-1-ip={{ .Values.controllers.service.exposureclassZone1IP }}
+        - --service-exposureclass-zone-2-ip={{ .Values.controllers.service.exposureclassZone2IP }}
         - --backupbucket-local-dir={{ .Values.controllers.backupbucket.localDir }}
         - --backupbucket-container-mount-path={{ .Values.controllers.backupbucket.containerMountPath }}
         - --heartbeat-namespace={{ .Release.Namespace }}

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -40,6 +40,7 @@ controllers:
     zone1IP: "172.18.255.11"
     zone2IP: "172.18.255.12"
     bastionIP: "172.18.255.22"
+    exposureclassIP: "172.18.255.31"
   backupbucket:
     localDir: "/dev/local-backupbuckets"
     containerMountPath: "/etc/gardener/local-backupbuckets"

--- a/charts/gardener/provider-local/values.yaml
+++ b/charts/gardener/provider-local/values.yaml
@@ -41,6 +41,9 @@ controllers:
     zone2IP: "172.18.255.12"
     bastionIP: "172.18.255.22"
     exposureclassIP: "172.18.255.31"
+    exposureclassZone0IP: "172.18.255.40"
+    exposureclassZone1IP: "172.18.255.41"
+    exposureclassZone2IP: "172.18.255.42"
   backupbucket:
     localDir: "/dev/local-backupbuckets"
     containerMountPath: "/etc/gardener/local-backupbuckets"

--- a/dev-setup/gardenconfig/components/exposureclasses/exposureclass.yaml
+++ b/dev-setup/gardenconfig/components/exposureclasses/exposureclass.yaml
@@ -1,5 +1,5 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: ExposureClass
 metadata:
-  name: exposureclass
-handler: exposureclass
+  name: local
+handler: local

--- a/dev-setup/gardenconfig/components/exposureclasses/exposureclass.yaml
+++ b/dev-setup/gardenconfig/components/exposureclasses/exposureclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: core.gardener.cloud/v1beta1
+kind: ExposureClass
+metadata:
+  name: exposureclass
+handler: exposureclass

--- a/dev-setup/gardenconfig/components/exposureclasses/kustomization.yaml
+++ b/dev-setup/gardenconfig/components/exposureclasses/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- exposureclass.yaml
+

--- a/dev-setup/gardenconfig/overlays/operator/kustomization.yaml
+++ b/dev-setup/gardenconfig/overlays/operator/kustomization.yaml
@@ -13,3 +13,4 @@ components:
 - ../../components/credentials/secret-project-garden
 - ../../components/credentials/secret-project-local
 - ../../components/credentials/workloadidentity-project-local
+- ../../components/exposureclasses

--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -10,6 +10,11 @@ spec:
   config:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration
+    exposureClassHandlers:
+      - name: exposureclass
+        sni:
+          ingress:
+            namespace: istio-ingress-exposureclass
     featureGates:
       DefaultSeccompProfile: true
       IstioTLSTermination: true

--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -11,10 +11,10 @@ spec:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration
     exposureClassHandlers:
-      - name: exposureclass
+      - name: local
         sni:
           ingress:
-            namespace: istio-ingress-exposureclass
+            namespace: istio-ingress-local
     featureGates:
       DefaultSeccompProfile: true
       IstioTLSTermination: true

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2141,8 +2141,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>
@@ -13589,8 +13588,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>
@@ -14336,8 +14334,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -907,7 +907,7 @@ DNSRecordType
 </em>
 </td>
 <td>
-<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.</p>
+<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.</p>
 </td>
 </tr>
 <tr>
@@ -2737,7 +2737,7 @@ DNSRecordType
 </em>
 </td>
 <td>
-<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.</p>
+<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.</p>
 </td>
 </tr>
 <tr>

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -18,6 +18,18 @@
   hostPort: 8443
   listenAddress: {{ $listenAddress }}
 {{- end }}
+{{- range $listenAddress :=  .Values.gardener.seed.exposureClass.listenAddresses }}
+- containerPort:  32767
+  hostPort: 443
+  listenAddress: {{ $listenAddress }}
+# http proxy
+- containerPort:  32766
+  hostPort: 8443
+  listenAddress: {{ $listenAddress }}
+- containerPort:  32765
+  hostPort: 8132
+  listenAddress: {{ $listenAddress }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
+++ b/example/gardener-local/kind/cluster/templates/_extra_port_mappings.tpl
@@ -18,15 +18,15 @@
   hostPort: 8443
   listenAddress: {{ $listenAddress }}
 {{- end }}
-{{- range $listenAddress :=  .Values.gardener.seed.exposureClass.listenAddresses }}
-- containerPort:  32767
+{{- range $i, $listenAddress :=  .Values.gardener.seed.exposureClass.listenAddresses }}
+- containerPort:  {{ add 32003 $i }}
   hostPort: 443
   listenAddress: {{ $listenAddress }}
 # http proxy
-- containerPort:  32766
+- containerPort: {{ add 32447 $i }}
   hostPort: 8443
   listenAddress: {{ $listenAddress }}
-- containerPort:  32765
+- containerPort:  {{ add 31132 $i }}
   hostPort: 8132
   listenAddress: {{ $listenAddress }}
 {{- end }}

--- a/example/gardener-local/kind/cluster/values-dual.yaml
+++ b/example/gardener-local/kind/cluster/values-dual.yaml
@@ -7,6 +7,10 @@ gardener:
       listenAddresses:
       - "::1"
       - "172.18.255.1"
+    exposureClass:
+      listenAddresses:
+      - ::31
+      - "172.18.255.31"
     bastion:
       listenAddresses:
       - "::22"

--- a/example/gardener-local/kind/cluster/values-ipv6.yaml
+++ b/example/gardener-local/kind/cluster/values-ipv6.yaml
@@ -9,7 +9,9 @@ gardener:
     bastion:
       listenAddresses:
       - ::22
-
+    exposureClass:
+      listenAddresses:
+      - ::31
 networking:
   ipFamily: ipv6
   podSubnet: "fd00:10:1::/48"

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -11,6 +11,9 @@ gardener:
     deployed: true
   seed:
     deployed: true
+    exposureClass:
+      listenAddresses:
+      - 172.18.255.31
     istio:
       listenAddresses:
       - 172.18.255.1

--- a/example/gardener-local/kind/local2/values.yaml
+++ b/example/gardener-local/kind/local2/values.yaml
@@ -2,6 +2,9 @@ gardener:
   controlPlane:
     deployed: false
   seed:
+    exposureClass:
+      listenAddresses:
+      - 172.18.255.32
     istio:
       listenAddresses:
       - 172.18.255.2

--- a/example/gardener-local/kind/multi-node2/values.yaml
+++ b/example/gardener-local/kind/multi-node2/values.yaml
@@ -2,6 +2,9 @@ gardener:
   controlPlane:
     deployed: false
   seed:
+    exposureClass:
+      listenAddresses:
+      - 172.18.255.32
     istio:
       listenAddresses:
       - 172.18.255.2

--- a/example/gardener-local/kind/multi-zone/values.yaml
+++ b/example/gardener-local/kind/multi-zone/values.yaml
@@ -4,6 +4,13 @@ gardener:
     kindIsGardenCluster: false
     customEtcdStatefulSet: false
   seed:
+    exposureClass:
+      # Add one 'global' address and one per zone
+      listenAddresses:
+      - 172.18.255.31
+      - 172.18.255.40
+      - 172.18.255.41
+      - 172.18.255.42
     istio:
       # Add one 'global' address and one per zone, see https://github.com/gardener/gardener/pull/6997
       listenAddresses:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -79,7 +79,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               recordType:
                 description: RecordType is the DNS record type. Only A, CNAME, and
-                  TXT records are currently supported. This field is immutable.
+                  TXT records are currently supported.
                 type: string
               region:
                 description: |-

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -57,6 +57,13 @@ if ${EXPOSURE_CLASS}; then
     LOOPBACK_IP_ADDRESSES+=(::31)
   fi
 
+  if [[ "$MULTI_ZONAL" == "true" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(172.18.255.40 172.18.255.41 172.18.255.42)
+    if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+      LOOPBACK_IP_ADDRESSES+=(::40 ::41 ::42)
+    fi
+  fi
+
   if [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-local-multi-node2" ]]; then
     LOOPBACK_IP_ADDRESSES+=(172.18.255.32)
     if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -8,6 +8,7 @@ set -o nounset
 
 MULTI_ZONAL="false"
 CLUSTER_NAME=""
+EXPOSURE_CLASS=false
 IPFAMILY="ipv4"
 
 SUDO=""
@@ -27,6 +28,9 @@ parse_flags() {
     --multi-zonal)
       MULTI_ZONAL=true
       ;;
+    --exposure-class)
+      EXPOSURE_CLASS=true
+      ;;
     esac
 
     shift
@@ -44,6 +48,13 @@ if [[ "$MULTI_ZONAL" == "true" ]]; then
   LOOPBACK_IP_ADDRESSES+=(172.18.255.10 172.18.255.11 172.18.255.12)
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::10 ::11 ::12)
+  fi
+fi
+
+if ${EXPOSURE_CLASS}; then 
+  LOOPBACK_IP_ADDRESSES+=(172.18.255.31)
+  if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(::31)
   fi
 fi
 

--- a/hack/kind-setup-loopback-devices.sh
+++ b/hack/kind-setup-loopback-devices.sh
@@ -56,6 +56,13 @@ if ${EXPOSURE_CLASS}; then
   if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
     LOOPBACK_IP_ADDRESSES+=(::31)
   fi
+
+  if [[ "$CLUSTER_NAME" == "gardener-local2" || "$CLUSTER_NAME" == "gardener-local-multi-node2" ]]; then
+    LOOPBACK_IP_ADDRESSES+=(172.18.255.32)
+    if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+      LOOPBACK_IP_ADDRESSES+=(::32)
+    fi
+  fi
 fi
 
 if [[ "$CLUSTER_NAME" != "*local2*" ]] ; then

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -279,7 +279,7 @@ additional_params=""
 if [[ ${MULTI_ZONAL} == "true" ]]; then
   additional_params="--multi-zonal"
 fi
-./hack/kind-setup-loopback-devices.sh --cluster-name "${CLUSTER_NAME}" --ip-family "${IPFAMILY}" "${additional_params}"
+./hack/kind-setup-loopback-devices.sh --cluster-name "${CLUSTER_NAME}" --ip-family "${IPFAMILY}" "${additional_params}" --exposure-class
 
 setup_kind_network
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -98,4 +98,7 @@ case $TYPE in
     ;;
 esac
 
-GO111MODULE=on ginkgo run --timeout=105m $ginkgo_flags --v --show-node-events "$@"
+# enable netdns debug log
+GODEBUG=netdns=2 \
+GO111MODULE=on \
+ginkgo run --timeout=105m $ginkgo_flags --v --show-node-events "$@"

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -65,42 +65,7 @@ case $TYPE in
 
   default)
     seed_name="local"
-    shoot_names=(
-      e2e-managedseed.garden
-      e2e-hib.local
-      e2e-hib-wl.local
-      e2e-unpriv.local
-      e2e-wake-up.local
-      e2e-wake-up-wl.local
-      e2e-wake-up-ncp.local
-      e2e-migrate.local
-      e2e-migrate-wl.local
-      e2e-mgr-hib.local
-      e2e-rotate.local
-      e2e-rotate-wl.local
-      e2e-rot-noroll.local
-      e2e-rot-ip.local
-      e2e-rot-nr-ip.local
-      e2e-rot-etcd.local
-      e2e-default.local
-      e2e-default-wl.local
-      e2e-default-ip.local
-      e2e-force-delete.local
-      e2e-fd-hib.local
-      e2e-upd-node.local
-      e2e-upd-node-wl.local
-      e2e-upd-node-ovr.local
-      e2e-upgrade.local
-      e2e-upgrade-wl.local
-      e2e-upg-ha.local
-      e2e-upg-ha-wl.local
-      e2e-upg-hib.local
-      e2e-upg-hib-wl.local
-      e2e-auth-one.local
-      e2e-auth-two.local
-      e2e-layer4-lb.local
-    )
-
+    
     ingress_names=(
       gu-local--e2e-rotate
       gu-local--e2e-rotate-wl
@@ -109,34 +74,12 @@ case $TYPE in
     )
 
     if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
-      for shoot in "${shoot_names[@]}" ; do
-        if [[ "${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" && ("$shoot" == "e2e-upg-ha.local" || "$shoot" == "e2e-upg-ha-wl.local") ]]; then
-          # Do not add the entry for the e2e-upd-zone test as the target ip is dynamic.
-          # The shoot cluster in e2e-upd-zone is created as single-zone control plane and afterwards updated to a multi-zone control plane.
-          # This means that the external loadbalancer IP will change from a zone-specific istio ingress gateway to the default istio ingress gateway.
-          # A static mapping (to the default istio ingress gateway) as done here will not work in this scenario.
-          # The e2e-upd-zone test uses the in-cluster coredns for name resolution and can therefore resolve the api endpoint.
-          continue
-        fi
-        printf "\n$local_address api.%s.external.local.gardener.cloud\n$local_address api.%s.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
-      done
       for ingress in "${ingress_names[@]}" ; do
         printf "\n$local_address %s.ingress.$seed_name.seed.local.gardener.cloud\n" $ingress >>/etc/hosts
       done
     else
       missing_entries=()
 
-      for shoot in "${shoot_names[@]}"; do
-        if [[ ("${SHOOT_FAILURE_TOLERANCE_TYPE:-}" == "zone" || -z "${SHOOT_FAILURE_TOLERANCE_TYPE:-}") && ("$shoot" == "e2e-upg-ha.local" || "$shoot" == "e2e-upg-ha-wl.local") ]]; then
-          # Do not check the entry for the e2e-upg-ha and e2e-upg-ha-wl tests as the target IP is dynamic.
-          continue
-        fi
-        for ip in internal external; do
-          if ! grep -q -x "$local_address api.$shoot.$ip.local.gardener.cloud" /etc/hosts; then
-            missing_entries+=("$local_address api.$shoot.$ip.local.gardener.cloud")
-          fi
-        done
-      done
       for ingress in "${ingress_names[@]}" ; do
           if ! grep -q -x "$local_address $ingress.ingress.$seed_name.seed.local.gardener.cloud" /etc/hosts; then
             missing_entries+=("$local_address $ingress.ingress.$seed_name.seed.local.gardener.cloud")

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3423,7 +3423,6 @@ message ShootSpec {
   repeated Toleration tolerations = 17;
 
   // ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-  // This field is immutable.
   // +optional
   optional string exposureClassName = 18;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -123,7 +123,6 @@ type ShootSpec struct {
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,17,rep,name=tolerations"`
 	// ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-	// This field is immutable.
 	// +optional
 	ExposureClassName *string `json:"exposureClassName,omitempty" protobuf:"bytes,18,opt,name=exposureClassName"`
 	// SystemComponents contains the settings of system components in the control or data plane of the Shoot cluster.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -403,7 +403,6 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	if !migrationFromSecBindingToCredBinding {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SecretBindingName, oldSpec.SecretBindingName, fldPath.Child("secretBindingName"))...)
 	}
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ExposureClassName, oldSpec.ExposureClassName, fldPath.Child("exposureClassName"))...)
 
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, newSpec.SeedName != nil, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, false, fldPath.Child("kubernetes", "version"))...)
@@ -847,7 +846,7 @@ func validateNodeLocalDNSUpdate(newSpec, oldSpec *core.ShootSpec, fldPath *field
 		}
 
 		for i, worker := range oldSpec.Provider.Workers {
-			var idxPath = field.NewPath("spec", "provider", "workers").Index(i)
+			idxPath := field.NewPath("spec", "provider", "workers").Index(i)
 			workerK8sVersion, err := helper.CalculateEffectiveKubernetesVersion(defaultVersion, worker.Kubernetes)
 			if err != nil {
 				return field.ErrorList{field.Invalid(idxPath, "", fmt.Sprintf("failed to calculate effective Kubernetes version for worker %q: %v", worker.Name, err))}
@@ -3311,7 +3310,7 @@ func validateOperationRolloutWorkers(operation string, shoot *core.Shoot, fldPat
 func validatePendingWorkerUpdates(shoot *core.Shoot, fldPath *field.Path, operation string) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	var forbiddenPendingWorkerUpdatesMessageTemplate = "cannot start %s if status.inPlaceUpdates.pendingWorkerUpdates.%s is not empty"
+	forbiddenPendingWorkerUpdatesMessageTemplate := "cannot start %s if status.inPlaceUpdates.pendingWorkerUpdates.%s is not empty"
 	if shoot.Status.InPlaceUpdates != nil && shoot.Status.InPlaceUpdates.PendingWorkerUpdates != nil {
 		if len(shoot.Status.InPlaceUpdates.PendingWorkerUpdates.AutoInPlaceUpdate) > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf(forbiddenPendingWorkerUpdatesMessageTemplate, operation, "autoInPlaceUpdate")))

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -629,19 +629,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should forbid to change the exposure class", func() {
+			It("should allow to change the exposure class", func() {
 				shoot.Spec.ExposureClassName = ptr.To("exposure-class-1")
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.ExposureClassName = ptr.To("exposure-class-2")
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.exposureClassName"),
-					})),
-				))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 
@@ -2232,7 +2227,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 					errorList := ValidateShoot(shoot)
 					Expect(errorList).To(matcher)
-
 				},
 					Entry("empty APIVersion",
 						autoscalingv1.CrossVersionObjectReference{APIVersion: "", Kind: "Secret", Name: dnsSecretName},
@@ -3129,7 +3123,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Detail": Equal("must not contain a fragment"),
 					}))))
 				})
-
 			})
 
 			Context("Autoscaling validation", func() {
@@ -3537,7 +3530,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field":  Equal("spec.kubernetes.kubeScheduler"),
 					"Detail": ContainSubstring("this field should not be set for workerless Shoot clusters"),
 				}))))
-
 			})
 
 			It("should succeed when using valid scheduling profile", func() {
@@ -8472,30 +8464,28 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Describe("#ValidateInPlaceUpdateStrategyOnCreation", func() {
-			var (
-				shoot = &core.Shoot{
-					Spec: core.ShootSpec{
-						Provider: core.Provider{
-							Workers: []core.Worker{
-								{
-									Name: "worker-1",
-									Machine: core.Machine{
-										Type: "xlarge",
-									},
-									UpdateStrategy: ptr.To(core.AutoInPlaceUpdate),
+			shoot := &core.Shoot{
+				Spec: core.ShootSpec{
+					Provider: core.Provider{
+						Workers: []core.Worker{
+							{
+								Name: "worker-1",
+								Machine: core.Machine{
+									Type: "xlarge",
 								},
-								{
-									Name: "worker-2",
-									Machine: core.Machine{
-										Type: "xlarge",
-									},
-									UpdateStrategy: ptr.To(core.ManualInPlaceUpdate),
+								UpdateStrategy: ptr.To(core.AutoInPlaceUpdate),
+							},
+							{
+								Name: "worker-2",
+								Machine: core.Machine{
+									Type: "xlarge",
 								},
+								UpdateStrategy: ptr.To(core.ManualInPlaceUpdate),
 							},
 						},
 					},
-				}
-			)
+				},
+			}
 
 			It("should not allow to set update strategy to AutoInPlaceUpdate/ManualInPlaceUpdate if feature gate is disabled", func() {
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.InPlaceNodeUpdates, false))
@@ -9683,7 +9673,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}),
 				)))
 			}
-
 		},
 			Entry("should succeed if issuer URL is valid", "https://issuer.com/auth", ""),
 			Entry("should fail if issuerURL URL scheme is not https", "http://issuer.com", "must have https scheme"),

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -75,7 +75,7 @@ type DNSRecordSpec struct {
 	Zone *string `json:"zone,omitempty"`
 	// Name is the fully qualified domain name, e.g. "api.<shoot domain>". This field is immutable.
 	Name string `json:"name"`
-	// RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.
+	// RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.
 	RecordType DNSRecordType `json:"recordType"`
 	// Values is a list of IP addresses for A records, a single hostname for CNAME records, or a list of texts for TXT records.
 	Values []string `json:"values"`

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -103,7 +103,6 @@ func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, del
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Name, old.Name, fldPath.Child("name"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.RecordType, old.RecordType, fldPath.Child("recordType"))...)
 
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -236,7 +236,7 @@ var _ = Describe("DNSRecord validation tests", func() {
 			}))))
 		})
 
-		It("should prevent updating the type, name, or recordType", func() {
+		It("should prevent updating the type or name", func() {
 			newDNSRecord := prepareDNSRecordForUpdate(dns)
 			newDNSRecord.Spec.Type = "changed-type"
 			newDNSRecord.Spec.Name = "changed-test.example.com"
@@ -250,10 +250,8 @@ var _ = Describe("DNSRecord validation tests", func() {
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.name"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.recordType"),
-			}))))
+			})),
+			))
 		})
 
 		It("should allow updating everything else", func() {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -9764,7 +9764,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"exposureClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy. This field is immutable.",
+							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -81,7 +81,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               recordType:
                 description: RecordType is the DNS record type. Only A, CNAME, and
-                  TXT records are currently supported. This field is immutable.
+                  TXT records are currently supported.
                 type: string
               region:
                 description: |-

--- a/pkg/controller/service/add.go
+++ b/pkg/controller/service/add.go
@@ -29,6 +29,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, predicates ...predicate.P
 	if r.BastionIP == "" {
 		r.BastionIP = "172.18.255.22"
 	}
+	if r.ExposureClassIP == "" {
+		r.ExposureClassIP = "172.18.255.31"
+	}
 
 	return builder.
 		ControllerManagedBy(mgr).

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -26,10 +26,10 @@ var (
 	keyIstioIngressGatewayZone1 = client.ObjectKey{Namespace: "istio-ingress--1", Name: "istio-ingressgateway"}
 	keyIstioIngressGatewayZone2 = client.ObjectKey{Namespace: "istio-ingress--2", Name: "istio-ingressgateway"}
 
-	keyIstioIngressGatewayExposureClass      = client.ObjectKey{Namespace: "istio-ingress-exposureclass", Name: "istio-ingressgateway"}
-	keyIstioIngressGatewayExposureClassZone0 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--0", Name: "istio-ingressgateway"}
-	keyIstioIngressGatewayExposureClassZone1 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--1", Name: "istio-ingressgateway"}
-	keyIstioIngressGatewayExposureClassZone2 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--2", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClass      = client.ObjectKey{Namespace: "istio-ingress-local", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone0 = client.ObjectKey{Namespace: "istio-ingress-local--0", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone1 = client.ObjectKey{Namespace: "istio-ingress-local--1", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone2 = client.ObjectKey{Namespace: "istio-ingress-local--2", Name: "istio-ingressgateway"}
 
 	keyVirtualGardenIstioIngressGateway = client.ObjectKey{Namespace: "virtual-garden-istio-ingress", Name: "istio-ingressgateway"}
 )

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -26,25 +26,36 @@ var (
 	keyIstioIngressGatewayZone1 = client.ObjectKey{Namespace: "istio-ingress--1", Name: "istio-ingressgateway"}
 	keyIstioIngressGatewayZone2 = client.ObjectKey{Namespace: "istio-ingress--2", Name: "istio-ingressgateway"}
 
-	keyIstioIngressGatewayExposureClass = client.ObjectKey{Namespace: "istio-ingress-exposureclass", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClass      = client.ObjectKey{Namespace: "istio-ingress-exposureclass", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone0 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--0", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone1 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--1", Name: "istio-ingressgateway"}
+	keyIstioIngressGatewayExposureClassZone2 = client.ObjectKey{Namespace: "istio-ingress-exposureclass--2", Name: "istio-ingressgateway"}
 
 	keyVirtualGardenIstioIngressGateway = client.ObjectKey{Namespace: "virtual-garden-istio-ingress", Name: "istio-ingressgateway"}
 )
 
 const (
-	nodePortIstioIngressGateway              int32 = 30443
-	nodePortIstioIngressGatewayZone0         int32 = 30444
-	nodePortIstioIngressGatewayZone1         int32 = 30445
-	nodePortIstioIngressGatewayZone2         int32 = 30446
-	nodePortIstioIngressGatewayExposureClass int32 = 32767
+	nodePortIstioIngressGateway      int32 = 30443
+	nodePortIstioIngressGatewayZone0 int32 = 30444
+	nodePortIstioIngressGatewayZone1 int32 = 30445
+	nodePortIstioIngressGatewayZone2 int32 = 30446
+
+	nodePortIstioIngressGatewayExposureClass      int32 = 32003
+	nodePortIstioIngressGatewayExposureClassZone0 int32 = 32004
+	nodePortIstioIngressGatewayExposureClassZone1 int32 = 32005
+	nodePortIstioIngressGatewayExposureClassZone2 int32 = 32006
 
 	nodePortVirtualGardenIstioIngressGateway int32 = 31443
 
-	nodePortHTTPProxyIstioIngressGateway              int32 = 32443
-	nodePortHTTPProxyIstioIngressGatewayZone0         int32 = 32444
-	nodePortHTTPProxyIstioIngressGatewayZone1         int32 = 32445
-	nodePortHTTPProxyIstioIngressGatewayZone2         int32 = 32446
-	nodePortHTTPProxyIstioIngressGatewayExposureClass int32 = 32766
+	nodePortHTTPProxyIstioIngressGateway      int32 = 32443
+	nodePortHTTPProxyIstioIngressGatewayZone0 int32 = 32444
+	nodePortHTTPProxyIstioIngressGatewayZone1 int32 = 32445
+	nodePortHTTPProxyIstioIngressGatewayZone2 int32 = 32446
+
+	nodePortHTTPProxyIstioIngressGatewayExposureClass      int32 = 32447
+	nodePortHTTPProxyIstioIngressGatewayExposureClassZone0 int32 = 32448
+	nodePortHTTPProxyIstioIngressGatewayExposureClassZone1 int32 = 32449
+	nodePortHTTPProxyIstioIngressGatewayExposureClassZone2 int32 = 32450
 
 	nodePortBastion int32 = 30022
 )
@@ -56,19 +67,25 @@ const (
 	nodePortTunnelIstioIngressGatewayZone1 int32 = 32134
 	nodePortTunnelIstioIngressGatewayZone2 int32 = 32135
 
-	nodePortTunnelIstioIngressGatewayExposureClass int32 = 32765
+	nodePortTunnelIstioIngressGatewayExposureClass      int32 = 31132
+	nodePortTunnelIstioIngressGatewayExposureClassZone0 int32 = 31133
+	nodePortTunnelIstioIngressGatewayExposureClassZone1 int32 = 31134
+	nodePortTunnelIstioIngressGatewayExposureClassZone2 int32 = 31135
 )
 
 // Reconciler is a reconciler for Service resources.
 type Reconciler struct {
-	Client          client.Client
-	HostIP          string
-	VirtualGardenIP string
-	Zone0IP         string
-	Zone1IP         string
-	Zone2IP         string
-	BastionIP       string
-	ExposureClassIP string
+	Client               client.Client
+	HostIP               string
+	VirtualGardenIP      string
+	Zone0IP              string
+	Zone1IP              string
+	Zone2IP              string
+	BastionIP            string
+	ExposureClassIP      string
+	ExposureClassIPZone0 string
+	ExposureClassIPZone1 string
+	ExposureClassIPZone2 string
 }
 
 // Reconcile reconciles Service resources.
@@ -132,6 +149,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		nodePortHTTPProxy = nodePortHTTPProxyIstioIngressGatewayExposureClass
 		nodePortTunnel = nodePortTunnelIstioIngressGatewayExposureClass
 		ips = append(ips, r.ExposureClassIP)
+	case keyIstioIngressGatewayExposureClassZone0:
+		nodePort = nodePortIstioIngressGatewayExposureClassZone0
+		nodePortHTTPProxy = nodePortHTTPProxyIstioIngressGatewayExposureClassZone0
+		nodePortTunnel = nodePortTunnelIstioIngressGatewayExposureClassZone0
+		ips = append(ips, r.ExposureClassIPZone0)
+	case keyIstioIngressGatewayExposureClassZone1:
+		nodePort = nodePortIstioIngressGatewayExposureClassZone1
+		nodePortHTTPProxy = nodePortHTTPProxyIstioIngressGatewayExposureClassZone1
+		nodePortTunnel = nodePortTunnelIstioIngressGatewayExposureClassZone1
+		ips = append(ips, r.ExposureClassIPZone1)
+	case keyIstioIngressGatewayExposureClassZone2:
+		nodePort = nodePortIstioIngressGatewayExposureClassZone2
+		nodePortHTTPProxy = nodePortHTTPProxyIstioIngressGatewayExposureClassZone2
+		nodePortTunnel = nodePortTunnelIstioIngressGatewayExposureClassZone2
+		ips = append(ips, r.ExposureClassIPZone2)
 	}
 
 	if isBastion {

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -26,21 +26,25 @@ var (
 	keyIstioIngressGatewayZone1 = client.ObjectKey{Namespace: "istio-ingress--1", Name: "istio-ingressgateway"}
 	keyIstioIngressGatewayZone2 = client.ObjectKey{Namespace: "istio-ingress--2", Name: "istio-ingressgateway"}
 
+	keyIstioIngressGatewayExposureClass = client.ObjectKey{Namespace: "istio-ingress-exposureclass", Name: "istio-ingressgateway"}
+
 	keyVirtualGardenIstioIngressGateway = client.ObjectKey{Namespace: "virtual-garden-istio-ingress", Name: "istio-ingressgateway"}
 )
 
 const (
-	nodePortIstioIngressGateway      int32 = 30443
-	nodePortIstioIngressGatewayZone0 int32 = 30444
-	nodePortIstioIngressGatewayZone1 int32 = 30445
-	nodePortIstioIngressGatewayZone2 int32 = 30446
+	nodePortIstioIngressGateway              int32 = 30443
+	nodePortIstioIngressGatewayZone0         int32 = 30444
+	nodePortIstioIngressGatewayZone1         int32 = 30445
+	nodePortIstioIngressGatewayZone2         int32 = 30446
+	nodePortIstioIngressGatewayExposureClass int32 = 32767
 
 	nodePortVirtualGardenIstioIngressGateway int32 = 31443
 
-	nodePortHTTPProxyIstioIngressGateway      int32 = 32443
-	nodePortHTTPProxyIstioIngressGatewayZone0 int32 = 32444
-	nodePortHTTPProxyIstioIngressGatewayZone1 int32 = 32445
-	nodePortHTTPProxyIstioIngressGatewayZone2 int32 = 32446
+	nodePortHTTPProxyIstioIngressGateway              int32 = 32443
+	nodePortHTTPProxyIstioIngressGatewayZone0         int32 = 32444
+	nodePortHTTPProxyIstioIngressGatewayZone1         int32 = 32445
+	nodePortHTTPProxyIstioIngressGatewayZone2         int32 = 32446
+	nodePortHTTPProxyIstioIngressGatewayExposureClass int32 = 32766
 
 	nodePortBastion int32 = 30022
 )
@@ -51,6 +55,8 @@ const (
 	nodePortTunnelIstioIngressGatewayZone0 int32 = 32133
 	nodePortTunnelIstioIngressGatewayZone1 int32 = 32134
 	nodePortTunnelIstioIngressGatewayZone2 int32 = 32135
+
+	nodePortTunnelIstioIngressGatewayExposureClass int32 = 32765
 )
 
 // Reconciler is a reconciler for Service resources.
@@ -62,6 +68,7 @@ type Reconciler struct {
 	Zone1IP         string
 	Zone2IP         string
 	BastionIP       string
+	ExposureClassIP string
 }
 
 // Reconcile reconciles Service resources.
@@ -120,6 +127,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	case keyVirtualGardenIstioIngressGateway:
 		nodePort = nodePortVirtualGardenIstioIngressGateway
 		ips = append(ips, r.VirtualGardenIP)
+	case keyIstioIngressGatewayExposureClass:
+		nodePort = nodePortIstioIngressGatewayExposureClass
+		nodePortHTTPProxy = nodePortHTTPProxyIstioIngressGatewayExposureClass
+		nodePortTunnel = nodePortTunnelIstioIngressGatewayExposureClass
+		ips = append(ips, r.ExposureClassIP)
 	}
 
 	if isBastion {

--- a/pkg/provider-local/controller/dnsrecord/actuator.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator.go
@@ -154,7 +154,7 @@ func (a *Actuator) configForDNSRecord(ctx context.Context, dnsRecord *extensions
 func (a *Actuator) exposureClassNamespaceName(ctx context.Context, exposureClass string) (string, error) {
 	exposureClassNamespaceLabels := client.MatchingLabels{
 		v1beta1constants.LabelExposureClassHandlerName: exposureClass,
-		v1beta1constants.GardenRole: v1beta1constants.GardenRoleExposureClassHandler,
+		v1beta1constants.GardenRole:                    v1beta1constants.GardenRoleExposureClassHandler,
 	}
 	namespaceList := &corev1.NamespaceList{}
 

--- a/pkg/provider-local/controller/dnsrecord/actuator.go
+++ b/pkg/provider-local/controller/dnsrecord/actuator.go
@@ -144,14 +144,18 @@ func (a *Actuator) configForDNSRecord(ctx context.Context, dnsRecord *extensions
 		if err != nil {
 			return "", err
 		}
-		istioNamespaceSuffix, _ = strings.CutPrefix(expClassNamespace, "istio-ingress")
+		expClassNamespace, _ = strings.CutPrefix(expClassNamespace, "istio-ingress")
+		istioNamespaceSuffix = expClassNamespace + istioNamespaceSuffix
 	}
 
 	return "rewrite stop name regex " + regexp.QuoteMeta(dnsRecord.Spec.Name) + " istio-ingressgateway.istio-ingress" + istioNamespaceSuffix + ".svc.cluster.local answer auto", nil
 }
 
 func (a *Actuator) exposureClassNamespaceName(ctx context.Context, exposureClass string) (string, error) {
-	exposureClassNamespaceLabels := client.MatchingLabels{v1beta1constants.LabelExposureClassHandlerName: exposureClass}
+	exposureClassNamespaceLabels := client.MatchingLabels{
+		v1beta1constants.LabelExposureClassHandlerName: exposureClass,
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleExposureClassHandler,
+	}
 	namespaceList := &corev1.NamespaceList{}
 
 	if err := a.RuntimeClient.List(ctx, namespaceList, exposureClassNamespaceLabels); err != nil {

--- a/pkg/provider-local/controller/networkpolicy/add.go
+++ b/pkg/provider-local/controller/networkpolicy/add.go
@@ -8,13 +8,19 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
@@ -35,11 +41,43 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
+		WatchesRawSource(source.Kind(
+			mgr.GetCache(),
+			&extensionsv1alpha1.Cluster{},
+			&handler.TypedEnqueueRequestForObject[*extensionsv1alpha1.Cluster]{},
+			exposureClassChanged(),
+		)).
 		For(&corev1.Namespace{}, builder.WithPredicates(IsShootNamespace(), IsShootProviderLocal())).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 5,
 		}).
 		Complete(r)
+}
+
+func exposureClassChanged() predicate.TypedFuncs[*extensionsv1alpha1.Cluster] {
+	return predicate.TypedFuncs[*extensionsv1alpha1.Cluster]{
+		CreateFunc: func(event.TypedCreateEvent[*extensionsv1alpha1.Cluster]) bool {
+			return true
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*extensionsv1alpha1.Cluster]) bool {
+			oldShoot, err := extensions.ShootFromCluster(e.ObjectOld)
+			if err != nil {
+				return false
+			}
+			newShoot, err := extensions.ShootFromCluster(e.ObjectNew)
+			if err != nil {
+				return false
+			}
+			// enqueue if exposureclasses are not the same
+			return !equality.Semantic.DeepEqual(oldShoot.Spec.ExposureClassName, newShoot.Spec.ExposureClassName)
+		},
+		DeleteFunc: func(event.TypedDeleteEvent[*extensionsv1alpha1.Cluster]) bool {
+			return false
+		},
+		GenericFunc: func(event.TypedGenericEvent[*extensionsv1alpha1.Cluster]) bool {
+			return false
+		},
+	}
 }
 
 // IsShootNamespace returns a predicate that returns true if the namespace is a shoot namespace.

--- a/pkg/provider-local/controller/networkpolicy/reconciler.go
+++ b/pkg/provider-local/controller/networkpolicy/reconciler.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, err
 		}
 		if peer != nil {
-			networkPolicyAllowToIstioIngressGateway.Spec.Egress[0].To = append(networkPolicyAllowToIstioIngressGateway.Spec.Egress[0].To, *peer)
+			networkPolicyAllowToIstioIngressGateway.Spec.Egress[0].To = []networkingv1.NetworkPolicyPeer{*peer}
 		}
 	}
 
@@ -102,7 +102,7 @@ func (r *Reconciler) exposureClassNetworkPolicyPeer(ctx context.Context, exposur
 	}
 
 	if len(namespaceList.Items) != 1 {
-		return nil, nil
+		return nil, fmt.Errorf("namespace for exposure class %s not found", exposureClass)
 	}
 
 	return &networkingv1.NetworkPolicyPeer{
@@ -110,6 +110,7 @@ func (r *Reconciler) exposureClassNetworkPolicyPeer(ctx context.Context, exposur
 		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 			"app":                       "istio-ingressgateway",
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleExposureClassHandler,
+			v1beta1constants.LabelExposureClassHandlerName: exposureClass,
 		}},
 	}, nil
 }

--- a/pkg/provider-local/controller/networkpolicy/reconciler_test.go
+++ b/pkg/provider-local/controller/networkpolicy/reconciler_test.go
@@ -163,14 +163,17 @@ var _ = Describe("Reconciler", func() {
 			[]networkingv1.NetworkPolicyPeer{
 				{
 					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": testExposureclass,
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/metadata.name",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{testExposureclass},
+							},
 						},
 					},
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"app":                 "istio-ingressgateway",
-							"gardener.cloud/role": "exposureclass-handler",
+							"app": "istio-ingressgateway",
 							"handler.exposureclass.gardener.cloud/name": testExposureclass,
 						},
 					},

--- a/pkg/provider-local/controller/networkpolicy/reconciler_test.go
+++ b/pkg/provider-local/controller/networkpolicy/reconciler_test.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkpolicy_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/provider-local/controller/networkpolicy"
+)
+
+const testExposureclass = "exposureclass"
+
+var _ = Describe("Reconciler", func() {
+	var (
+		r *Reconciler
+		k komega.Komega
+		c client.Client
+	)
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		k = komega.New(c)
+		r = &Reconciler{
+			Client: c,
+		}
+	})
+
+	DescribeTable("#Reconcile", func(ctx context.Context, shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, expectedPeers []networkingv1.NetworkPolicyPeer) {
+		k = k.WithContext(ctx)
+		cluster := defaultCluster(shoot, seed)
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Name}}
+		exposureclassNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testExposureclass, Labels: map[string]string{constants.LabelExposureClassHandlerName: testExposureclass}}}
+		Expect(c.Create(ctx, namespace)).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, exposureclassNamespace)).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, cluster)).NotTo(HaveOccurred())
+
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(namespace)})
+		Expect(err).NotTo(HaveOccurred(), "reconcile")
+
+		netpol := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-to-istio-ingress-gateway",
+				Namespace: namespace.Name,
+			},
+		}
+
+		expected := netpol.DeepCopy()
+		expected.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: expectedPeers,
+			},
+		}
+		Expect(k.Object(netpol)()).To(komega.EqualObject(expected, komega.MatchPaths{"spec.egress[0].to"}))
+	},
+		Entry("Cluster",
+			&gardencorev1beta1.Shoot{},
+			&gardencorev1beta1.Seed{},
+			[]networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "istio-ingress",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":   "istio-ingressgateway",
+							"istio": "ingressgateway",
+						},
+					},
+				},
+			},
+		),
+		Entry("Cluster with zones in seed",
+			&gardencorev1beta1.Shoot{},
+			&gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Provider: gardencorev1beta1.SeedProvider{
+						Zones: []string{"1", "2", "3"},
+					},
+				},
+			},
+			[]networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "istio-ingress",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":   "istio-ingressgateway",
+							"istio": "ingressgateway",
+						},
+					},
+				},
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "istio-ingress--1",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":   "istio-ingressgateway",
+							"istio": "ingressgateway--zone--1",
+						},
+					},
+				},
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "istio-ingress--2",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":   "istio-ingressgateway",
+							"istio": "ingressgateway--zone--2",
+						},
+					},
+				},
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": "istio-ingress--3",
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":   "istio-ingressgateway",
+							"istio": "ingressgateway--zone--3",
+						},
+					},
+				},
+			},
+		),
+		Entry("Cluster with exposure class",
+			&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					ExposureClassName: ptr.To(testExposureclass),
+				},
+			},
+			&gardencorev1beta1.Seed{},
+			[]networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": testExposureclass,
+						},
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app":                 "istio-ingressgateway",
+							"gardener.cloud/role": "exposureclass-handler",
+							"handler.exposureclass.gardener.cloud/name": testExposureclass,
+						},
+					},
+				},
+			},
+		),
+	)
+})
+
+func defaultCluster(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed) *extensionsv1alpha1.Cluster {
+	GinkgoHelper()
+
+	encoder := json.NewSerializerWithOptions(json.DefaultMetaFactory, kubernetes.SeedScheme, kubernetes.SeedScheme, json.SerializerOptions{Yaml: false, Pretty: false, Strict: false})
+	rawSeed, err := runtime.Encode(encoder, seed)
+	Expect(err).NotTo(HaveOccurred())
+
+	rawShoot, err := runtime.Encode(encoder, shoot)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &extensionsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mycluster",
+		},
+		Spec: extensionsv1alpha1.ClusterSpec{
+			Seed: runtime.RawExtension{
+				Raw: rawSeed,
+			},
+			Shoot: runtime.RawExtension{
+				Raw: rawShoot,
+			},
+		},
+	}
+}

--- a/pkg/provider-local/controller/service/add.go
+++ b/pkg/provider-local/controller/service/add.go
@@ -40,6 +40,8 @@ type AddOptions struct {
 	Zone2IP string
 	// BastionIP is the bastion IP.
 	BastionIP string
+	// ExposureClassIP is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass".
+	ExposureClassIP string
 }
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
@@ -71,6 +73,12 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 	}
 	predicates = append(predicates, bastionPredicate)
 
+	exposureclassPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{"app": "istio-ingressgateway", v1beta1constants.GardenRole: v1beta1constants.GardenRoleExposureClassHandler}})
+	if err != nil {
+		return err
+	}
+	predicates = append(predicates, exposureclassPredicate)
+
 	return (&service.Reconciler{
 		HostIP:          opts.HostIP,
 		VirtualGardenIP: opts.VirtualGardenIP,
@@ -78,6 +86,7 @@ func AddToManagerWithOptions(_ context.Context, mgr manager.Manager, opts AddOpt
 		Zone1IP:         opts.Zone1IP,
 		Zone2IP:         opts.Zone2IP,
 		BastionIP:       opts.BastionIP,
+		ExposureClassIP: opts.ExposureClassIP,
 	}).AddToManager(mgr, predicate.Or(predicates...))
 }
 

--- a/pkg/provider-local/controller/service/options.go
+++ b/pkg/provider-local/controller/service/options.go
@@ -28,6 +28,12 @@ type ControllerOptions struct {
 	BastionIP string
 	// ExposureClassIP is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass".
 	ExposureClassIP string
+	// ExposureClassIPZone0 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 0.
+	ExposureClassIPZone0 string
+	// ExposureClassIPZone1 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 1.
+	ExposureClassIPZone1 string
+	// ExposureClassIPZone2 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 2.
+	ExposureClassIPZone2 string
 
 	config *ControllerConfig
 }
@@ -42,11 +48,15 @@ func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 2")
 	fs.StringVar(&c.BastionIP, "bastion-ip", c.BastionIP, "Overwrite LoadBalancer IP to use for bastion service")
 	fs.StringVar(&c.ExposureClassIP, "exposureclass-ip", c.ExposureClassIP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service of ExposureClass \"exposureclass\"")
+	fs.StringVar(&c.ExposureClassIPZone0, "exposureclass-zone-0-ip", c.ExposureClassIPZone0, "Overwrite LoadBalancer IP to use for istio ingress-gateway service of ExposureClass \"exposureclass\" for zone 0")
+	fs.StringVar(&c.ExposureClassIPZone1, "exposureclass-zone-1-ip", c.ExposureClassIPZone1, "Overwrite LoadBalancer IP to use for istio ingress-gateway service of ExposureClass \"exposureclass\" for zone 1")
+
+	fs.StringVar(&c.ExposureClassIPZone2, "exposureclass-zone-2-ip", c.ExposureClassIPZone2, "Overwrite LoadBalancer IP to use for istio ingress-gateway service of ExposureClass \"exposureclass\" for zone 2")
 }
 
 // Complete implements Completer.Complete.
 func (c *ControllerOptions) Complete() error {
-	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.VirtualGardenIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP, c.ExposureClassIP}
+	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.VirtualGardenIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP, c.ExposureClassIP, c.ExposureClassIPZone0, c.ExposureClassIPZone1, c.ExposureClassIPZone2}
 	return nil
 }
 
@@ -73,6 +83,12 @@ type ControllerConfig struct {
 	BastionIP string
 	// ExposureClassIP is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass".
 	ExposureClassIP string
+	// ExposureClassIPZone0 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 0.
+	ExposureClassIPZone0 string
+	// ExposureClassIPZone1 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 1.
+	ExposureClassIPZone1 string
+	// ExposureClassIPZone2 is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass" for zone 2.
+	ExposureClassIPZone2 string
 }
 
 // Apply sets the values of this ControllerConfig in the given AddOptions.
@@ -85,4 +101,7 @@ func (c *ControllerConfig) Apply(opts *AddOptions) {
 	opts.Zone2IP = c.Zone2IP
 	opts.BastionIP = c.BastionIP
 	opts.ExposureClassIP = c.ExposureClassIP
+	opts.ExposureClassIPZone0 = c.ExposureClassIPZone0
+	opts.ExposureClassIPZone1 = c.ExposureClassIPZone1
+	opts.ExposureClassIPZone2 = c.ExposureClassIPZone2
 }

--- a/pkg/provider-local/controller/service/options.go
+++ b/pkg/provider-local/controller/service/options.go
@@ -26,6 +26,8 @@ type ControllerOptions struct {
 	Zone2IP string
 	// BastionIP is the bastion IP.
 	BastionIP string
+	// ExposureClassIP is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass".
+	ExposureClassIP string
 
 	config *ControllerConfig
 }
@@ -39,11 +41,12 @@ func (c *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Zone1IP, "zone-1-ip", c.Zone1IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 1")
 	fs.StringVar(&c.Zone2IP, "zone-2-ip", c.Zone2IP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service for seed in zone 2")
 	fs.StringVar(&c.BastionIP, "bastion-ip", c.BastionIP, "Overwrite LoadBalancer IP to use for bastion service")
+	fs.StringVar(&c.ExposureClassIP, "exposureclass-ip", c.ExposureClassIP, "Overwrite LoadBalancer IP to use for istio ingress-gateway service of ExposureClass \"exposureclass\"")
 }
 
 // Complete implements Completer.Complete.
 func (c *ControllerOptions) Complete() error {
-	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.VirtualGardenIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP}
+	c.config = &ControllerConfig{c.MaxConcurrentReconciles, c.HostIP, c.VirtualGardenIP, c.Zone0IP, c.Zone1IP, c.Zone2IP, c.BastionIP, c.ExposureClassIP}
 	return nil
 }
 
@@ -68,6 +71,8 @@ type ControllerConfig struct {
 	Zone2IP string
 	// BastionIP is the bastion IP.
 	BastionIP string
+	// ExposureClassIP is the IP address used for the istio ingress gateway of the ExposureClass "exposureclass".
+	ExposureClassIP string
 }
 
 // Apply sets the values of this ControllerConfig in the given AddOptions.
@@ -79,4 +84,5 @@ func (c *ControllerConfig) Apply(opts *AddOptions) {
 	opts.Zone1IP = c.Zone1IP
 	opts.Zone2IP = c.Zone2IP
 	opts.BastionIP = c.BastionIP
+	opts.ExposureClassIP = c.ExposureClassIP
 }

--- a/test/e2e/gardener/e2e_suite_test.go
+++ b/test/e2e/gardener/e2e_suite_test.go
@@ -31,9 +31,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestE2E(t *testing.T) {
-	if os.Getenv("USE_PROVIDER_LOCAL_COREDNS_SERVER") == "true" {
-		e2e.UseProviderLocalCoreDNSServer()
-	}
+	e2e.UseProviderLocalCoreDNSServer()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test E2E Gardener Suite")
 }

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/gardener/gardener/test/e2e/gardener"
 	"github.com/gardener/gardener/test/e2e/gardener/seed"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/bastion"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/exposureclass"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
 	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/zerodowntimevalidator"
 	"github.com/gardener/gardener/test/utils/access"
@@ -150,36 +151,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldInitializeShootClient(s)
 			verifyNodeKubernetesVersions(s)
 
-			// TODO: Layer 7 Loadbalancing is currently not working with switching exposure classes
-			// as the aliases for the API server is not updated correctly on the controlplane components (controller-manager, gardener-resource-manager etc.)
-			if s.Shoot.Annotations[v1beta1constants.ShootDisableIstioTLSTermination] == "true" {
-				Describe("switching exposure class", func() {
-					verifyAPIServerAccess := func() {
-						It("should be able to talk to API server", func(ctx SpecContext) {
-							Eventually(ctx, s.ShootKomega.Get(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}})).Should(Succeed())
-						}, SpecTimeout(time.Minute))
-						if !v1beta1helper.IsWorkerless(s.Shoot) {
-							inclusterclient.VerifyInClusterAccessToAPIServer(s)
-						}
-					}
-
-					It("Switch exposure class", func(ctx SpecContext) {
-						Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
-							s.Shoot.Spec.ExposureClassName = ptr.To("exposureclass")
-						})).Should(Succeed())
-					}, SpecTimeout(time.Minute))
-					ItShouldWaitForShootToBeReconciledAndHealthy(s)
-					Describe("with exposure class", verifyAPIServerAccess)
-
-					It("Without exposure class", func(ctx SpecContext) {
-						Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
-							s.Shoot.Spec.ExposureClassName = nil
-						})).Should(Succeed())
-					}, SpecTimeout(time.Minute))
-					ItShouldWaitForShootToBeReconciledAndHealthy(s)
-					Describe("Without exposure class", verifyAPIServerAccess)
-				})
-			}
+			exposureclass.VerifyExposureClassSwitch(s, ItShouldWaitForShootToBeReconciledAndHealthy)
 
 			if v1beta1helper.IsHAControlPlaneConfigured(s.Shoot) {
 				zeroDowntimeValidatorJob.ItShouldEnsureThereWasNoDowntime(s)

--- a/test/e2e/gardener/shoot/create_update_delete.go
+++ b/test/e2e/gardener/shoot/create_update_delete.go
@@ -150,6 +150,37 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			ItShouldInitializeShootClient(s)
 			verifyNodeKubernetesVersions(s)
 
+			// TODO: Layer 7 Loadbalancing is currently not working with switching exposure classes
+			// as the aliases for the API server is not updated correctly on the controlplane components (controller-manager, gardener-resource-manager etc.)
+			if s.Shoot.Annotations[v1beta1constants.ShootDisableIstioTLSTermination] == "true" {
+				Describe("switching exposure class", func() {
+					verifyAPIServerAccess := func() {
+						It("should be able to talk to API server", func(ctx SpecContext) {
+							Eventually(ctx, s.ShootKomega.Get(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}})).Should(Succeed())
+						}, SpecTimeout(time.Minute))
+						if !v1beta1helper.IsWorkerless(s.Shoot) {
+							inclusterclient.VerifyInClusterAccessToAPIServer(s)
+						}
+					}
+
+					It("Switch exposure class", func(ctx SpecContext) {
+						Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+							s.Shoot.Spec.ExposureClassName = ptr.To("exposureclass")
+						})).Should(Succeed())
+					}, SpecTimeout(time.Minute))
+					ItShouldWaitForShootToBeReconciledAndHealthy(s)
+					Describe("with exposure class", verifyAPIServerAccess)
+
+					It("Without exposure class", func(ctx SpecContext) {
+						Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+							s.Shoot.Spec.ExposureClassName = nil
+						})).Should(Succeed())
+					}, SpecTimeout(time.Minute))
+					ItShouldWaitForShootToBeReconciledAndHealthy(s)
+					Describe("Without exposure class", verifyAPIServerAccess)
+				})
+			}
+
 			if v1beta1helper.IsHAControlPlaneConfigured(s.Shoot) {
 				zeroDowntimeValidatorJob.ItShouldEnsureThereWasNoDowntime(s)
 			}

--- a/test/e2e/gardener/shoot/internal/exposureclass/exposureclass.go
+++ b/test/e2e/gardener/shoot/internal/exposureclass/exposureclass.go
@@ -1,0 +1,51 @@
+package exposureclass
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/shoot/internal/inclusterclient"
+)
+
+func VerifyExposureClassSwitch(s *ShootContext, waitForReconcileFunc func(s *ShootContext)) {
+	GinkgoHelper()
+
+	// TODO: Layer 7 Loadbalancing is currently not working with switching exposure classes
+	// as the aliases for the API server is not updated correctly on the controlplane components (controller-manager, gardener-resource-manager etc.)
+	if s.Shoot.Annotations[v1beta1constants.ShootDisableIstioTLSTermination] == "true" {
+		Describe("switching exposure class", func() {
+			verifyAPIServerAccess := func() {
+				It("should be able to talk to API server", func(ctx SpecContext) {
+					Eventually(ctx, s.ShootKomega.Get(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}})).Should(Succeed())
+				}, SpecTimeout(time.Minute))
+				if !v1beta1helper.IsWorkerless(s.Shoot) {
+					inclusterclient.VerifyInClusterAccessToAPIServer(s)
+				}
+			}
+
+			It("Switch exposure class", func(ctx SpecContext) {
+				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+					s.Shoot.Spec.ExposureClassName = ptr.To("exposureclass")
+				})).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+			waitForReconcileFunc(s)
+			Describe("with exposure class", verifyAPIServerAccess)
+
+			It("Without exposure class", func(ctx SpecContext) {
+				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+					s.Shoot.Spec.ExposureClassName = nil
+				})).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+			waitForReconcileFunc(s)
+			Describe("Without exposure class", verifyAPIServerAccess)
+		})
+	}
+}

--- a/test/e2e/operator/e2e_suite_test.go
+++ b/test/e2e/operator/e2e_suite_test.go
@@ -5,7 +5,6 @@
 package operator_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,9 +15,7 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	if os.Getenv("USE_PROVIDER_LOCAL_COREDNS_SERVER") == "true" {
-		e2e.UseProviderLocalCoreDNSServer()
-	}
+	e2e.UseProviderLocalCoreDNSServer()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test E2E Operator Suite")
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR allows to change the, currently immutable, `exposureClassName` field of Shoots as well as the DNSRecord `recordType`.
In addition a new test scenario in the e2e tests is added to test switching exposure classes back and forth.

**Changes to local setup**:
- Introduce an ExposureClass "exposureclass" into the local setup to test exposure class code
- Always use provider local CoreDNS resolution in e2e tests as the IP of the API servers DNSRecord might dynamically change

**Which issue(s) this PR fixes**:
Part of #13648 

**Special notes for your reviewer**:
The switch currently does not work Layer 7 API server loadbalancing as the feature gate `IstioTLSTermination` as this does not roll the deployments of kube-controller-manager etc. that communicate to the API server using the istio's service IP.
Therefore the hostAlias is not correctly updated to point to the new istio service.
As this PR is quite large already, this should be probably be fixed in a separate PR as it requires a bit more sophisticated logic when to actually roll the pods. 
/cc @oliver-goetz 

There is a bit of a fundamental issue with the local setup relying on both `/etc/hosts` static entries as well as the provider-local CoreDNS: 
In Go's DNS resolver, the `/etc/hosts` is always prefered. This makes it impossible to resolve API server DNS records dynamically to get the correct IP of the istio load balancer when there is a entry in `/etc/hosts` for that record.
However as we can use the provider-local CoreDNS to resolve only a subset of domains on all operating systems, this is a bit of a dead end. How do the E2E reliably work without always needing to touch `/etc/hosts`.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow switching exposure class for shoots
```
