### PR TITLE
Wait for Garden CRD before applying garden

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -15,6 +15,9 @@ VALID_COMMANDS=("up down")
 
 case "$COMMAND" in
   up)
+    echo "Waiting for Garden CRD to be established..."
+    kubectl wait --for=condition=Established crd/gardens.operator.gardener.cloud --timeout=60s
+
     kubectl apply -k "$(dirname "$0")/garden/overlays/$SCENARIO"
     # We deliberately only wait for the last operation to be 'Reconcile Succeeded' in order to be able to faster deploy
     # the gardenlet.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind flake

**What this PR does / why we need it**:
Adds a wait for the Garden CRD to be ready before applying the Garden resource to prevent intermittent error "no matches for kind Garden" in e2e tests.

Related failures - 
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13536/pull-gardener-e2e-kind-ha-multi-node/2019775349126074368#1:build-log.txt%3A547
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13959/pull-gardener-e2e-kind-ha-multi-node/2019117899205054464#1:build-log.txt%3A527

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
