### PR TITLE
Fix Ginkgo panic in seed e2e tests during tree construction

### DIFF
--- a/test/e2e/gardener/seed/renew_garden_access_secrets.go
+++ b/test/e2e/gardener/seed/renew_garden_access_secrets.go
@@ -59,7 +59,6 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			}
 
 			s = testContext.ForSeed(&seedList.Items[seedIndex])
-			ItShouldInitializeSeedClient(s)
 
 			seedNamespace = gardenerutils.ComputeGardenNamespace(s.Seed.Name)
 			gardenAccessName = "test-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
@@ -77,6 +76,8 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 				},
 			}
 		})
+
+		ItShouldInitializeSeedClient(s)
 
 		It("Should create garden access secret", func(ctx SpecContext) {
 			Eventually(ctx, func() error {

--- a/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
+++ b/test/e2e/gardener/seed/renew_gardenlet_kubeconfig.go
@@ -48,8 +48,9 @@ var _ = Describe("Seed Tests", Label("Seed", "default"), func() {
 			}
 
 			s = testContext.ForSeed(&seedList.Items[seedIndex])
-			ItShouldInitializeSeedClient(s)
 		})
+
+		ItShouldInitializeSeedClient(s)
 
 		It("Create gardenlet kubeconfig rotation verifier", func(_ SpecContext) {
 			verifier = rotation.GardenletKubeconfigRotationVerifier{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind flake

**What this PR does / why we need it**:
Fix panic in seed e2e tests by moving `ItShouldInitializeSeedClient` outside `BeforeTestSetup`, since `ItShouldInitializeSeedClient` makes assertions, which should not be made during tree construction in ginkgo.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Occurrences - 
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13986/pull-gardener-e2e-kind/2020735048516374528
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13830/pull-gardener-e2e-kind-upgrade/2020752728044605440
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/13986/pull-gardener-e2e-kind/2020763202547093504

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
