### PR TITLE
Update MCM version to v0.61.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gardener/cert-management v0.19.0
 	github.com/gardener/dependency-watchdog v1.6.0
 	github.com/gardener/etcd-druid/api v0.35.0
-	github.com/gardener/machine-controller-manager v0.60.2
+	github.com/gardener/machine-controller-manager v0.61.1
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-test/deep v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/gardener/dependency-watchdog v1.6.0 h1:ARCIbcNmhjefmV7ex8ADReeD2MPsEa
 github.com/gardener/dependency-watchdog v1.6.0/go.mod h1:NXkna7bW5O+IGxLAX0KdEaW8yFREDfSHSccuoY+YZu0=
 github.com/gardener/etcd-druid/api v0.35.0 h1:Rr7HQbaQOgyMB5KB+fcckjF0snGWpHyWy072PRbrocI=
 github.com/gardener/etcd-druid/api v0.35.0/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
-github.com/gardener/machine-controller-manager v0.60.2 h1:lY6z67lDlwl9dQUEmlJbrmpxWK10o/rVRUu4JB7xK4U=
-github.com/gardener/machine-controller-manager v0.60.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/gardener/machine-controller-manager v0.61.1 h1:Aa7FsFC4AppZ0VWqpNWUKwT25yscO9/9TF4Vsw9Vauc=
+github.com/gardener/machine-controller-manager v0.61.1/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -130,7 +130,7 @@ images:
   - name: machine-controller-manager
     sourceRepository: github.com/gardener/machine-controller-manager
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
-    tag: "v0.60.2"
+    tag: "v0.61.1"
     labels:
       - name: gardener.cloud/cve-categorisation
         value:

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -51,14 +51,14 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 		It("Delete Nodes and Machines to trigger new Node bootstrap", func(ctx SpecContext) {
 			machineList := &machinev1alpha1.MachineList{}
 			Eventually(ctx, func(g Gomega) {
-				g.Expect(s.ShootClient.List(ctx, machineList)).To(Succeed())
+				g.Expect(s.SeedClient.List(ctx, machineList)).To(Succeed())
 				g.Expect(machineList.Items).To(Not(BeEmpty()))
 				for _, machine := range machineList.Items {
 					patch := client.MergeFrom(machine.DeepCopy())
 					metav1.SetMetaDataLabel(&machine.ObjectMeta, markMachinesForcefulDeletionLabel, "True")
-					g.Expect(s.ShootClient.Patch(ctx, &machine, patch)).To(Succeed())
-					g.Expect(s.ShootClient.Delete(ctx, &machine)).To(Succeed())
+					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed())
 				}
+				g.Expect(s.ShootClient.DeleteAllOf(ctx, &corev1.Node{})).To(Succeed())
 			}).Should(Succeed())
 		}, SpecTimeout(time.Minute))
 

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -51,12 +51,12 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 		It("Delete Nodes and Machines to trigger new Node bootstrap", func(ctx SpecContext) {
 			machineList := &machinev1alpha1.MachineList{}
 			Eventually(ctx, func(g Gomega) {
-				g.Expect(s.SeedClient.List(ctx, machineList), client.InNamespace(seedNamespace)).To(Succeed())
+				g.Expect(s.ShootClient.List(ctx, machineList)).To(Succeed())
 				g.Expect(machineList.Items).To(Not(BeEmpty()))
 				for _, machine := range machineList.Items {
 					patch := client.MergeFrom(machine.DeepCopy())
 					metav1.SetMetaDataLabel(&machine.ObjectMeta, markMachinesForcefulDeletionLabel, "True")
-					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed())
+					g.Expect(s.ShootClient.Patch(ctx, &machine, patch)).To(Succeed())
 				}
 				g.Expect(s.SeedClient.DeleteAllOf(ctx, &machinev1alpha1.Machine{}, client.InNamespace(seedNamespace))).To(Succeed())
 			}).Should(Succeed())

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -33,7 +33,7 @@ const nodeCriticalDaemonSetName = "e2e-test-node-critical"
 const csiNodeDaemonSetName = "e2e-test-csi-node"
 const waitForCSINodeAnnotation = v1beta1constants.AnnotationPrefixWaitForCSINode + "driver"
 const driverName = "foo.driver.example.org"
-const markMachinesForcefulDeletionLabel = "force-deletion"
+const machineForcefulDeletionLabel = "force-deletion"
 
 // VerifyNodeCriticalComponentsBootstrapping tests the node readiness feature (see docs/usage/advanced/node-readiness.md).
 func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
@@ -55,7 +55,7 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 				g.Expect(machineList.Items).To(Not(BeEmpty()))
 				for _, machine := range machineList.Items {
 					patch := client.MergeFrom(machine.DeepCopy())
-					metav1.SetMetaDataLabel(&machine.ObjectMeta, markMachinesForcefulDeletionLabel, "True")
+					metav1.SetMetaDataLabel(&machine.ObjectMeta, machineForcefulDeletionLabel, "true")
 					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed())
 				}
 				g.Expect(s.ShootClient.DeleteAllOf(ctx, &corev1.Node{})).To(Succeed())
@@ -260,6 +260,8 @@ func waitForTerminatingNodesToBeDeleted(ctx context.Context, shootClient client.
 	Eventually(ctx, func(g Gomega) {
 		nodeList := &corev1.NodeList{}
 		g.Expect(shootClient.List(ctx, nodeList)).To(Succeed())
-		g.Expect(nodeList.Items).To(HaveLen(1))
+		for _, node := range nodeList.Items {
+			Expect(node.DeletionTimestamp).To(BeNil())
+		}
 	}).Should(Succeed())
 }

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -52,7 +52,7 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 			machineList := &machinev1alpha1.MachineList{}
 			Eventually(ctx, func(g Gomega) {
 				g.Expect(s.SeedClient.List(ctx, machineList)).To(Succeed())
-				g.Expect(machineList.Items).To(Not(BeEmpty()))
+				g.Expect(machineList.Items).NotTo(BeEmpty())
 				for _, machine := range machineList.Items {
 					patch := client.MergeFrom(machine.DeepCopy())
 					metav1.SetMetaDataLabel(&machine.ObjectMeta, machineForcefulDeletionLabel, "true")
@@ -261,7 +261,7 @@ func waitForTerminatingNodesToBeDeleted(ctx context.Context, shootClient client.
 		nodeList := &corev1.NodeList{}
 		g.Expect(shootClient.List(ctx, nodeList)).To(Succeed())
 		for _, node := range nodeList.Items {
-			Expect(node.DeletionTimestamp).To(BeNil())
+			g.Expect(node.DeletionTimestamp).To(BeNil())
 		}
 	}).Should(Succeed())
 }

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -66,7 +66,7 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 				g.Expect(idx).To(BeNumerically(">=", 0))
 				node = nodeList.Items[idx].DeepCopy()
 			}).Should(Succeed())
-		}, SpecTimeout(30*time.Minute))
+		}, SpecTimeout(10*time.Minute))
 
 		It("Verify node-critical components not ready taint is present", func(ctx SpecContext) {
 			Eventually(ctx, s.ShootKomega.Object(node)).MustPassRepeatedly(3).WithPolling(2 * time.Second).Should(

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -59,7 +59,6 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed())
 				}
 				g.Expect(s.SeedClient.DeleteAllOf(ctx, &machinev1alpha1.Machine{}, client.InNamespace(seedNamespace))).To(Succeed())
-				g.Expect(s.ShootClient.DeleteAllOf(ctx, &corev1.Node{})).To(Succeed())
 			}).Should(Succeed())
 		}, SpecTimeout(time.Minute))
 

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -57,8 +57,8 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 					patch := client.MergeFrom(machine.DeepCopy())
 					metav1.SetMetaDataLabel(&machine.ObjectMeta, markMachinesForcefulDeletionLabel, "True")
 					g.Expect(s.ShootClient.Patch(ctx, &machine, patch)).To(Succeed())
+					g.Expect(s.ShootClient.Delete(ctx, &machine)).To(Succeed())
 				}
-				g.Expect(s.SeedClient.DeleteAllOf(ctx, &machinev1alpha1.Machine{}, client.InNamespace(seedNamespace))).To(Succeed())
 			}).Should(Succeed())
 		}, SpecTimeout(time.Minute))
 

--- a/test/e2e/gardener/shoot/internal/node/node.go
+++ b/test/e2e/gardener/shoot/internal/node/node.go
@@ -56,7 +56,7 @@ func VerifyNodeCriticalComponentsBootstrapping(s *ShootContext) {
 				for _, machine := range machineList.Items {
 					patch := client.MergeFrom(machine.DeepCopy())
 					metav1.SetMetaDataLabel(&machine.ObjectMeta, machineForcefulDeletionLabel, "true")
-					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed())
+					g.Expect(s.SeedClient.Patch(ctx, &machine, patch)).To(Succeed(), "for machine "+client.ObjectKeyFromObject(&machine).String())
 				}
 				g.Expect(s.ShootClient.DeleteAllOf(ctx, &corev1.Node{})).To(Succeed())
 			}).Should(Succeed())
@@ -261,7 +261,7 @@ func waitForTerminatingNodesToBeDeleted(ctx context.Context, shootClient client.
 		nodeList := &corev1.NodeList{}
 		g.Expect(shootClient.List(ctx, nodeList)).To(Succeed())
 		for _, node := range nodeList.Items {
-			g.Expect(node.DeletionTimestamp).To(BeNil())
+			g.Expect(node.DeletionTimestamp).To(BeNil(), "for node "+client.ObjectKeyFromObject(&node).String())
 		}
 	}).Should(Succeed())
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR upgrades mcm version from `v0.60.2` to `v0.61.1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependencies have been updated:
- `gardener/machine-controller-manager` from `v0.60.2` to `v0.61.1`. [Release Notes](https://github.com/gardener/machine-controller-manager/releases/tag/v0.61.1)
```
