### PR TITLE
Fix unnecessary reconciliations of project activity reconciler due to cache resyncs

### DIFF
--- a/pkg/controllermanager/controller/project/activity/add.go
+++ b/pkg/controllermanager/controller/project/activity/add.go
@@ -77,8 +77,8 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Complete(r)
 }
 
-// OnlyNewlyCreatedObjects filters for objects which are created less than an hour ago for create events. This can be
-// used to prevent unnecessary reconciliations in case of controller restarts.
+// OnlyNewlyCreatedObjects filters for objects which are created less than an hour ago for create events and update events where the resource version
+// has changed. This can be used to prevent unnecessary reconciliations in case of controller restarts or cache resyncs.
 func (r *Reconciler) OnlyNewlyCreatedObjects() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -88,6 +88,9 @@ func (r *Reconciler) OnlyNewlyCreatedObjects() predicate.Predicate {
 			}
 
 			return r.Clock.Now().UTC().Sub(objMeta.GetCreationTimestamp().UTC()) <= time.Hour
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},
 	}
 }

--- a/pkg/controllermanager/controller/project/activity/add_test.go
+++ b/pkg/controllermanager/controller/project/activity/add_test.go
@@ -92,8 +92,15 @@ var _ = Describe("Add", func() {
 		})
 
 		Describe("#Update", func() {
-			It("should return true", func() {
-				Expect(p.Update(event.UpdateEvent{})).To(BeTrue())
+			It("should return false if resourceVersion has not changed (cache resync)", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secretSecretBindingRef, ObjectNew: secretSecretBindingRef})).To(BeFalse())
+			})
+
+			It("should return true if resourceVersion has changed", func() {
+				newSecretSecretBindingRef := secretSecretBindingRef.DeepCopy()
+				newSecretSecretBindingRef.ResourceVersion = "new-resource-version"
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secretSecretBindingRef, ObjectNew: newSecretSecretBindingRef})).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/project/activity/add_test.go
+++ b/pkg/controllermanager/controller/project/activity/add_test.go
@@ -56,11 +56,11 @@ var _ = Describe("Add", func() {
 		}
 	})
 
-	Describe("OnlyNewlyCreatedObjects", func() {
+	Describe("OnlyRelevantCreatesAndUpdates", func() {
 		var p predicate.Predicate
 
 		BeforeEach(func() {
-			p = reconciler.OnlyNewlyCreatedObjects()
+			p = reconciler.OnlyRelevantCreatesAndUpdates()
 		})
 
 		Describe("#Create", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area user-management
/kind bug

**What this PR does / why we need it**:
During cache resyncs, the reconciler receives update events for all existing resources, this was causing unnecessary reconcilations if some secret is present in the project with referred label. This was stopping the stale reconciler from marking the project as stale because the `lastActivityTimestamp` gets updated every 10h (default cache sync period in controller-runtime) or so.
This PR fixes this issue by ignoring update events where the `resourceVersion` has not changed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Credits to @acumino for finding out the bug

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing unwanted reconciliations of Secrets and other objects due to cache resyncs in the project activity reconciler is now fixed.
```
