### PR TITLE
Re-add `terminal-controller-manager` Go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gardener/dependency-watchdog v1.6.0
 	github.com/gardener/etcd-druid/api v0.35.0
 	github.com/gardener/machine-controller-manager v0.61.1
+	github.com/gardener/terminal-controller-manager v0.35.0
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-test/deep v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/gardener/etcd-druid/api v0.35.0 h1:Rr7HQbaQOgyMB5KB+fcckjF0snGWpHyWy0
 github.com/gardener/etcd-druid/api v0.35.0/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
 github.com/gardener/machine-controller-manager v0.61.1 h1:Aa7FsFC4AppZ0VWqpNWUKwT25yscO9/9TF4Vsw9Vauc=
 github.com/gardener/machine-controller-manager v0.61.1/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/gardener/terminal-controller-manager v0.35.0 h1:LccE3ZT8KCZtdfMtyVtHuFIXwFnnBpIKE68aoDpgJss=
+github.com/gardener/terminal-controller-manager v0.35.0/go.mod h1:GJKKMxXs8Cu84TdJYwQrXCK30YShOZHCOliouEHEGqc=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=

--- a/pkg/component/gardener/dashboard/terminal/assets/crd-dashboard.gardener.cloud_terminals.yaml
+++ b/pkg/component/gardener/dashboard/terminal/assets/crd-dashboard.gardener.cloud_terminals.yaml
@@ -172,7 +172,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This is an alpha field and requires enabling the
+                                  This field depends on the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.
@@ -398,7 +398,7 @@ spec:
                         description: ProjectMemberships defines the (temporary) project
                           memberships of the "access" service account. Each project
                           is updated by using the target.credential, hence the target
-                          has the be the (virtual) garden cluster.
+                          has to be the (virtual) garden cluster.
                         items:
                           description: ProjectMembership defines the (temporary) project
                             membership of the "access" service account. The project
@@ -442,8 +442,10 @@ spec:
                                 should be unique
                               type: string
                             roleRef:
-                              description: RoleRef can reference a Role in the current
-                                namespace or a ClusterRole in the global namespace.
+                              description: RoleRef references the Role or ClusterRole
+                                to bind to. For RoleBinding, it can reference a Role
+                                in the same namespace or a ClusterRole. For ClusterRoleBinding,
+                                it can only reference a ClusterRole.
                               properties:
                                 apiGroup:
                                   description: APIGroup is the group for the resource

--- a/pkg/component/gardener/dashboard/terminal/assets/doc.go
+++ b/pkg/component/gardener/dashboard/terminal/assets/doc.go
@@ -5,3 +5,7 @@
 //go:generate ../../../../../../hack/generate-crds.sh -p crd- dashboard.gardener.cloud
 
 package assets
+
+import (
+	_ "github.com/gardener/terminal-controller-manager/api/v1alpha1" // required for generating CRDs
+)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Partial revert of: https://github.com/gardener/gardener/commit/662a2e7609c952cb08cce6935181029297d14cfa

With #13944, the `terminal-controller-manager` Go dependency was removed. Unfortunately, when generating the CRDs for `dashboard.gardener.cloud`, this dependency is still required.
This PR brings back the dependency using an anonymous import with a comment explaining why it's necessary.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

Context: https://github.com/gardener/gardener/pull/13944#issuecomment-3859811139

/cc @petersutter @LucaBernstein @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
