### PR TITLE
Ignore `Lease` UPDATE calls in `etcd-druid` component protection webhook

### DIFF
--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -398,7 +398,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 								Resources:   []string{"leases"},
 								Scope:       ptr.To(admissionregistrationv1.AllScopes),
 							},
-							Operations: opUpdateAndDelete,
+							Operations: getEtcdComponentProtectionWebhookLeaseOperations(b.etcdConfig),
 						},
 					},
 				},
@@ -590,6 +590,13 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	}
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
+}
+
+func getEtcdComponentProtectionWebhookLeaseOperations(etcdConfig *gardenletconfigv1alpha1.ETCDConfig) []admissionregistrationv1.OperationType {
+	if etcdConfig.ComponentProtectionWebhookIgnoreLeaseUpdates {
+		return []admissionregistrationv1.OperationType{admissionregistrationv1.Delete}
+	}
+	return []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Delete}
 }
 
 func getDruidDeployArgs(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, namespace string, webhookServerTLSMountPath string) []string {

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -398,7 +398,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 								Resources:   []string{"leases"},
 								Scope:       ptr.To(admissionregistrationv1.AllScopes),
 							},
-							Operations: getEtcdComponentProtectionWebhookLeaseOperations(b.etcdConfig),
+							Operations: opDelete,
 						},
 					},
 				},
@@ -590,13 +590,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	}
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
-}
-
-func getEtcdComponentProtectionWebhookLeaseOperations(etcdConfig *gardenletconfigv1alpha1.ETCDConfig) []admissionregistrationv1.OperationType {
-	if etcdConfig.ComponentProtectionWebhookIgnoreLeaseUpdates {
-		return []admissionregistrationv1.OperationType{admissionregistrationv1.Delete}
-	}
-	return []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Delete}
 }
 
 func getDruidDeployArgs(etcdConfig *gardenletconfigv1alpha1.ETCDConfig, namespace string, webhookServerTLSMountPath string) []string {

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -612,7 +612,7 @@ var _ = Describe("Etcd", func() {
 									Resources:   []string{"leases"},
 									Scope:       ptr.To(admissionregistrationv1.AllScopes),
 								},
-								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Update, admissionregistrationv1.Delete},
+								Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Delete},
 							},
 						},
 					},
@@ -777,35 +777,6 @@ var _ = Describe("Etcd", func() {
 					deploymentWithImageVectorOverwrite,
 					configMapImageVectorOverwrite,
 				)
-			})
-		})
-
-		Context("ignoring lease updates for etcd component protection webhook", func() {
-			var validatingWebhookConfigurationWithLeaseDeleteOnly *admissionregistrationv1.ValidatingWebhookConfiguration
-
-			BeforeEach(func() {
-				validatingWebhookConfigurationWithLeaseDeleteOnly = validatingWebhookConfiguration.DeepCopy()
-				// The leases rule is the last rule in the first webhook
-				leasesIdx := len(validatingWebhookConfigurationWithLeaseDeleteOnly.Webhooks[0].Rules) - 1
-				validatingWebhookConfigurationWithLeaseDeleteOnly.Webhooks[0].Rules[leasesIdx].Operations = []admissionregistrationv1.OperationType{admissionregistrationv1.Delete}
-			})
-
-			It("should generate the correct validating webhook configuration", func() {
-				etcdConfig.ComponentProtectionWebhookIgnoreLeaseUpdates = true
-				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, false)
-				Expect(bootstrapper.Deploy(ctx)).To(Succeed())
-
-				expectedResources = []client.Object{
-					serviceAccount,
-					clusterRole,
-					clusterRoleBinding,
-					podDisruption,
-					vpa,
-					service,
-					validatingWebhookConfigurationWithLeaseDeleteOnly,
-					serviceMonitor,
-					deploymentWithoutImageVectorOverwriteFor,
-				}
 			})
 		})
 	})

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -779,6 +779,35 @@ var _ = Describe("Etcd", func() {
 				)
 			})
 		})
+
+		Context("ignoring lease updates for etcd component protection webhook", func() {
+			var validatingWebhookConfigurationWithLeaseDeleteOnly *admissionregistrationv1.ValidatingWebhookConfiguration
+
+			BeforeEach(func() {
+				validatingWebhookConfigurationWithLeaseDeleteOnly = validatingWebhookConfiguration.DeepCopy()
+				// The leases rule is the last rule in the first webhook
+				leasesIdx := len(validatingWebhookConfigurationWithLeaseDeleteOnly.Webhooks[0].Rules) - 1
+				validatingWebhookConfigurationWithLeaseDeleteOnly.Webhooks[0].Rules[leasesIdx].Operations = []admissionregistrationv1.OperationType{admissionregistrationv1.Delete}
+			})
+
+			It("should generate the correct validating webhook configuration", func() {
+				etcdConfig.ComponentProtectionWebhookIgnoreLeaseUpdates = true
+				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, false)
+				Expect(bootstrapper.Deploy(ctx)).To(Succeed())
+
+				expectedResources = []client.Object{
+					serviceAccount,
+					clusterRole,
+					clusterRoleBinding,
+					podDisruption,
+					vpa,
+					service,
+					validatingWebhookConfigurationWithLeaseDeleteOnly,
+					serviceMonitor,
+					deploymentWithoutImageVectorOverwriteFor,
+				}
+			})
+		})
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -601,6 +601,10 @@ type ETCDConfig struct {
 	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
 	// +optional
 	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
+	// ComponentProtectionWebhookIgnoreLeaseUpdates configures the validating webhook for leases to ignore update operations,
+	// effectively matching only delete operations for leases. When unset or false, both update and delete are matched (default behavior).
+	// +optional
+	ComponentProtectionWebhookIgnoreLeaseUpdates bool `json:"componentProtectionWebhookIgnoreLeaseUpdates,omitempty"`
 }
 
 // ETCDController contains config specific to ETCD controller

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -601,10 +601,6 @@ type ETCDConfig struct {
 	// DeltaSnapshotRetentionPeriod defines the duration for which delta snapshots will be retained, excluding the latest snapshot set.
 	// +optional
 	DeltaSnapshotRetentionPeriod *metav1.Duration `json:"deltaSnapshotRetentionPeriod,omitempty"`
-	// ComponentProtectionWebhookIgnoreLeaseUpdates configures the validating webhook for leases to ignore update operations,
-	// effectively matching only delete operations for leases. When unset or false, both update and delete are matched (default behavior).
-	// +optional
-	ComponentProtectionWebhookIgnoreLeaseUpdates bool `json:"componentProtectionWebhookIgnoreLeaseUpdates,omitempty"`
 }
 
 // ETCDController contains config specific to ETCD controller


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind task

**What this PR does / why we need it**:
Ignore lease UPDATE calls in druid component protection webhook.

Etcd member/snapshot lease updates are quite frequent in a productive cluster, and every lease update generally needs to be validated by etcd-druid to ensure that there are no unauthorized updates to the leases managed by etcd-druid, causing high traffic to the kube-apiserver by the validating webhook. This PR ensures that lease updates are ignored by the webhook in order to reduce this load. Components managed by druid other than leases will still be validated, and lease deletions will also continue to be validated.

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
