### PR TITLE
Compaction Alerts : Adapt Existing Alert + Introduce Two New Alerts

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -53,16 +53,42 @@ func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 			},
 		},
 		{
-			Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
-			Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+			Alert: "EtcdSnapshotCompactionJobsFailingForSeed",
+			Expr:  intstr.FromString(`count(count by (etcd_namespace) (increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1)) / count(count by (etcd_namespace) (increase(etcddruid_compaction_jobs_total[3h]))) > 0.1`),
 			Labels: map[string]string{
 				"severity":   "warning",
 				"type":       "seed",
 				"visibility": "operator",
 			},
 			Annotations: map[string]string{
-				"description": "Seed {{$externalLabels.seed}} has too many etcd snapshot compaction jobs failing in the past 3 hours.",
-				"summary":     "Too many etcd snapshot compaction jobs are failing in the seed.",
+				"description": "Seed {{$externalLabels.seed}} has more than 10 percent of shoot namespaces with at least one etcd snapshot compaction job failure in the past 3 hours.",
+				"summary":     "Too many shoot namespaces have etcd snapshot compaction job failures.",
+			},
+		},
+		{
+			Alert: "EtcdSnapshotCompactionJobsFailingForNamespace",
+			Expr:  intstr.FromString(`sum by (etcd_namespace) (increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h])) / sum by (etcd_namespace) (increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+			Labels: map[string]string{
+				"severity":   "warning",
+				"type":       "seed",
+				"visibility": "operator",
+			},
+			Annotations: map[string]string{
+				"description": "Namespace {{$labels.etcd_namespace}} on seed {{$externalLabels.seed}} has more than 10 percent of etcd snapshot compaction jobs failing in the past 3 hours.",
+				"summary":     "Too many etcd snapshot compaction jobs are failing for a specific namespace.",
+			},
+		},
+		{
+			Alert: "EtcdFullSnapshotsFailingForNamespace",
+			Expr:  intstr.FromString(`sum by (etcd_namespace) (increase(etcddruid_compaction_full_snapshot_triggered_total{succeeded="false"}[3h])) / sum by (etcd_namespace) (increase(etcddruid_compaction_full_snapshot_triggered_total[3h])) > 0.1`),
+			Labels: map[string]string{
+				"severity":   "warning",
+				"type":       "seed",
+				"visibility": "operator",
+			},
+			Annotations: map[string]string{
+				"description": "Namespace {{$labels.etcd_namespace}} on seed {{$externalLabels.seed}} has more than 10 percent of etcd full snapshots (triggered by compaction controller) failing in the past 3 hours.",
+				"summary":     "Too many etcd full snapshots are failing for a specific namespace.",
 			},
 		},
 	}

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules.go
@@ -62,7 +62,7 @@ func CentralPrometheusRules(seedIsGarden bool) []*monitoringv1.PrometheusRule {
 			},
 			Annotations: map[string]string{
 				"description": "Seed {{$externalLabels.seed}} has more than 10 percent of shoot namespaces with at least one etcd snapshot compaction job failure in the past 3 hours.",
-				"summary":     "Too many shoot namespaces have etcd snapshot compaction job failures.",
+				"summary":     "Too many shoot namespaces have failing etcd snapshot compaction jobs.",
 			},
 		},
 		{

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -34,16 +34,42 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 				},
 			},
 			{
-				Alert: "TooManyEtcdSnapshotCompactionJobsFailing",
-				Expr:  intstr.FromString(`count(increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1) / count(increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+				Alert: "EtcdSnapshotCompactionJobsFailingForSeed",
+				Expr:  intstr.FromString(`count(count by (etcd_namespace) (increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h]) >= 1)) / count(count by (etcd_namespace) (increase(etcddruid_compaction_jobs_total[3h]))) > 0.1`),
 				Labels: map[string]string{
 					"severity":   "warning",
 					"type":       "seed",
 					"visibility": "operator",
 				},
 				Annotations: map[string]string{
-					"description": "Seed {{$externalLabels.seed}} has too many etcd snapshot compaction jobs failing in the past 3 hours.",
-					"summary":     "Too many etcd snapshot compaction jobs are failing in the seed.",
+					"description": "Seed {{$externalLabels.seed}} has more than 10 percent of shoot namespaces with at least one etcd snapshot compaction job failure in the past 3 hours.",
+					"summary":     "Too many shoot namespaces have etcd snapshot compaction job failures.",
+				},
+			},
+			{
+				Alert: "EtcdSnapshotCompactionJobsFailingForNamespace",
+				Expr:  intstr.FromString(`sum by (etcd_namespace) (increase(etcddruid_compaction_jobs_total{succeeded="false", failureReason=~"processFailure|unknown"}[3h])) / sum by (etcd_namespace) (increase(etcddruid_compaction_jobs_total[3h])) > 0.1`),
+				Labels: map[string]string{
+					"severity":   "warning",
+					"type":       "seed",
+					"visibility": "operator",
+				},
+				Annotations: map[string]string{
+					"description": "Namespace {{$labels.etcd_namespace}} on seed {{$externalLabels.seed}} has more than 10 percent of etcd snapshot compaction jobs failing in the past 3 hours.",
+					"summary":     "Too many etcd snapshot compaction jobs are failing for a specific namespace.",
+				},
+			},
+			{
+				Alert: "EtcdFullSnapshotsFailingForNamespace",
+				Expr:  intstr.FromString(`sum by (etcd_namespace) (increase(etcddruid_compaction_full_snapshot_triggered_total{succeeded="false"}[3h])) / sum by (etcd_namespace) (increase(etcddruid_compaction_full_snapshot_triggered_total[3h])) > 0.1`),
+				Labels: map[string]string{
+					"severity":   "warning",
+					"type":       "seed",
+					"visibility": "operator",
+				},
+				Annotations: map[string]string{
+					"description": "Namespace {{$labels.etcd_namespace}} on seed {{$externalLabels.seed}} has more than 10 percent of etcd full snapshots (triggered by compaction controller) failing in the past 3 hours.",
+					"summary":     "Too many etcd full snapshots are failing for a specific namespace.",
 				},
 			},
 		}

--- a/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/prometheusrules_test.go
@@ -43,7 +43,7 @@ var _ = ginkgo.Describe("PrometheusRules", func() {
 				},
 				Annotations: map[string]string{
 					"description": "Seed {{$externalLabels.seed}} has more than 10 percent of shoot namespaces with at least one etcd snapshot compaction job failure in the past 3 hours.",
-					"summary":     "Too many shoot namespaces have etcd snapshot compaction job failures.",
+					"summary":     "Too many shoot namespaces have failing etcd snapshot compaction jobs.",
 				},
 			},
 			{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR introduces improvements to the existing etcd-druid compaction monitoring alerts and adds two new per-namespace alerts for better observability.

1. Renamed and Fixed Existing Alert

   - Renamed TooManyEtcdSnapshotCompactionJobsFailing → EtcdSnapshotCompactionJobsFailingForSeed
   - Fixed the PromQL expression to correctly count unique namespaces with failures rather than counting time series
   - Previous behaviour (incorrect): The expression was counting the number of failure time series divided by total time series, which gave misleading results when a namespace had multiple failure types (e.g., both processFailure and unknown)
   - New behaviour (correct): The expression now correctly calculates the fraction of shoot namespaces that have at least one compaction job failure
 
2. Added New Alert: EtcdSnapshotCompactionJobsFailingForNamespace

   - Fires when more than 10% of compaction jobs are failing within a specific namespace
   - Uses sum by (etcd_namespace) to correctly sum up actual job counts
   - Each namespace exceeding the threshold fires its own alert, enabling operators to identify the exact affected shoot

3. Added New Alert: EtcdFullSnapshotsFailingForNamespace

   - Fires when more than 10% of full snapshots (triggered by compaction controller) are failing within a specific namespace
   - Similar to the above, uses sum by (etcd_namespace) for accurate failure rate calculation
   - Helps identify shoots where full snapshot operations are consistently failing

**Special notes for your reviewer**:

The earlier alert only provided a seed-level view of failures, making it difficult to pinpoint which specific shoot clusters were affected. With the addition of new per-namespace alerts, operators can now also identify specific issues that shoot namespaces experience and differentiate them with the seed wide issues w.rt. compaction.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The existing `TooManyEtcdSnapshotCompactionJobsFailing` alert has been renamed to `EtcdSnapshotCompactionJobsFailingForSeed` and its expression has been fixed to correctly measure the fraction of namespaces with failures.
Two new per-namespace alerts (`EtcdSnapshotCompactionJobsFailingForNamespace` and `EtcdFullSnapshotsFailingForNamespace`) have been added to help operators identify specific shoot clusters where compaction jobs or full snapshots are failing above the 10% threshold.
```
