### PR TITLE
Introduce Env Variable for Setting Parallel Workers Count for `make generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,15 +186,16 @@ tools-for-generate: $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_D
 	@go mod download
 
 define GENERATE_HELP_INFO
-# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"]
+# Usage: make generate [WHAT="<targets>"] [MODE="<mode>"] [CODEGEN_GROUPS="<groups>"] [MANIFESTS_DIRS="<folders>"] [MAX_PARALLEL_WORKERS="<num>"]
 #
 # Options:
-#   WHAT              - Specify the targets to run (e.g., "protobuf codegen manifests logcheck")
-#   CODEGEN_GROUPS    - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication_groups core_groups extensions_groups resources_groups
-#                       operator_groups seedmanagement_groups operations_groups settings_groups operatorconfig_groups controllermanager_groups admissioncontroller_groups scheduler_groups
-#                       gardenlet_groups resourcemanager_groups shoottolerationrestriction_groups shootdnsrewriting_groups shootresourcereservation_groups provider_local_groups extensions_config_groups")
-#   MANIFESTS_DIRS    - Specify which directories to run the 'manifests' target in, not applicable for other targets (Default directories are "charts cmd example extensions imagevector pkg plugin test")
-#   MODE              - Specify the mode for the 'manifests' (default=parallel) or 'codegen' (default=sequential) target (e.g., "parallel" or "sequential")
+#   WHAT                   - Specify the targets to run (e.g., "protobuf codegen manifests logcheck")
+#   CODEGEN_GROUPS         - Specify which groups to run the 'codegen' target for, not applicable for other targets (e.g., "authentication_groups core_groups extensions_groups resources_groups
+#                            operator_groups seedmanagement_groups operations_groups settings_groups operatorconfig_groups controllermanager_groups admissioncontroller_groups scheduler_groups
+#                            gardenlet_groups resourcemanager_groups shoottolerationrestriction_groups shootdnsrewriting_groups shootresourcereservation_groups provider_local_groups extensions_config_groups")
+#   MANIFESTS_DIRS         - Specify which directories to run the 'manifests' target in, not applicable for other targets (Default directories are "charts cmd example extensions imagevector pkg plugin test")
+#   MODE                   - Specify the mode for the 'manifests' (default=parallel) or 'codegen' (default=sequential) target (e.g., "parallel" or "sequential")
+#   MAX_PARALLEL_WORKERS   - Specify the number of maximum parallel workers that will be used in the case that MODE='parallel' (default=number of cores/hyperthreads)
 #
 # Examples:
 #   make generate
@@ -213,7 +214,7 @@ generate:
 else
 generate: tools-for-generate
 	@printf "\nFor more info on the generate command, Run 'make generate PRINT_HELP=y'\n"
-	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegen-groups "$(CODEGEN_GROUPS)" --manifests-dirs "$(MANIFESTS_DIRS)" --mode "$(MODE)"
+	@REPO_ROOT=$(REPO_ROOT) LOGCHECK_DIR=$(LOGCHECK_DIR) hack/generate.sh --what "$(WHAT)" --codegen-groups "$(CODEGEN_GROUPS)" --manifests-dirs "$(MANIFESTS_DIRS)" --mode "$(MODE)" --max-parallel-workers "$(MAX_PARALLEL_WORKERS)"
 	$(MAKE) format
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ define GENERATE_HELP_INFO
 #                            gardenlet_groups resourcemanager_groups shoottolerationrestriction_groups shootdnsrewriting_groups shootresourcereservation_groups provider_local_groups extensions_config_groups")
 #   MANIFESTS_DIRS         - Specify which directories to run the 'manifests' target in, not applicable for other targets (Default directories are "charts cmd example extensions imagevector pkg plugin test")
 #   MODE                   - Specify the mode for the 'manifests' (default=parallel) or 'codegen' (default=sequential) target (e.g., "parallel" or "sequential")
-#   MAX_PARALLEL_WORKERS   - Specify the number of maximum parallel workers that will be used in the case that MODE='parallel' (default=number of cores/hyperthreads)
+#   MAX_PARALLEL_WORKERS   - Specify the number of maximum parallel workers that will be used in the case that MODE='parallel' (default=4)
 #
 # Examples:
 #   make generate

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ define GENERATE_HELP_INFO
 #                            gardenlet_groups resourcemanager_groups shoottolerationrestriction_groups shootdnsrewriting_groups shootresourcereservation_groups provider_local_groups extensions_config_groups")
 #   MANIFESTS_DIRS         - Specify which directories to run the 'manifests' target in, not applicable for other targets (Default directories are "charts cmd example extensions imagevector pkg plugin test")
 #   MODE                   - Specify the mode for the 'manifests' (default=parallel) or 'codegen' (default=sequential) target (e.g., "parallel" or "sequential")
-#   MAX_PARALLEL_WORKERS   - Specify the number of maximum parallel workers that will be used in the case that MODE='parallel' (default=4)
+#   MAX_PARALLEL_WORKERS   - Specify the number of maximum parallel workers that will be used when MODE='parallel' (default=4)
 #
 # Examples:
 #   make generate

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ define GENERATE_HELP_INFO
 #   make generate WHAT="manifests" MANIFESTS_DIRS="pkg/component plugin" MODE="sequential"
 #   make generate WHAT="codegen" CODEGEN_GROUPS="core_groups extensions_groups"
 #   make generate WHAT="codegen manifests" CODEGEN_GROUPS="operator_groups controllermanager_groups" MANIFESTS_DIRS="charts extensions/pkg"
+#   make generate WHAT="manifests" MAX_PARALLEL_WORKERS=8
 #
 endef
 export GENERATE_HELP_INFO

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -286,5 +286,5 @@ echo "$ROOTS" | while IFS= read -r dir; do
     # Directory has non-skippable directives, always generate
     echo "github.com/gardener/gardener/$dir"
   fi
-  # TODO(rrhubenov) Revisit whether MAX_PARALLEL_WORKERS will be neede after nodes start using coreutils >= 9.8. Ref: https://github.com/gardener/gardener/pull/13903#issuecomment-3835448178
+  # TODO(rrhubenov): Revisit whether MAX_PARALLEL_WORKERS will be needed after prow cluster nodes start using coreutils >= 9.8. Ref: https://github.com/gardener/gardener/pull/13903#issuecomment-3835448178
 done | parallel --will-cite $([ "${MAX_PARALLEL_WORKERS}" != "" ] && echo "-j ${MAX_PARALLEL_WORKERS}") 'echo "Generate {}"; go generate {}'

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -286,4 +286,5 @@ echo "$ROOTS" | while IFS= read -r dir; do
     # Directory has non-skippable directives, always generate
     echo "github.com/gardener/gardener/$dir"
   fi
+  # TODO(rrhubenov) Revisit whether MAX_PARALLEL_WORKERS will be neede after nodes start using coreutils >= 9.8. Ref: https://github.com/gardener/gardener/pull/13903#issuecomment-3835448178
 done | parallel --will-cite $([ "${MAX_PARALLEL_WORKERS}" != "" ] && echo "-j ${MAX_PARALLEL_WORKERS}") 'echo "Generate {}"; go generate {}'

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -286,4 +286,4 @@ echo "$ROOTS" | while IFS= read -r dir; do
     # Directory has non-skippable directives, always generate
     echo "github.com/gardener/gardener/$dir"
   fi
-done | parallel --will-cite 'echo "Generate {}"; go generate {}'
+done | parallel --will-cite $([ "${MAX_PARALLEL_WORKERS}" != "" ] && echo "-j ${MAX_PARALLEL_WORKERS}") 'echo "Generate {}"; go generate {}'

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -10,6 +10,7 @@ WHAT="protobuf codegen manifests logcheck"
 CODEGEN_GROUPS=""
 MANIFESTS_DIRS=""
 MODE=""
+MAX_PARALLEL_WORKERS=""
 DEFAULT_MANIFESTS_DIRS=(
   "charts"
   "cmd"
@@ -42,6 +43,10 @@ parse_flags() {
       --manifests-dirs)
         shift
         MANIFESTS_DIRS="${1:-$MANIFESTS_DIRS}"
+        ;;
+      --max-parallel-workers)
+        shift
+        export MAX_PARALLEL_WORKERS=${1:-$MAX_PARALLEL_WORKERS}
         ;;
       *)
         echo "Unknown argument: $1"

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -10,7 +10,7 @@ WHAT="protobuf codegen manifests logcheck"
 CODEGEN_GROUPS=""
 MANIFESTS_DIRS=""
 MODE=""
-MAX_PARALLEL_WORKERS=""
+MAX_PARALLEL_WORKERS="4"
 DEFAULT_MANIFESTS_DIRS=(
   "charts"
   "cmd"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
When running `make generate`, memory usage reaches unhealthy levels. Example prow job: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13708/pull-gardener-unit/2016114961889103872

This is caused due to using [parallel](https://www.gnu.org/software/parallel/) for parallelising the calls to `go generate` thus decreasing the time it takes for the whole job to finish, but increasing the total amount of memory used (number_of_workers X average_memory_consumption_per_worker).

In some cases, as in the prow job I linked, it causes OOM issues. In fact, with the [Victoria Operator PR](https://github.com/gardener/gardener/pull/13708), this issue is consistently repeatable.

Another factor to this issue is that `parallel`, when not given a max number of workers with the `-j` flag, decides the number by checking the number of hyper-threads that node has access to, rather than checking how much CPU cores the container has been scheduled with. In other words, parallel is not container aware.

This causes it to start a bigger number of workers, which in turn increases the amount of memory being consumed. And since CPU and memory resources are often set in some relation to each other, this causes an OOM.

Huge thanks to @ialidzhikov for helping with this issue. He was able to test and confirm that parallel indeed acts this way.

The new environment variable called `MAX_PARALLEL_WORKERS` can now be used in container environments where this issue would be hit.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Environment variable `MAX_PARALLEL_WORKERS` can now be used to control the number of parallel workers that are spawned during the call to the `make generate` target.
```
