### PR TITLE
[GEP-34] Skip Collector Deployment if Seed is Garden

### DIFF
--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -24,6 +24,7 @@ func NewOpenTelemetryCollector(
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
 	clusterType component.ClusterType,
+	isGardenCluster bool,
 ) (
 	deployer collector.Interface,
 	err error,
@@ -50,6 +51,7 @@ func NewOpenTelemetryCollector(
 			SecretNameServerCA:      secretNameServerCA,
 			PriorityClassName:       priorityClassName,
 			ClusterType:             clusterType,
+			IsGardenCluster:         isGardenCluster,
 		},
 		secretsManager,
 	), nil

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -140,10 +140,6 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name: "Destroying aggregate Prometheus",
 			Fn:   c.aggregatePrometheus.Destroy,
 		})
-		destroyOpenTelemetryCollector = g.Add(flow.Task{
-			Name: "Destroying OpenTelemetry Collector",
-			Fn:   component.OpDestroyAndWait(c.openTelemetryCollector).Destroy,
-		})
 		destroyAlertManager = g.Add(flow.Task{
 			Name: "Destroying AlertManager",
 			Fn:   c.alertManager.Destroy,
@@ -203,6 +199,11 @@ func (r *Reconciler) runDeleteSeedFlow(
 		destroyPrometheusOperator = g.Add(flow.Task{
 			Name:   "Destroy Prometheus Operator",
 			Fn:     component.OpDestroyAndWait(c.prometheusOperator).Destroy,
+			SkipIf: seedIsGarden,
+		})
+		destroyOpenTelemetryCollector = g.Add(flow.Task{
+			Name:   "Destroying OpenTelemetry Collector",
+			Fn:     component.OpDestroyAndWait(c.openTelemetryCollector).Destroy,
 			SkipIf: seedIsGarden,
 		})
 		destroyOpenTelemetryOperator = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -430,6 +430,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name:         "Deploying OpenTelemetry Collector",
 			Fn:           c.openTelemetryCollector.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
+			SkipIf:       seedIsGarden,
 		})
 		deployFluentOperator = g.Add(flow.Task{
 			Name:         "Deploying Fluent Operator",

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -151,6 +151,7 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane100,
 			ValiHost:                b.ComputeValiHost(),
 			ClusterType:             component.ClusterTypeShoot,
+			IsGardenCluster:         false,
 		},
 		b.SecretsManager,
 	), nil

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1574,6 +1574,7 @@ func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Int
 		secretsManager,
 		operatorv1alpha1.SecretNameCARuntime,
 		component.ClusterTypeSeed,
+		true,
 	)
 }
 

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -702,7 +702,6 @@ var _ = Describe("Seed controller tests", func() {
 					"prometheus-aggregate",
 					"kube-state-metrics-seed",
 					"referenced-resources-" + seedName,
-					"opentelemetry-collector",
 				}
 
 				if !seedIsGarden {
@@ -718,6 +717,7 @@ var _ = Describe("Seed controller tests", func() {
 						"prometheus-operator",
 						"perses-operator",
 						"opentelemetry-operator",
+						"opentelemetry-collector",
 					)
 				} else {
 					expectedManagedResources = append(expectedManagedResources,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
This is a quick fix to an issue that @plkokanov noticed in the [previous PR](https://github.com/gardener/gardener/pull/13481#pullrequestreview-3740169375)
Additionally, it fixes some issues with the labels of the service monitors.
**Which issue(s) this PR fixes**:
NONE
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
