### PR TITLE
[release-v1.135] Update local `CloudProfile` to Kubernetes 1.34.3

### DIFF
--- a/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
+++ b/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
@@ -8,7 +8,7 @@ spec:
   - name: local
   kubernetes:
     versions:
-    - version: 1.34.0
+    - version: 1.34.3
     - version: 1.33.0
     - version: 1.32.0
     - version: 1.31.1

--- a/example/provider-local/managedseedset/managedseedset.yaml
+++ b/example/provider-local/managedseedset/managedseedset.yaml
@@ -62,7 +62,7 @@ spec:
             maxSurge: 1
             maxUnavailable: 0
       kubernetes:
-        version: 1.34.0
+        version: 1.34.3
         kubelet:
           seccompDefault: true
           serializeImagePulls: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Update the local `CloudProfile` to Kubernetes version 1.34.3 for release v1.135.

This is necessary because in `v1.136.0-dev` we want to switch the base e2e shoot to Kubernetes 1.34.3 (see #13820), but fail to do so because only `1.34.0` is available.

See failing upgrade test as a reference: [shoot upgrade test](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13820/pull-gardener-e2e-kind/2014587160895688704)
See why we need 1.34.3 instead of 1.34.0: https://github.com/gardener/gardener/pull/13855

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vicwicker @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `CloudProfile` for the local dev setup was updated from Kubernetes version 1.34.0 to 1.34.3.
```
