### PR TITLE
Increase maximum values for inflight `kube-apiserver` requests

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1318,7 +1318,7 @@ func ValidateAPIServerRequests(requests *core.APIServerRequests, fldPath *field.
 	allErrs := field.ErrorList{}
 
 	if requests != nil {
-		const maxNonMutatingRequestsInflight = 800
+		const maxNonMutatingRequestsInflight = 5000
 		if v := requests.MaxNonMutatingInflight; v != nil {
 			path := fldPath.Child("maxNonMutatingInflight")
 
@@ -1328,7 +1328,7 @@ func ValidateAPIServerRequests(requests *core.APIServerRequests, fldPath *field.
 			}
 		}
 
-		const maxMutatingRequestsInflight = 400
+		const maxMutatingRequestsInflight = 2500
 		if v := requests.MaxMutatingInflight; v != nil {
 			path := fldPath.Child("maxMutatingInflight")
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
In large clusters, it is beneficial increase the maximum number of inflight requests beyond the limits Gardener's validation code currently imposes.
Back then, when we introduced configurability of these values, we used `800`/`400` as maximum since these were the doubled values of the defaults in Kubernetes `400`/`200`.

**Special notes for your reviewer**:
/cc @ScheererJ 
FYI @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `.spec.kubernetes.kubeAPIServer.requests.max{Non}MutatingInflight` flags can now be increased to `5000` (non-mutating) / `2500` (mutating).
```
