### PR TITLE
Adapt component VPAs to new guideline: container-specific policy + catch-all policy

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/vpa.yaml
@@ -8,7 +8,7 @@ spec:
   {{- if .Values.vpa.resourcePolicy }}
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
+    - containerName: {{ include "name" . }}
       {{- if .Values.vpa.resourcePolicy.minAllowed }}
       minAllowed:
         memory: {{ required ".Values.vpa.resourcePolicy.minAllowed.memory is required" .Values.vpa.resourcePolicy.minAllowed.memory }}
@@ -18,6 +18,8 @@ spec:
         cpu: {{ required ".Values.vpa.resourcePolicy.maxAllowed.cpu is required" .Values.vpa.resourcePolicy.maxAllowed.cpu }}
         memory: {{ required ".Values.vpa.resourcePolicy.maxAllowed.memory is required" .Values.vpa.resourcePolicy.maxAllowed.memory }}
       {{- end }}
+    - containerName: '*'
+      mode: "Off"
   {{- end }}
   targetRef:
     apiVersion: apps/v1

--- a/charts/gardener/provider-local/templates/vpa.yaml
+++ b/charts/gardener/provider-local/templates/vpa.yaml
@@ -8,9 +8,11 @@ spec:
   {{- if .Values.vpa.resourcePolicy }}
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
+    - containerName: {{ include "name" . }}
       minAllowed:
         memory: {{ required ".Values.vpa.resourcePolicy.minAllowed.memory is required" .Values.vpa.resourcePolicy.minAllowed.memory }}
+    - containerName: '*'
+      mode: "Off"
   {{- end }}
   targetRef:
     apiVersion: apps/v1

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -268,13 +268,18 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 					UpdateMode: &vpaUpdateMode,
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-						ContainerName: Druid,
-						MinAllowed: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("100M"),
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+						{
+							ContainerName: Druid,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("100M"),
+							},
+							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						},
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-					}},
+						{
+							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						}},
 				},
 			},
 		}

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -244,6 +244,10 @@ var _ = Describe("Etcd", func() {
 								},
 								ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							},
+							{
+								ContainerName: "*",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+							},
 						},
 					},
 					TargetRef: &autoscalingv1.CrossVersionObjectReference{

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -792,11 +792,6 @@ func (e *etcd) emptyVerticalPodAutoscaler() *vpaautoscalingv1.VerticalPodAutosca
 }
 
 func (e *etcd) reconcileVerticalPodAutoscaler(ctx context.Context, vpa *vpaautoscalingv1.VerticalPodAutoscaler, minAllowedETCD corev1.ResourceList) error {
-	vpaUpdateMode := vpaautoscalingv1.UpdateModeRecreate
-	containerPolicyOff := vpaautoscalingv1.ContainerScalingModeOff
-	containerPolicyAuto := vpaautoscalingv1.ContainerScalingModeAuto
-	controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, vpa, func() error {
 		var evictionRequirement *string
 
@@ -822,20 +817,19 @@ func (e *etcd) reconcileVerticalPodAutoscaler(ctx context.Context, vpa *vpaautos
 				Name:       e.etcd.Name,
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-				UpdateMode: &vpaUpdateMode,
+				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 			},
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
 						ContainerName:    containerNameEtcd,
 						MinAllowed:       minAllowedETCD,
-						ControlledValues: &controlledValues,
-						Mode:             &containerPolicyAuto,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeAuto),
 					},
 					{
-						ContainerName:    containerNameBackupRestore,
-						Mode:             &containerPolicyOff,
-						ControlledValues: &controlledValues,
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -113,12 +113,8 @@ var _ = Describe("Etcd", func() {
 		backupLeaderElectionEtcdConnectionTimeout = &metav1.Duration{Duration: 10 * time.Second}
 		backupLeaderElectionReelectionPeriod      = &metav1.Duration{Duration: 11 * time.Second}
 
-		vpaUpdateMode       = vpaautoscalingv1.UpdateModeRecreate
-		containerPolicyOff  = vpaautoscalingv1.ContainerScalingModeOff
-		containerPolicyAuto = vpaautoscalingv1.ContainerScalingModeAuto
-		controlledValues    = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		metricsBasic        = druidcorev1alpha1.Basic
-		metricsExtensive    = druidcorev1alpha1.Extensive
+		metricsBasic     = druidcorev1alpha1.Basic
+		metricsExtensive = druidcorev1alpha1.Extensive
 
 		etcdName string
 		vpaName  string
@@ -413,20 +409,19 @@ var _ = Describe("Etcd", func() {
 						Name:       etcdName,
 					},
 					UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-						UpdateMode: &vpaUpdateMode,
+						UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 							{
 								ContainerName:    "etcd",
 								MinAllowed:       minAllowedConfig,
-								ControlledValues: &controlledValues,
-								Mode:             &containerPolicyAuto,
+								ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+								Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeAuto),
 							},
 							{
-								ContainerName:    "backup-restore",
-								Mode:             &containerPolicyOff,
-								ControlledValues: &controlledValues,
+								ContainerName: "*",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 							},
 						},
 					},

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -258,6 +258,10 @@ var _ = Describe("GardenerAPIServer", func() {
 							},
 							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						},
 					},
 				},
 			},

--- a/pkg/component/gardener/apiserver/vpa.go
+++ b/pkg/component/gardener/apiserver/vpa.go
@@ -44,6 +44,10 @@ func (g *gardenerAPIServer) verticalPodAutoscaler() *vpaautoscalingv1.VerticalPo
 						},
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+					},
 				},
 			},
 		},

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -377,6 +377,10 @@ var _ = Describe("KubeAPIServer", func() {
 								corev1.ResourceMemory: resource.MustParse("200M"),
 							},
 						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						},
 					},
 				),
 				Entry("HA VPN is enabled",
@@ -394,15 +398,7 @@ var _ = Describe("KubeAPIServer", func() {
 							},
 						},
 						{
-							ContainerName: "vpn-client-0",
-							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						},
-						{
-							ContainerName: "vpn-client-1",
-							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						},
-						{
-							ContainerName: "vpn-path-controller",
+							ContainerName: "*",
 							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
@@ -421,6 +417,10 @@ var _ = Describe("KubeAPIServer", func() {
 								corev1.ResourceMemory: resource.MustParse("200M"),
 							},
 						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						},
 					},
 				),
 				Entry("minAllowed configured",
@@ -436,6 +436,10 @@ var _ = Describe("KubeAPIServer", func() {
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("2Gi"),
 							},
+						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
 				),

--- a/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
+++ b/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
@@ -43,7 +43,17 @@ func (k *kubeAPIServer) reconcileVerticalPodAutoscaler(ctx context.Context, vert
 				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 			},
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-				ContainerPolicies: k.computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed),
+				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+					{
+						ContainerName:    ContainerNameKubeAPIServer,
+						MinAllowed:       kubeAPIServerMinAllowed,
+						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+					},
+				},
 			},
 		}
 
@@ -59,22 +69,4 @@ func (k *kubeAPIServer) reconcileVerticalPodAutoscaler(ctx context.Context, vert
 	})
 
 	return err
-}
-
-func (k *kubeAPIServer) computeVerticalPodAutoscalerContainerResourcePolicies(kubeAPIServerMinAllowed corev1.ResourceList) []vpaautoscalingv1.ContainerResourcePolicy {
-	var (
-		vpaContainerResourcePolicies = []vpaautoscalingv1.ContainerResourcePolicy{
-			{
-				ContainerName:    ContainerNameKubeAPIServer,
-				MinAllowed:       kubeAPIServerMinAllowed,
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			},
-			{
-				ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
-				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-			},
-		}
-	)
-
-	return vpaContainerResourcePolicies
 }

--- a/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
+++ b/pkg/component/kubernetes/apiserver/verticalpodautoscaler.go
@@ -6,7 +6,6 @@ package apiserver
 
 import (
 	"context"
-	"fmt"
 	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,21 +69,12 @@ func (k *kubeAPIServer) computeVerticalPodAutoscalerContainerResourcePolicies(ku
 				MinAllowed:       kubeAPIServerMinAllowed,
 				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			},
+			{
+				ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+			},
 		}
 	)
-
-	if k.values.VPN.HighAvailabilityEnabled {
-		for i := 0; i < k.values.VPN.HighAvailabilityNumberOfSeedServers; i++ {
-			vpaContainerResourcePolicies = append(vpaContainerResourcePolicies, vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName: fmt.Sprintf("%s-%d", containerNameVPNSeedClient, i),
-				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-			})
-		}
-		vpaContainerResourcePolicies = append(vpaContainerResourcePolicies, vpaautoscalingv1.ContainerResourcePolicy{
-			ContainerName: containerNameVPNPathController,
-			Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-		})
-	}
 
 	return vpaContainerResourcePolicies
 }

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-vpa.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-vpa.yaml
@@ -20,4 +20,6 @@ spec:
       controlledValues: RequestsOnly
       controlledResources:
       - memory
+    - containerName: '*'
+      mode: "Off"
 {{- end }}

--- a/pkg/component/networking/istio/charts/istio/istio-istiod/templates/autoscale.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-istiod/templates/autoscale.yaml
@@ -17,3 +17,5 @@ spec:
       - containerName: discovery
         minAllowed:
           memory: 128Mi
+      - containerName: '*'
+        mode: "Off"

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler_tls_termination_vpa.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler_tls_termination_vpa.yaml
@@ -20,3 +20,5 @@ spec:
       controlledValues: RequestsOnly
       controlledResources:
       - memory
+    - containerName: '*'
+      mode: "Off"

--- a/pkg/component/networking/istio/test_charts/istiod_autoscale.yaml
+++ b/pkg/component/networking/istio/test_charts/istiod_autoscale.yaml
@@ -18,3 +18,5 @@ spec:
       - containerName: discovery
         minAllowed:
           memory: 128Mi
+      - containerName: '*'
+        mode: "Off"

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -654,7 +654,7 @@ spec:
     containerPolicies:
     - containerName: node-cache
       controlledValues: RequestsOnly
-    - containerName: coredns-config-adapter
+    - containerName: '*'
       mode: "Off"
   targetRef:
     apiVersion: apps/v1
@@ -731,7 +731,7 @@ spec:
     containerPolicies:
     - containerName: node-cache
       controlledValues: RequestsOnly
-    - containerName: coredns-config-adapter
+    - containerName: '*'
       mode: "Off"
   targetRef:
     apiVersion: apps/v1
@@ -952,6 +952,8 @@ spec:
     containerPolicies:
     - containerName: node-cache
       controlledValues: RequestsOnly
+    - containerName: '*'
+      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
@@ -1169,7 +1171,7 @@ spec:
     containerPolicies:
     - containerName: node-cache
       controlledValues: RequestsOnly
-    - containerName: coredns-config-adapter
+    - containerName: '*'
       mode: "Off"
   targetRef:
     apiVersion: apps/v1

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -425,15 +425,13 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 								ContainerName:    containerName,
 								ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							},
+							{
+								ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+							},
 						},
 					},
 				},
-			}
-			if n.values.CustomDNSServerInNodeLocalDNS {
-				vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
-					ContainerName: sideCarName,
-					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				})
 			}
 			clientObjects = append(clientObjects, vpa)
 		}

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -864,25 +864,19 @@ func (v *vpnSeedServer) deployVPA(ctx context.Context) error {
 			UpdateMode: vpaUpdateMode,
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName: deploymentName,
-					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				},
-			},
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{},
 		}
 
-		if v.values.HighAvailabilityEnabled {
-			vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName: openVPNExporterContainerName,
-				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-			})
-		} else {
+		if !v.values.HighAvailabilityEnabled {
 			vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
 				ContainerName:    envoyProxyContainerName,
 				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			})
 		}
+		vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
+			ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+			Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+		})
 		return nil
 	})
 	return err

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -665,24 +665,19 @@ var _ = Describe("VpnSeedServer", func() {
 				targetKindRef = "StatefulSet"
 			}
 
-			containerPolicies := []vpaautoscalingv1.ContainerResourcePolicy{
-				{
-					ContainerName: "vpn-seed-server",
-					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				},
-			}
+			containerPolicies := []vpaautoscalingv1.ContainerResourcePolicy{}
 
-			if highAvailabilityEnabled {
-				containerPolicies = append(containerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
-					ContainerName: "openvpn-exporter",
-					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				})
-			} else {
+			if !highAvailabilityEnabled {
 				containerPolicies = append(containerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
 					ContainerName:    "envoy-proxy",
 					ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 				})
 			}
+
+			containerPolicies = append(containerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
+				ContainerName: "*",
+				Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+			})
 
 			return &vpaautoscalingv1.VerticalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -500,7 +500,6 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 		if v.values.VPAUpdateDisabled {
 			vpaUpdateMode = vpaautoscalingv1.UpdateModeOff
 		}
-		controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		kind := "Deployment"
 		if _, ok := deploymentOrStatefulSet.(*appsv1.StatefulSet); ok {
 			kind = "StatefulSet"
@@ -520,9 +519,13 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN *corev1.Secret, secretsVPNSh
 				MinAllowed: corev1.ResourceList{
 					corev1.ResourceMemory: resource.MustParse("10Mi"),
 				},
-				ControlledValues: &controlledValues,
+				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 			})
 		}
+		containerPolicies = append(containerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
+			ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+			Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+		})
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "vpn-shoot",

--- a/pkg/component/networking/vpn/shoot/shoot_test.go
+++ b/pkg/component/networking/vpn/shoot/shoot_test.go
@@ -329,6 +329,10 @@ var _ = Describe("VPNShoot", func() {
 									corev1.ResourceMemory: resource.MustParse("10Mi"),
 								},
 							},
+							{
+								ContainerName: "*",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+							},
 						},
 					},
 				},
@@ -380,6 +384,10 @@ var _ = Describe("VPNShoot", func() {
 								MinAllowed: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("10Mi"),
 								},
+							},
+							{
+								ContainerName: "*",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 							},
 						},
 					},

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -326,10 +326,15 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 		}
 		vpa.Spec.UpdatePolicy = &vpaautoscalingv1.PodUpdatePolicy{UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate)}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-				ContainerName:    containerName,
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			}},
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+				{
+					ContainerName:    containerName,
+					ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+				},
+				{
+					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff)},
+			},
 		}
 		return nil
 	}); err != nil {

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -330,10 +330,16 @@ var _ = Describe("MachineControllerManager", func() {
 					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-						ContainerName:    "machine-controller-manager",
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-					}},
+					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+						{
+							ContainerName:    "machine-controller-manager",
+							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						},
+					},
 				},
 			},
 		}

--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -318,33 +318,12 @@ func (v *vali) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{
-						ContainerName:    curatorName,
-						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-					},
-					{
-						ContainerName:    initLargeDirName,
-						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},
 		},
-	}
-
-	if v.values.ShootNodeLoggingEnabled {
-		vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies,
-			vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName:    kubeRBACProxyName,
-				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			},
-			vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName:    telegrafName,
-				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			},
-		)
 	}
 
 	return vpa

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Vali", func() {
 				Expect(managedResource).To(consistOf(
 					getTelegrafConfigMap(),
 					getValiConfigMap(),
-					getVPA(true),
+					getVPA(),
 					getIngress("/vali/api/v1/push", "logging", 8080),
 					getService(true, "shoot"),
 					getStatefulSet(true),
@@ -278,7 +278,7 @@ var _ = Describe("Vali", func() {
 				Expect(managedResource).To(DeepEqual(expectedMr))
 				Expect(managedResource).To(consistOf(
 					getValiConfigMap(),
-					getVPA(true),
+					getVPA(),
 					getService(true, "shoot"),
 					getStatefulSet(false),
 					getServiceMonitor("shoot", true),
@@ -349,7 +349,7 @@ var _ = Describe("Vali", func() {
 			Expect(managedResource).To(consistOf(
 				getValiConfigMap(),
 				getService(false, "seed"),
-				getVPA(false),
+				getVPA(),
 				getStatefulSet(false),
 				getServiceMonitor("aggregate", false),
 				getPrometheusRule("aggregate"),
@@ -1081,7 +1081,7 @@ wait
 	return configMap
 }
 
-func getVPA(isRBACProxyEnabled bool) *vpaautoscalingv1.VerticalPodAutoscaler {
+func getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 	vpa := &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      valiName + "-vpa",
@@ -1106,33 +1106,12 @@ func getVPA(isRBACProxyEnabled bool) *vpaautoscalingv1.VerticalPodAutoscaler {
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{
-						ContainerName:    "curator",
-						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-					},
-					{
-						ContainerName:    "init-large-dir",
-						Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
+						ContainerName: "*",
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},
 		},
-	}
-
-	if isRBACProxyEnabled {
-		vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies,
-			vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName:    "kube-rbac-proxy",
-				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			},
-			vpaautoscalingv1.ContainerResourcePolicy{
-				ContainerName:    "telegraf",
-				Mode:             ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-				ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
-			},
-		)
 	}
 
 	return vpa

--- a/pkg/component/observability/logging/victoria/operator/victoria_operator.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator.go
@@ -36,6 +36,7 @@ const (
 	name = "victoria-operator"
 
 	// Resource names
+	containerName           = name
 	managedResourceName     = name
 	serviceAccountName      = name
 	deploymentName          = name
@@ -151,7 +152,7 @@ func (v *victoriaOperator) deployment() *appsv1.Deployment {
 					},
 					Containers: []corev1.Container{
 						{
-							Name:            "victoria-operator",
+							Name:            containerName,
 							Image:           v.values.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
@@ -255,10 +256,14 @@ func (v *victoriaOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ContainerName: containerName,
 						MinAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
+					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},

--- a/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
@@ -256,10 +256,14 @@ var _ = Describe("VictoriaOperator", func() {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName: "*",
+							ContainerName: "victoria-operator",
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
+						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
 				},

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -207,12 +207,6 @@ var _ = Describe("Alertmanager", func() {
 			},
 		}
 
-		var (
-			vpaUpdateMode                   = vpaautoscalingv1.UpdateModeRecreate
-			vpaControlledValuesRequestsOnly = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-			vpaContainerScalingModeOff      = vpaautoscalingv1.ContainerScalingModeOff
-		)
-
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "alertmanager-" + name,
@@ -231,7 +225,7 @@ var _ = Describe("Alertmanager", func() {
 					Name:       name,
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &vpaUpdateMode,
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
@@ -243,12 +237,12 @@ var _ = Describe("Alertmanager", func() {
 							MaxAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("200Mi"),
 							},
-							ControlledValues:    &vpaControlledValuesRequestsOnly,
+							ControlledValues:    ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 						},
 						{
-							ContainerName: "config-reloader",
-							Mode:          &vpaContainerScalingModeOff,
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
 				},

--- a/pkg/component/observability/monitoring/alertmanager/vpa.go
+++ b/pkg/component/observability/monitoring/alertmanager/vpa.go
@@ -11,18 +11,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
 func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
-	var (
-		updateMode                   = vpaautoscalingv1.UpdateModeRecreate
-		controlledValuesRequestsOnly = vpaautoscalingv1.ContainerControlledValuesRequestsOnly
-		containerScalingModeOff      = vpaautoscalingv1.ContainerScalingModeOff
-	)
-
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      a.name(),
@@ -38,7 +33,7 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 				Name:       a.values.Name,
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-				UpdateMode: &updateMode,
+				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 			},
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
@@ -50,12 +45,12 @@ func (a *alertManager) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 						MaxAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
-						ControlledValues:    &controlledValuesRequestsOnly,
+						ControlledValues:    ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 					},
 					{
-						ContainerName: "config-reloader",
-						Mode:          &containerScalingModeOff,
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -411,7 +411,7 @@ honor_labels: true`
 							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 						},
 						{
-							ContainerName: "config-reloader",
+							ContainerName: "*",
 							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 						},
 					},
@@ -1168,11 +1168,6 @@ query_range:
 						Port:       81,
 						TargetPort: intstr.FromInt32(9091),
 						Protocol:   corev1.ProtocolTCP,
-					})
-
-					vpa.Spec.ResourcePolicy.ContainerPolicies = append(vpa.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
-						ContainerName: "cortex",
-						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					})
 
 					prometheusRule.Namespace = namespace

--- a/pkg/component/observability/monitoring/prometheus/vpa.go
+++ b/pkg/component/observability/monitoring/prometheus/vpa.go
@@ -45,19 +45,12 @@ func (p *prometheus) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 						ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 					},
 					{
-						ContainerName: "config-reloader",
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
 						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
 					},
 				},
 			},
 		},
-	}
-
-	if p.values.Cortex != nil {
-		obj.Spec.ResourcePolicy.ContainerPolicies = append(obj.Spec.ResourcePolicy.ContainerPolicies, vpaautoscalingv1.ContainerResourcePolicy{
-			ContainerName: containerNameCortex,
-			Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
-		})
 	}
 
 	return obj

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -397,6 +397,10 @@ func (o *openTelemetryOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
 					},
+					{
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+					},
 				},
 			},
 		},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -327,6 +327,10 @@ var _ = Describe("OpenTelemetry Operator", func() {
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
 						},
+						{
+							ContainerName: "*",
+							Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+						},
 					},
 				},
 			},

--- a/pkg/utils/gardener/vpa.go
+++ b/pkg/utils/gardener/vpa.go
@@ -33,12 +33,18 @@ func ReconcileVPAForGardenerComponent(ctx context.Context, c client.Client, name
 			UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 		}
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
-			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-				ContainerName: name,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("200Mi"),
+			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+				{
+					ContainerName: name,
+					MinAllowed: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("200Mi"),
+					},
 				},
-			}},
+				{
+					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+					Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+				},
+			},
 		}
 		return nil
 	})

--- a/pkg/utils/gardener/vpa_test.go
+++ b/pkg/utils/gardener/vpa_test.go
@@ -64,12 +64,18 @@ var _ = Describe("VPA", func() {
 						UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeRecreate),
 					},
 					ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
-						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-							ContainerName: name,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("200Mi"),
+						ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
+							{
+								ContainerName: name,
+								MinAllowed: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+								},
 							},
-						}},
+							{
+								ContainerName: "*",
+								Mode:          ptr.To(vpaautoscalingv1.ContainerScalingModeOff),
+							},
+						},
 					},
 				},
 			}))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This is a follow-up to https://github.com/gardener/gardener/pull/13819, covering all VPAs, which haven't been part of that first PR.

This PR ensures that all VPAs have a ContainerResourcePolicy with a concrete Container name for all those containers which should be under VPA control. Additionally, it introduces a "switch all other Containers off" ContainerResourcePolicy to the respective VPAs.

The reasoning behind this change is to make it explicit, which Containers should be under VPA control (and with which settings). This avoids having VPA unintentionally activated for sidecar Containers (e.g. injected later on by a different Controller).

Unfortunately, vpa-recommender always injects the default "catch-all" policy, even when a ContainerResourcePolicy using a specific Container name is defined.
The behavior of vpa-recommender when both kinds of ContainerResourcePolicies are present is that the [match-by-name is done first, and if there is no such ContainerResourcePolicy found, it returns the catch-all Policy](https://github.com/kubernetes/autoscaler/blob/0e5b02cbab66c244e21afbacae7fccb0f783b827/vertical-pod-autoscaler/pkg/utils/vpa/api.go#L250-L257).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Adapted golang components:
* etcd
* etcd-druid
* kube-apiserver
* prometheus
* alertmanager
* vali
* vpn-shoot
* vpn-seed
* machine-controller-manager
* gardener-apiserver
* nodelocal-dns
* victoria-operator
* otel-operator
* utils/gardener

Adapted helm charts:
* provider-local
* admission-local
* istiod
* istio-ingressgateway


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
All VerticalPodAutoscaler resources managed by Gardener are enhanced to define an explicit container policy for all containers that need to be auto-scaled and to have a `catch-all` container policy (`containerName: '*'` and `mode: Off`) always.
```
