### PR TITLE
nit: align calls of `export_resource_yamls_for` for `Garden` resource

### DIFF
--- a/hack/ci-e2e-kind-ha-multi-node.sh
+++ b/hack/ci-e2e-kind-ha-multi-node.sh
@@ -20,7 +20,7 @@ make kind-multi-node-up
 
 # export all container logs and events after test execution
 trap "
-  ( export KUBECONFIG=$PWD/example/gardener-local/kind/multi-zone/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for gardens extop)
+  ( export KUBECONFIG=$PWD/example/gardener-local/kind/multi-zone/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden extop)
   ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig; export cluster_name='virtual-garden'; export_resource_yamls_for seeds shoots; export_events_for_shoots)
   ( make kind-multi-node-down )
 " EXIT


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
This PR aligns the calls to `export_resource_yamls_for` for `Garden` resources to use the singular.

For all other occasions, except this one, the singular was used.
As this argument is also used as a file name, let's align this.

https://github.com/gardener/gardener/blob/7d0b1a60584955172100e0548ecb63e24e3e8399/hack/ci-e2e-kind-gardenadm.sh#L19
https://github.com/gardener/gardener/blob/ead07a0f481e36633dc9fe3320b40af5868915dc/hack/ci-e2e-kind-ha-multi-node.sh#L23
https://github.com/gardener/gardener/blob/7d0b1a60584955172100e0548ecb63e24e3e8399/hack/ci-e2e-kind-ha-multi-zone.sh#L22
https://github.com/gardener/gardener/blob/7d0b1a60584955172100e0548ecb63e24e3e8399/hack/ci-e2e-kind-migration-ha-multi-node.sh#L23
https://github.com/gardener/gardener/blob/7d0b1a60584955172100e0548ecb63e24e3e8399/hack/ci-e2e-kind-operator.sh#L22

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
> [!NOTE]
> Another option would be to rename everything to the plural, as the other resources are also generally called through the plural.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
