### PR TITLE
Enable `discovery.k8s.io/v1` API for workerless api-servers by default with `>=1.33`

### DIFF
--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -445,7 +445,7 @@ func (k *kubeAPIServer) computeKubeAPIServerArgs() []string {
 			"storage.k8s.io/v1/csinodes": false,
 		}
 
-		if versionutils.ConstraintK8sLess134.Check(k.values.Version) {
+		if versionutils.ConstraintK8sLess133.Check(k.values.Version) {
 			disableAPIs["discovery.k8s.io/v1"] = false
 		}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

- `gardener-operator` deploys a workerless kube-apiserver as the `virtual-garden-kube-apiserver`
- Connection between `gardener-apiserver` and `virtual-garden-kube-apiserver` is facilitated through `Endpoint`-API (deprecated with `1.33`)
- We implemented switching to the `EndpointSlice`-API with `virtual-garden-kube-apiserver` `>=1.33` ([ref](https://github.com/gardener/gardener/pull/12883/changes/0131a4356306b7fe504b727475f75bc8f9a8bb71))
- API was disabled until `1.34` (before this PR)
- Enabling it for `1.33` already should not be a problem ([ref](https://github.com/gardener/gardener/commit/e4950e24c7527d41ed035eaee03ed469885d7731))

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
No `bugfix` release note, because https://github.com/gardener/gardener/pull/13820 was not released yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The `discovery.k8s.io/v1`-API is enabled by default for workerless `Shoot`s with Kubernetes `>=1.33`.
```
