### PR TITLE
[control-plane-migration] Clarify destination `gardenlet` access window

### DIFF
--- a/docs/operations/control_plane_migration.md
+++ b/docs/operations/control_plane_migration.md
@@ -30,6 +30,10 @@ If the process is successful, we update the status of the `Shoot` by setting the
 
 The etcd backups will be copied over to the `BackupBucket` of the `Destination Seed` during control plane migration and any future backups will be uploaded there.
 
+> [!NOTE]
+> During the migration phase, the destination seed's `gardenlet` may already have access to the `Shoot` and its related resources in the garden cluster, while the source seed's `gardenlet` is still responsible for shutting down the control plane and persisting the current state to the `ShootState` resource.
+> This overlap is intentional and simplifies the implementation since the destination seed's `gardenlet` will eventually require access to these resources for control plane restoration anyway.
+
 ## Triggering the Migration
 
 For control plane migration, operators with the necessary RBAC can use the [`shoots/binding`](../concepts/scheduler.md#shootsbinding-subresource) subresource to change the `.spec.seedName`, with the following commands:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Clarify destination `gardenlet` access window during control plane migration.

**Special notes for your reviewer**:
/cc @vpnachev @dimityrmirchev @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
