### PR TITLE
Remove obsolete `GOPATH` reference

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -37,8 +37,6 @@ AVAILABLE_CODEGEN_OPTIONS=(
 CODE_GEN_DIR=$(go list -m -f '{{.Dir}}' k8s.io/code-generator)
 source "${CODE_GEN_DIR}/kube_codegen.sh"
 
-rm -f ${GOPATH}/bin/*-gen
-
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 export PROJECT_ROOT
@@ -387,12 +385,7 @@ openapi_definitions() {
   echo "> Generating openapi definitions"
   rm -Rf ./${PROJECT_ROOT}/openapi/openapi_generated.go
 
-  GO111MODULE=on go install k8s.io/kube-openapi/cmd/openapi-gen
-
-  # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
-  gobin="${GOBIN:-$(go env GOPATH)/bin}"
-
-  "${gobin}/openapi-gen" \
+  "openapi-gen" \
     -v 1 \
     --output-file openapi_generated.go \
     --go-header-file "${PROJECT_ROOT}/hack/LICENSE_BOILERPLATE.txt" \


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
Removes obsolete `GOPATH` reference that leads to release errors, see [example](https://github.com/gardener/gardener/actions/runs/21393809834/job/61587006777).

Introduced with https://github.com/gardener/gardener/pull/13556.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
