### PR TITLE
docs: Update the values passed to the extension admission charts

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -146,6 +146,9 @@ The following values are passed to the chart during reconciliation:
 gardener:
   runtimeCluster:
     priorityClassName: <Class to be used for extension admission>
+  virtualCluster:
+    enabled: true
+    namespace: <Extension Namespace name in the virtual cluster (format "extension-<extension-name>")>
 ```
 
 ##### Virtual
@@ -156,6 +159,7 @@ The following values are passed to the chart during reconciliation:
 ```yaml
 gardener:
   virtualCluster:
+    enabled: true
     serviceAccount:
       name: <Name of the service account used to connect to the garden cluster>
       namespace: <Namespace of the service account>


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
With @dnaeon we noticed few missing values in the docs that describes the values passed by the operator when deploying the runtime and virtual charts.

The current runtime cluster chart values: https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/operator/controller/extension/extension/admission/admission.go#L101-L111

The current virtual cluster chart values: https://github.com/gardener/gardener/blob/485c25124ea536e4610c627109017dd34d434921/pkg/operator/controller/extension/extension/admission/admission.go#L188-L198

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
