### PR TITLE
extensions/webhook: Return http.StatusForbidden if validation/mutation fails

### DIFF
--- a/extensions/pkg/webhook/handler.go
+++ b/extensions/pkg/webhook/handler.go
@@ -174,7 +174,7 @@ func (h *handler) handle(ctx context.Context, req admission.Request, action hand
 	case action.mutator != nil:
 		if err = action.mutator.Mutate(ctx, newObj, oldObj); err != nil {
 			h.logger.Error(fmt.Errorf("could not process: %w", err), "Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
-			return admission.Errored(http.StatusUnprocessableEntity, err)
+			return admission.Denied(err.Error())
 		}
 
 		// Return a patch response if the resource should be changed
@@ -194,7 +194,7 @@ func (h *handler) handle(ctx context.Context, req admission.Request, action hand
 	case action.validator != nil:
 		if err = action.validator.Validate(ctx, newObj, oldObj); err != nil {
 			h.logger.Error(fmt.Errorf("could not process: %w", err), "Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
-			return admission.Errored(http.StatusUnprocessableEntity, err)
+			return admission.Denied(err.Error())
 		}
 	}
 

--- a/extensions/pkg/webhook/handler_test.go
+++ b/extensions/pkg/webhook/handler_test.go
@@ -176,8 +176,9 @@ var _ = Describe("Handler", func() {
 				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: false,
 					Result: &metav1.Status{
-						Code:    http.StatusUnprocessableEntity,
+						Code:    http.StatusForbidden,
 						Message: "test error",
+						Reason:  metav1.StatusReasonForbidden,
 					},
 				},
 			}))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

This PR fixes the status code returned by extension webhooks to `http.StatusForbidden`, so that proper error details are propagated back to clients.

**Which issue(s) this PR fixes**:
Fixes #14010 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
extension library: Extension admission webhooks now return `http.StatusForbidden` when validation/mutation fails. With this, the failure reason is now properly displayed when updating the resource with `kubectl edit`.
```
