### PR TITLE
Split the `ShootDNS` admission plugin into mutating and validating admission plugin

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -197,7 +197,7 @@ When the seed is using `WorkloadIdentity` as backup credentials, the plugin ensu
 
 ## `ShootDNS`
 
-**Type**: Mutating. **Enabled by default**: Yes.
+**Type**: Validating and Mutating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It tries to assign a default domain to the `Shoot`.

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -154,17 +154,10 @@ func (d *DNS) Admit(_ context.Context, a admission.Attributes, _ admission.Objec
 		return nil
 	}
 
-	specPath := field.NewPath("spec")
-
 	// Generate a Shoot domain if none is configured.
 	if !helper.ShootUsesUnmanagedDNS(shoot) {
 		if err := assignDefaultDomainIfNeeded(shoot, d.projectLister, defaultDomains); err != nil {
 			return err
-		}
-
-		if !isShootDomainSet(shoot) {
-			fieldErr := field.Required(specPath.Child("DNS"), fmt.Sprintf("shoot domain field .spec.dns.domain must be set if provider != %s", core.DNSUnmanaged))
-			return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
 		}
 	}
 

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -104,7 +104,10 @@ func (d *DNS) ValidateInitialization() error {
 	return nil
 }
 
-var _ admission.MutationInterface = (*DNS)(nil)
+var (
+	_ admission.MutationInterface   = (*DNS)(nil)
+	_ admission.ValidationInterface = (*DNS)(nil)
+)
 
 // Admit tries to determine a DNS hosted zone for the Shoot's external domain.
 func (d *DNS) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
@@ -393,4 +396,9 @@ func getDefaultDomains(secretLister kubecorev1listers.SecretLister, seedLister g
 		defaultDomains = append(defaultDomains, domain)
 	}
 	return defaultDomains, nil
+}
+
+// Validate validates the Shoot DNS specification.
+func (d *DNS) Validate(_ context.Context, _ admission.Attributes, _ admission.ObjectInterfaces) error {
+	return nil
 }

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -91,6 +91,7 @@ var _ = Describe("dns", func() {
 
 	Describe("#Admit", func() {
 		var (
+			ctx                 context.Context
 			admissionHandler    *DNS
 			kubeInformerFactory kubeinformers.SharedInformerFactory
 			coreInformerFactory gardencoreinformers.SharedInformerFactory
@@ -172,6 +173,7 @@ var _ = Describe("dns", func() {
 		)
 
 		BeforeEach(func() {
+			ctx = context.Background()
 			admissionHandler, _ = New()
 			admissionHandler.AssignReadyFunc(func() bool { return true })
 			kubeInformerFactory = kubeinformers.NewSharedInformerFactory(nil, 0)
@@ -192,7 +194,7 @@ var _ = Describe("dns", func() {
 		It("should do nothing if the resource is not a Shoot", func() {
 			attrs := admission.NewAttributesRecord(nil, nil, core.Kind("foo").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-			Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+			Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 		})
 
 		It("should do nothing because the shoot status is updated", func() {
@@ -202,7 +204,7 @@ var _ = Describe("dns", func() {
 
 			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "status", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-			Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+			Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			Expect(*shootCopy).To(Equal(*shootBefore))
 		})
 
@@ -213,7 +215,7 @@ var _ = Describe("dns", func() {
 
 			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+			err := admissionHandler.Admit(ctx, attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*shootCopy).To(Equal(*shootBefore))
@@ -226,7 +228,7 @@ var _ = Describe("dns", func() {
 
 			attrs := admission.NewAttributesRecord(shootCopy, shootCopy, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+			err := admissionHandler.Admit(ctx, attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*shootCopy).To(Equal(*shootBefore))
@@ -239,7 +241,7 @@ var _ = Describe("dns", func() {
 			Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 			attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+			err := admissionHandler.Admit(ctx, attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shoot).To(Equal(*shootBefore))
@@ -266,7 +268,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
@@ -299,7 +301,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
@@ -348,7 +350,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
@@ -390,7 +392,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -403,7 +405,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -418,7 +420,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -432,7 +434,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -456,7 +458,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domain)))
@@ -476,7 +478,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -488,7 +490,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 
 				Expect(err).To(MatchError(error(apierrors.NewInternalError(fmt.Errorf("Project.core.gardener.cloud %q not found", "<unknown>")))))
 			})
@@ -507,7 +509,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
 					Expect(err).To(Not(HaveOccurred()))
 
 					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
@@ -515,7 +517,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs = admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err = admissionHandler.Admit(context.TODO(), attrs, nil)
+					err = admissionHandler.Admit(ctx, attrs, nil)
 
 					Expect(err).To(Not(HaveOccurred()))
 
@@ -529,7 +531,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -542,7 +544,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -558,7 +560,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					err := admissionHandler.Admit(ctx, attrs, nil)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
@@ -594,7 +596,7 @@ var _ = Describe("dns", func() {
 				shoot.Spec.SeedName = &destinationSeedName
 				attrs := admission.NewAttributesRecord(&shoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				err := admissionHandler.Admit(ctx, attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -215,9 +215,7 @@ var _ = Describe("dns", func() {
 
 			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(ctx, attrs, nil)
-
-			Expect(err).NotTo(HaveOccurred())
+			Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			Expect(*shootCopy).To(Equal(*shootBefore))
 		})
 
@@ -228,9 +226,7 @@ var _ = Describe("dns", func() {
 
 			attrs := admission.NewAttributesRecord(shootCopy, shootCopy, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(ctx, attrs, nil)
-
-			Expect(err).NotTo(HaveOccurred())
+			Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			Expect(*shootCopy).To(Equal(*shootBefore))
 		})
 
@@ -241,9 +237,7 @@ var _ = Describe("dns", func() {
 			Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 			attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-			err := admissionHandler.Admit(ctx, attrs, nil)
-
-			Expect(err).NotTo(HaveOccurred())
+			Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			Expect(shoot).To(Equal(*shootBefore))
 		})
 
@@ -268,9 +262,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
 				Expect(shoot.Spec.DNS.Providers).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
 					"Type":    Equal(ptr.To(providerType)),
@@ -301,9 +293,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
 				Expect(shoot.Spec.DNS.Providers).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -350,9 +340,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
 				Expect(shoot.Spec.DNS.Providers).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -392,9 +380,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, "overwrite.example.com")))
 			})
@@ -405,9 +391,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domain)))
 			})
@@ -420,9 +404,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domainHigherPriority)))
 			})
@@ -434,9 +416,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domain)))
 			})
@@ -458,9 +438,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domain)))
 				Expect(shoot.Spec.DNS.Providers).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
 					"Type":           Equal(ptr.To(providerType)),
@@ -478,9 +456,7 @@ var _ = Describe("dns", func() {
 				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 				Expect(shoot.Spec.DNS.Providers).To(BeNil())
 				Expect(*shoot.Spec.DNS.Domain).To(Equal(shootDomain))
 			})
@@ -491,7 +467,6 @@ var _ = Describe("dns", func() {
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
 				err := admissionHandler.Admit(ctx, attrs, nil)
-
 				Expect(err).To(MatchError(error(apierrors.NewInternalError(fmt.Errorf("Project.core.gardener.cloud %q not found", "<unknown>")))))
 			})
 
@@ -509,18 +484,14 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(ctx, attrs, nil)
-					Expect(err).To(Not(HaveOccurred()))
+					Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 
 					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
 					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs = admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err = admissionHandler.Admit(ctx, attrs, nil)
-
-					Expect(err).To(Not(HaveOccurred()))
-
+					Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 					Expect(*shoot.Spec.DNS.Domain).NotTo(Equal(*shootCopy.Spec.DNS.Domain))
 				})
 
@@ -531,9 +502,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(ctx, attrs, nil)
-
-					Expect(err).NotTo(HaveOccurred())
+					Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
 					Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shoot.Name, projectName, domain)))
 				})
@@ -544,9 +513,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(ctx, attrs, nil)
-
-					Expect(err).NotTo(HaveOccurred())
+					Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
 					Expect(*shoot.Spec.DNS.Domain).To(HaveSuffix(fmt.Sprintf(".%s.%s", projectName, domain)))
 				})
@@ -560,9 +527,7 @@ var _ = Describe("dns", func() {
 					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(ctx, attrs, nil)
-
-					Expect(err).NotTo(HaveOccurred())
+					Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 					Expect(shoot.Spec.DNS.Providers).To(BeNil())
 					Expect(*shoot.Spec.DNS.Domain).To(HaveSuffix(fmt.Sprintf(".%s.%s", projectName, domain)))
 				})
@@ -596,8 +561,7 @@ var _ = Describe("dns", func() {
 				shoot.Spec.SeedName = &destinationSeedName
 				attrs := admission.NewAttributesRecord(&shoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-				err := admissionHandler.Admit(ctx, attrs, nil)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(admissionHandler.Admit(ctx, attrs, nil)).To(Succeed())
 			})
 		})
 	})

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -817,4 +817,8 @@ var _ = Describe("dns", func() {
 			})
 		})
 	})
+
+	Describe("#Validate", func() {
+
+	})
 })

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -29,6 +29,17 @@ import (
 	. "github.com/gardener/gardener/plugin/pkg/shoot/dns"
 )
 
+const (
+	namespace   = "my-namespace"
+	projectName = "my-project"
+	seedName    = "my-seed"
+	shootName   = "shoot"
+
+	domain               = "example.com"
+	domainHigherPriority = "higher.example.com"
+	domainLowerPriority  = "lower.example.com"
+)
+
 var _ = Describe("dns", func() {
 
 	Describe("#Admit", func() {
@@ -40,15 +51,6 @@ var _ = Describe("dns", func() {
 			seed  gardencorev1beta1.Seed
 			shoot core.Shoot
 
-			namespace   = "my-namespace"
-			projectName = "my-project"
-			seedName    = "my-seed"
-			shootName   = "shoot"
-
-			domain               = "example.com"
-			domainHigherPriority = "higher.example.com"
-			domainLowerPriority  = "lower.example.com"
-
 			provider = core.DNSUnmanaged
 
 			project = gardencorev1beta1.Project{
@@ -56,7 +58,7 @@ var _ = Describe("dns", func() {
 					Name: projectName,
 				},
 				Spec: gardencorev1beta1.ProjectSpec{
-					Namespace: &namespace,
+					Namespace: ptr.To(namespace),
 				},
 			}
 
@@ -118,7 +120,7 @@ var _ = Describe("dns", func() {
 				},
 				Spec: core.ShootSpec{
 					DNS:      &core.DNS{},
-					SeedName: &seedName,
+					SeedName: ptr.To(seedName),
 				},
 			}
 		)

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -493,16 +493,6 @@ var _ = Describe("dns", func() {
 				Expect(err).To(MatchError(error(apierrors.NewInternalError(fmt.Errorf("Project.core.gardener.cloud %q not found", "<unknown>")))))
 			})
 
-			It("should reject because no domain was configured for the shoot and default domain secret is missing", func() {
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).To(BeInvalidError())
-			})
-
 			Context("#Shoot GenerateName used", func() {
 				BeforeEach(func() {
 					shoot.Name = ""


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/13618

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13618

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The mutating `ShootDNS` admission plugin is now also a validating one. Validations which are executed by this admission plugin during the mutation phase are now moved to the validating `ShootDNS` admission plugin.
```

