### PR TITLE
[GEP-34] Promote `OpenTelemetryCollector` feature gate to Beta

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -13,7 +13,6 @@ spec:
     featureGates:
       DefaultSeccompProfile: true
       IstioTLSTermination: true
-      OpenTelemetryCollector: true
       VPAInPlaceUpdates: true
       VPNBondingModeRoundRobin: true
     controllers:

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,8 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | InPlaceNodeUpdates            | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination           | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities      | `false` | `Alpha` | `1.117` |         |
-| OpenTelemetryCollector        | `false` | `Alpha` | `1.124` | `1.134` |
-| OpenTelemetryCollector        | `true`  | `Beta`  | `1.135` |         |
+| OpenTelemetryCollector        | `false` | `Alpha` | `1.124` | `1.135` |
+| OpenTelemetryCollector        | `true`  | `Beta`  | `1.136` |         |
 | UseUnifiedHTTPProxyPort       | `false` | `Alpha` | `1.130` |         |
 | VPAInPlaceUpdates             | `false` | `Alpha` | `1.133` |         |
 | CustomDNSServerInNodeLocalDNS | `true`  | `Beta`  | `1.133` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,7 +26,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | InPlaceNodeUpdates            | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination           | `false` | `Alpha` | `1.114` |         |
 | CloudProfileCapabilities      | `false` | `Alpha` | `1.117` |         |
-| OpenTelemetryCollector        | `false` | `Alpha` | `1.124` |         |
+| OpenTelemetryCollector        | `false` | `Alpha` | `1.124` | `1.134` |
+| OpenTelemetryCollector        | `true`  | `Beta`  | `1.135` |         |
 | UseUnifiedHTTPProxyPort       | `false` | `Alpha` | `1.130` |         |
 | VPAInPlaceUpdates             | `false` | `Alpha` | `1.133` |         |
 | CustomDNSServerInNodeLocalDNS | `true`  | `Beta`  | `1.133` |         |

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,7 +39,6 @@ config:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
     IstioTLSTermination: true
-    OpenTelemetryCollector: true
     UseUnifiedHTTPProxyPort: true
     VPAInPlaceUpdates: true
     VPNBondingModeRoundRobin: true

--- a/pkg/component/extensions/operatingsystemconfig/original/original_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/original_test.go
@@ -98,6 +98,10 @@ var _ = Describe("Original", func() {
 	})
 
 	Describe("#Components", func() {
+		BeforeEach(func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, false))
+		})
+
 		It("should compute the units and files", func() {
 			var order []string
 			for _, component := range Components(true) {
@@ -139,10 +143,6 @@ var _ = Describe("Original", func() {
 	})
 
 	Describe("#Components with OpenTelemetryCollector feature gate enabled", func() {
-		BeforeEach(func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
-		})
-
 		It("should compute the units and files", func() {
 			var order []string
 			for _, component := range Components(true) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,7 +62,7 @@ const (
 	// All logs will be routed through the Collector before they reach the Vali instance.
 	// owner: @rrhubenov
 	// alpha: v1.124.0
-	// beta: v1.135.0
+	// beta: v1.136.0
 	OpenTelemetryCollector featuregate.Feature = "OpenTelemetryCollector"
 
 	// UseUnifiedHTTPProxyPort enables the gardenlet to set up the unified HTTP proxy network infrastructure.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -62,6 +62,7 @@ const (
 	// All logs will be routed through the Collector before they reach the Vali instance.
 	// owner: @rrhubenov
 	// alpha: v1.124.0
+	// beta: v1.135.0
 	OpenTelemetryCollector featuregate.Feature = "OpenTelemetryCollector"
 
 	// UseUnifiedHTTPProxyPort enables the gardenlet to set up the unified HTTP proxy network infrastructure.
@@ -118,7 +119,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	IstioTLSTermination:           {Default: false, PreRelease: featuregate.Alpha},
 	CloudProfileCapabilities:      {Default: false, PreRelease: featuregate.Alpha},
 	DoNotCopyBackupCredentials:    {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	OpenTelemetryCollector:        {Default: false, PreRelease: featuregate.Alpha},
+	OpenTelemetryCollector:        {Default: true, PreRelease: featuregate.Beta},
 	UseUnifiedHTTPProxyPort:       {Default: false, PreRelease: featuregate.Alpha},
 	VPAInPlaceUpdates:             {Default: false, PreRelease: featuregate.Alpha},
 	CustomDNSServerInNodeLocalDNS: {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/gardenlet/operation/botanist/logging_test.go
+++ b/pkg/gardenlet/operation/botanist/logging_test.go
@@ -139,6 +139,10 @@ var _ = Describe("Logging", func() {
 	})
 
 	Describe("#DeployLogging", func() {
+		BeforeEach(func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, false))
+		})
+
 		It("should successfully delete the logging stack when shoot is with testing purpose", func() {
 			botanist.Shoot.Purpose = shootPurposeTesting
 			gomock.InOrder(


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
For more context, check the [GEP-34](https://github.com/gardener/gardener/pull/11861) and it's accompanying [implementation umbrella issue](https://github.com/gardener/gardener/issues/12164).

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `OpenTelemetryCollector` feature gate has been promoted to Beta and is enabled by default.
```
