### PR TITLE
Unconditionally enable `discovery.k8s.io/v1` for workerless shoots

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -3496,7 +3496,7 @@ kind: AuthorizationConfiguration
 						"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 						"--requestheader-group-headers=X-Remote-Group",
 						"--requestheader-username-headers=X-Remote-User",
-						"--runtime-config=apps/v1=false,autoscaling/v2=false,batch/v1=false,discovery.k8s.io/v1=false,policy/v1=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=false,autoscaling/v2=false,batch/v1=false,policy/v1=false,storage.k8s.io/v1/csinodes=false",
 						"--secure-port=443",
 						"--service-cluster-ip-range="+serviceNetworkCIDRs[0].String()+","+serviceNetworkCIDRs[1].String(),
 						"--service-account-issuer="+serviceAccountIssuer,
@@ -4296,7 +4296,7 @@ kind: AuthenticationConfiguration
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement(
-						"--runtime-config=apps/v1=true,autoscaling/v2=false,bar=false,batch/v1=false,discovery.k8s.io/v1=false,policy/v1=false,storage.k8s.io/v1/csinodes=false",
+						"--runtime-config=apps/v1=true,autoscaling/v2=false,bar=false,batch/v1=false,policy/v1=false,storage.k8s.io/v1/csinodes=false",
 					))
 				})
 

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -37,7 +37,6 @@ import (
 	netutils "github.com/gardener/gardener/pkg/utils/net"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -443,10 +442,6 @@ func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 			"batch/v1":                   false,
 			"policy/v1":                  false,
 			"storage.k8s.io/v1/csinodes": false,
-		}
-
-		if versionutils.ConstraintK8sLess134.Check(k.values.Version) {
-			disableAPIs["discovery.k8s.io/v1"] = false
 		}
 
 		// Allow users to explicitly enable disabled APIs via RuntimeConfig.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The PR unconditionally enables `discovery.k8s.io/v1` for workerless shoots. This is needed because from [this](https://github.com/gardener/gardener/pull/13820) PR, endpoint slices are created in the virtual garden cluster that require `discovery.k8s.io/v1` APIs.

Also, disabling them for workerless shoots in general doesn't make sense because service creation is allowed in workerless shoots.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
