### PR TITLE
controlplane chart: Fix gardener-apiserver values for topology-aware routing

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
@@ -30,10 +30,10 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.global.apiserver.securePort | default 8443 }}
-  {{- if and .Values.global.admission.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.global.apiserver.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
-  {{- if and .Values.global.admission.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.global.apiserver.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferSameZone
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area high-availability
/kind bug

**What this PR does / why we need it**:
Currently the gardener-apiserver Service in the controlplane chart uses values for the gardener-admission-controller Service (`.Values.global.apiserver.service.topologyAwareRouting.enabled`) to decide if the topology-aware routing is enabled or not.
The gardener-apiserver value (`.Values.global.apiserver.service.topologyAwareRouting.enabled`) should be used instead.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/12883

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
