### PR TITLE
Revert "Use debian 13 (trixie) distroless image as base image (#13660)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN make build EFFECTIVE_VERSION=$EFFECTIVE_VERSION GOOS=$TARGETOS GOARCH=$TARGETARCH BUILD_OUTPUT_FILE="/output/bin/"
 
 # distroless-static
-FROM gcr.io/distroless/static-debian13:nonroot AS distroless-static
+FROM gcr.io/distroless/static-debian12:nonroot AS distroless-static
 
 # apiserver
 FROM distroless-static AS apiserver

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -117,7 +117,7 @@ This document provides a checklist for them that you can walk through.
 
    Avoid running containers as root. Usually, components such as Kubernetes controllers and admission webhook servers don't need root user capabilities to do their jobs.
 
-   The problem with running as root, starts with how the container is first built. Unless a non-privileged user is configured in the `Dockerfile`, container build systems by default set up the container with the root user. Add a non-privileged user to your `Dockerfile` or use a base image with a non-root user (for example the `nonroot` images from [distroless](https://github.com/GoogleContainerTools/distroless) such as `gcr.io/distroless/static-debian13:nonroot`).
+   The problem with running as root, starts with how the container is first built. Unless a non-privileged user is configured in the `Dockerfile`, container build systems by default set up the container with the root user. Add a non-privileged user to your `Dockerfile` or use a base image with a non-root user (for example the `nonroot` images from [distroless](https://github.com/GoogleContainerTools/distroless) such as `gcr.io/distroless/static-debian12:nonroot`).
 
    If the image is an upstream one, then consider configuring a securityContext for the container/Pod with a non-privileged user. Explicitly set `securityContext.runAsNonRoot=true` as well as `securityContext.runAsUser=<UID>` and `securityContext.runAsGroup=<GID>` if possible. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression

**What this PR does / why we need it**:
This reverts commit 4df31d73b01372a5863e6c1f30f05aff650d4473.

Revert happens because many time zones are missing in the trixie distroless. See https://github.com/gardener/gardener/pull/13856#issuecomment-3784769854.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I will open a follow up issue to update to Debian 13 again, but with the time zone regression in mind.
One idea is to import `time/tzdata` which serves as an additional data base.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
