### PR TITLE
[release-v1.134] Fix unnecessary reconciliations of project activity reconciler due to cache resyncs

### DIFF
--- a/pkg/controllermanager/controller/project/activity/add.go
+++ b/pkg/controllermanager/controller/project/activity/add.go
@@ -52,29 +52,30 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Watches(
 			&gardencorev1beta1.Shoot{},
 			handler.EnqueueRequestsFromMapFunc(r.MapObjectToProject(mgr.GetLogger().WithValues("controller", ControllerName))),
-			builder.WithPredicates(r.OnlyNewlyCreatedObjects(), predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(r.OnlyRelevantCreatesAndUpdates(), predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
 			&gardencorev1beta1.BackupEntry{},
 			handler.EnqueueRequestsFromMapFunc(r.MapObjectToProject(mgr.GetLogger().WithValues("controller", ControllerName))),
-			builder.WithPredicates(r.OnlyNewlyCreatedObjects(), predicate.GenerationChangedPredicate{}),
+			builder.WithPredicates(r.OnlyRelevantCreatesAndUpdates(), predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
 			&gardencorev1beta1.Quota{},
 			handler.EnqueueRequestsFromMapFunc(r.MapObjectToProject(mgr.GetLogger().WithValues("controller", ControllerName))),
-			builder.WithPredicates(r.OnlyNewlyCreatedObjects(), r.NeedsSecretOrCredentialsBindingReferenceLabelPredicate()),
+			builder.WithPredicates(r.OnlyRelevantCreatesAndUpdates(), r.NeedsSecretOrCredentialsBindingReferenceLabelPredicate()),
 		).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.MapObjectToProject(mgr.GetLogger().WithValues("controller", ControllerName))),
-			builder.WithPredicates(r.OnlyNewlyCreatedObjects(), r.NeedsSecretOrCredentialsBindingReferenceLabelPredicate()),
+			builder.WithPredicates(r.OnlyRelevantCreatesAndUpdates(), r.NeedsSecretOrCredentialsBindingReferenceLabelPredicate()),
 		).
 		Complete(r)
 }
 
-// OnlyNewlyCreatedObjects filters for objects which are created less than an hour ago for create events. This can be
-// used to prevent unnecessary reconciliations in case of controller restarts.
-func (r *Reconciler) OnlyNewlyCreatedObjects() predicate.Predicate {
+// OnlyRelevantCreatesAndUpdates returns a predicate that filters CREATE/UPDATE events:
+// - CREATE events: only pass if the object was created within the last hour. This helps to ignore stale create events for existing objects during controller restarts.
+// - UPDATE events: only pass if the resource version changed. This helps to ignore update events that do not change the object (e.g. periodic cache resyncs).
+func (r *Reconciler) OnlyRelevantCreatesAndUpdates() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			objMeta, err := meta.Accessor(e.Object)
@@ -83,6 +84,9 @@ func (r *Reconciler) OnlyNewlyCreatedObjects() predicate.Predicate {
 			}
 
 			return r.Clock.Now().UTC().Sub(objMeta.GetCreationTimestamp().UTC()) <= time.Hour
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
 		},
 	}
 }

--- a/pkg/controllermanager/controller/project/activity/add_test.go
+++ b/pkg/controllermanager/controller/project/activity/add_test.go
@@ -56,11 +56,11 @@ var _ = Describe("Add", func() {
 		}
 	})
 
-	Describe("OnlyNewlyCreatedObjects", func() {
+	Describe("OnlyRelevantCreatesAndUpdates", func() {
 		var p predicate.Predicate
 
 		BeforeEach(func() {
-			p = reconciler.OnlyNewlyCreatedObjects()
+			p = reconciler.OnlyRelevantCreatesAndUpdates()
 		})
 
 		Describe("#Create", func() {
@@ -92,8 +92,15 @@ var _ = Describe("Add", func() {
 		})
 
 		Describe("#Update", func() {
-			It("should return true", func() {
-				Expect(p.Update(event.UpdateEvent{})).To(BeTrue())
+			It("should return false if resourceVersion has not changed (cache resync)", func() {
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secretSecretBindingRef, ObjectNew: secretSecretBindingRef})).To(BeFalse())
+			})
+
+			It("should return true if resourceVersion has changed", func() {
+				newSecretSecretBindingRef := secretSecretBindingRef.DeepCopy()
+				newSecretSecretBindingRef.ResourceVersion = "new-resource-version"
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: secretSecretBindingRef, ObjectNew: newSecretSecretBindingRef})).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
This is a cherry-pick of https://github.com/gardener/gardener/pull/13945 on `release-v1.134`

```bugfix operator
An issue causing unwanted reconciliations of Secrets and other objects due to cache resyncs in the project activity reconciler is now fixed.
```
