### PR TITLE
Tolerate certain leftovers during shoot cleanup

### DIFF
--- a/docs/usage/advanced/shoot_cleanup.md
+++ b/docs/usage/advanced/shoot_cleanup.md
@@ -26,3 +26,8 @@ It is possible to override the finalization grace periods via annotations on the
 
 ⚠️ If `"0"` is provided, then all resources are finalized immediately without waiting for any graceful deletion.
 Please be aware that this might lead to orphaned infrastructure artifacts.
+
+In some cases, even with the described cleanup logic, shoot deletion may still become stuck due to remaining resources in the shoot cluster.
+To address this, Gardener ignores any remaining resources in the following situations:
+- Objects that belong to namespaces which have already been deleted (finalized).
+- Objects that were created after the cleanup process began for the first time, plus the finalize grace period.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -736,6 +736,9 @@ const (
 	// Kubernetes resources' step. Concretely, after the specified seconds, all the finalizers of the affected resources
 	// are forcefully removed.
 	AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds"
+	// AnnotationShootCleanupKubernetesResourcesStartTime is a key for an annotation on a shoot Namespace
+	// that records the start time of the 'cleanup Kubernetes resources' step.
+	AnnotationShootCleanupKubernetesResourcesStartTime = "shoot.gardener.cloud/cleanup-kubernetes-resources-start-time"
 	// AnnotationShootCloudConfigExecutionMaxDelaySeconds is a key for an annotation on a Shoot resource that declares
 	// the maximum delay in seconds when potentially updated cloud-config user data is executed on the worker nodes.
 	// Concretely, the gardener-node-agent systemd service running on all worker nodes will wait

--- a/pkg/gardenlet/operation/botanist/controlplane.go
+++ b/pkg/gardenlet/operation/botanist/controlplane.go
@@ -104,7 +104,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 			// Note: if custom csi-drivers are installed in the cluster (controllers running on the shoot itself), the VolumeAttachments will
 			// probably not be finalized, because the controller pods are drained like all the other pods, so we still need to cleanup
 			// VolumeAttachments of those csi-drivers.
-			if err := CleanVolumeAttachments(ctxWithTimeOut, b.ShootClientSet.Client()); err != nil {
+			if err := CleanVolumeAttachments(ctxWithTimeOut, b.Logger, b.ShootClientSet.Client()); err != nil {
 				return err
 			}
 		}

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -163,7 +163,8 @@ func (cl *cleaner) doClean(ctx context.Context, c client.Client, obj client.Obje
 		}
 
 		if hasFinalizers {
-			return cl.finalizer.Finalize(ctx, c, obj)
+			// Ignore NotFound errors which might happen if the object or its namespace got deleted in the meantime.
+			return client.IgnoreNotFound(cl.finalizer.Finalize(ctx, c, obj))
 		}
 	}
 

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -492,7 +493,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().Get(ctx, cm1Key, &cm1).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-			Expect(EnsureGone(ctx, c, &cm1)).To(Succeed())
+			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
 		})
 
 		It("should ensure that the object is gone when no match error occurs", func() {
@@ -500,7 +501,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().Get(ctx, cm1Key, &cm1).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
 
-			Expect(EnsureGone(ctx, c, &cm1)).To(Succeed())
+			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone", func() {
@@ -511,7 +512,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().List(ctx, &list)
 
-			Expect(EnsureGone(ctx, c, &list)).To(Succeed())
+			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone when not found error occurs", func() {
@@ -522,7 +523,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().List(ctx, &list).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-			Expect(EnsureGone(ctx, c, &list)).To(Succeed())
+			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone when no match error occurs", func() {
@@ -533,7 +534,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().List(ctx, &list).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
 
-			Expect(EnsureGone(ctx, c, &list)).To(Succeed())
+			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
 		})
 
 		It("should error that the object is still present", func() {
@@ -541,7 +542,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().Get(ctx, cm1Key, &cm1)
 
-			Expect(EnsureGone(ctx, c, &cm1)).To(Equal(NewObjectsRemaining(&cm1)))
+			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Equal(NewObjectsRemaining(&cm1)))
 		})
 
 		It("should ensure that the object is ignored", func() {
@@ -549,9 +550,9 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().Get(ctx, cm1Key, &cm1)
 
-			Expect(EnsureGone(ctx, c, &cm1, &CleanOptions{
+			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1, &CleanOptions{
 				IgnoreLeftovers: []IgnoreLeftoverFunc{
-					func(obj client.Object) bool {
+					func(_ logr.Logger, _ client.Object) bool {
 						return true
 					},
 				},
@@ -566,7 +567,7 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
 
-			Expect(EnsureGone(ctx, c, &list)).To(Equal(NewObjectsRemaining(&cmList)))
+			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Equal(NewObjectsRemaining(&cmList)))
 		})
 
 		It("should ensure objects in list are ignored", func() {
@@ -577,9 +578,9 @@ var _ = Describe("Cleaner", func() {
 
 			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
 
-			Expect(EnsureGone(ctx, c, &list, &CleanOptions{
+			Expect(EnsureGone(ctx, logr.Discard(), c, &list, &CleanOptions{
 				IgnoreLeftovers: []IgnoreLeftoverFunc{
-					func(obj client.Object) bool {
+					func(_ logr.Logger, _ client.Object) bool {
 						return true
 					},
 				},
@@ -605,10 +606,10 @@ var _ = Describe("Cleaner", func() {
 
 				gomock.InOrder(
 					cleaner.EXPECT().Clean(ctx, c, &cm1),
-					ensurer.EXPECT().EnsureGone(ctx, c, &cm1),
+					ensurer.EXPECT().EnsureGone(ctx, logr.Discard(), c, &cm1),
 				)
 
-				Expect(o.CleanAndEnsureGone(ctx, c, &cm1)).To(Succeed())
+				Expect(o.CleanAndEnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -544,6 +544,20 @@ var _ = Describe("Cleaner", func() {
 			Expect(EnsureGone(ctx, c, &cm1)).To(Equal(NewObjectsRemaining(&cm1)))
 		})
 
+		It("should ensure that the object is ignored", func() {
+			ctx := context.TODO()
+
+			c.EXPECT().Get(ctx, cm1Key, &cm1)
+
+			Expect(EnsureGone(ctx, c, &cm1, &CleanOptions{
+				IgnoreLeftovers: []IgnoreLeftoverFunc{
+					func(obj client.Object) bool {
+						return true
+					},
+				},
+			})).To(Succeed())
+		})
+
 		It("should error that the list is non-empty", func() {
 			var (
 				ctx  = context.TODO()
@@ -553,6 +567,23 @@ var _ = Describe("Cleaner", func() {
 			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
 
 			Expect(EnsureGone(ctx, c, &list)).To(Equal(NewObjectsRemaining(&cmList)))
+		})
+
+		It("should ensure objects in list are ignored", func() {
+			var (
+				ctx  = context.TODO()
+				list = corev1.ConfigMapList{}
+			)
+
+			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
+
+			Expect(EnsureGone(ctx, c, &list, &CleanOptions{
+				IgnoreLeftovers: []IgnoreLeftoverFunc{
+					func(obj client.Object) bool {
+						return true
+					},
+				},
+			})).To(Succeed())
 		})
 	})
 

--- a/pkg/utils/kubernetes/client/mock/mocks.go
+++ b/pkg/utils/kubernetes/client/mock/mocks.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	client "github.com/gardener/gardener/pkg/utils/kubernetes/client"
+	logr "github.com/go-logr/logr"
 	gomock "go.uber.org/mock/gomock"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	client0 "sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,9 +88,9 @@ func (m *MockGoneEnsurer) EXPECT() *MockGoneEnsurerMockRecorder {
 }
 
 // EnsureGone mocks base method.
-func (m *MockGoneEnsurer) EnsureGone(ctx context.Context, c client0.Client, obj runtime.Object, opts ...client.CleanOption) error {
+func (m *MockGoneEnsurer) EnsureGone(ctx context.Context, log logr.Logger, c client0.Client, obj runtime.Object, opts ...client.CleanOption) error {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, c, obj}
+	varargs := []any{ctx, log, c, obj}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -99,8 +100,8 @@ func (m *MockGoneEnsurer) EnsureGone(ctx context.Context, c client0.Client, obj 
 }
 
 // EnsureGone indicates an expected call of EnsureGone.
-func (mr *MockGoneEnsurerMockRecorder) EnsureGone(ctx, c, obj any, opts ...any) *gomock.Call {
+func (mr *MockGoneEnsurerMockRecorder) EnsureGone(ctx, log, c, obj any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, c, obj}, opts...)
+	varargs := append([]any{ctx, log, c, obj}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureGone", reflect.TypeOf((*MockGoneEnsurer)(nil).EnsureGone), varargs...)
 }

--- a/pkg/utils/kubernetes/client/mock/mocks.go
+++ b/pkg/utils/kubernetes/client/mock/mocks.go
@@ -87,7 +87,7 @@ func (m *MockGoneEnsurer) EXPECT() *MockGoneEnsurerMockRecorder {
 }
 
 // EnsureGone mocks base method.
-func (m *MockGoneEnsurer) EnsureGone(ctx context.Context, c client0.Client, obj runtime.Object, opts ...client0.ListOption) error {
+func (m *MockGoneEnsurer) EnsureGone(ctx context.Context, c client0.Client, obj runtime.Object, opts ...client.CleanOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, c, obj}
 	for _, a := range opts {

--- a/pkg/utils/kubernetes/client/options.go
+++ b/pkg/utils/kubernetes/client/options.go
@@ -5,6 +5,7 @@
 package client
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -88,7 +89,15 @@ func (s FinalizeGracePeriodSeconds) ApplyToClean(opts *CleanOptions) {
 // TolerateErrors uses the given toleration funcs for a clean operation.
 type TolerateErrors []TolerateErrorFunc
 
-// ApplyToClean specifies a errors to be tolerated for a clean operation.
+// ApplyToClean specifies errors to be tolerated for a clean operation.
 func (m TolerateErrors) ApplyToClean(opts *CleanOptions) {
 	opts.ErrorToleration = append(opts.ErrorToleration, m...)
+}
+
+// IgnoreUnknownNamespaces returns an IgnoreLeftoverFunc that ignores objects in unknown namespaces.
+func IgnoreUnknownNamespaces(namespaces []string) IgnoreLeftoverFunc {
+	namespaceSet := sets.New(namespaces...)
+	return func(obj client.Object) bool {
+		return obj.GetNamespace() != "" && !namespaceSet.Has(obj.GetNamespace())
+	}
 }

--- a/pkg/utils/kubernetes/client/options.go
+++ b/pkg/utils/kubernetes/client/options.go
@@ -13,8 +13,11 @@ type CleanOption interface {
 	ApplyToClean(*CleanOptions)
 }
 
-// TolerateErrorFunc is a function for tolerating errors.
+// TolerateErrorFunc is a function type for tolerating errors.
 type TolerateErrorFunc func(err error) bool
+
+// IgnoreLeftoverFunc is a function type for ignoring objects that remain in the cluster.
+type IgnoreLeftoverFunc func(obj client.Object) bool
 
 // CleanOptions are options to clean certain resources.
 // If FinalizeGracePeriodSeconds is set, the finalizers of the resources are removed if the resources still
@@ -24,6 +27,7 @@ type CleanOptions struct {
 	DeleteOptions              []client.DeleteOption
 	FinalizeGracePeriodSeconds *int64
 	ErrorToleration            []TolerateErrorFunc
+	IgnoreLeftovers            []IgnoreLeftoverFunc
 }
 
 var _ CleanOption = &CleanOptions{}
@@ -41,6 +45,9 @@ func (o *CleanOptions) ApplyToClean(co *CleanOptions) {
 	}
 	if o.ErrorToleration != nil {
 		co.ErrorToleration = o.ErrorToleration
+	}
+	if o.IgnoreLeftovers != nil {
+		co.IgnoreLeftovers = o.IgnoreLeftovers
 	}
 }
 

--- a/pkg/utils/kubernetes/client/options.go
+++ b/pkg/utils/kubernetes/client/options.go
@@ -5,6 +5,8 @@
 package client
 
 import (
+	"time"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,5 +106,16 @@ func IgnoreUnknownNamespaces(namespaces []string) IgnoreLeftoverFunc {
 			log.Info("Ignoring leftover object in unknown namespace", "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
 		}
 		return ignore
+	}
+}
+
+// IgnoreObjectsCreatedAfter returns an IgnoreLeftoverFunc that ignores objects created after the given time.
+func IgnoreObjectsCreatedAfter(timeStamp time.Time) IgnoreLeftoverFunc {
+	return func(log logr.Logger, obj client.Object) bool {
+		if obj.GetCreationTimestamp().After(timeStamp) {
+			log.Info("Ignoring leftover object created after cleanup start time", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind, "creationTimestamp", obj.GetCreationTimestamp(), "cleanupStartTime", timeStamp.Format(time.RFC3339))
+			return true
+		}
+		return false
 	}
 }

--- a/pkg/utils/kubernetes/client/options_test.go
+++ b/pkg/utils/kubernetes/client/options_test.go
@@ -7,64 +7,81 @@ package client_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 )
 
-var _ = Describe("CleanOptions", func() {
-	It("should allow setting ListWith", func() {
-		co := &CleanOptions{}
-		ListWith{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}.ApplyToClean(co)
-		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
-	})
-
-	It("should allow setting DeleteWith", func() {
-		co := &CleanOptions{}
-		DeleteWith{client.GracePeriodSeconds(42), client.DryRunAll}.ApplyToClean(co)
-		Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
-	})
-
-	It("should allow setting FinalizeGracePeriodSeconds", func() {
-		co := &CleanOptions{}
-		FinalizeGracePeriodSeconds(42).ApplyToClean(co)
-		gp := int64(42)
-		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
-	})
-
-	It("should allow setting ErrorToleration", func() {
-		co := &CleanOptions{}
-		TolerateErrors{apierrors.IsConflict}.ApplyToClean(co)
-		Expect(co.ErrorToleration).To(HaveLen(1))
-	})
-
-	It("should allow setting CleanOptions", func() {
-		co := &CleanOptions{}
-		(&CleanOptions{
-			ListOptions:                []client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}},
-			DeleteOptions:              []client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll},
-			FinalizeGracePeriodSeconds: ptr.To[int64](42),
-			ErrorToleration:            []TolerateErrorFunc{apierrors.IsConflict},
-			IgnoreLeftovers:            []IgnoreLeftoverFunc{func(obj client.Object) bool { return false }},
-		}).ApplyToClean(co)
-		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
-		Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
-		gp := int64(42)
-		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
-		Expect(co.ErrorToleration).To(HaveLen(1))
-		Expect(co.IgnoreLeftovers).To(HaveLen(1))
-	})
-
-	It("should merge multiple options together", func() {
-		gp := int64(7)
-		co := &CleanOptions{}
-		co.ApplyOptions([]CleanOption{
-			ListWith{client.InNamespace("ns")},
-			FinalizeGracePeriodSeconds(gp),
+var _ = Describe("Options", func() {
+	Describe("#CleanOptions", func() {
+		It("should allow setting ListWith", func() {
+			co := &CleanOptions{}
+			ListWith{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}.ApplyToClean(co)
+			Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
 		})
-		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns")}))
-		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
+
+		It("should allow setting DeleteWith", func() {
+			co := &CleanOptions{}
+			DeleteWith{client.GracePeriodSeconds(42), client.DryRunAll}.ApplyToClean(co)
+			Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
+		})
+
+		It("should allow setting FinalizeGracePeriodSeconds", func() {
+			co := &CleanOptions{}
+			FinalizeGracePeriodSeconds(42).ApplyToClean(co)
+			gp := int64(42)
+			Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
+		})
+
+		It("should allow setting ErrorToleration", func() {
+			co := &CleanOptions{}
+			TolerateErrors{apierrors.IsConflict}.ApplyToClean(co)
+			Expect(co.ErrorToleration).To(HaveLen(1))
+		})
+
+		It("should allow setting CleanOptions", func() {
+			co := &CleanOptions{}
+			(&CleanOptions{
+				ListOptions:                []client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}},
+				DeleteOptions:              []client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll},
+				FinalizeGracePeriodSeconds: ptr.To[int64](42),
+				ErrorToleration:            []TolerateErrorFunc{apierrors.IsConflict},
+				IgnoreLeftovers:            []IgnoreLeftoverFunc{func(obj client.Object) bool { return false }},
+			}).ApplyToClean(co)
+			Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
+			Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
+			gp := int64(42)
+			Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
+			Expect(co.ErrorToleration).To(HaveLen(1))
+			Expect(co.IgnoreLeftovers).To(HaveLen(1))
+		})
+
+		It("should merge multiple options together", func() {
+			gp := int64(7)
+			co := &CleanOptions{}
+			co.ApplyOptions([]CleanOption{
+				ListWith{client.InNamespace("ns")},
+				FinalizeGracePeriodSeconds(gp),
+			})
+			Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns")}))
+			Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
+		})
+	})
+
+	Describe("#IgnoreUnknownNamespaces", func() {
+		It("should ignore objects in unknown namespaces", func() {
+			namespaces := []string{"test1", "test2"}
+
+			ignore := IgnoreUnknownNamespaces(namespaces)
+
+			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test1"}})).To(BeFalse())
+			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test2"}})).To(BeFalse())
+			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ""}})).To(BeFalse())
+			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test3"}})).To(BeTrue())
+		})
 	})
 })

--- a/pkg/utils/kubernetes/client/options_test.go
+++ b/pkg/utils/kubernetes/client/options_test.go
@@ -47,12 +47,14 @@ var _ = Describe("CleanOptions", func() {
 			DeleteOptions:              []client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll},
 			FinalizeGracePeriodSeconds: ptr.To[int64](42),
 			ErrorToleration:            []TolerateErrorFunc{apierrors.IsConflict},
+			IgnoreLeftovers:            []IgnoreLeftoverFunc{func(obj client.Object) bool { return false }},
 		}).ApplyToClean(co)
 		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
 		Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
 		gp := int64(42)
 		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
 		Expect(co.ErrorToleration).To(HaveLen(1))
+		Expect(co.IgnoreLeftovers).To(HaveLen(1))
 	})
 
 	It("should merge multiple options together", func() {

--- a/pkg/utils/kubernetes/client/options_test.go
+++ b/pkg/utils/kubernetes/client/options_test.go
@@ -5,6 +5,7 @@
 package client_test
 
 import (
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -50,7 +51,7 @@ var _ = Describe("Options", func() {
 				DeleteOptions:              []client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll},
 				FinalizeGracePeriodSeconds: ptr.To[int64](42),
 				ErrorToleration:            []TolerateErrorFunc{apierrors.IsConflict},
-				IgnoreLeftovers:            []IgnoreLeftoverFunc{func(obj client.Object) bool { return false }},
+				IgnoreLeftovers:            []IgnoreLeftoverFunc{func(_ logr.Logger, _ client.Object) bool { return false }},
 			}).ApplyToClean(co)
 			Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
 			Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
@@ -78,10 +79,10 @@ var _ = Describe("Options", func() {
 
 			ignore := IgnoreUnknownNamespaces(namespaces)
 
-			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test1"}})).To(BeFalse())
-			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test2"}})).To(BeFalse())
-			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ""}})).To(BeFalse())
-			Expect(ignore(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test3"}})).To(BeTrue())
+			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test1"}})).To(BeFalse())
+			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test2"}})).To(BeFalse())
+			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ""}})).To(BeFalse())
+			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test3"}})).To(BeTrue())
 		})
 	})
 })

--- a/pkg/utils/kubernetes/client/types.go
+++ b/pkg/utils/kubernetes/client/types.go
@@ -7,6 +7,7 @@ package client
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,14 +33,14 @@ type Cleaner interface {
 type GoneEnsurer interface {
 	// EnsureGone ensures that the given resource is gone. If the resource is not gone, it will throw
 	// a NewObjectsRemaining error.
-	EnsureGone(ctx context.Context, c client.Client, obj runtime.Object, opts ...CleanOption) error
+	EnsureGone(ctx context.Context, log logr.Logger, c client.Client, obj runtime.Object, opts ...CleanOption) error
 }
 
 // GoneEnsurerFunc is a function that implements GoneEnsurer.
-type GoneEnsurerFunc func(ctx context.Context, c client.Client, obj runtime.Object, opts ...CleanOption) error
+type GoneEnsurerFunc func(ctx context.Context, log logr.Logger, c client.Client, obj runtime.Object, opts ...CleanOption) error
 
 // CleanOps are ops to clean.
 type CleanOps interface {
 	// CleanAndEnsureGone cleans the resource(s) and ensures that it/they are gone afterwards.
-	CleanAndEnsureGone(ctx context.Context, c client.Client, obj runtime.Object, opts ...CleanOption) error
+	CleanAndEnsureGone(ctx context.Context, log logr.Logger, c client.Client, obj runtime.Object, opts ...CleanOption) error
 }

--- a/pkg/utils/kubernetes/client/types.go
+++ b/pkg/utils/kubernetes/client/types.go
@@ -32,11 +32,11 @@ type Cleaner interface {
 type GoneEnsurer interface {
 	// EnsureGone ensures that the given resource is gone. If the resource is not gone, it will throw
 	// a NewObjectsRemaining error.
-	EnsureGone(ctx context.Context, c client.Client, obj runtime.Object, opts ...client.ListOption) error
+	EnsureGone(ctx context.Context, c client.Client, obj runtime.Object, opts ...CleanOption) error
 }
 
 // GoneEnsurerFunc is a function that implements GoneEnsurer.
-type GoneEnsurerFunc func(ctx context.Context, c client.Client, obj runtime.Object, opts ...client.ListOption) error
+type GoneEnsurerFunc func(ctx context.Context, c client.Client, obj runtime.Object, opts ...CleanOption) error
 
 // CleanOps are ops to clean.
 type CleanOps interface {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the shoot deletion flow to tolerate resource leftovers in the following situations:
- Objects that belong to namespaces which have already been deleted (finalized).
- Objects that were created after the cleanup process began for the first time, plus the finalize grace period.

`Gardenlet` logs the remaining but tolerated objects during shoot deletion, so operators can review them retrospectively.

**Which issue(s) this PR fixes**:
Fixes #13847

**Special notes for your reviewer**:
I consider this PR as an enhancement rather than a bug fix. Shoot deletion and resource cleanup have functioned as intended, but this update extends support to scenarios reported by users and operators (see #13847)

In particular, the situation where objects remain in deleted namespaces is exceptional and should be treated as such. Namespaces have special deletion protection, and users should not bypass this.

/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The shoot deletion flow has been enhanced to tolerate leftover resources in the following situations:
- Objects that belong to namespaces which have already been deleted (finalized).
- Objects that were created after the cleanup process began for the first time, plus the finalize grace period.
```
