### PR TITLE
Move the validation for functionless Shoot DNS providers to the storage layer

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1044,6 +1044,13 @@ func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
 		if provider.CredentialsRef != nil && provider.Type == nil {
 			allErrs = append(allErrs, field.Required(idxPath.Child("type"), "type must be set when credentialsRef is set"))
 		}
+
+		// Check for functionless DNS providers
+		if !ptr.Deref(provider.Primary, false) {
+			if provider.CredentialsRef == nil {
+				allErrs = append(allErrs, field.Required(idxPath.Child("credentialsRef"), "non-primary DNS providers must specify `credentialsRef`"))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1946,8 +1946,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.domain"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("spec.dns.domain"),
+					"Detail": Equal("domain must be set when primary provider type is not set to \"unmanaged\""),
 				}))))
 			})
 
@@ -1972,8 +1973,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.domain"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.dns.domain"),
+					"Detail": ContainSubstring("a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"),
 				}))))
 			})
 
@@ -1989,8 +1991,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.providers[0].credentialsRef"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+					"Detail": Equal("credentialsRef must not be set when type is \"unmanaged\""),
 				}))))
 			})
 
@@ -2005,8 +2008,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].type"),
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("spec.dns.providers[0].type"),
+					"Detail": Equal("type must be set when credentialsRef is set"),
 				}))))
 			})
 
@@ -2041,8 +2045,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.dns"),
+					"Detail": Equal("field is immutable"),
 				}))))
 			})
 
@@ -2053,8 +2058,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.domain"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.dns.domain"),
+					"Detail": Equal("field is immutable"),
 				}))))
 			})
 
@@ -2069,8 +2075,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, oldShoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.dns.providers"),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.dns.providers"),
+					"Detail": Equal("removing a primary provider is not allowed"),
 				}))))
 			})
 
@@ -2082,8 +2089,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.dns.providers"),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.dns.providers"),
+					"Detail": Equal("removing the primary provider type is not allowed"),
 				}))))
 			})
 
@@ -2094,9 +2102,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.dns.providers"),
+				Expect(errorList).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.dns.providers"),
+					"Detail": Equal("removing a primary provider is not allowed"),
 				}))))
 			})
 
@@ -2110,8 +2119,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.dns.providers[1].primary"),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.dns.providers[1].primary"),
+					"Detail": Equal("multiple primary DNS providers are not supported"),
 				}))))
 			})
 
@@ -2159,8 +2169,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.providers[1]"),
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.dns.providers[1]"),
+					"Detail": Equal("combination of .credentialsRef and .type must be unique across dns providers"),
 				}))))
 			})
 
@@ -2183,8 +2194,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				errorList := ValidateShoot(shoot)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.dns.providers[1].primary"),
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("spec.dns.providers[1].primary"),
+					"Detail": Equal("multiple primary DNS providers are not supported"),
 				}))))
 			})
 
@@ -2192,6 +2204,38 @@ var _ = Describe("Shoot Validation Tests", func() {
 				shoot.Spec.DNS.Providers[0].CredentialsRef = &dnsWorkloadIdentityRef
 
 				Expect(ValidateShoot(shoot)).To(BeEmpty())
+			})
+
+			It("should forbid functionless non-primary DNS providers", func() {
+				shoot.Spec.DNS.Providers = []core.DNSProvider{
+					{
+						Type: &providerType,
+					},
+					{
+						Type:           &providerType,
+						SecretName:     &dnsSecretName,
+						CredentialsRef: &dnsSecretRef,
+					},
+					{
+						SecretName:     &dnsSecretName,
+						CredentialsRef: &dnsSecretRef,
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+						"Detail": Equal("non-primary DNS providers must specify `credentialsRef`"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.dns.providers[2].type"),
+						"Detail": Equal("type must be set when credentialsRef is set"),
+					})),
+				))
 			})
 
 			Context("#validateDNSCredentialsRef", func() {

--- a/test/integration/controllermanager/controllerregistration/seed/seed_test.go
+++ b/test/integration/controllermanager/controllerregistration/seed/seed_test.go
@@ -7,6 +7,7 @@ package seed_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -70,7 +71,8 @@ var _ = Describe("ControllerRegistration controller test", func() {
 				}},
 				DNS: &gardencorev1beta1.DNS{
 					Providers: []gardencorev1beta1.DNSProvider{{
-						Type: &shootProviderType,
+						Type:           &shootProviderType,
+						CredentialsRef: &autoscalingv1.CrossVersionObjectReference{APIVersion: "v1", Kind: "Secret", Name: "foo"},
 					}},
 				},
 				SeedName: &seed.Name,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
With @vpnachev , after the merge of https://github.com/gardener/gardener/pull/13552, we noticed the following improvement point. 

We saw that a `kubectl apply` for a Shoot was failing with:
```
The Shoot "foo" is invalid: spec.dns.providers[0]: Required value: non-primary DNS providers must specify `type` and `credentialsRef`
```

We saw that the `spec.dns.providers[0].credentialsRef` was set (most probably by a `kubectl apply` by another actor) in the last-applied annotation. The manifest file was only setting the `spec.dns.providers[0].secretName` field.

The conclusion was that the `ShootDNS` admission plugin could be improved. It is a mutating admission plugin which currently also performs validation (see https://github.com/gardener/gardener/issues/13618). This means that during the mutation phase of the request, the request gets rejected before the sync logic between the `secretName` and the `credentialsRef` field.

**Which issue(s) this PR fixes**:
Rework of https://github.com/gardener/gardener/pull/13822
Part of https://github.com/gardener/gardener/issues/9586
Part of https://github.com/gardener/gardener/issues/13618
Follow-up on https://github.com/gardener/gardener/pull/13552

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/pull/13822#discussion_r2715376402

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
gardener-apiserver: An issue in gardener-apiserver v1.135.0 causing `kubectl apply` for a Shoot to be wrongly rejected with "spec.dns.providers[0]: Required value: non-primary DNS providers must specify `type` and `credentialsRef`" in some cases is now fixed.
```
