### PR TITLE
Make node CIDR mask size configurable for IPv6

### DIFF
--- a/charts/gardener/operator/templates/crd-gardens.yaml
+++ b/charts/gardener/operator/templates/crd-gardens.yaml
@@ -1957,6 +1957,12 @@ spec:
                               immutable.
                             format: int32
                             type: integer
+                          nodeCIDRMaskSizeIPv6:
+                            description: NodeCIDRMaskSizeIPv6 defines the mask size
+                              for node cidr in cluster (default is 64). This field
+                              is immutable.
+                            format: int32
+                            type: integer
                           nodeMonitorGracePeriod:
                             description: NodeMonitorGracePeriod defines the grace
                               period before an unresponsive node is marked unhealthy.

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -7302,18 +7302,6 @@ int32
 </tr>
 <tr>
 <td>
-<code>nodeCIDRMaskSizeIPv6</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>podEvictionTimeout</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
@@ -7346,6 +7334,18 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeCIDRMaskSizeIPv6</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -7302,6 +7302,18 @@ int32
 </tr>
 <tr>
 <td>
+<code>nodeCIDRMaskSizeIPv6</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>podEvictionTimeout</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -260,6 +260,7 @@ spec:
   #       memory: 3Gi
   # kubeControllerManager:
   #   nodeCIDRMaskSize: 24
+  #   nodeCIDRMaskSizeIPv6: 80
   #   podEvictionTimeout: 2m0s # This field is no-op and is forbidden to be set starting from Kubernetes 1.33
   #   nodeMonitorGracePeriod: 40s
   #   featureGates:

--- a/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_gardens.yaml
@@ -1957,6 +1957,12 @@ spec:
                               immutable.
                             format: int32
                             type: integer
+                          nodeCIDRMaskSizeIPv6:
+                            description: NodeCIDRMaskSizeIPv6 defines the mask size
+                              for node cidr in cluster (default is 64). This field
+                              is immutable.
+                            format: int32
+                            type: integer
                           nodeMonitorGracePeriod:
                             description: NodeMonitorGracePeriod defines the grace
                               period before an unresponsive node is marked unhealthy.

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -771,7 +771,10 @@ func validateKubeControllerManagerUpdate(newConfig, oldConfig *core.KubeControll
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(nodeCIDRMaskNew, nodeCIDRMaskOld, fldPath.Child("nodeCIDRMaskSize"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(nodeCIDRMaskIPv6New, nodeCIDRMaskIPv6Old, fldPath.Child("nodeCIDRMaskSizeIPv6"))...)
+	// allow nodeCIDRMaskSizeIPv6 to be added if it was not set before for migration to dual-stack.
+	if nodeCIDRMaskIPv6Old != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(nodeCIDRMaskIPv6New, nodeCIDRMaskIPv6Old, fldPath.Child("nodeCIDRMaskSizeIPv6"))...)
+	}
 
 	return allErrs
 }

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1920,14 +1920,13 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 		}
 
 		if maskSize := kcm.NodeCIDRMaskSize; maskSize != nil && networking != nil {
-			if core.IsIPv4SingleStack(networking.IPFamilies) && !core.IsIPv6SingleStack(networking.IPFamilies) {
+			if core.IsIPv6SingleStack(networking.IPFamilies) {
+				if *maskSize < 64 || *maskSize > 124 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 64 and 128 for IPv6 single-stack clusters"))
+				}
+			} else if core.IsIPv4SingleStack(networking.IPFamilies) {
 				if *maskSize < 16 || *maskSize > 28 {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 16 and 28"))
-				}
-			}
-			if core.IsIPv6SingleStack(networking.IPFamilies) {
-				if *maskSize < 64 || *maskSize > 128 {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 64 and 128 for IPv6 single-stack clusters"))
 				}
 			}
 		}
@@ -1935,7 +1934,7 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 		if maskSize := kcm.NodeCIDRMaskSizeIPv6; maskSize != nil && networking != nil {
 			if core.IsIPv4SingleStack(networking.IPFamilies) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("nodeCIDRMaskSizeIPv6"), "nodeCIDRMaskSizeIPv6 cannot be set for IPv4 single-stack clusters"))
-			} else if *maskSize < 64 || *maskSize > 128 {
+			} else if *maskSize < 64 || *maskSize > 124 {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSizeIPv6"), *maskSize, "nodeCIDRMaskSizeIPv6 must be between 64 and 128"))
 			}
 		}

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1922,7 +1922,7 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 		if maskSize := kcm.NodeCIDRMaskSize; maskSize != nil && networking != nil {
 			if core.IsIPv6SingleStack(networking.IPFamilies) {
 				if *maskSize < 64 || *maskSize > 124 {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 64 and 128 for IPv6 single-stack clusters"))
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSize"), *maskSize, "nodeCIDRMaskSize must be between 64 and 124 for IPv6 single-stack clusters"))
 				}
 			} else if core.IsIPv4SingleStack(networking.IPFamilies) {
 				if *maskSize < 16 || *maskSize > 28 {
@@ -1935,7 +1935,7 @@ func ValidateKubeControllerManager(kcm *core.KubeControllerManagerConfig, networ
 			if core.IsIPv4SingleStack(networking.IPFamilies) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("nodeCIDRMaskSizeIPv6"), "nodeCIDRMaskSizeIPv6 cannot be set for IPv4 single-stack clusters"))
 			} else if *maskSize < 64 || *maskSize > 124 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSizeIPv6"), *maskSize, "nodeCIDRMaskSizeIPv6 must be between 64 and 128"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeCIDRMaskSizeIPv6"), *maskSize, "nodeCIDRMaskSizeIPv6 must be between 64 and 124"))
 			}
 		}
 

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -3677,7 +3677,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			It("should prevent setting the pod eviction timeout for kubernetes versions >= 1.33", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig = nil
-				// shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = nil
 				shoot.Spec.Kubernetes.KubeControllerManager.PodEvictionTimeout = &metav1.Duration{Duration: time.Minute}
 				shoot.Spec.Kubernetes.Version = "1.33.0"
 
@@ -4922,7 +4921,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			It("should forbid specifying unsupported IP family", func() {
-				// shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = nil
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{"IPv5"}
 
 				errorList := ValidateShoot(shoot)

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -3703,7 +3703,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSizeIPv6"),
-						"Detail": ContainSubstring("nodeCIDRMaskSizeIPv6 must be between 64 and 128"),
+						"Detail": ContainSubstring("nodeCIDRMaskSizeIPv6 must be between 64 and 124"),
 					}))))
 				})
 
@@ -3714,7 +3714,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSizeIPv6"),
-						"Detail": ContainSubstring("nodeCIDRMaskSizeIPv6 must be between 64 and 128"),
+						"Detail": ContainSubstring("nodeCIDRMaskSizeIPv6 must be between 64 and 124"),
 					}))))
 				})
 
@@ -3751,7 +3751,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-							"Detail": ContainSubstring("nodeCIDRMaskSize must be between 64 and 128"),
+							"Detail": ContainSubstring("nodeCIDRMaskSize must be between 64 and 124"),
 						})),
 						PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeForbidden),

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -965,6 +965,9 @@ type KubeControllerManagerConfig struct {
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig
 	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	NodeCIDRMaskSize *int32
+	// NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
+	NodeCIDRMaskSizeIPv6 *int32
+
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes.
 	//
 	// Deprecated: The corresponding kube-controller-manager flag `--pod-eviction-timeout` is deprecated

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Shoot defaulting", func() {
 
 					It("should default both NodeCIDRMaskSize and NodeCIDRMaskSizeIPv6", func() {
 						SetObjectDefaults_Shoot(obj)
-						Expect(obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Not(BeNil()))
+						Expect(obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(PointTo(Equal(int32(24))))
 						Expect(obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSizeIPv6).To(PointTo(Equal(int32(64))))
 					})
 				})

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -5481,7 +5481,7 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 	if m.NodeCIDRMaskSizeIPv6 != nil {
 		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSizeIPv6))
 		i--
-		dAtA[i] = 0x38
+		dAtA[i] = 0x30
 	}
 	if m.NodeMonitorGracePeriod != nil {
 		{
@@ -5493,7 +5493,7 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 			i = encodeVarintGenerated(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x32
+		dAtA[i] = 0x2a
 	}
 	if m.PodEvictionTimeout != nil {
 		{
@@ -5505,7 +5505,7 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 			i = encodeVarintGenerated(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x22
 	}
 	if m.NodeCIDRMaskSize != nil {
 		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSize))
@@ -36357,7 +36357,7 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.NodeCIDRMaskSize = &v
-		case 5:
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PodEvictionTimeout", wireType)
 			}
@@ -36393,7 +36393,7 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 6:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field NodeMonitorGracePeriod", wireType)
 			}
@@ -36429,7 +36429,7 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 7:
+		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field NodeCIDRMaskSizeIPv6", wireType)
 			}

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -5478,6 +5478,11 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 	_ = i
 	var l int
 	_ = l
+	if m.NodeCIDRMaskSizeIPv6 != nil {
+		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSizeIPv6))
+		i--
+		dAtA[i] = 0x38
+	}
 	if m.NodeMonitorGracePeriod != nil {
 		{
 			size, err := m.NodeMonitorGracePeriod.MarshalToSizedBuffer(dAtA[:i])
@@ -5501,11 +5506,6 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 		}
 		i--
 		dAtA[i] = 0x2a
-	}
-	if m.NodeCIDRMaskSizeIPv6 != nil {
-		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSizeIPv6))
-		i--
-		dAtA[i] = 0x20
 	}
 	if m.NodeCIDRMaskSize != nil {
 		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSize))
@@ -15427,9 +15427,6 @@ func (m *KubeControllerManagerConfig) Size() (n int) {
 	if m.NodeCIDRMaskSize != nil {
 		n += 1 + sovGenerated(uint64(*m.NodeCIDRMaskSize))
 	}
-	if m.NodeCIDRMaskSizeIPv6 != nil {
-		n += 1 + sovGenerated(uint64(*m.NodeCIDRMaskSizeIPv6))
-	}
 	if m.PodEvictionTimeout != nil {
 		l = m.PodEvictionTimeout.Size()
 		n += 1 + l + sovGenerated(uint64(l))
@@ -15437,6 +15434,9 @@ func (m *KubeControllerManagerConfig) Size() (n int) {
 	if m.NodeMonitorGracePeriod != nil {
 		l = m.NodeMonitorGracePeriod.Size()
 		n += 1 + l + sovGenerated(uint64(l))
+	}
+	if m.NodeCIDRMaskSizeIPv6 != nil {
+		n += 1 + sovGenerated(uint64(*m.NodeCIDRMaskSizeIPv6))
 	}
 	return n
 }
@@ -19733,9 +19733,9 @@ func (this *KubeControllerManagerConfig) String() string {
 		`KubernetesConfig:` + strings.Replace(strings.Replace(this.KubernetesConfig.String(), "KubernetesConfig", "KubernetesConfig", 1), `&`, ``, 1) + `,`,
 		`HorizontalPodAutoscalerConfig:` + strings.Replace(this.HorizontalPodAutoscalerConfig.String(), "HorizontalPodAutoscalerConfig", "HorizontalPodAutoscalerConfig", 1) + `,`,
 		`NodeCIDRMaskSize:` + valueToStringGenerated(this.NodeCIDRMaskSize) + `,`,
-		`NodeCIDRMaskSizeIPv6:` + valueToStringGenerated(this.NodeCIDRMaskSizeIPv6) + `,`,
 		`PodEvictionTimeout:` + strings.Replace(fmt.Sprintf("%v", this.PodEvictionTimeout), "Duration", "v11.Duration", 1) + `,`,
 		`NodeMonitorGracePeriod:` + strings.Replace(fmt.Sprintf("%v", this.NodeMonitorGracePeriod), "Duration", "v11.Duration", 1) + `,`,
+		`NodeCIDRMaskSizeIPv6:` + valueToStringGenerated(this.NodeCIDRMaskSizeIPv6) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -36357,26 +36357,6 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.NodeCIDRMaskSize = &v
-		case 4:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeCIDRMaskSizeIPv6", wireType)
-			}
-			var v int32
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowGenerated
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.NodeCIDRMaskSizeIPv6 = &v
 		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PodEvictionTimeout", wireType)
@@ -36449,6 +36429,26 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeCIDRMaskSizeIPv6", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NodeCIDRMaskSizeIPv6 = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -5488,7 +5488,7 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 			i = encodeVarintGenerated(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x32
 	}
 	if m.PodEvictionTimeout != nil {
 		{
@@ -5500,7 +5500,12 @@ func (m *KubeControllerManagerConfig) MarshalToSizedBuffer(dAtA []byte) (int, er
 			i = encodeVarintGenerated(dAtA, i, uint64(size))
 		}
 		i--
-		dAtA[i] = 0x22
+		dAtA[i] = 0x2a
+	}
+	if m.NodeCIDRMaskSizeIPv6 != nil {
+		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSizeIPv6))
+		i--
+		dAtA[i] = 0x20
 	}
 	if m.NodeCIDRMaskSize != nil {
 		i = encodeVarintGenerated(dAtA, i, uint64(*m.NodeCIDRMaskSize))
@@ -15422,6 +15427,9 @@ func (m *KubeControllerManagerConfig) Size() (n int) {
 	if m.NodeCIDRMaskSize != nil {
 		n += 1 + sovGenerated(uint64(*m.NodeCIDRMaskSize))
 	}
+	if m.NodeCIDRMaskSizeIPv6 != nil {
+		n += 1 + sovGenerated(uint64(*m.NodeCIDRMaskSizeIPv6))
+	}
 	if m.PodEvictionTimeout != nil {
 		l = m.PodEvictionTimeout.Size()
 		n += 1 + l + sovGenerated(uint64(l))
@@ -19725,6 +19733,7 @@ func (this *KubeControllerManagerConfig) String() string {
 		`KubernetesConfig:` + strings.Replace(strings.Replace(this.KubernetesConfig.String(), "KubernetesConfig", "KubernetesConfig", 1), `&`, ``, 1) + `,`,
 		`HorizontalPodAutoscalerConfig:` + strings.Replace(this.HorizontalPodAutoscalerConfig.String(), "HorizontalPodAutoscalerConfig", "HorizontalPodAutoscalerConfig", 1) + `,`,
 		`NodeCIDRMaskSize:` + valueToStringGenerated(this.NodeCIDRMaskSize) + `,`,
+		`NodeCIDRMaskSizeIPv6:` + valueToStringGenerated(this.NodeCIDRMaskSizeIPv6) + `,`,
 		`PodEvictionTimeout:` + strings.Replace(fmt.Sprintf("%v", this.PodEvictionTimeout), "Duration", "v11.Duration", 1) + `,`,
 		`NodeMonitorGracePeriod:` + strings.Replace(fmt.Sprintf("%v", this.NodeMonitorGracePeriod), "Duration", "v11.Duration", 1) + `,`,
 		`}`,
@@ -36349,6 +36358,26 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 			}
 			m.NodeCIDRMaskSize = &v
 		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeCIDRMaskSizeIPv6", wireType)
+			}
+			var v int32
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NodeCIDRMaskSizeIPv6 = &v
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field PodEvictionTimeout", wireType)
 			}
@@ -36384,7 +36413,7 @@ func (m *KubeControllerManagerConfig) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field NodeMonitorGracePeriod", wireType)
 			}

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1549,6 +1549,10 @@ message KubeControllerManagerConfig {
   // +optional
   optional int32 nodeCIDRMaskSize = 3;
 
+  // NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
+  // +optional
+  optional int32 nodeCIDRMaskSizeIPv6 = 4;
+
   // PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
   // +optional
   //
@@ -1560,11 +1564,11 @@ message KubeControllerManagerConfig {
   // `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting
   // from Kubernetes 1.33.
   // TODO(plkokanov): Drop this field after support for Kubernetes 1.32 is dropped.
-  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration podEvictionTimeout = 4;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration podEvictionTimeout = 5;
 
   // NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
   // +optional
-  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeMonitorGracePeriod = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeMonitorGracePeriod = 6;
 }
 
 // KubeProxyConfig contains configuration settings for the kube-proxy.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1549,10 +1549,6 @@ message KubeControllerManagerConfig {
   // +optional
   optional int32 nodeCIDRMaskSize = 3;
 
-  // NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
-  // +optional
-  optional int32 nodeCIDRMaskSizeIPv6 = 4;
-
   // PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
   // +optional
   //
@@ -1569,6 +1565,10 @@ message KubeControllerManagerConfig {
   // NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeMonitorGracePeriod = 6;
+
+  // NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
+  // +optional
+  optional int32 nodeCIDRMaskSizeIPv6 = 7;
 }
 
 // KubeProxyConfig contains configuration settings for the kube-proxy.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1560,15 +1560,15 @@ message KubeControllerManagerConfig {
   // `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting
   // from Kubernetes 1.33.
   // TODO(plkokanov): Drop this field after support for Kubernetes 1.32 is dropped.
-  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration podEvictionTimeout = 5;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration podEvictionTimeout = 4;
 
   // NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
   // +optional
-  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeMonitorGracePeriod = 6;
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeMonitorGracePeriod = 5;
 
   // NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
   // +optional
-  optional int32 nodeCIDRMaskSizeIPv6 = 7;
+  optional int32 nodeCIDRMaskSizeIPv6 = 6;
 }
 
 // KubeProxyConfig contains configuration settings for the kube-proxy.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1267,13 +1267,13 @@ type KubeControllerManagerConfig struct {
 	// `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting
 	// from Kubernetes 1.33.
 	// TODO(plkokanov): Drop this field after support for Kubernetes 1.32 is dropped.
-	PodEvictionTimeout *metav1.Duration `json:"podEvictionTimeout,omitempty" protobuf:"bytes,5,opt,name=podEvictionTimeout"`
+	PodEvictionTimeout *metav1.Duration `json:"podEvictionTimeout,omitempty" protobuf:"bytes,4,opt,name=podEvictionTimeout"`
 	// NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
 	// +optional
-	NodeMonitorGracePeriod *metav1.Duration `json:"nodeMonitorGracePeriod,omitempty" protobuf:"bytes,6,opt,name=nodeMonitorGracePeriod"`
+	NodeMonitorGracePeriod *metav1.Duration `json:"nodeMonitorGracePeriod,omitempty" protobuf:"bytes,5,opt,name=nodeMonitorGracePeriod"`
 	// NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
 	// +optional
-	NodeCIDRMaskSizeIPv6 *int32 `json:"nodeCIDRMaskSizeIPv6,omitempty" protobuf:"varint,7,opt,name=nodeCIDRMaskSizeIPv6"`
+	NodeCIDRMaskSizeIPv6 *int32 `json:"nodeCIDRMaskSizeIPv6,omitempty" protobuf:"varint,6,opt,name=nodeCIDRMaskSizeIPv6"`
 }
 
 // HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1256,6 +1256,9 @@ type KubeControllerManagerConfig struct {
 	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	// +optional
 	NodeCIDRMaskSize *int32 `json:"nodeCIDRMaskSize,omitempty" protobuf:"varint,3,opt,name=nodeCIDRMaskSize"`
+	// NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
+	// +optional
+	NodeCIDRMaskSizeIPv6 *int32 `json:"nodeCIDRMaskSizeIPv6,omitempty" protobuf:"varint,4,opt,name=nodeCIDRMaskSizeIPv6"`
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
 	// +optional
 	//
@@ -1267,10 +1270,10 @@ type KubeControllerManagerConfig struct {
 	// `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting
 	// from Kubernetes 1.33.
 	// TODO(plkokanov): Drop this field after support for Kubernetes 1.32 is dropped.
-	PodEvictionTimeout *metav1.Duration `json:"podEvictionTimeout,omitempty" protobuf:"bytes,4,opt,name=podEvictionTimeout"`
+	PodEvictionTimeout *metav1.Duration `json:"podEvictionTimeout,omitempty" protobuf:"bytes,5,opt,name=podEvictionTimeout"`
 	// NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
 	// +optional
-	NodeMonitorGracePeriod *metav1.Duration `json:"nodeMonitorGracePeriod,omitempty" protobuf:"bytes,5,opt,name=nodeMonitorGracePeriod"`
+	NodeMonitorGracePeriod *metav1.Duration `json:"nodeMonitorGracePeriod,omitempty" protobuf:"bytes,6,opt,name=nodeMonitorGracePeriod"`
 }
 
 // HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1256,9 +1256,6 @@ type KubeControllerManagerConfig struct {
 	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	// +optional
 	NodeCIDRMaskSize *int32 `json:"nodeCIDRMaskSize,omitempty" protobuf:"varint,3,opt,name=nodeCIDRMaskSize"`
-	// NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
-	// +optional
-	NodeCIDRMaskSizeIPv6 *int32 `json:"nodeCIDRMaskSizeIPv6,omitempty" protobuf:"varint,4,opt,name=nodeCIDRMaskSizeIPv6"`
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
 	// +optional
 	//
@@ -1274,6 +1271,9 @@ type KubeControllerManagerConfig struct {
 	// NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.
 	// +optional
 	NodeMonitorGracePeriod *metav1.Duration `json:"nodeMonitorGracePeriod,omitempty" protobuf:"bytes,6,opt,name=nodeMonitorGracePeriod"`
+	// NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.
+	// +optional
+	NodeCIDRMaskSizeIPv6 *int32 `json:"nodeCIDRMaskSizeIPv6,omitempty" protobuf:"varint,7,opt,name=nodeCIDRMaskSizeIPv6"`
 }
 
 // HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -4558,9 +4558,9 @@ func autoConvert_v1beta1_KubeControllerManagerConfig_To_core_KubeControllerManag
 	}
 	out.HorizontalPodAutoscalerConfig = (*core.HorizontalPodAutoscalerConfig)(unsafe.Pointer(in.HorizontalPodAutoscalerConfig))
 	out.NodeCIDRMaskSize = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSize))
-	out.NodeCIDRMaskSizeIPv6 = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSizeIPv6))
 	out.PodEvictionTimeout = (*metav1.Duration)(unsafe.Pointer(in.PodEvictionTimeout))
 	out.NodeMonitorGracePeriod = (*metav1.Duration)(unsafe.Pointer(in.NodeMonitorGracePeriod))
+	out.NodeCIDRMaskSizeIPv6 = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSizeIPv6))
 	return nil
 }
 
@@ -4849,7 +4849,15 @@ func autoConvert_v1beta1_Kubernetes_To_core_Kubernetes(in *Kubernetes, out *core
 	} else {
 		out.KubeAPIServer = nil
 	}
-	out.KubeControllerManager = (*core.KubeControllerManagerConfig)(unsafe.Pointer(in.KubeControllerManager))
+	if in.KubeControllerManager != nil {
+		in, out := &in.KubeControllerManager, &out.KubeControllerManager
+		*out = new(core.KubeControllerManagerConfig)
+		if err := Convert_v1beta1_KubeControllerManagerConfig_To_core_KubeControllerManagerConfig(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.KubeControllerManager = nil
+	}
 	out.KubeScheduler = (*core.KubeSchedulerConfig)(unsafe.Pointer(in.KubeScheduler))
 	out.KubeProxy = (*core.KubeProxyConfig)(unsafe.Pointer(in.KubeProxy))
 	if in.Kubelet != nil {
@@ -4891,7 +4899,15 @@ func autoConvert_core_Kubernetes_To_v1beta1_Kubernetes(in *core.Kubernetes, out 
 	} else {
 		out.KubeAPIServer = nil
 	}
-	out.KubeControllerManager = (*KubeControllerManagerConfig)(unsafe.Pointer(in.KubeControllerManager))
+	if in.KubeControllerManager != nil {
+		in, out := &in.KubeControllerManager, &out.KubeControllerManager
+		*out = new(KubeControllerManagerConfig)
+		if err := Convert_core_KubeControllerManagerConfig_To_v1beta1_KubeControllerManagerConfig(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.KubeControllerManager = nil
+	}
 	out.KubeScheduler = (*KubeSchedulerConfig)(unsafe.Pointer(in.KubeScheduler))
 	out.KubeProxy = (*KubeProxyConfig)(unsafe.Pointer(in.KubeProxy))
 	if in.Kubelet != nil {

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -4558,6 +4558,7 @@ func autoConvert_v1beta1_KubeControllerManagerConfig_To_core_KubeControllerManag
 	}
 	out.HorizontalPodAutoscalerConfig = (*core.HorizontalPodAutoscalerConfig)(unsafe.Pointer(in.HorizontalPodAutoscalerConfig))
 	out.NodeCIDRMaskSize = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSize))
+	out.NodeCIDRMaskSizeIPv6 = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSizeIPv6))
 	out.PodEvictionTimeout = (*metav1.Duration)(unsafe.Pointer(in.PodEvictionTimeout))
 	out.NodeMonitorGracePeriod = (*metav1.Duration)(unsafe.Pointer(in.NodeMonitorGracePeriod))
 	return nil
@@ -4574,6 +4575,7 @@ func autoConvert_core_KubeControllerManagerConfig_To_v1beta1_KubeControllerManag
 	}
 	out.HorizontalPodAutoscalerConfig = (*HorizontalPodAutoscalerConfig)(unsafe.Pointer(in.HorizontalPodAutoscalerConfig))
 	out.NodeCIDRMaskSize = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSize))
+	out.NodeCIDRMaskSizeIPv6 = (*int32)(unsafe.Pointer(in.NodeCIDRMaskSizeIPv6))
 	out.PodEvictionTimeout = (*metav1.Duration)(unsafe.Pointer(in.PodEvictionTimeout))
 	out.NodeMonitorGracePeriod = (*metav1.Duration)(unsafe.Pointer(in.NodeMonitorGracePeriod))
 	return nil

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -2775,6 +2775,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NodeCIDRMaskSizeIPv6 != nil {
+		in, out := &in.NodeCIDRMaskSizeIPv6, &out.NodeCIDRMaskSizeIPv6
+		*out = new(int32)
+		**out = **in
+	}
 	if in.PodEvictionTimeout != nil {
 		in, out := &in.PodEvictionTimeout, &out.PodEvictionTimeout
 		*out = new(metav1.Duration)

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -2775,11 +2775,6 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
-	if in.NodeCIDRMaskSizeIPv6 != nil {
-		in, out := &in.NodeCIDRMaskSizeIPv6, &out.NodeCIDRMaskSizeIPv6
-		*out = new(int32)
-		**out = **in
-	}
 	if in.PodEvictionTimeout != nil {
 		in, out := &in.PodEvictionTimeout, &out.PodEvictionTimeout
 		*out = new(metav1.Duration)
@@ -2788,6 +2783,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 	if in.NodeMonitorGracePeriod != nil {
 		in, out := &in.NodeMonitorGracePeriod, &out.NodeMonitorGracePeriod
 		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.NodeCIDRMaskSizeIPv6 != nil {
+		in, out := &in.NodeCIDRMaskSizeIPv6, &out.NodeCIDRMaskSizeIPv6
+		*out = new(int32)
 		**out = **in
 	}
 	return

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -2775,6 +2775,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(int32)
 		**out = **in
 	}
+	if in.NodeCIDRMaskSizeIPv6 != nil {
+		in, out := &in.NodeCIDRMaskSizeIPv6, &out.NodeCIDRMaskSizeIPv6
+		*out = new(int32)
+		**out = **in
+	}
 	if in.PodEvictionTimeout != nil {
 		in, out := &in.PodEvictionTimeout, &out.PodEvictionTimeout
 		*out = new(metav1.Duration)

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5075,6 +5075,13 @@ func schema_pkg_apis_core_v1beta1_KubeControllerManagerConfig(ref common.Referen
 							Format:      "int32",
 						},
 					},
+					"nodeCIDRMaskSizeIPv6": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"podEvictionTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.\n\nDeprecated: The corresponding kube-controller-manager flag `--pod-eviction-timeout` is deprecated in favor of the kube-apiserver flags `--default-not-ready-toleration-seconds` and `--default-unreachable-toleration-seconds`. The `--pod-eviction-timeout` flag does not have effect when the taint based eviction is enabled. The taint based eviction is beta (enabled by default) since Kubernetes 1.13 and GA since Kubernetes 1.18. Hence, instead of setting this field, set the `spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting from Kubernetes 1.33.",

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -5075,13 +5075,6 @@ func schema_pkg_apis_core_v1beta1_KubeControllerManagerConfig(ref common.Referen
 							Format:      "int32",
 						},
 					},
-					"nodeCIDRMaskSizeIPv6": {
-						SchemaProps: spec.SchemaProps{
-							Description: "NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.",
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 					"podEvictionTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.\n\nDeprecated: The corresponding kube-controller-manager flag `--pod-eviction-timeout` is deprecated in favor of the kube-apiserver flags `--default-not-ready-toleration-seconds` and `--default-unreachable-toleration-seconds`. The `--pod-eviction-timeout` flag does not have effect when the taint based eviction is enabled. The taint based eviction is beta (enabled by default) since Kubernetes 1.13 and GA since Kubernetes 1.18. Hence, instead of setting this field, set the `spec.kubernetes.kubeAPIServer.defaultNotReadyTolerationSeconds` and `spec.kubernetes.kubeAPIServer.defaultUnreachableTolerationSeconds`. Setting this field is forbidden starting from Kubernetes 1.33.",
@@ -5092,6 +5085,13 @@ func schema_pkg_apis_core_v1beta1_KubeControllerManagerConfig(ref common.Referen
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeMonitorGracePeriod defines the grace period before an unresponsive node is marked unhealthy.",
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
+						},
+					},
+					"nodeCIDRMaskSizeIPv6": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeCIDRMaskSizeIPv6 defines the mask size for node cidr in cluster (default is 64). This field is immutable.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -677,12 +677,28 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 			nodeMonitorGracePeriod = *v
 		}
 
-		if k.values.Config.NodeCIDRMaskSize != nil {
-			if k.isDualStack() {
+		if k.isDualStack() {
+			// Dual-stack: use separate IPv4 and IPv6 flags
+			if k.values.Config.NodeCIDRMaskSize != nil {
 				command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv4=%d", *k.values.Config.NodeCIDRMaskSize))
-				command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", 64))
-			} else {
-				command = append(command, fmt.Sprintf("--node-cidr-mask-size=%d", *k.values.Config.NodeCIDRMaskSize))
+			}
+
+			ipv6MaskSize := int32(64) // default IPv6 mask size for dual-stack
+			if k.values.Config.NodeCIDRMaskSizeIPv6 != nil {
+				ipv6MaskSize = *k.values.Config.NodeCIDRMaskSizeIPv6
+			}
+			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", ipv6MaskSize))
+		} else {
+			// Single-stack: use generic flag (works for both IPv4 and IPv6)
+			var maskSize *int32
+			if k.values.Config.NodeCIDRMaskSize != nil {
+				maskSize = k.values.Config.NodeCIDRMaskSize
+			} else if k.values.Config.NodeCIDRMaskSizeIPv6 != nil {
+				maskSize = k.values.Config.NodeCIDRMaskSizeIPv6
+			}
+
+			if maskSize != nil {
+				command = append(command, fmt.Sprintf("--node-cidr-mask-size=%d", *maskSize))
 			}
 		}
 

--- a/pkg/component/kubernetes/controllermanager/controllermanager.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager.go
@@ -682,18 +682,16 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 			if k.values.Config.NodeCIDRMaskSize != nil {
 				command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv4=%d", *k.values.Config.NodeCIDRMaskSize))
 			}
-
-			ipv6MaskSize := int32(64) // default IPv6 mask size for dual-stack
 			if k.values.Config.NodeCIDRMaskSizeIPv6 != nil {
-				ipv6MaskSize = *k.values.Config.NodeCIDRMaskSizeIPv6
+				command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", *k.values.Config.NodeCIDRMaskSizeIPv6))
 			}
-			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", ipv6MaskSize))
 		} else {
 			// Single-stack: use generic flag (works for both IPv4 and IPv6)
 			var maskSize *int32
 			if k.values.Config.NodeCIDRMaskSize != nil {
 				maskSize = k.values.Config.NodeCIDRMaskSize
-			} else if k.values.Config.NodeCIDRMaskSizeIPv6 != nil {
+			}
+			if k.values.Config.NodeCIDRMaskSizeIPv6 != nil {
 				maskSize = k.values.Config.NodeCIDRMaskSizeIPv6
 			}
 

--- a/pkg/component/kubernetes/controllermanager/controllermanager_test.go
+++ b/pkg/component/kubernetes/controllermanager/controllermanager_test.go
@@ -1025,12 +1025,10 @@ func commandForKubernetesVersion(
 		if nodeCIDRMaskSize != nil {
 			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv4=%d", *nodeCIDRMaskSize))
 		}
-		// IPv6 flag is always added in dual-stack mode
-		ipv6MaskSize := int32(64) // default
+		// Only add IPv6 flag if explicitly set (dual-stack or IPv6 single-stack)
 		if nodeCIDRMaskSizeIPv6 != nil {
-			ipv6MaskSize = *nodeCIDRMaskSizeIPv6
+			command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", *nodeCIDRMaskSizeIPv6))
 		}
-		command = append(command, fmt.Sprintf("--node-cidr-mask-size-ipv6=%d", ipv6MaskSize))
 
 		command = append(command,
 			"--allocate-node-cidrs=true",

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -113,7 +113,7 @@ func (b *Botanist) CalculateMaxNodesForShootNetworks(shoot *gardencorev1beta1.Sh
 
 func (b *Botanist) calculateMaxNodesForPodsNetwork(shoot *gardencorev1beta1.Shoot) (int64, error) {
 	resultPerIPFamily := map[gardencorev1beta1.IPFamily]int64{}
-	isDualStack := !gardencorev1beta1.IsIPv4SingleStack(shoot.Spec.Networking.IPFamilies) && !gardencorev1beta1.IsIPv6SingleStack(shoot.Spec.Networking.IPFamilies)
+	isDualStack := gardencorev1beta1.IsDualStack(shoot.Spec.Networking.IPFamilies)
 
 	for _, podNetwork := range b.Shoot.Networks.Pods {
 		// In dual-stack scenarios, only consider IPv4


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for configuring the IPv6 node CIDR mask size separately from IPv4. Previously, the nodeCIDRMaskSize field only supported configuring IPv4, and IPv6 was hardcoded to 64 bits in dual-stack clusters.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added `nodeCIDRMaskSizeIPv6` field to `KubeControllerManagerConfig` to allow configuring the IPv6 node CIDR mask size (defaults to 64). This enables more flexible IPv6 network configurations in both dual-stack and IPv6-only clusters.
```
