### PR TITLE
Add Go bin (e.g. `gofmt`) to Renovate `$PATH` var on `generate` run

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,7 +113,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'make generate MODE=sequential',
+          'PATH="$PATH:$(go env GOROOT)/bin" make generate MODE=sequential',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Else, the `make generate` run in Renovate can fail with `Unable to apply gofmt for github.com.gardener.gardener.pkg.apis.authentication.v1alpha1: exec: "gofmt": executable file not found in $PATH`.

See commit: https://github.com/gardener/gardener/commit/58c6fd87da3f0ea5a254820e6a7d657d36b9cdf9 (in https://github.com/gardener/gardener/pull/13978)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @rfranzke @oliver-goetz

By default, this path is not included in the `renovate/renovate` OCI image.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
