### PR TITLE
Add defaults for VPA Misalignments dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/seed/vpa-misalignments-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/seed/vpa-misalignments-dashboard.json
@@ -338,6 +338,11 @@
       },
       {
         "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "30m",
+          "value": "30"
+        },
         "description": "",
         "error": null,
         "hide": 0,
@@ -404,6 +409,11 @@
       },
       {
         "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "0.2",
+          "value": "0.2"
+        },
         "description": null,
         "error": null,
         "hide": 0,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adds defaults for the Seed's Plutono VPA Misalignments dashboard, since @ialidzhikov mentioned that they weren't set when he was trying to access the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @Kostov6 @vitanovs 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
