### PR TITLE
Adjust Quotas for increased resources post-Gardener update

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -297,7 +297,7 @@ The `ResourceQuota` reconciler only reconciles `ResourceQuota`s in `Project` nam
 
 In the lifecycle of a `Shoot`, Gardener also creates some resources (`Secret`s and `ConfigMap`s) e.g. for certain CAs of the `Shoot`s in the `Project` namespace. This means that the `ResourceQuota` must allow for the creation of these resources, otherwise the `Shoot` reconciliation would fail due to quota violations.
 
-The reconciler ensures this by adding annotations to the `ResourceQuota`s as to how many resources (`Secret`s, `ConfigMap`s, etc.) Gardener itself will create in the `Project` namespace.
+The reconciler ensures this by adding annotations to the `ResourceQuota`s specifying how many resources (`Secret`s, `ConfigMap`s, etc.) Gardener itself will create in the `Project` namespace.
 This might change throughout Gardener versions. When such a change happens, the controller will update the annotations accordingly. 
 On a mismatch between the actual and the expected annotations, the reconciler will also update the `ResourceQuota` to ensure that the required resources can be created by Gardener.
 

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -291,6 +291,16 @@ Since the other two reconcilers are unable to actively monitor the relevant obje
 
 The `Project Activity Reconciler` is implemented to take care of such cases. An event handler will notify the reconciler for any activity and then it will update the `status.lastActivityTimestamp`. This update will also trigger the `Stale Project Reconciler`.
 
+#### [`ResourceQuota` Reconciler](../../pkg/controllermanager/controller/project/resourcequota)
+
+The `ResourceQuota` reconciler only reconciles `ResourceQuota`s in `Project` namespaces and ensures that the specified quotas do not interfere with Gardener's operations.
+
+In the lifecycle of a `Shoot`, Gardener also creates some resources (`Secret`s and `ConfigMap`s) e.g. for certain CAs of the `Shoot`s in the `Project` namespace. This means that the `ResourceQuota` must allow for the creation of these resources, otherwise the `Shoot` reconciliation would fail due to quota violations.
+
+The reconciler ensures this by adding annotations to the `ResourceQuota`s as to how many resources (`Secret`s, `ConfigMap`s, etc.) Gardener itself will create in the `Project` namespace.
+This might change throughout Gardener versions. When such a change happens, the controller will update the annotations accordingly. 
+On a mismatch between the actual and the expected annotations, the reconciler will also update the `ResourceQuota` to ensure that the required resources can be created by Gardener.
+
 ### [`SecretBinding` Controller](../../pkg/controllermanager/controller/secretbinding)
 
 `SecretBinding`s reference `Secret`s and `Quota`s and are themselves referenced by `Shoot`s.

--- a/pkg/controllermanager/controller/add.go
+++ b/pkg/controllermanager/controller/add.go
@@ -107,7 +107,7 @@ func AddToManager(ctx context.Context, mgr manager.Manager, cfg *controllermanag
 		return fmt.Errorf("failed adding ManagedSeedSet controller: %w", err)
 	}
 
-	if err := project.AddToManager(mgr, *cfg); err != nil {
+	if err := project.AddToManager(ctx, mgr, *cfg); err != nil {
 		return fmt.Errorf("failed adding Project controller: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/project/add.go
+++ b/pkg/controllermanager/controller/project/add.go
@@ -5,6 +5,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -12,11 +13,12 @@ import (
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/project/activity"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/project/project"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/project/resourcequota"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/project/stale"
 )
 
 // AddToManager adds all Project controllers to the given manager.
-func AddToManager(mgr manager.Manager, cfg controllermanagerconfigv1alpha1.ControllerManagerConfiguration) error {
+func AddToManager(ctx context.Context, mgr manager.Manager, cfg controllermanagerconfigv1alpha1.ControllerManagerConfiguration) error {
 	if err := (&activity.Reconciler{
 		Config: *cfg.Controllers.Project,
 	}).AddToManager(mgr); err != nil {
@@ -33,6 +35,12 @@ func AddToManager(mgr manager.Manager, cfg controllermanagerconfigv1alpha1.Contr
 		Config: *cfg.Controllers.Project,
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding stale reconciler: %w", err)
+	}
+
+	if err := (&resourcequota.Reconciler{
+		Config: *cfg.Controllers.Project,
+	}).AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed adding resourcequota reconciler: %w", err)
 	}
 
 	return nil

--- a/pkg/controllermanager/controller/project/resourcequota/add.go
+++ b/pkg/controllermanager/controller/project/resourcequota/add.go
@@ -7,8 +7,6 @@ package resourcequota
 import (
 	"context"
 
-	"github.com/gardener/gardener/pkg/controllerutils"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -17,6 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.

--- a/pkg/controllermanager/controller/project/resourcequota/add.go
+++ b/pkg/controllermanager/controller/project/resourcequota/add.go
@@ -49,7 +49,8 @@ func (r *Reconciler) ObjectInProjectNamespace(ctx context.Context, log logr.Logg
 		project, err := gardenerutils.ProjectForNamespaceFromReader(ctx, r.Client, namespace)
 		if err != nil {
 			log.Error(err, "Unable to find gardener project", "namespace", namespace)
+			return false
 		}
-		return err == nil && project != nil
+		return project != nil
 	})
 }

--- a/pkg/controllermanager/controller/project/resourcequota/add.go
+++ b/pkg/controllermanager/controller/project/resourcequota/add.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "project-resourcequota"
+
+// AddToManager adds a controller with the given Options to the given manager.
+func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+
+	log := mgr.GetLogger().WithValues("controller", ControllerName)
+
+	return builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: ptr.Deref(r.Config.ConcurrentSyncs, 0),
+			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,
+		}).
+		For(&corev1.ResourceQuota{}, builder.WithPredicates(r.ObjectInProjectNamespace(ctx, log))).
+		Complete(r)
+}
+
+// ObjectInProjectNamespace returns a predicate that filters objects that are in Project namespaces.
+func (r *Reconciler) ObjectInProjectNamespace(ctx context.Context, log logr.Logger) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		namespace := object.GetNamespace()
+		project, err := gardenerutils.ProjectForNamespaceFromReader(ctx, r.Client, namespace)
+		if err != nil {
+			log.Error(err, "Unable to find gardener project", "namespace", namespace)
+		}
+		return err == nil && project != nil
+	})
+}

--- a/pkg/controllermanager/controller/project/resourcequota/add_test.go
+++ b/pkg/controllermanager/controller/project/resourcequota/add_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/api/indexer"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/project/resourcequota"
+)
+
+var _ = Describe("Add", func() {
+	var (
+		reconciler    *resourcequota.Reconciler
+		fakeClient    client.Client
+		ctx           context.Context
+		namespaceName = "garden-test"
+		resourceQuota = &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-resourcequota",
+				Namespace: namespaceName,
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					"count/configmaps": resource.MustParse("2"),
+				},
+			},
+		}
+		project = &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: &namespaceName,
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		fakeClient = fake.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithIndex(&gardencorev1beta1.Project{}, core.ProjectNamespace, indexer.ProjectNamespaceIndexerFunc).Build()
+
+		reconciler = &resourcequota.Reconciler{
+			Client: fakeClient,
+		}
+	})
+
+	Describe("#ObjectInProjectNamespace", func() {
+		var p predicate.Predicate
+
+		BeforeEach(func() {
+			p = reconciler.ObjectInProjectNamespace(ctx, GinkgoLogr)
+		})
+
+		It("return true for objects that are in a project namespace", func() {
+			Expect(fakeClient.Create(ctx, project)).To(Succeed())
+
+			Expect(p.Create(event.CreateEvent{Object: resourceQuota})).To(BeTrue())
+			Expect(p.Update(event.UpdateEvent{ObjectNew: resourceQuota})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: resourceQuota})).To(BeTrue())
+			Expect(p.Generic(event.GenericEvent{Object: resourceQuota})).To(BeTrue())
+		})
+
+		It("return false for objects that are not in a project namespace", func() {
+			nonProjectObject := resourceQuota.DeepCopy()
+			nonProjectObject.Namespace = namespaceName + "aaa"
+
+			Expect(fakeClient.Create(ctx, nonProjectObject)).To(Succeed())
+
+			Expect(p.Create(event.CreateEvent{Object: nonProjectObject})).To(BeFalse())
+			Expect(p.Update(event.UpdateEvent{ObjectNew: nonProjectObject})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: nonProjectObject})).To(BeFalse())
+			Expect(p.Generic(event.GenericEvent{Object: nonProjectObject})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controllermanager/controller/project/resourcequota/reconciler.go
+++ b/pkg/controllermanager/controller/project/resourcequota/reconciler.go
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+const (
+	annotationKeyConfigMapsPerShoot = "quota.gardener.cloud/configmaps-per-shoot"
+	annotationKeySecretsPerShoot    = "quota.gardener.cloud/secrets-per-shoot"
+
+	shootCountResource = "count/shoots.core.gardener.cloud"
+)
+
+// ResourceQuotaUsages describes the resource quota usages per shoot cluster in project namespaces.
+type ResourceQuotaUsages struct {
+	Annotation       string
+	QuotaKey         corev1.ResourceName
+	ExpectedPerShoot int
+}
+
+var (
+	// PerShootQuotaDescriptors describes resources that Gardener creates per Shoot Cluster in the project namespace.
+	// Exposed for testing.
+	PerShootQuotaDescriptors = []ResourceQuotaUsages{
+		{
+			annotationKeyConfigMapsPerShoot,
+			"count/configmaps",
+			len(gardenerutils.GetShootProjectConfigMapSuffixes()),
+		},
+		{
+			annotationKeySecretsPerShoot,
+			"count/secrets",
+			len(gardenerutils.GetShootProjectSecretSuffixes()),
+		},
+	}
+)
+
+// Reconciler reconciles ResourceQuotas in Project namespaces.
+// It ensures that ResourceQuota objects in project namespaces allow enough resources for all possible Shoot resources.
+// It checks the current quota limits and adjusts them if needed, so that the namespace can accommodate the maximum number of Shoots and their related resources (like ConfigMaps and Secrets) according to the configured limits.
+type Reconciler struct {
+	Client client.Client
+	Config controllermanagerconfigv1alpha1.ProjectControllerConfiguration
+}
+
+// Reconcile adjusts the ResourceQuota in a Project namespace to ensure that it can accommodate all Shoots, according to the Shoot limit.
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	resourceQuota := &corev1.ResourceQuota{}
+	if err := r.Client.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Object is gone, stop reconciling")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
+	}
+
+	if resourceQuota.DeletionTimestamp != nil || resourceQuota.Spec.Hard == nil {
+		return reconcile.Result{}, nil
+	}
+
+	patch := client.MergeFrom(resourceQuota.DeepCopy())
+
+	for _, resourceQuotaUsage := range PerShootQuotaDescriptors {
+		usageAnnotation := resourceQuotaUsage.Annotation
+		usageSpecKey := resourceQuotaUsage.QuotaKey
+		expectedCount := resourceQuotaUsage.ExpectedPerShoot
+
+		annotationCountString, ok := resourceQuota.Annotations[usageAnnotation]
+		if !ok {
+			if err := r.handleMissingAnnotation(ctx, log, resourceQuota, usageAnnotation, usageSpecKey, expectedCount); err != nil {
+				return reconcile.Result{}, fmt.Errorf("error aligning resource quota %q in namespace %q: %w", resourceQuota.Name, resourceQuota.Namespace, err)
+			}
+			continue
+		}
+
+		annotationCount, err := strconv.Atoi(annotationCountString)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed converting resource quota annotation %q to int: %w", usageAnnotation, err)
+		}
+
+		if annotationCount != expectedCount {
+			if err := r.handleAnnotationMismatch(ctx, log, resourceQuota, usageAnnotation, usageSpecKey, annotationCount, expectedCount); err != nil {
+				return reconcile.Result{}, fmt.Errorf("error aligning resource quota %q in namespace %q: %w", resourceQuota.Name, resourceQuota.Namespace, err)
+			}
+		}
+	}
+
+	if err := r.Client.Patch(ctx, resourceQuota, patch); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed updating resource quota %q in namespace %q: %w", resourceQuota.Name, resourceQuota.Namespace, err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) handleMissingAnnotation(ctx context.Context, log logr.Logger, resourceQuota *corev1.ResourceQuota, usageAnnotation string, usageSpecKey corev1.ResourceName, expectedCount int) error {
+	maximumShootsInProject, err := r.getMaximumShootsInProject(ctx, *resourceQuota)
+	if err != nil {
+		return err
+	}
+
+	currentQuotaResource, ok := resourceQuota.Spec.Hard[usageSpecKey]
+	if !ok {
+		metav1.SetMetaDataAnnotation(&resourceQuota.ObjectMeta, usageAnnotation, strconv.Itoa(expectedCount))
+		return nil
+	}
+
+	currentQuota := ptr.To(currentQuotaResource).Value()
+	requiredQuota := int64(expectedCount) * maximumShootsInProject
+
+	if currentQuota < requiredQuota {
+		log.Info("Current quota is less than required quota, bumping up", "currentQuota", currentQuota, "requiredQuota", requiredQuota, "quotaType", usageSpecKey.String())
+		resourceQuota.Spec.Hard[usageSpecKey] = resource.MustParse(strconv.Itoa(int(requiredQuota)))
+	} else {
+		log.Info("Current quota is sufficient for required quota, not changing quota", "currentQuota", currentQuota, "requiredQuota", requiredQuota, "quotaType", usageSpecKey.String())
+	}
+
+	metav1.SetMetaDataAnnotation(&resourceQuota.ObjectMeta, usageAnnotation, strconv.Itoa(expectedCount))
+	return nil
+}
+
+func (r *Reconciler) handleAnnotationMismatch(ctx context.Context, log logr.Logger, resourceQuota *corev1.ResourceQuota, usageAnnotation string, usageSpecKey corev1.ResourceName, annotationCount, expectedCount int) error {
+	log.Info("Bumping resource quota per shoot", "quotaType", usageSpecKey.String(), "from", annotationCount, "to", expectedCount)
+	countDiff := int64(max(expectedCount-annotationCount, 0))
+
+	if countDiff > 0 {
+		maximum, err := r.getMaximumShootsInProject(ctx, *resourceQuota)
+		if err != nil {
+			return err
+		}
+
+		newQuota := ptr.To(resourceQuota.Spec.Hard[usageSpecKey]).Value() + maximum*countDiff
+		newVal := strconv.Itoa(int(newQuota))
+		log.Info("Updating resource quota with value", "quotaType", usageSpecKey.String(), "value", newVal)
+		resourceQuota.Spec.Hard[usageSpecKey] = resource.MustParse(newVal)
+	}
+
+	metav1.SetMetaDataAnnotation(&resourceQuota.ObjectMeta, usageAnnotation, strconv.Itoa(expectedCount))
+	return nil
+}
+
+func (r *Reconciler) getMaximumShootsInProject(ctx context.Context, resourceQuota corev1.ResourceQuota) (int64, error) {
+	if limit, hasQuota := resourceQuota.Spec.Hard[corev1.ResourceName(shootCountResource)]; hasQuota {
+		return limit.Value(), nil
+	}
+	shootList := &metav1.PartialObjectMetadataList{}
+	shootList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
+	if err := r.Client.List(ctx, shootList, client.InNamespace(resourceQuota.Namespace)); err != nil {
+		return 0, fmt.Errorf("could not list shoots in project namespace %q: %w", resourceQuota.Namespace, err)
+	}
+	return int64(len(shootList.Items)), nil
+}

--- a/pkg/controllermanager/controller/project/resourcequota/resourcequota_suite_test.go
+++ b/pkg/controllermanager/controller/project/resourcequota/resourcequota_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestResourceQuota(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager Controller Project ResourceQuota Suite")
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -757,6 +757,7 @@ build:
             - pkg/controllermanager/controller/project
             - pkg/controllermanager/controller/project/activity
             - pkg/controllermanager/controller/project/project
+            - pkg/controllermanager/controller/project/resourcequota
             - pkg/controllermanager/controller/project/stale
             - pkg/controllermanager/controller/quota
             - pkg/controllermanager/controller/secretbinding

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -313,6 +313,7 @@ build:
             - pkg/controllermanager/controller/project
             - pkg/controllermanager/controller/project/activity
             - pkg/controllermanager/controller/project/project
+            - pkg/controllermanager/controller/project/resourcequota
             - pkg/controllermanager/controller/project/stale
             - pkg/controllermanager/controller/quota
             - pkg/controllermanager/controller/secretbinding

--- a/test/integration/controllermanager/project/resourcequota/resourcequota_suite_test.go
+++ b/test/integration/controllermanager/project/resourcequota/resourcequota_suite_test.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/gardener/pkg/api/indexer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/project/resourcequota"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerenvtest "github.com/gardener/gardener/test/envtest"
+)
+
+func TestResourceQuota(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration ControllerManager Project ResourceQuota Suite")
+}
+
+const testID = "project-resourcequota-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+	mgrClient  client.Client
+
+	testRunID string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("Start test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ExtensionLabels,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator"},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+	log.Info("Using test run ID for test", "testRunID", testRunID)
+
+	By("Setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:  kubernetes.GardenScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			DefaultLabelSelector: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
+
+	By("Setup field indexes")
+	Expect(indexer.AddProjectNamespace(ctx, mgr.GetFieldIndexer())).To(Succeed())
+
+	By("Register controller")
+	Expect((&resourcequota.Reconciler{
+		Config: controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
+			ConcurrentSyncs: ptr.To(5),
+		},
+	}).AddToManager(ctx, mgr)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/controllermanager/project/resourcequota/resourcequota_test.go
+++ b/test/integration/controllermanager/project/resourcequota/resourcequota_test.go
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcequota_test
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/project/resourcequota"
+	"github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+const (
+	ActualConfigMaps = 2
+	ActualSecrets    = 4
+)
+
+var _ = Describe("ResourceQuota Controller tests", func() {
+	var (
+		testNamespace *corev1.Namespace
+		resourceQuota *corev1.ResourceQuota
+	)
+
+	BeforeEach(func() {
+		resourcequota.PerShootQuotaDescriptors = []resourcequota.ResourceQuotaUsages{
+			{
+				Annotation:       "gardener.cloud/configmaps-per-shoot",
+				QuotaKey:         "count/configmaps",
+				ExpectedPerShoot: ActualConfigMaps,
+			},
+			{
+				Annotation:       "gardener.cloud/secrets-per-shoot",
+				QuotaKey:         "count/secrets",
+				ExpectedPerShoot: ActualSecrets,
+			},
+		}
+	})
+
+	Context("ResourceQuota in non-project namespace", func() {
+		BeforeEach(func() {
+			By("Create test Namespace")
+			testNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: testID + "-",
+					Labels:       map[string]string{testID: testRunID},
+				},
+			}
+			Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+			log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+			DeferCleanup(func() {
+				By("Delete test Namespace")
+				Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			By("Create ResourceQuota")
+			resourceQuota = &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-resource-quota",
+					Namespace: testNamespace.Name,
+					Labels:    map[string]string{testID: testRunID},
+				},
+				Spec: corev1.ResourceQuotaSpec{},
+			}
+			Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+			log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+			}).Should(Succeed())
+
+			DeferCleanup(func() {
+				By("Delete ResourceQuota")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+			})
+		})
+
+		It("should not have added the gardener created resource annotations to the resource quota", func() {
+			Consistently(func(g Gomega) {
+				currentResourceQuota := &corev1.ResourceQuota{}
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+				_, hasAnnotation := currentResourceQuota.Annotations["gardener.cloud/configmaps-per-shoot"]
+				g.Expect(hasAnnotation).To(BeFalse())
+			}).Should(Succeed())
+		})
+	})
+
+	Context("ResourceQuota in project namespace", func() {
+		var project *gardencorev1beta1.Project
+
+		BeforeEach(func() {
+			By("Create test Namespace with project label")
+			testNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "garden-",
+					Labels: map[string]string{
+						testID: testRunID,
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+			log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+			DeferCleanup(func() {
+				By("Delete test Namespace")
+				Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			By("Create Project")
+			project = &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-" + utils.ComputeSHA256Hex([]byte(testRunID + CurrentSpecReport().LeafNodeLocation.String()))[:5],
+					Labels: map[string]string{testID: testRunID},
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: &testNamespace.Name,
+				},
+			}
+			Expect(testClient.Create(ctx, project)).To(Succeed())
+			log.Info("Created Project", "project", client.ObjectKeyFromObject(project))
+
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(project), &gardencorev1beta1.Project{})
+			}).Should(Succeed())
+
+			DeferCleanup(func() {
+				By("Delete Project")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, project))).To(Succeed())
+
+				By("Wait for Project to be gone")
+				Eventually(func() error {
+					return testClient.Get(ctx, client.ObjectKeyFromObject(project), project)
+				}).Should(BeNotFoundError())
+			})
+		})
+
+		Context("Annotations do not exist", func() {
+			Context("Quota is enough", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with sufficient quota")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+								"count/configmaps":                 resource.MustParse("2"),
+								"count/secrets":                    resource.MustParse("4"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should only add the gardener created resource annotations to the resource quota", func() {
+					originalConfigMapQuota := ptr.To(resourceQuota.Spec.Hard["count/configmaps"]).Value()
+					originalSecretQuota := ptr.To(resourceQuota.Spec.Hard["count/secrets"]).Value()
+
+					eventuallyExpectActualUsageAnnotations(ctx, resourceQuota)
+					consistentlyExpectQuotaSpec(ctx, resourceQuota, originalConfigMapQuota, originalSecretQuota)
+				})
+			})
+
+			Context("No relevant Quota is specified", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with shoot quota but without configmap/secret quotas")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should only add the gardener created resource annotations to the resource quota", func() {
+					eventuallyExpectActualUsageAnnotations(ctx, resourceQuota)
+					Consistently(func(g Gomega) {
+						currentResourceQuota := &corev1.ResourceQuota{}
+						g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+						g.Expect(currentResourceQuota.Spec.Hard).NotTo(HaveKey("count/configmaps"))
+						g.Expect(currentResourceQuota.Spec.Hard).NotTo(HaveKey("count/secrets"))
+					}).Should(Succeed())
+				})
+			})
+
+			Context("Quota is not enough", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with insufficient quota")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+								"count/configmaps":                 resource.MustParse("1"),
+								"count/secrets":                    resource.MustParse("2"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should bump the quota to fit the specified number of shoots", func() {
+					eventuallyExpectActualUsageAnnotations(ctx, resourceQuota)
+					eventuallyExpectQuotaSpec(ctx, resourceQuota, 2, 4)
+				})
+			})
+		})
+
+		Context("Annotations already exist", func() {
+			Context("Annotation values are equal to the expected values", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with matching annotations")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+							Annotations: map[string]string{
+								"gardener.cloud/configmaps-per-shoot": "2",
+								"gardener.cloud/secrets-per-shoot":    "4",
+							},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+								"count/configmaps":                 resource.MustParse("2"),
+								"count/secrets":                    resource.MustParse("4"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should do nothing", func() {
+					originalConfigMapQuota := ptr.To(resourceQuota.Spec.Hard["count/configmaps"]).Value()
+					originalSecretQuota := ptr.To(resourceQuota.Spec.Hard["count/secrets"]).Value()
+
+					consistentlyExpectUsageAnnotations(ctx, resourceQuota, "2", "4")
+					consistentlyExpectQuotaSpec(ctx, resourceQuota, originalConfigMapQuota, originalSecretQuota)
+				})
+			})
+
+			Context("New annotation value is smaller than the existing one", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with higher annotation values")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+							Annotations: map[string]string{
+								"gardener.cloud/configmaps-per-shoot": "3",
+								"gardener.cloud/secrets-per-shoot":    "5",
+							},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+								"count/configmaps":                 resource.MustParse("3"),
+								"count/secrets":                    resource.MustParse("5"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should just update the annotations", func() {
+					originalConfigMapQuota := ptr.To(resourceQuota.Spec.Hard["count/configmaps"]).Value()
+					originalSecretQuota := ptr.To(resourceQuota.Spec.Hard["count/secrets"]).Value()
+
+					consistentlyExpectQuotaSpec(ctx, resourceQuota, originalConfigMapQuota, originalSecretQuota)
+					eventuallyExpectActualUsageAnnotations(ctx, resourceQuota)
+				})
+			})
+
+			Context("New annotation value is bigger than the existing one", func() {
+				BeforeEach(func() {
+					By("Create ResourceQuota with lower annotation values")
+					resourceQuota = &corev1.ResourceQuota{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-resource-quota",
+							Namespace: testNamespace.Name,
+							Labels:    map[string]string{testID: testRunID},
+							Annotations: map[string]string{
+								"gardener.cloud/configmaps-per-shoot": "1",
+								"gardener.cloud/secrets-per-shoot":    "3",
+							},
+						},
+						Spec: corev1.ResourceQuotaSpec{
+							Hard: corev1.ResourceList{
+								"count/shoots.core.gardener.cloud": resource.MustParse("1"),
+								"count/configmaps":                 resource.MustParse("1"),
+								"count/secrets":                    resource.MustParse("3"),
+							},
+						},
+					}
+					Expect(testClient.Create(ctx, resourceQuota)).To(Succeed())
+					log.Info("Created ResourceQuota", "resourceQuota", client.ObjectKeyFromObject(resourceQuota))
+
+					Eventually(func() error {
+						return mgrClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), &corev1.ResourceQuota{})
+					}).Should(Succeed())
+
+					DeferCleanup(func() {
+						By("Delete ResourceQuota")
+						Expect(client.IgnoreNotFound(testClient.Delete(ctx, resourceQuota))).To(Succeed())
+					})
+				})
+
+				It("should update the annotations and bump the quota", func() {
+					eventuallyExpectQuotaSpec(ctx, resourceQuota, 2, 4)
+					eventuallyExpectActualUsageAnnotations(ctx, resourceQuota)
+				})
+			})
+		})
+	})
+})
+
+func consistentlyExpectUsageAnnotations(ctx context.Context, resourceQuota *corev1.ResourceQuota, configMapsPerShoot, secretsPerShoot string) {
+	GinkgoHelper()
+	Consistently(func(g Gomega) {
+		currentResourceQuota := &corev1.ResourceQuota{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+		expectUsageAnnotations(g, currentResourceQuota, configMapsPerShoot, secretsPerShoot)
+	}).Should(Succeed())
+}
+
+func eventuallyExpectActualUsageAnnotations(ctx context.Context, resourceQuota *corev1.ResourceQuota) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		currentResourceQuota := &corev1.ResourceQuota{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+		expectUsageAnnotations(g, currentResourceQuota, strconv.Itoa(ActualConfigMaps), strconv.Itoa(ActualSecrets))
+	}).Should(Succeed())
+}
+
+func expectUsageAnnotations(g Gomega, resourceQuota *corev1.ResourceQuota, configMapsPerShoot, secretsPerShoot string) {
+	GinkgoHelper()
+	configMapAnnotationValue, hasConfigMapAnnotation := resourceQuota.Annotations["gardener.cloud/configmaps-per-shoot"]
+	secretAnnotationValue, hasSecretAnnotation := resourceQuota.Annotations["gardener.cloud/secrets-per-shoot"]
+
+	g.Expect(hasConfigMapAnnotation).To(BeTrue(), "expected ConfigMap annotation to be present")
+	g.Expect(configMapAnnotationValue).To(Equal(configMapsPerShoot), "expected ConfigMap annotation to have correct value")
+	g.Expect(hasSecretAnnotation).To(BeTrue(), "expected secret annotation to be present")
+	g.Expect(secretAnnotationValue).To(Equal(secretsPerShoot), "expected secret annotation to have correct value")
+}
+
+func eventuallyExpectQuotaSpec(ctx context.Context, resourceQuota *corev1.ResourceQuota, configMapCount, secretCount int64) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		currentResourceQuota := &corev1.ResourceQuota{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+		expectQuotaSpec(g, currentResourceQuota, configMapCount, secretCount)
+	}).Should(Succeed())
+}
+
+func consistentlyExpectQuotaSpec(ctx context.Context, resourceQuota *corev1.ResourceQuota, configMapCount, secretCount int64) {
+	GinkgoHelper()
+	Consistently(func(g Gomega) {
+		currentResourceQuota := &corev1.ResourceQuota{}
+		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(resourceQuota), currentResourceQuota)).To(Succeed())
+		expectQuotaSpec(g, currentResourceQuota, configMapCount, secretCount)
+	}).Should(Succeed())
+}
+
+func expectQuotaSpec(g Gomega, resourceQuota *corev1.ResourceQuota, configMapCount, secretCount int64) {
+	GinkgoHelper()
+	g.Expect(resourceQuota.Spec.Hard["count/configmaps"]).To(Equal(resource.MustParse(strconv.FormatInt(configMapCount, 10))))
+	g.Expect(resourceQuota.Spec.Hard["count/secrets"]).To(Equal(resource.MustParse(strconv.FormatInt(secretCount, 10))))
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR adds a controller to the `gardener-controller-manager` that adds annotations to all `ResourceQuota`s in project namespaces, containing information about how many resources Gardener creates per shoot in them.

When a Gardener update contains a change, e.g. now creating `5` instead of `4` `Secret`s in the project namespace per shoot, the reconciler will increase all applicable `ResourceQuota`s by `(new amount - old amount) * max. shoots in Project`.
`max. shoots in Project` is either determined by the `ResourceQuota` itself, if it exists, or by the amount of shoots already in the project.

The following cases exist for each ResourceQuota:

| Annotations differ from expected | bigger / smaller value | expected behavior |
| ---- | --- | --- |
| no | N/A | do nothing |
| yes | bigger | bump by `diff * max. shootcount` |
| yes | smaller | do nothing (no decrease) |

When the Annotations are not present:

| applicable Quota keys exist | is enough | expected behavior |
| --- | --- | --- |
| yes | yes | just set the annotation |
| yes | no | bump quota to fit shoots; set the annotation |
| no | N/A | just set the annotation |

**Which issue(s) this PR fixes**:
Fixes #12805 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-controller-manager` now increases all `ResourceQuota`s in project namespaces when a Gardener update leads to Gardener creating more resources in them. This was introduced to prevent failing Shoot reconciliations when `ResourceQuota`s of projects are near their limit.
```
