### PR TITLE
[GEP-28] Attempt to reduce the amount of end-to-end test flakes in the `gardenadm` scenario

### DIFF
--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -357,7 +357,7 @@ func run(ctx context.Context, opts *Options) error {
 					b.Shoot.Components.ControlPlane.ResourceManager.Wait,
 				),
 				b.WaitUntilExtensionControllerInstallationsHealthy,
-			),
+			).Timeout(5 * time.Minute),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeControllerManagerIsActive),
 		})
 		deployMachineControllerManager = g.Add(flow.Task{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/area robustness
/area quality
/kind flake

**What this PR does / why we need it**:

Attempt to reduce the amount of end-to-end test flakes in the `gardenadm` scenario.

When transitioning from the bootstrap `etcd` to the ordinary `etcd`, `kube-apiserver` is temporarily not available because `etcd` goes down. This can lead to a number of controllers to crash and go in backoff.

Considering the increase in end-to-end test flakes reported in #13811, it seems obvious that the runtime `gardener-resource-manager` needs to be health-checked. In addition to that, we also need to ensure that `kube-controller-manager` is active as many health checks rely on the status of managed resources being properly maintained. Before the `etcd` update everything may have been running flawlessly. Hence, if `kube-controller-manager` was not able to update the state we may believe the old status values. Hence, we check that `kube-controller-manager` is active as well.

**Which issue(s) this PR fixes**:
Fixes #13811

**Special notes for your reviewer**:

/cc @tobschli @rfranzke 

/hold

Let's wait for multiple test runs.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```