### PR TITLE
[GEP-28] `gardenadm init`: Deploy `cluster-autoscaler`

### DIFF
--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -34,7 +34,8 @@ spec:
         image:
           name: local
       minimum: 1
-      maximum: 1
+      # Setting max > min triggers the deployment of the cluster-autoscaler
+      maximum: 2
   kubernetes:
     version: 1.33.0
     kubelet:

--- a/pkg/gardenadm/botanist/clusterautoscaler.go
+++ b/pkg/gardenadm/botanist/clusterautoscaler.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/autoscaling/clusterautoscaler"
+)
+
+// DeployClusterAutoscaler deploys the cluster-autoscaler for self-hosted shoots.
+func (b *GardenadmBotanist) DeployClusterAutoscaler(ctx context.Context) error {
+	if err := component.OpWait(clusterautoscaler.NewBootstrapper(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace)).Deploy(ctx); err != nil {
+		return fmt.Errorf("failed deploying cluster-autoscaler bootstrapper: %w", err)
+	}
+
+	if err := b.Shoot.Components.Extensions.Worker.WaitUntilWorkerStatusMachineDeploymentsUpdated(ctx); err != nil {
+		return fmt.Errorf("failed waiting for worker status machine deployments: %w", err)
+	}
+
+	return b.Botanist.DeployClusterAutoscaler(ctx)
+}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -374,6 +374,12 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Deploying cluster-autoscaler",
+			Fn:           b.DeployClusterAutoscaler,
+			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
+			Dependencies: flow.NewTaskIDs(finalizeGardenerNodeAgentBootstrapping),
+		})
+		_ = g.Add(flow.Task{
 			Name:         "Waiting until gardener-node-agent lease is renewed",
 			Fn:           b.WaitUntilGardenerNodeAgentLeaseIsRenewed,
 			Dependencies: flow.NewTaskIDs(finalizeGardenerNodeAgentBootstrapping),

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -373,16 +373,16 @@ func run(ctx context.Context, opts *Options) error {
 			Fn:           b.FinalizeGardenerNodeAgentBootstrapping,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady),
 		})
+		waitUntilGardenerNodeAgentLeaseIsRenewed = g.Add(flow.Task{
+			Name:         "Waiting until gardener-node-agent lease is renewed",
+			Fn:           b.WaitUntilGardenerNodeAgentLeaseIsRenewed,
+			Dependencies: flow.NewTaskIDs(finalizeGardenerNodeAgentBootstrapping),
+		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-autoscaler",
 			Fn:           b.DeployClusterAutoscaler,
 			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
-			Dependencies: flow.NewTaskIDs(finalizeGardenerNodeAgentBootstrapping),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Waiting until gardener-node-agent lease is renewed",
-			Fn:           b.WaitUntilGardenerNodeAgentLeaseIsRenewed,
-			Dependencies: flow.NewTaskIDs(finalizeGardenerNodeAgentBootstrapping),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerNodeAgentLeaseIsRenewed),
 		})
 	)
 

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -26,6 +26,12 @@ import (
 )
 
 func (b *Botanist) determineControllerReplicas(ctx context.Context, deploymentName string, defaultReplicas int32) (int32, error) {
+	// Self-Hosted Shoots should always use defaultReplicas because they don't support
+	// hibernation and have no dependency-watchdog.
+	if b.Shoot.IsSelfHosted() {
+		return defaultReplicas, nil
+	}
+
 	isCreateOrRestoreOperation := b.Shoot.GetInfo().Status.LastOperation != nil &&
 		(b.Shoot.GetInfo().Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate ||
 			b.Shoot.GetInfo().Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore)

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -284,6 +284,11 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 			))
 		}, SpecTimeout(time.Minute))
 
+		It("should deploy the cluster-autoscaler in the shoot", func(ctx SpecContext) {
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameClusterAutoscaler, Namespace: "kube-system"}}
+			Eventually(ctx, shootKomega.Object(deployment)).Should(BeHealthy(health.CheckDeployment))
+		}, SpecTimeout(time.Minute))
+
 		It("should adopt and keep the initial control plane machine", func(ctx SpecContext) {
 			// This check verifies that the control plane machine that was created in the bootstrap cluster is adopted by
 			// gardenadm init and the machine-controller-manager running in the self-hosted shoot.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
This PR adds the deployment of the  `cluster-autoscaler` for Self-Hosted Shoot Clusters as part of `gardenadm init`.
With this change, `gardenadm init` deploys the `cluster-autoscaler` component after finalizing the `gardener-node-agent` bootstrapping. This enables automatic scaling of worker nodes in Self-Hosted Shoot Clusters with managed infrastructure.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
/cc @timebertt

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
