### PR TITLE
[GEP-28] `gardenadm join`: Ensure no active `Shoot` reconciliation

### DIFF
--- a/pkg/gardenadm/cmd/join/join_test.go
+++ b/pkg/gardenadm/cmd/join/join_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenadm/cmd/join"
 	operationpkg "github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
 )
 
 var _ = Describe("Join", func() {
@@ -45,6 +46,7 @@ var _ = Describe("Join", func() {
 				Botanist: &botanistpkg.Botanist{
 					Operation: &operationpkg.Operation{
 						ShootClientSet: fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build(),
+						Shoot:          &shootpkg.Shoot{ControlPlaneNamespace: "kube-system"},
 					},
 				},
 			}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
When joining control plane nodes, we don't want `gardenlet` to potentially interfere with the ETCD configuration (part of the usual `Shoot` reconciliation) while we are joining a new node.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
