### PR TITLE
[GEP-28] `gardener-node-agent` waits for rollout + readiness of static pods

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -63,7 +63,6 @@ type GardenadmBotanist struct {
 
 	operatingSystemConfigSecret       *corev1.Secret
 	gardenerResourceManagerServiceIPs []string
-	staticPodNameToHash               map[string]string
 	useEtcdManagedByDruid             bool
 
 	// controlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.

--- a/pkg/gardenadm/botanist/controlplane_test.go
+++ b/pkg/gardenadm/botanist/controlplane_test.go
@@ -5,25 +5,11 @@
 package botanist
 
 import (
-	"context"
-	"time"
-
 	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/gardenlet/operation"
-	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
-	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("ControlPlane", func() {
@@ -44,142 +30,6 @@ var _ = Describe("ControlPlane", func() {
 			version, err := b.DiscoverKubernetesVersion(fakekubernetes.NewClientSetBuilder().WithVersion("cannot-parse").Build())
 			Expect(err).To(MatchError(ContainSubstring("failed parsing semver version")))
 			Expect(version).To(BeNil())
-		})
-	})
-
-	Describe("#WaitUntilControlPlaneDeploymentsReady", func() {
-		var (
-			ctx           = context.Background()
-			fakeClient    client.Client
-			fakeClientSet kubernetes.Interface
-
-			podName  = "static-pod"
-			poolName = "pool"
-			nodeName = "node"
-
-			staticPod               *corev1.Pod
-			gardenerNodeAgentSecret *corev1.Secret
-			node                    *corev1.Node
-			managedResource         *resourcesv1alpha1.ManagedResource
-		)
-
-		BeforeEach(func() {
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
-			fakeClientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
-
-			b.Botanist = &botanistpkg.Botanist{Operation: &operation.Operation{
-				SeedClientSet:  fakeClientSet,
-				ShootClientSet: fakeClientSet,
-				Shoot: &shoot.Shoot{
-					ControlPlaneNamespace: "kube-system",
-				},
-			}}
-
-			b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Provider: gardencorev1beta1.Provider{
-						Workers: []gardencorev1beta1.Worker{{Name: poolName}},
-					},
-				},
-			})
-
-			DeferCleanup(test.WithVars(
-				&botanistpkg.IntervalWaitOperatingSystemConfigUpdated, 5*time.Millisecond,
-				&botanistpkg.GetTimeoutWaitOperatingSystemConfigUpdated, func(_ *shoot.Shoot) time.Duration { return 10 * time.Millisecond },
-			))
-
-			staticPod = &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        podName + "-" + nodeName,
-					Namespace:   "kube-system",
-					Labels:      map[string]string{"static-pod": "true"},
-					Annotations: map[string]string{"gardener.cloud/config.mirror": "hash1"},
-				},
-				Spec: corev1.PodSpec{NodeName: nodeName},
-			}
-			gardenerNodeAgentSecret = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-node-agent-" + poolName,
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"worker.gardener.cloud/pool": poolName,
-						"gardener.cloud/role":        "operating-system-config",
-					},
-					Annotations: map[string]string{"checksum/data-script": "foo"},
-				},
-			}
-			node = &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        nodeName,
-					Labels:      map[string]string{"worker.gardener.cloud/pool": poolName},
-					Annotations: map[string]string{"checksum/cloud-config-data": gardenerNodeAgentSecret.Annotations["checksum/data-script"]},
-				},
-			}
-			managedResource = &resourcesv1alpha1.ManagedResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "shoot-gardener-node-agent",
-					Namespace:  "kube-system",
-					Generation: 1,
-				},
-				Status: resourcesv1alpha1.ManagedResourceStatus{
-					ObservedGeneration: 1,
-					Conditions: []gardencorev1beta1.Condition{
-						{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue},
-						{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue},
-					},
-				},
-			}
-
-			Expect(fakeClient.Create(ctx, staticPod)).To(Succeed())
-			Expect(fakeClient.Create(ctx, gardenerNodeAgentSecret)).To(Succeed())
-			Expect(fakeClient.Create(ctx, node)).To(Succeed())
-			Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
-		})
-
-		It("should succeed when the hashes match and the OSC is up-to-date", func() {
-			b.staticPodNameToHash = map[string]string{podName: staticPod.Annotations["gardener.cloud/config.mirror"]}
-
-			Expect(b.WaitUntilControlPlaneDeploymentsReady(ctx)).To(Succeed())
-		})
-
-		It("should fail when the hashes is outdated", func() {
-			b.staticPodNameToHash = map[string]string{podName: "some-other-hash"}
-
-			Expect(b.WaitUntilControlPlaneDeploymentsReady(ctx)).To(MatchError(ContainSubstring("not all static pods have been updated yet")))
-		})
-
-		It("should fail when a desired static pod is missing", func() {
-			b.staticPodNameToHash = map[string]string{
-				podName: staticPod.Annotations["gardener.cloud/config.mirror"],
-				"foo":   "bar",
-			}
-
-			Expect(b.WaitUntilControlPlaneDeploymentsReady(ctx)).To(MatchError(ContainSubstring("not all static pods have been updated yet")))
-		})
-
-		It("should fail when there is an unexpected static pod", func() {
-			b.staticPodNameToHash = map[string]string{podName: staticPod.Annotations["gardener.cloud/config.mirror"]}
-
-			Expect(fakeClient.Create(ctx, &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "some-other-pod-" + nodeName,
-					Namespace:   "kube-system",
-					Labels:      map[string]string{"static-pod": "true"},
-					Annotations: map[string]string{"gardener.cloud/config.mirror": "foo"},
-				},
-				Spec: corev1.PodSpec{NodeName: nodeName},
-			})).To(Succeed())
-
-			Expect(b.WaitUntilControlPlaneDeploymentsReady(ctx)).To(MatchError(ContainSubstring("not all static pods have been updated yet")))
-		})
-
-		It("should fail when the operating system config is not up-to-date", func() {
-			b.staticPodNameToHash = map[string]string{podName: staticPod.Annotations["gardener.cloud/config.mirror"]}
-
-			node.Annotations["checksum/cloud-config-data"] = "some-outdated-checksum"
-			Expect(fakeClient.Update(ctx, node)).To(Succeed())
-
-			Expect(b.WaitUntilControlPlaneDeploymentsReady(ctx)).To(MatchError(ContainSubstring(`the last successfully applied operating system config on node "` + nodeName + `" is outdated`)))
 		})
 	})
 })

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -83,7 +83,6 @@ func (b *GardenadmBotanist) deployOperatingSystemConfig(ctx context.Context) (*o
 	if err != nil {
 		return nil, "", fmt.Errorf("failed computing files for static control plane pods: %w", err)
 	}
-	b.staticPodNameToHash = pods.nameToHashMap()
 
 	files, err := b.appendAdminKubeconfigToFiles(pods.allFiles())
 	if err != nil {

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -327,7 +327,7 @@ func run(ctx context.Context, opts *Options) error {
 		})
 		waitUntilControlPlaneDeploymentsReady = g.Add(flow.Task{
 			Name:         "Waiting until control plane components (static pods) are ready",
-			Fn:           b.WaitUntilControlPlaneDeploymentsReady,
+			Fn:           b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools,
 			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -326,8 +326,10 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilEtcdsReady),
 		})
 		waitUntilControlPlaneDeploymentsReady = g.Add(flow.Task{
-			Name:         "Waiting until control plane components (static pods) are ready",
-			Fn:           b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools,
+			Name: "Waiting until control plane components (static pods) are ready",
+			Fn: func(ctx context.Context) error {
+				return b.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)
+			},
 			Dependencies: flow.NewTaskIDs(deployControlPlaneDeployments),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -918,8 +918,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(syncPointAllSystemComponentsDeployed, waitUntilNetworkIsReady, waitUntilWorkerReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Waiting until all shoot worker nodes have updated the operating system config",
-			Fn:           botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools,
+			Name: "Waiting until all shoot worker nodes have updated the operating system config",
+			Fn: func(ctx context.Context) error {
+				return botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)
+			},
 			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -194,7 +194,7 @@ func getTimeoutWaitOperatingSystemConfigUpdated(shoot *shootpkg.Shoot) time.Dura
 
 // WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools waits for a maximum of 6 minutes until all the nodes for all
 // the worker pools in the Shoot have successfully applied the desired version of their operating system config.
-func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx context.Context) error {
+func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx context.Context, tolerateErrors bool) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
 	defer cancel()
 
@@ -205,15 +205,20 @@ func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx co
 	timeoutCtx2, cancel2 := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
 	defer cancel2()
 
+	retryFn := retry.SevereError
+	if tolerateErrors {
+		retryFn = retry.MinorError
+	}
+
 	return retry.Until(timeoutCtx2, IntervalWaitOperatingSystemConfigUpdated, func(ctx context.Context) (done bool, err error) {
 		workerPoolToNodes, err := WorkerPoolToNodesMap(ctx, b.ShootClientSet.Client())
 		if err != nil {
-			return retry.SevereError(err)
+			return retryFn(err)
 		}
 
 		workerPoolToOperatingSystemConfigSecretMeta, err := WorkerPoolToOperatingSystemConfigSecretMetaMap(ctx, b.ShootClientSet.Client(), v1beta1constants.GardenRoleOperatingSystemConfig)
 		if err != nil {
-			return retry.SevereError(err)
+			return retryFn(err)
 		}
 
 		if err := OperatingSystemConfigUpdatedForAllWorkerPools(b.Shoot.GetInfo().Spec.Provider.Workers, workerPoolToNodes, workerPoolToOperatingSystemConfigSecretMeta); err != nil {

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Worker", func() {
 				})).AnyTimes(),
 			)
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx)).To(MatchError(ContainSubstring("the operating system configs for the worker nodes were not populated yet")))
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(MatchError(ContainSubstring("the operating system configs for the worker nodes were not populated yet")))
 		})
 
 		It("should fail when the operating system config was not updated for all worker pools", func() {
@@ -473,7 +473,7 @@ var _ = Describe("Worker", func() {
 				}).AnyTimes(),
 			)
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx)).To(MatchError(ContainSubstring("is outdated")))
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(MatchError(ContainSubstring("is outdated")))
 		})
 
 		It("should succeed when the operating system config was updated for all worker pools", func() {
@@ -539,7 +539,7 @@ var _ = Describe("Worker", func() {
 				}).AnyTimes(),
 			)
 
-			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx)).To(Succeed())
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(Succeed())
 		})
 	})
 })

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -1165,7 +1165,8 @@ func (r *Reconciler) ensureStaticPodsReconciledAndReady(ctx context.Context, log
 
 func (r *Reconciler) getDesiredStaticPodHashes(log logr.Logger, osc *extensionsv1alpha1.OperatingSystemConfig) (map[string]string, error) {
 	staticPodFiles := slices.DeleteFunc(append(osc.Spec.Files, osc.Status.ExtensionFiles...), func(file extensionsv1alpha1.File) bool {
-		return !strings.HasPrefix(file.Path, kubeletcomponent.FilePathKubernetesManifests)
+		return !strings.HasPrefix(file.Path, kubeletcomponent.FilePathKubernetesManifests) ||
+			(file.HostName != nil && *file.HostName != r.HostName)
 	})
 
 	staticPodNameToHash := make(map[string]string)

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -1148,7 +1148,7 @@ func (r *Reconciler) ensureStaticPodsReconciledAndReady(ctx context.Context, log
 	}
 
 	for _, pod := range staticPodList.Items {
-		if err := health.CheckPod(&pod); err != nil {
+		if health.CheckPod(&pod) != nil {
 			log.Info("Static pod is not healthy yet, requeuing", "pod", client.ObjectKeyFromObject(&pod))
 			return false, nil //nolint:nilerr
 		}

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -454,6 +454,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/routes
             - pkg/features
+            - pkg/gardenadm/staticpod
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -622,6 +622,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/routes
             - pkg/features
+            - pkg/gardenadm/staticpod
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1606,6 +1606,7 @@ build:
             - pkg/controllerutils/predicate
             - pkg/controllerutils/routes
             - pkg/features
+            - pkg/gardenadm/staticpod
             - pkg/gardenlet/apis/config/v1alpha1
             - pkg/healthz
             - pkg/logger

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_suite_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_suite_test.go
@@ -6,11 +6,13 @@ package operatingsystemconfig_test
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -38,9 +40,10 @@ func TestOperatingSystemConfig(t *testing.T) {
 const testID = "osc-controller-test"
 
 var (
-	ctx   = context.Background()
-	log   logr.Logger
-	codec runtime.Codec
+	ctx       = context.Background()
+	log       logr.Logger
+	logBuffer *gbytes.Buffer
+	codec     runtime.Codec
 
 	restConfig *rest.Config
 	testEnv    *envtest.Environment
@@ -59,7 +62,8 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logBuffer = gbytes.NewBuffer()
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(io.MultiWriter(GinkgoWriter, logBuffer))))
 	log = logf.Log.WithName(testID)
 
 	By("Start test environment")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impSimp = "Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion." includes /kind enhancement maybe.
-->
/area os
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR refines how Gardener determines the readiness of control plane nodes during operating system configuration rollouts as part of GEP-28.

It removes the explicit, ad-hoc waiting logic for static pod rollouts (notably in `gardenadm init`) and instead consolidates readiness checks behind the `OperatingSystemConfig` reconciliation and status handling. The reconciler is enhanced to more accurately reflect rollout completion, including tolerance to transient errors while waiting for the rollout to converge.

With these changes, when gardener-node-agent reports `OperatingSystemConfig` readiness, it is a stronger signal that control plane nodes are fully updated, including rollout and readiness of static pods. This improves robustness, avoids duplicated waiting logic, and simplifies the control plane bootstrap and reconciliation flow.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

- The explicit wait for static pod rollout in `gardenadm init` has been dropped in favor of relying on `OperatingSystemConfig` readiness.
- Waiting logic now tolerates certain errors during rollout observation to avoid premature failures.
- Includes integration tests and updated documentation to reflect the adjusted semantics and flow.

/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```