### PR TITLE
Escape HTML tags in Markdown

### DIFF
--- a/docs/proposals/10-shoot-additional-container-runtimes.md
+++ b/docs/proposals/10-shoot-additional-container-runtimes.md
@@ -99,8 +99,8 @@ Each extension will need to address the following concerns:
     2. The installation above should be done by a new kind of extension: ContainerRuntime resource. For each container runtime type (Kata-container/gvisor), a dedicate extension controller will be created.
         1. A label for each container runtime support will be added to every node that belongs to the worker pool. This should be done similarly to the way labels are created today for each node, through kubelet execution parameters (`_kubelet.flags: --node-labels`). When creating the OperatingSystemConfig (original) for the worker, each container runtime support should be mapped to a label on the node.
            For Example:
-           label: `container.runtime.kata-containers=true` (shoot.spec.cloud.<IAAS>.worker.containerRuntimes.kata-container)
-           label: `container.runtime.gvisor=true` (shoot.spec.cloud.<IAAS>.worker.containerRuntimes.gvisor)
+           label: `container.runtime.kata-containers=true` (`shoot.spec.cloud.<IAAS>.worker.containerRuntimes.kata-container`)
+           label: `container.runtime.gvisor=true` (`shoot.spec.cloud.<IAAS>.worker.containerRuntimes.gvisor`)
         1. During the shoot reconciliation (Similar steps to the Extensions today), Gardener will create new ContainerRuntime resource if a container runtime exist in at least one worker spec:
             ```yaml
             apiVersion: extensions.gardener.cloud/v1alpha1

--- a/docs/proposals/15-manage-bastions-and-ssh-key-pair-rotation.md
+++ b/docs/proposals/15-manage-bastions-and-ssh-key-pair-rotation.md
@@ -65,9 +65,9 @@ The following is a list of involved components that either need to be newly intr
   - Creates `Bastion` resource in the garden cluster
   - Establishes an `ssh` connection to a shoot node, using a bastion host as proxy
   - Heartbeats / keeps alive the `Bastion` resource during `ssh` connection
-- Gardener extension provider <infra>
+- Gardener extension provider `<infra>`
   - Provider specific bastion controller
-  - Should be added to gardener-extension-provider-<infra> repos, e.g. https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/controller
+  - Should be added to `gardener-extension-provider-<infra>` repos, e.g. https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/controller
   - Has the permission to update the `Bastion/status` subresource on the seed cluster
   - Runs on seed (of course)
 - Gardener Controller Manager (`GCM`)
@@ -94,7 +94,7 @@ The following is a list of involved components that either need to be newly intr
     - Watches `Bastion` resource for own seed under api group `operations.gardener.cloud` in the garden cluster.
     - Creates `Bastion` custom resource under api group `extensions.gardener.cloud/v1alpha1` in the seed cluster.
       - Populates bastion user data under field under `spec.userData`, similar to https://github.com/gardener/gardenctl/blob/1e3e5fa1d5603e2161f45046ba7c6b5b4107369e/pkg/cmd/ssh.go#L160-L171. This means that the `spec.sshPublicKey` from the `Bastion` resource in the garden cluster will end up in the `authorized_keys` file on the bastion host.
-4. Gardener extension provider <infra> / Bastion Controller on Seed:
+4. Gardener extension provider `<infra>` / Bastion Controller on Seed:
     - With own `Bastion` Custom Resource Definition in the seed under the api group `extensions.gardener.cloud/v1alpha1`.
     - Watches `Bastion` custom resources that are created by the `gardenlet` in the seed.
     - The controller reads the `cloudprovider` credentials from the seed-shoot namespace.
@@ -117,7 +117,7 @@ The following is a list of involved components that either need to be newly intr
     - Once `status.expirationTimestamp` is reached, the `Bastion` will be marked for deletion.
 8. `gardenlet`:
     - Once the `Bastion` resource in the garden cluster is marked for deletion, it marks the `Bastion` resource in the seed for deletion.
-9. Gardener extension provider <infra> / Bastion Controller on Seed:
+9. Gardener extension provider `<infra>` / Bastion Controller on Seed:
     - All created resources will be cleaned up.
     - On success, removes finalizer on `Bastion` resource in seed.
 10. `gardenlet`:

--- a/docs/proposals/20-ha-control-planes.md
+++ b/docs/proposals/20-ha-control-planes.md
@@ -952,9 +952,9 @@ kubectl get po -n <shoot-control-ns> # list of pods in the shoot control plane
 | csi-snapshot-validation-7c99986c85-ft2qp     | 1/1   | Running | ip-10-242-60-155.eu-west-1.compute.internal |
 | etcd-events-0    | 2/2   | Running | ip-10-242-60-155.eu-west-1.compute.internal |
 | etcd-events-1    | 2/2   | Running | ip-10-242-73-89.eu-west-1.compute.internal |
-| etcd-events-2     | 0/2   | Pending | <none> |
+| etcd-events-2     | 0/2   | Pending | &lt;none&gt; |
 | etcd-main-0     | 2/2   | Running | ip-10-242-73-77.eu-west-1.compute.internal |
-| etcd-main-1    | 0/2  | Pending | <none> |
+| etcd-main-1    | 0/2  | Pending | &lt;none&gt; |
 | etcd-main-2    | 2/2   | Running | ip-10-242-53-131.eu-west-1.compute.internal |
 | gardener-resource-manager-7fff9f77f6-8wr5n     | 1/1   | Running | ip-10-242-73-89.eu-west-1.compute.internal |
 | gardener-resource-manager-7fff9f77f6-jwggx     | 1/1   | Running | ip-10-242-73-89.eu-west-1.compute.internal |


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:

We want to move the Gardener Enhancement Proposals (GEPs) from this repository to `gardener/enhancements` ([ref](https://github.com/gardener/gardener/issues/12644#issuecomment-3879039678)).
With this move, they should also be included as part of the documentation:
* https://github.com/gardener/documentation/pull/848

The documentation framework parses the Markdown files and converts them to HTML. Therefore, unclosed HTML tags such as `<none>` that appear outside of a Markdown code block cause issues. This PR escapes `<` and `>` that appear in a regular Markdown table using HTML entities `&lt;` and `&gt;` or using Markdown inline code.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

_n.a._

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
