### PR TITLE
[WIP] Improve stability of `gardenadm` e2e test

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -212,7 +212,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			mgr, err := manager.New(restOpts.Completed().Config, mgrOpts.Completed().Options())
+			// TODO(tobschli): See if this removes the flake of grm not getting ready because extension is CLPing.
+			restConfig := restOpts.Completed().Config
+			restConfig.QPS = 10
+			restConfig.Burst = 20
+
+			mgr, err := manager.New(restConfig, mgrOpts.Completed().Options())
 			if err != nil {
 				return fmt.Errorf("could not instantiate manager: %w", err)
 			}

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -214,8 +214,8 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 			// TODO(tobschli): See if this removes the flake of grm not getting ready because extension is CLPing.
 			restConfig := restOpts.Completed().Config
-			restConfig.QPS = 10
-			restConfig.Burst = 20
+			restConfig.QPS = 100
+			restConfig.Burst = 200
 
 			mgr, err := manager.New(restConfig, mgrOpts.Completed().Options())
 			if err != nil {

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -29,6 +29,8 @@ case "$COMMAND" in
     if [[ "$SCENARIO" != "connect" ]]; then
       # Prepare resources and generate manifests.
       # The manifests are copied to the unmanaged-infra machine pods or can be passed to the `--config-dir` flag of `gardenadm bootstrap`.
+      exec 3>&1
+
       skaffold build \
         -p "$SCENARIO" \
         -m gardenadm,provider-local-node,provider-local \

--- a/dev-setup/gardenadm/resources/generate-imagevector-overwrite.sh
+++ b/dev-setup/gardenadm/resources/generate-imagevector-overwrite.sh
@@ -13,6 +13,8 @@ image_name="$1"
 patch_file="$dir/${2:-.imagevector-overwrite.yaml}"
 ref="$SKAFFOLD_IMAGE"
 
+echo "DEBUG: Updating imagevector overwrite patch file '$patch_file' (pwd: $(pwd) with image '$image_name' and ref '$ref'">&3
+
 if [[ ! -f "$patch_file" ]]; then
   cat <<EOF > "$patch_file"
 images: []

--- a/dev-setup/get-skaffold-cache-artifacts.sh
+++ b/dev-setup/get-skaffold-cache-artifacts.sh
@@ -46,7 +46,7 @@ git_abbrev_commit_sha=$(git rev-parse --short=10 HEAD)
 for patch_file in "${patch_files[@]}"; do
   # Check if the patch file contains the expected version pattern: `<Gardener version>-<Git commit abbreviated SHA>` -> e.g. `v1.113.0-dev-215797c884`.
   # The gardenadm image references use an unpredictable, full 64 character hash, e.g. `v1.120.0-dev-d31a82d927f943360a385ea5d646bb61ddf6996183ebbe3a614a800556934dbc`.
-  if ! grep -q -E "(tag: |ref: .+)$gardener_version-($git_abbrev_commit_sha|[a-z0-9]{64}$)" "$patch_file"; then
+  if [[ ! -f "$patch_file" ]] || ! grep -q -E "(tag: |ref: .+)$gardener_version-($git_abbrev_commit_sha|[a-z0-9]{64}$)" "$patch_file"; then
     # The patch file does not exist or does not contain the expected version pattern.
     # Skaffold should not cache artifacts.
     echo "false"

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -368,7 +368,7 @@ func run(ctx context.Context, opts *Options) error {
 		})
 		deployWorker = g.Add(flow.Task{
 			Name:         "Deploying shoot worker pools",
-			Fn:           b.DeployWorker,
+			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(time.Second, time.Minute),
 			SkipIf:       !b.Shoot.HasManagedInfrastructure(),
 			Dependencies: flow.NewTaskIDs(deployMachineControllerManager),
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind flake

**What this PR does / why we need it**:

For `gardenadm`, the `patch_files` are generated by `skaffold build`. 
So the first time `make` will always exit with error `1`, because `grep` cannot find the file.

**Which issue(s) this PR fixes**:
Part of #12624

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
