### PR TITLE
Fix a flaky Prometheus healthcheck

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/healthcheck.yaml
@@ -22,11 +22,11 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         # The scrape job for the shoot prometheus is excluded,
         # because it might yield no samples when a shoot control plane is being deleted.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling{job!="shoot-prometheus"} == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling{job!="shoot-prometheus"}) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/aggregate/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/testdata/healthcheck.prometheusrule.test.yaml
@@ -113,7 +113,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/aggregate/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/testdata/healthcheck.prometheusrule.test.yaml
@@ -122,8 +122,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: scrape_samples_post_metric_relabeling{job="shoot-prometheus"}
         values: 0     0     0     0     0     0     0     0     0     0     0
       - series: expected_healthcheck:up

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
@@ -18,9 +18,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling{job!="etcd-druid"} == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling{job!="etcd-druid"}) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
@@ -121,7 +121,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/testdata/healthcheck.prometheusrule.test.yaml
@@ -130,8 +130,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: scrape_samples_post_metric_relabeling{job="etcd-druid"}
         values: 0     0     0     0     0     0     0     0     0     0     0
       - series: expected_healthcheck:up

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/healthcheck.yaml.tmpl
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/healthcheck.yaml.tmpl
@@ -18,9 +18,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/healthcheck.prometheusrule.test.yaml
@@ -109,7 +109,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/healthcheck.prometheusrule.test.yaml
@@ -118,8 +118,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: expected_healthcheck:up
         values: 0     1     0     1     1     0     0     0     0     0     1
 

--- a/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/healthcheck.yaml
@@ -18,9 +18,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/longterm/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/testdata/healthcheck.prometheusrule.test.yaml
@@ -118,8 +118,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: expected_healthcheck:up
         values: 0     1     0     1     1     0     0     0     0     0     1
 

--- a/pkg/component/observability/monitoring/prometheus/longterm/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/testdata/healthcheck.prometheusrule.test.yaml
@@ -109,7 +109,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/seed/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/seed/assets/prometheusrules/healthcheck.yaml
@@ -18,9 +18,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/seed/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/seed/testdata/healthcheck.prometheusrule.test.yaml
@@ -111,8 +111,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: expected_healthcheck:up
         values: 0     1     0     1     1     0     0     0     0     0     1
 

--- a/pkg/component/observability/monitoring/prometheus/seed/testdata/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/seed/testdata/healthcheck.prometheusrule.test.yaml
@@ -102,7 +102,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/healthcheck.yaml
@@ -21,9 +21,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/healthcheck.yaml
@@ -21,9 +21,9 @@ spec:
           labels:
             task: scrape_pool:empty
 
-        # healthcheck{task="scrape:empty"} is present for each scrape job target that yields no samples after metric relabeling.
+        # healthcheck{task="scrape:empty"} is present for each scrape job that yields no samples after metric relabeling.
         - record: healthcheck
-          expr: scrape_samples_post_metric_relabeling == 0
+          expr: sum by (job) (scrape_samples_post_metric_relabeling) == 0
           labels:
             task: scrape:empty
 

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/healthcheck.prometheusrule.test.yaml
@@ -143,7 +143,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/healthcheck.prometheusrule.test.yaml
@@ -152,8 +152,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: expected_healthcheck:up
         values: 0     1     0     1     1     0     0     0     0     0     1
 

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/workerless/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/workerless/healthcheck.prometheusrule.test.yaml
@@ -140,8 +140,10 @@ tests:
       - series: eval_time
         values: 0     1     2     3     4     5     6     7     8     9     10
 
-      - series: scrape_samples_post_metric_relabeling
-        values: 100   100   0     100   100   0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="1"}
+        values: 100   100   0     100   0     0     0     0     0     0     100
+      - series: scrape_samples_post_metric_relabeling{job="foo", instance="2"}
+        values: 0     0     0     0     100   0     0     0     0     0     0
       - series: expected_healthcheck:up
         values: 0     1     0     1     1     0     0     0     0     0     1
 

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/workerless/healthcheck.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/workerless/healthcheck.prometheusrule.test.yaml
@@ -131,7 +131,7 @@ tests:
         values: 0+1x10
     promql_expr_test: *promql_expr_test
 
-  # The focus of this test is the scrape_samples_scraped_scrape_samples_post_metric_relabeling time series.
+  # The focus of this test is the scrape_samples_post_metric_relabeling time series.
   #
   # This test shows that healthcheck:up will report an unhealthy state if a scrape job yields zero samples.
   - input_series:


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind regression

**What this PR does / why we need it**:

The `scrape:empty` Prometheus healthcheck rule is improved to aggregate samples across all the targets of a scrape job, instead of checking each target individually.

Previously, the healthcheck would fail for individual targets that yielded zero samples, which caused false positives. For example, in the kubelet scrape job of the cache Prometheus, only persistent volume related metrics are retained. Nodes without attached PVs legitimately yield zero samples after metric relabeling, triggering a false healthcheck failure.

With this change, the `scrape:empty` healthcheck rule considers whether *any* target of a job yields some samples, avoiding false positives while still catching actual misconfigurations.

This regression was introduced in #13341 and only affects the local setup and PR validation because the respective feature gate is not enabled by default. This issue has caused flaky tests in the CI pipeline (#13859) and inconvenience during local development.

**Which issue(s) this PR fixes**:
Fixes #13859

**Special notes for your reviewer**:

*Why was this failure sporadic rather than consistent?*

The sporadic nature depends on cluster topology:

- In a local setup with a single KinD node, the test never failed because that node always has volume attachments (at least for the cache Prometheus pod itself).
- In an HA local setup with 3 KinD nodes, there's a chance that 1 or 2 KinD nodes have no persistent volumes attached, triggering the false positive healthcheck failure.

cc @vicwicker 

**Release note**:
```bugfix developer
NONE
```
