### PR TITLE
Drop immutability of Shoot exposureClassName

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2172,8 +2172,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>
@@ -14160,8 +14159,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>
@@ -14910,8 +14908,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-This field is immutable.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -410,7 +410,6 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	if !migrationFromSecBindingToCredBinding {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SecretBindingName, oldSpec.SecretBindingName, fldPath.Child("secretBindingName"))...)
 	}
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.ExposureClassName, oldSpec.ExposureClassName, fldPath.Child("exposureClassName"))...)
 
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, newSpec.SeedName != nil, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, ValidateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, false, fldPath.Child("kubernetes", "version"))...)

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -625,19 +625,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should forbid to change the exposure class", func() {
+			It("should allow to change the exposure class", func() {
 				shoot.Spec.ExposureClassName = ptr.To("exposure-class-1")
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.ExposureClassName = ptr.To("exposure-class-2")
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.exposureClassName"),
-					})),
-				))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -3568,7 +3568,6 @@ message ShootSpec {
   repeated Toleration tolerations = 17;
 
   // ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-  // This field is immutable.
   // +optional
   optional string exposureClassName = 18;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -126,7 +126,6 @@ type ShootSpec struct {
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,17,rep,name=tolerations"`
 	// ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
-	// This field is immutable.
 	// +optional
 	ExposureClassName *string `json:"exposureClassName,omitempty" protobuf:"bytes,18,opt,name=exposureClassName"`
 	// SystemComponents contains the settings of system components in the control or data plane of the Shoot cluster.

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -10157,7 +10157,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"exposureClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy. This field is immutable.",
+							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord.go
@@ -109,12 +109,7 @@ func New(
 		waitTimeout:         waitTimeout,
 		deployCredentials:   deployCredentials,
 
-		dnsRecord: &extensionsv1alpha1.DNSRecord{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      values.Name,
-				Namespace: values.Namespace,
-			},
-		},
+		dnsRecord: newDNSRecord(values),
 		secret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      values.SecretName,
@@ -187,12 +182,26 @@ func (d *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 		return nil
 	}
 
-	if d.values.ReconcileOnlyOnChangeOrError {
-		if err := d.client.Get(ctx, client.ObjectKeyFromObject(d.dnsRecord), d.dnsRecord); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, err
-			}
+	var create bool
+	if err := d.client.Get(ctx, client.ObjectKeyFromObject(d.dnsRecord), d.dnsRecord); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		create = true
+	}
 
+	// if the DNSRecord does not exist yet, we don't need to recreate
+	if !create && d.recordTypeChanged(d.dnsRecord.Spec.RecordType, d.values.RecordType) {
+		if err := component.OpDestroyAndWait(d).Destroy(ctx); err != nil {
+			return nil, err
+		}
+		// set dnsRecord to be "unpopulated" so that we don't issue create request with a set resourceVersion
+		d.dnsRecord = newDNSRecord(d.values)
+		create = true
+	}
+
+	if d.values.ReconcileOnlyOnChangeOrError {
+		if create {
 			// DNSRecord doesn't exist yet, create it.
 			_ = mutateFn()
 			if err := d.client.Create(ctx, d.dnsRecord); err != nil {
@@ -357,6 +366,19 @@ func (d *dnsRecord) isTimestampInvalidOrAfterLastUpdateTime() bool {
 	}
 
 	return false
+}
+
+func (d *dnsRecord) recordTypeChanged(old, new extensionsv1alpha1.DNSRecordType) bool {
+	return old != new
+}
+
+func newDNSRecord(values *Values) *extensionsv1alpha1.DNSRecord {
+	return &extensionsv1alpha1.DNSRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      values.Name,
+			Namespace: values.Namespace,
+		},
+	}
 }
 
 // DeploySecretCredentials returns a [CredentialsDeployFunc] that deploys the given secret data into a Secret.

--- a/pkg/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/component/extensions/dnsrecord/dnsrecord_test.go
@@ -45,6 +45,7 @@ const (
 	zone                = "zone"
 	dnsName             = "foo.bar.external.example.com"
 	address             = "1.2.3.4"
+	addressIP6          = "2001:db8::1"
 	ttl           int64 = 300
 )
 
@@ -342,6 +343,33 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
+		It("should recreate the DNSRecord", func(ctx context.Context) {
+			By("Deploy DNSRecord")
+			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout, credentialsDeployFunc)
+			Expect(dnsRecord.Deploy(ctx)).To(Succeed())
+
+			By("Verify DNSRecord")
+			deployedDNS := &extensionsv1alpha1.DNSRecord{}
+			err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
+			oldResourceVersion := deployedDNS.ResourceVersion
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployedDNS.Spec.RecordType).To(Equal(values.RecordType))
+
+			By("Change DNSRecordType to AAAA")
+			dnsRecord.SetRecordType(extensionsv1alpha1.DNSRecordTypeAAAA)
+			dnsRecord.SetValues([]string{addressIP6})
+			Expect(dnsRecord.Deploy(ctx)).To(Succeed())
+
+			By("Verify DNSRecord got recreated")
+			err = c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
+			Expect(err).NotTo(HaveOccurred())
+			// check that we didn't do an update but rather a recreation.
+			// Unfortunately the UID field is not populated by fake client
+			Expect(deployedDNS.ResourceVersion).To(Equal(oldResourceVersion))
+			Expect(deployedDNS.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeAAAA))
+			Expect(deployedDNS.Spec.Values).To(ContainElement(addressIP6))
+		})
+
 		It("should deploy the DNSRecord without operation annotation if it exists with desired spec", func() {
 			By("Create existing DNSRecord")
 			existingDNS := dns.DeepCopy()
@@ -551,8 +579,10 @@ var _ = Describe("DNSRecord", func() {
 					Expect(actual).To(DeepEqual(secret))
 					return nil
 				})
+			//  get should be called twice as its first used to decide whether we need to recreate
 			mc.EXPECT().Get(ctx, client.ObjectKeyFromObject(dns), gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{})).
-				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("dnsrecords"), name))
+				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("dnsrecords"), name)).MaxTimes(2)
+
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(dns)).DoAndReturn(
 				func(_ context.Context, actual client.Object, _ ...client.CreateOption) error {
 					Expect(actual).To(DeepEqual(dns))
@@ -660,7 +690,6 @@ var _ = Describe("DNSRecord", func() {
 				Entry("zone is nil", func() { values.Zone = nil }, func() { expectedDNSRecord.Spec.Zone = nil }),
 			)
 		})
-
 	})
 
 	Describe("#Wait", func() {
@@ -854,8 +883,10 @@ var _ = Describe("DNSRecord", func() {
 				})
 
 			metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationWaitForState)
+
+			//  get should be called twice as its first used to decide whether we need to recreate
 			mc.EXPECT().Get(ctx, client.ObjectKeyFromObject(dns), gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{})).
-				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("dnsrecords"), name))
+				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("dnsrecords"), name)).MaxTimes(2)
 			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(dns)).DoAndReturn(
 				func(_ context.Context, actual client.Object, _ ...client.CreateOption) error {
 					Expect(actual).To(DeepEqual(dns))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR allows to change the, currently immutable, `exposureClassName` field of Shoots.
Since the DNS Record of the exposure classes Istio Ingress-gateway might not be the same, the DNSRecord's `recordType` must also be mutable.

**Which issue(s) this PR fixes**:
Part of #13648 

**Special notes for your reviewer**:
Originally included in #13846

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user feature
Shoot's `exposureClass` is now no longer immutable.
```
