### PR TITLE
Update TM tests to not use Ingress NGINX Controller or the Kubernetes dashboard for Kubernetes 1.35

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -16,13 +16,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,7 +32,9 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/resources/templates"
 )
@@ -63,34 +65,33 @@ type GuestBookTest struct {
 
 // NewGuestBookTest creates a new guestbook application test
 // This test should run inside a testframework with a registered shoot test because otherwise created resources may leak.
-func NewGuestBookTest(f *framework.ShootFramework) (*GuestBookTest, error) {
-	allowedCharacters := "0123456789abcdefghijklmnopqrstuvwxyz"
-	randURLSuffix, err := utils.GenerateRandomStringFromCharset(3, allowedCharacters)
-	if err != nil {
-		return nil, err
-	}
+func NewGuestBookTest(f *framework.ShootFramework) *GuestBookTest {
 	return &GuestBookTest{
-		framework:        f,
-		guestBookAppHost: fmt.Sprintf("guestbook-%s.ingress.%s", randURLSuffix, *f.Shoot.Spec.DNS.Domain),
-	}, nil
+		framework: f,
+	}
 }
 
 // WaitUntilRedisIsReady waits until the redis master is ready.
 func (t *GuestBookTest) WaitUntilRedisIsReady(ctx context.Context) {
-	err := t.framework.WaitUntilStatefulSetIsRunning(ctx, RedisMaster, t.framework.Namespace, t.framework.ShootClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(t.framework.WaitUntilStatefulSetIsRunning(ctx, RedisMaster, t.framework.Namespace, t.framework.ShootClient)).To(Succeed())
 }
 
 // WaitUntilGuestbookDeploymentIsReady waits until the guestbook deployment is ready.
 func (t *GuestBookTest) WaitUntilGuestbookDeploymentIsReady(ctx context.Context) {
-	err := t.framework.WaitUntilDeploymentIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(t.framework.WaitUntilDeploymentIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)).To(Succeed())
 }
 
 // WaitUntilGuestbookIngressIsReady waits until the guestbook ingress is ready.
 func (t *GuestBookTest) WaitUntilGuestbookIngressIsReady(ctx context.Context) {
-	err := t.framework.WaitUntilIngressIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(t.framework.WaitUntilIngressIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)).To(Succeed())
+}
+
+// WaitUntilGuestbookLoadBalancerIsReady waits until the guestbook Service of type=LoadBalancer is ready.
+func (t *GuestBookTest) WaitUntilGuestbookLoadBalancerIsReady(ctx context.Context) string {
+	loadBalancerIngress, err := kubernetesutils.WaitUntilLoadBalancerIsReady(ctx, t.framework.Logger, t.framework.ShootClient.Client(), t.framework.Namespace, GuestBook, 10*time.Minute)
+	Expect(err).NotTo(HaveOccurred())
+
+	return loadBalancerIngress
 }
 
 // WaitUntilGuestbookURLsRespondOK waits until the deployed guestbook application can be reached via http
@@ -129,14 +130,18 @@ func (t *GuestBookTest) WaitUntilGuestbookURLsRespondOK(ctx context.Context, gue
 func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	if t.framework.Namespace == "" {
 		_, err := t.framework.CreateNewNamespace(ctx)
-		framework.ExpectNoError(err)
-	}
-	shoot := t.framework.Shoot
-	if !v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
-		ginkgo.Fail("The test requires .spec.addons.nginxIngress.enabled to be true")
+		Expect(err).NotTo(HaveOccurred())
 	}
 
-	ginkgo.By("Apply redis chart")
+	shoot := t.framework.Shoot
+	k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
+	Expect(err).NotTo(HaveOccurred())
+
+	if versionutils.ConstraintK8sLess135.Check(k8sVersion) && !v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
+		Fail("The test requires .spec.addons.nginxIngress.enabled to be true for Kubernetes versions less than 1.35")
+	}
+
+	By("Apply redis chart")
 	masterValues := map[string]any{
 		"command": "redis-server",
 	}
@@ -153,7 +158,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 
 	// GCP requires a specific storage class for ARM worker pools
 	if shoot.Spec.Provider.Type == "gcp" && hasARMWorkerPools {
-		err := t.framework.ShootClient.Client().Create(ctx, &storagev1.StorageClass{
+		Expect(t.framework.ShootClient.Client().Create(ctx, &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gce-hd-balanced",
 				Annotations: map[string]string{
@@ -166,8 +171,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 				"type": "hyperdisk-balanced",
 			},
 			VolumeBindingMode: ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		})).To(Succeed())
 
 		masterValues["persistence"] = map[string]any{
 			"storageClass": "gce-hd-balanced",
@@ -190,28 +194,38 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 		"master": masterValues,
 	}
 
-	err := t.framework.ShootClient.ChartApplier().ApplyFromEmbeddedFS(ctx, chartRedis, chartPathRedis, t.framework.Namespace, "redis", kubernetes.Values(values), kubernetes.ForceNamespace)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(t.framework.ShootClient.ChartApplier().ApplyFromEmbeddedFS(ctx, chartRedis, chartPathRedis, t.framework.Namespace, "redis", kubernetes.Values(values), kubernetes.ForceNamespace)).To(Succeed())
 
 	t.WaitUntilRedisIsReady(ctx)
 
-	ginkgo.By("Deploy the guestbook application")
-	guestBookParams := struct {
-		HelmDeployNamespace string
-		KubeVersion         string
-		ShootDNSHost        string
-	}{
-		t.framework.Namespace,
-		t.framework.Shoot.Spec.Kubernetes.Version,
-		t.guestBookAppHost,
+	By("Deploy the guestbook application")
+	guestBookValues := map[string]any{
+		"HelmDeployNamespace": t.framework.Namespace,
+		"KubeVersion":         shoot.Spec.Kubernetes.Version,
 	}
-	err = t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, templates.GuestbookAppName, guestBookParams)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	// TODO(ialidzhikov): Clean up the guestbook test not to use use Ingress when Kubernetes 1.34 is no longer supported.
+	if versionutils.ConstraintK8sLess135.Check(k8sVersion) {
+		allowedCharacters := "0123456789abcdefghijklmnopqrstuvwxyz"
+		randURLSuffix, err := utils.GenerateRandomStringFromCharset(3, allowedCharacters)
+		Expect(err).NotTo(HaveOccurred())
+
+		t.guestBookAppHost = fmt.Sprintf("guestbook-%s.ingress.%s", randURLSuffix, *shoot.Spec.DNS.Domain)
+
+		guestBookValues["ShootDNSHost"] = t.guestBookAppHost
+	}
+
+	Expect(t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, templates.GuestbookAppName, guestBookValues)).To(Succeed())
 
 	t.WaitUntilGuestbookDeploymentIsReady(ctx)
-	t.WaitUntilGuestbookIngressIsReady(ctx)
 
-	ginkgo.By("Guestbook app was deployed successfully!")
+	if versionutils.ConstraintK8sLess135.Check(k8sVersion) {
+		t.WaitUntilGuestbookIngressIsReady(ctx)
+	} else {
+		loadBalancerIngress := t.WaitUntilGuestbookLoadBalancerIsReady(ctx)
+		t.guestBookAppHost = loadBalancerIngress
+	}
+
+	By("Guestbook app was deployed successfully!")
 }
 
 // Test tests that a deployed guestbook application is working correctly
@@ -224,30 +238,29 @@ func (t *GuestBookTest) Test(ctx context.Context) {
 	pullURL := fmt.Sprintf("%s/lrange/guestbook", guestBookAppURL)
 
 	// Check availability of the guestbook app
-	err := t.WaitUntilGuestbookURLsRespondOK(ctx, []string{guestBookAppURL, pushURL, pullURL})
-	framework.ExpectNoError(err)
+	Expect(t.WaitUntilGuestbookURLsRespondOK(ctx, []string{guestBookAppURL, pushURL, pullURL})).To(Succeed())
 
 	// Push foobar-<shoot-name> to the guestbook app
-	_, err = framework.HTTPGet(ctx, pushURL)
-	framework.ExpectNoError(err)
+	_, err := framework.HTTPGet(ctx, pushURL)
+	Expect(err).NotTo(HaveOccurred())
 
 	// Pull foobar
 	pullResponse, err := framework.HTTPGet(ctx, pullURL)
-	framework.ExpectNoError(err)
-	gomega.Expect(pullResponse.StatusCode).To(gomega.Equal(http.StatusOK))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pullResponse.StatusCode).To(Equal(http.StatusOK))
 
 	responseBytes, err := io.ReadAll(pullResponse.Body)
-	framework.ExpectNoError(err)
+	Expect(err).NotTo(HaveOccurred())
 
 	// test if foobar-<shoot-name> was pulled successfully
 	bodyString := string(responseBytes)
-	gomega.Expect(bodyString).To(gomega.ContainSubstring(fmt.Sprintf("foobar-%s", shoot.Name)))
+	Expect(bodyString).To(ContainSubstring(fmt.Sprintf("foobar-%s", shoot.Name)))
 }
 
 // Dump logs the current state of all components of the guestbook test
 // if the test has failed
 func (t *GuestBookTest) dump(ctx context.Context) {
-	if !ginkgo.CurrentSpecReport().Failed() {
+	if !CurrentSpecReport().Failed() {
 		return
 	}
 
@@ -267,72 +280,18 @@ func (t *GuestBookTest) Cleanup(ctx context.Context) {
 	t.dump(ctx)
 
 	// Clean up shoot
-	ginkgo.By("Clean up guestbook app resources")
-	deleteResource := func(ctx context.Context, resource client.Object) error {
-		err := t.framework.ShootClient.Client().Delete(ctx, resource)
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
+	By("Clean up guestbook app resources")
 
-	cleanupGuestbook := func() {
-		var (
-			guestBookIngressToDelete client.Object = &networkingv1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: t.framework.Namespace,
-					Name:      GuestBook,
-				}}
+	Expect(kubernetesutils.DeleteObjects(ctx, t.framework.ShootClient.Client(),
+		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
+	)).To(Succeed())
 
-			guestBookDeploymentToDelete = &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: t.framework.Namespace,
-					Name:      GuestBook,
-				},
-			}
+	Expect(kubernetesutils.DeleteObjects(ctx, t.framework.ShootClient.Client(),
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: RedisMaster}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: RedisMaster}},
+	)).To(Succeed())
 
-			guestBookServiceToDelete = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: t.framework.Namespace,
-					Name:      GuestBook,
-				},
-			}
-		)
-
-		err := deleteResource(ctx, guestBookIngressToDelete)
-		framework.ExpectNoError(err)
-
-		err = deleteResource(ctx, guestBookDeploymentToDelete)
-		framework.ExpectNoError(err)
-
-		err = deleteResource(ctx, guestBookServiceToDelete)
-		framework.ExpectNoError(err)
-	}
-
-	cleanupRedis := func() {
-		var (
-			redisMasterServiceToDelete = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: t.framework.Namespace,
-					Name:      RedisMaster,
-				},
-			}
-			redisMasterStatefulSetToDelete = &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: t.framework.Namespace,
-					Name:      RedisMaster,
-				},
-			}
-		)
-
-		err := deleteResource(ctx, redisMasterServiceToDelete)
-		framework.ExpectNoError(err)
-
-		err = deleteResource(ctx, redisMasterStatefulSetToDelete)
-		framework.ExpectNoError(err)
-	}
-	cleanupGuestbook()
-	cleanupRedis()
-
-	ginkgo.By("Redis and the guestbook app have been cleaned up!")
+	By("Redis and the guestbook app have been cleaned up!")
 }

--- a/test/framework/resources/templates/guestbook-app.yaml.tpl
+++ b/test/framework/resources/templates/guestbook-app.yaml.tpl
@@ -30,6 +30,7 @@ spec:
               name: redis
               key: redis-password
 ---
+{{- if semverCompare "< 1.35-0" .KubeVersion }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -61,3 +62,18 @@ spec:
               number: 80
         path: /
         pathType: Prefix
+{{- else }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: guestbook
+  namespace: {{ .HelmDeployNamespace }}
+spec:
+  selector:
+    app: guestbook
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: LoadBalancer
+{{- end -}}

--- a/test/testmachinery/shoots/operations/operations.go
+++ b/test/testmachinery/shoots/operations/operations.go
@@ -69,8 +69,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 	var isShootHibernated bool
 
 	f.Default().Serial().CIt("Testing if Shoot can be hibernated successfully", func(ctx context.Context) {
-		guestBookTest, err := applications.NewGuestBookTest(f)
-		framework.ExpectNoError(err)
+		guestBookTest := applications.NewGuestBookTest(f)
 
 		defer guestBookTest.Cleanup(ctx)
 
@@ -80,7 +79,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 
 		ginkgo.By("Hibernate shoot")
 		isShootHibernated = true
-		err = f.HibernateShoot(ctx)
+		err := f.HibernateShoot(ctx)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Wake up shoot")

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -124,10 +124,7 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 	}
 
 	ginkgo.By("Verify Guest Book Application")
-	initializedApp, err := initGuestBookTest(t)
-	if err != nil {
-		return err
-	}
+	initializedApp := initGuestBookTest(t)
 	*guestBookApp = *initializedApp
 	guestBookApp.DeployGuestBookApp(ctx)
 	guestBookApp.Test(ctx)
@@ -177,7 +174,7 @@ func cleanUp(ctx context.Context, t *ShootMigrationTest, guestBookApp applicatio
 	return nil
 }
 
-func initGuestBookTest(t *ShootMigrationTest) (*applications.GuestBookTest, error) {
+func initGuestBookTest(t *ShootMigrationTest) *applications.GuestBookTest {
 	sFramework := ShootFramework{
 		GardenerFramework: t.GardenerFramework,
 		TestDescription:   NewTestDescription("Guestbook App for CP Migration test"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Currently, we use the `nginx-ingress` Shoot addon for the guestbook app test. Starting with Kubernetes 1.35, the addon can no longer be enabled, hence, there will be no Ingress API available in shoots.

There are two options:
- In the TM tests, deploy our own ingress controller (maybe` traefik`)
- Do not use Ingress at all but just plain Services of `type=LoadBalancer`.

We thought that 2. is the better choice since - from Gardener core's PoV -, the "interface/API" for exposing applications to the world is the Service API (type Loadbalancer). The Ingress API uses this API under the hood, so from g/g validation PoV, there is no benefit (but just effort) to deploy some third-party tool into the shoot that uses LB Services via a detour.

This PR:
- adapts the guestbook TM test to use Service of `type=LoadBalancer` for Kubernetes 1.35+. For Kubernetes < 1.35 the test continues to use Ingress and the nginx-ingress addon.
- skipts the kubernetes-dashboard test for Kubernetes 1.35+.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13687

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The TM tests are now adapted to run against Kubernetes 1.35.
```
