### PR TITLE
Ensure `kubelet` volume stats metrics availability

### DIFF
--- a/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
+++ b/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
@@ -8,7 +8,7 @@ spec:
   - name: local
   kubernetes:
     versions:
-    - version: 1.34.0
+    - version: 1.34.3
     - version: 1.33.0
     - version: 1.32.0
     - version: 1.31.1

--- a/example/provider-local/managedseedset/managedseedset.yaml
+++ b/example/provider-local/managedseedset/managedseedset.yaml
@@ -62,7 +62,7 @@ spec:
             maxSurge: 1
             maxUnavailable: 0
       kubernetes:
-        version: 1.34.0
+        version: 1.34.3
         kubelet:
           seccompDefault: true
           serializeImagePulls: false

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
@@ -60,6 +60,11 @@ spec:
           labels:
             task: kube_state_metrics:absent
 
+        - record: healthcheck
+          expr: absent(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"})
+          labels:
+            task: kubelet:volume_metrics:absent
+
         # healthcheck:up indicates the overall health status.
         #
         # A query for `healthcheck:up` can return

--- a/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
@@ -151,8 +151,12 @@ tests:
 
       - series: container_cpu_usage_seconds_total{pod="gardenlet-abc"}
         values: 1     1     stale 1     1     1     1     1     1     1     1
+      - series: container_cpu_usage_seconds_total{pod="foo"}
+        values: 1     1     1     stale 1     1     1     1     1     1     1
       - series: kube_pod_container_resource_requests{pod="gardenlet-abc"}
         values: 1     1     1     1     stale 1     1     1     1     1     1
+      - series: kube_pod_container_resource_requests{pod="foo"}
+        values: 1     1     1     1     1     stale 1     1     1     1     1
       - series: expected_healthcheck:up
         values: 0     1     0     1     0     1     1     1     1     1     1
 

--- a/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
@@ -42,6 +42,8 @@ tests:
         values: 100x10
       - series: kube_pod_container_resource_requests{pod="gardenlet-abc"}
         values: 100x10
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"}
+        values: 100x10
     promql_expr_test: &promql_expr_test
       - expr: &expr |2
             healthcheck:up          !=     expected_healthcheck:up
@@ -89,6 +91,8 @@ tests:
         values: 100x10
       - series: kube_pod_container_resource_requests{pod="gardenlet-abc"}
         values: 100x10
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"}
+        values: 100x10
       - series: prometheus_rule_group_iterations_total{rule_group="x;healthcheck"}
         values: 0+1x10
     promql_expr_test: *promql_expr_test
@@ -110,6 +114,8 @@ tests:
       - series: container_cpu_usage_seconds_total{pod="gardenlet-abc"}
         values: 100x10
       - series: kube_pod_container_resource_requests{pod="gardenlet-abc"}
+        values: 100x10
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"}
         values: 100x10
       - series: prometheus_rule_group_iterations_total{rule_group="x;healthcheck"}
         values: 0+1x10
@@ -135,14 +141,16 @@ tests:
         values: 100x10
       - series: kube_pod_container_resource_requests{pod="gardenlet-abc"}
         values: 100x10
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"}
+        values: 100x10
       - series: prometheus_rule_group_iterations_total{rule_group="x;healthcheck"}
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test are the cAdvisor and kube-state-metrics time series.
+  # The focus of this test are the cAdvisor, kube-state-metrics and kubelet volume stats time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state
-  # if the cAdvisor or kube-state-metrics metrics are missing.
+  # if the cAdvisor, kube-state-metrics or kubelet volume stats metrics are missing.
   - input_series:
       - series: indentation
         values: stale stale stale stale stale stale stale stale stale stale stale
@@ -157,8 +165,12 @@ tests:
         values: 1     1     1     1     stale 1     1     1     1     1     1
       - series: kube_pod_container_resource_requests{pod="foo"}
         values: 1     1     1     1     1     stale 1     1     1     1     1
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-db-prometheus-cache-0"}
+        values: 1     1     1     1     1     1     stale 1     1     1     1
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="foo"}
+        values: 1     1     1     1     1     1     1     stale 1     1     1
       - series: expected_healthcheck:up
-        values: 0     1     0     1     0     1     1     1     1     1     1
+        values: 0     1     0     1     0     1     0     1     1     1     1
 
       - series: prometheus_rule_group_iterations_total{rule_group="x;healthcheck"}
         values: 0+1x10


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Kubernetes 1.34.0 is affected by a regression where `kubelet` volume stats metrics are not exposed, as detailed in:

- https://github.com/kubernetes/kubernetes/issues/133847

This problem became apparent in Gardener with the following PR because the Prometheus health checks by the care controllers now detect scrape jobs that return no metrics:

- https://github.com/gardener/gardener/pull/13341

Although this issue was not caught during pull request validation - since end-to-end tests still deploy shoots with [Kubernetes 1.33](https://github.com/gardener/gardener/blob/0705fcb8445cad0ba4e568980cdac7b3363d7f17/test/e2e/gardener/common.go#L41) - it will become evident once they are upgraded.

This PR addresses this issue in two ways:

- First, it configures the local setup cloud profiles to use Kubernetes 1.34.3 since the aforementioned regression was fixed in 1.34.2.
- Second, it leverages the new Prometheus health checks to add a specific rule that ensures the presence of `kubelet` volume stats metrics, which are crucial for the upcoming [PVC autoscaler](https://github.com/gardener/pvc-autoscaler). See related [issue](https://github.com/gardener/pvc-autoscaler/pull/118).

**Special notes for your reviewer**:

/cc @istvanballok

**Release note**:

```other operator
Use Kubernetes 1.34.3 in the local setup.
```

```other operator
Add Prometheus health check rule in the cache Prometheus to ensure the presence of `kubelet` volume stats metrics.
```