### PR TITLE
docs: document generic token kubeconfig annotation for `Garden`

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -96,9 +96,12 @@ const (
 	// SecretNameGenericGardenKubeconfig is a constant for the name of the kubeconfig used by the extension
 	// components to authenticate against the garden Kubernetes API server.
 	SecretNameGenericGardenKubeconfig = "generic-garden-kubeconfig"
-	// AnnotationKeyGenericTokenKubeconfigSecretName is a constant for the key of an annotation on
-	// extensions.gardener.cloud/v1alpha1.Cluster resources whose value contains the name of the generic token
+
+	// AnnotationKeyGenericTokenKubeconfigSecretName is a constant for the key of an annotation on:
+	// - extensions.gardener.cloud/v1alpha1.Cluster resources whose value contains the name of the generic token
 	// kubeconfig secret in the seed cluster.
+	// - operator.gardener.cloud/v1alpha1.Garden resources whose value contains the name of the generic token
+	// kubeconfig secret in the garden cluster.
 	AnnotationKeyGenericTokenKubeconfigSecretName = "generic-token-kubeconfig.secret.gardener.cloud/name"
 
 	// ExtensionGardenServiceAccountPrefix is the prefix of the default garden ServiceAccount generated for each


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Enhance documentation for AnnotationKeyGenericTokenKubeconfigSecretName to clarify its usage in Cluster and Garden resources.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Identified via: https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/412#discussion_r2757915307

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
