### PR TITLE
[GEP-28] `gardenadm bootstrap`: pass all overrides to `gardenadm init`

### DIFF
--- a/dev-setup/gardenadm/resources/imagevector-overwrite-components.yaml
+++ b/dev-setup/gardenadm/resources/imagevector-overwrite-components.yaml
@@ -1,0 +1,9 @@
+# We don't make use of this image vector overwrite in our dev setup, but this serves as an example file in e2e tests
+# for verifying that `gardenadm bootstrap` correctly passes on the image vector overwrite for components to
+# `gardenadm init on the control plane machine.
+components:
+- name: etcd-druid
+  imageVectorOverwrite: |
+    images:
+    - name: not-used
+      repository: registry.local.gardener.cloud:5001/not-used

--- a/dev-setup/gardenadm/resources/imagevector-overwrite-components.yaml
+++ b/dev-setup/gardenadm/resources/imagevector-overwrite-components.yaml
@@ -1,6 +1,6 @@
 # We don't make use of this image vector overwrite in our dev setup, but this serves as an example file in e2e tests
 # for verifying that `gardenadm bootstrap` correctly passes on the image vector overwrite for components to
-# `gardenadm init on the control plane machine.
+# `gardenadm init` on the control plane machine.
 components:
 - name: etcd-druid
   imageVectorOverwrite: |

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,11 +67,17 @@ func (b *GardenadmBotanist) SSHConnection() *sshutils.Connection {
 }
 
 var (
+	// envToOverrideFile maps ImageVector overwrite environment variables to their corresponding remote file paths on
+	// the control plane machine. If the environment variable is set locally, the file is copied to the remote path
+	// and WithImageVectorOverwriteEnvMap configures the remote commands to use the respective file.
 	// NB: We don't use filepath.Join here, because we explicitly need Linux path separators for the target machine,
 	// even when running `gardenadm bootstrap` on Windows.
+	envToOverrideFile = map[string]string{
+		imagevector.OverrideEnv:          GardenadmBaseDir + "/imagevector-overwrite.yaml",
+		imagevector.ComponentOverrideEnv: GardenadmBaseDir + "/imagevector-overwrite-components.yaml",
+		imagevector.OverrideChartsEnv:    GardenadmBaseDir + "/imagevector-overwrite-charts.yaml",
+	}
 
-	// ImageVectorOverrideFile is the path where the image vector overwrite is copied to on the control plane machine.
-	ImageVectorOverrideFile = GardenadmBaseDir + "/imagevector-overwrite.yaml"
 	// ManifestsDir is the path where the manifests are copied to on the control plane machine.
 	ManifestsDir = GardenadmBaseDir + "/manifests"
 
@@ -93,7 +100,7 @@ func (b *GardenadmBotanist) CopyManifests(ctx context.Context, configDir fs.FS) 
 		return fmt.Errorf("error copying manifests: %w", err)
 	}
 
-	if err := copyImageVectorOverride(ctx, b.sshConnection); err != nil {
+	if err := copyImageVectorOverrides(ctx, b.sshConnection); err != nil {
 		return err
 	}
 
@@ -112,24 +119,31 @@ func prepareRemoteDirs(ctx context.Context, conn *sshutils.Connection) error {
 	return nil
 }
 
-func copyImageVectorOverride(ctx context.Context, conn *sshutils.Connection) (err error) {
-	imageVectorOverride := os.Getenv(imagevector.OverrideEnv)
-	if imageVectorOverride == "" {
-		return nil
-	}
-
-	file, err := os.Open(imageVectorOverride) // #nosec: G304 -- ImageVectorOverwrite is a feature.
-	if err != nil {
-		return fmt.Errorf("error opening image vector overwrite file: %w", err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			err = errors.Join(err, closeErr)
+func copyImageVectorOverrides(ctx context.Context, conn *sshutils.Connection) error {
+	for env, remotePath := range envToOverrideFile {
+		localPath := os.Getenv(env)
+		if localPath == "" {
+			continue
 		}
-	}()
 
-	if err := conn.CopyFile(ctx, ImageVectorOverrideFile, manifestFilePermissions, file); err != nil {
-		return fmt.Errorf("error copying image vector overwrite file: %w", err)
+		if err := func() (rErr error) {
+			localFile, err := os.Open(localPath) // #nosec: G304 -- ImageVectorOverwrite is a feature.
+			if err != nil {
+				return fmt.Errorf("error opening %s file: %w", env, err)
+			}
+			defer func() {
+				if closeErr := localFile.Close(); closeErr != nil {
+					rErr = errors.Join(rErr, closeErr)
+				}
+			}()
+
+			if err := conn.CopyFile(ctx, remotePath, manifestFilePermissions, localFile); err != nil {
+				return fmt.Errorf("error copying %s file: %w", env, err)
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -154,4 +168,20 @@ func (b *GardenadmBotanist) copyShootState(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// ImageVectorOverrideEnv returns the image vector overwrite environment variables for remote commands based on the
+// existence in the local environment in a key=value string format. The pairs are separated by spaces, values are
+// quoted, and a trailing space is added for convenience, so that the output can be directly prepended to remote
+// commands.
+func ImageVectorOverrideEnv() string {
+	out := strings.Builder{}
+
+	for env, filePath := range envToOverrideFile {
+		if os.Getenv(env) != "" {
+			out.WriteString(fmt.Sprintf("%s=%q ", env, filePath))
+		}
+	}
+
+	return out.String()
 }

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -69,7 +69,7 @@ func (b *GardenadmBotanist) SSHConnection() *sshutils.Connection {
 var (
 	// envToOverrideFile maps ImageVector overwrite environment variables to their corresponding remote file paths on
 	// the control plane machine. If the environment variable is set locally, the file is copied to the remote path
-	// and WithImageVectorOverwriteEnvMap configures the remote commands to use the respective file.
+	// and ImageVectorOverrideEnv configures the remote commands to use the respective file.
 	// NB: We don't use filepath.Join here, because we explicitly need Linux path separators for the target machine,
 	// even when running `gardenadm bootstrap` on Windows.
 	envToOverrideFile = map[string]string{

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -23,13 +23,13 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/nodeinit"
 	seedsystem "github.com/gardener/gardener/pkg/component/seed/system"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
-	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/publicip"
 )
 
@@ -293,8 +293,9 @@ func run(ctx context.Context, opts *Options) error {
 			Name: "Bootstrapping control plane on the first control plane machine",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return b.SSHConnection().RunWithStreams(ctx, nil, opts.Out, opts.ErrOut,
-					fmt.Sprintf("%s=%q /opt/bin/gardenadm init -d %q --log-level=%s",
-						imagevector.OverrideEnv, botanist.ImageVectorOverrideFile, botanist.ManifestsDir, opts.LogLevel,
+					fmt.Sprintf("%s%s init -d %q --log-level=%s",
+						botanist.ImageVectorOverrideEnv(),
+						nodeinit.GardenadmBinaryPath, botanist.ManifestsDir, opts.LogLevel,
 					),
 				)
 			}).Timeout(30 * time.Minute),

--- a/test/e2e/gardenadm/managedinfra/exec.go
+++ b/test/e2e/gardenadm/managedinfra/exec.go
@@ -44,6 +44,8 @@ func NewCommand(args ...string) *exec.Cmd { // #nosec G204 -- Used for e2e tests
 	cmd.Env = append(cmd.Env,
 		clientcmd.RecommendedConfigPathEnvVar+"=../../../example/gardener-local/kind/multi-zone/kubeconfig",
 		imagevector.OverrideEnv+"=../../../dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml",
+		imagevector.ComponentOverrideEnv+"=../../../dev-setup/gardenadm/resources/imagevector-overwrite-components.yaml",
+		imagevector.OverrideChartsEnv+"=../../../dev-setup/gardenadm/resources/generated/.imagevector-overwrite-charts.yaml",
 	)
 	return cmd
 }

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -174,9 +174,11 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 			Eventually(ctx, session.Err).Should(gbytes.Say("Copying manifests to the first control plane machine"))
 
 			for file, content := range map[string]string{
-				"manifests/shootstate.yaml":  "apiVersion: core.gardener.cloud/v1beta1\nkind: ShootState\n",
-				"manifests/manifests.yaml":   "apiVersion: core.gardener.cloud/v1beta1\nkind: Shoot\n",
-				"imagevector-overwrite.yaml": "registry.local.gardener.cloud:5001/local-skaffold_gardenadm",
+				"manifests/shootstate.yaml":             "apiVersion: core.gardener.cloud/v1beta1\nkind: ShootState\n",
+				"manifests/manifests.yaml":              "apiVersion: core.gardener.cloud/v1beta1\nkind: Shoot\n",
+				"imagevector-overwrite.yaml":            "registry.local.gardener.cloud:5001/local-skaffold_gardenadm",
+				"imagevector-overwrite-components.yaml": "registry.local.gardener.cloud:5001/not-used",
+				"imagevector-overwrite-charts.yaml":     "registry.local.gardener.cloud:5001/local-skaffold_gardenlet_chart",
 			} {
 				Eventually(ctx, func(g Gomega) *gbytes.Buffer {
 					stdOut, _, err := RunInMachine(ctx, technicalID, 0, "cat", "/var/lib/gardenadm/"+file)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:

When `gardenadm bootstrap` executes `gardenadm init` on the control plane machine, it now copies all overrides specified locally (images, charts, components) to the remote machine and sets the env vars accordingly.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
