### PR TITLE
Add band-aid for removed timezone `Asia/Calcutta`

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -2800,7 +2800,9 @@ func ValidateHibernationCronSpec(seenSpecs sets.Set[string], spec string, fldPat
 func ValidateHibernationScheduleLocation(location string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if _, err := time.LoadLocation(location); err != nil {
+	// TODO(timuthy): Checking for "asia/calcutta" is a band-aid since the deprecated time zone was removed in Debian 13.
+	// Check for better ways to handle this incompatibility, e.g., deprecating the usage of this time zone in Gardener or importing time/tzdata.
+	if _, err := time.LoadLocation(location); err != nil && strings.ToLower(location) != "asia/calcutta" {
 		allErrs = append(allErrs, field.Invalid(fldPath, location, fmt.Sprintf("not a valid location: %v", err)))
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -9618,6 +9618,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			},
 			Entry("utc location", "UTC", BeEmpty()),
 			Entry("empty location -> utc", "", BeEmpty()),
+			Entry("\"Asia/Calcutta\" location", "Asia/Calcutta", BeEmpty()),
 			Entry("invalid location", "should not exist", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type": Equal(field.ErrorTypeInvalid),
 			})))),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression

**What this PR does / why we need it**:
The deprecated timezone `Asia/Calcutta` has been removed in Debian 13 (Gardener's base image), introduced with https://github.com/gardener/gardener/commit/4df31d73b01372a5863e6c1f30f05aff650d4473.

This band-aid is needed because `Asia/Calcutta` is used by users, including the Gardener dashboard.

**Special notes for your reviewer**:
Credits to @shafeeqes and @petersutter for finding this regression.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
