### PR TITLE
Separate `golang-test` and `krte` steps in "Updating Go" guide

### DIFF
--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -74,18 +74,22 @@ Once a new Go version is released, please consider the guidance below for updati
 
 1. Check the [release notes](https://go.dev/doc/devel/release) to see whether there are any relevant changes that might be useful or affect us in another way.
 
-2. Maintain the image variants of the [`krte`](https://github.com/gardener/ci-infra/tree/master/images/krte) image used for end-to-end testing in [KinD](https://kind.sigs.k8s.io/) in the [`hack/tools/image/variants.yaml`](../../hack/tools/image/variants.yaml) file.
+2. Maintain the image variants of the [`golang-test`](../../hack/tools/image) image used for unit- and integration testing as well as being the base image for `krte` (see next step) in the [`hack/tools/image/variants.yaml`](../../hack/tools/image/variants.yaml) file.
    Remove older Go versions [if they are no longer supported](https://endoflife.date/go) and add the new version ([example](https://github.com/gardener/gardener/pull/12770)).  
-   Check the registry to see when the new image variants are available:
-   * [europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fkrte)
-   * [europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test)
+   Check the registry to see when the new image variant is available:  
+   [europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test)
 
-3. The images used by the CI jobs are maintained in the [ci-infra repository](https://github.com/gardener/ci-infra).
+3. Maintain the image variants of the [`krte`](https://github.com/gardener/ci-infra/tree/master/images/krte) image used for end-to-end testing in [KinD](https://kind.sigs.k8s.io/) in the [`ci-infra:hack/tools/image/variants.yaml`](https://github.com/gardener/ci-infra/blob/master/images/krte/variants.yaml) file.
+   Remove older Go versions [if they are no longer supported](https://endoflife.date/go) and add the new version ([example](https://github.com/gardener/ci-infra/pull/4332)).  
+   Check the registry to see when the new image variant is available:  
+   [europe-docker.pkg.dev/gardener-project/releases/ci-infra/krte](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fkrte)
+
+4. The images used by the CI jobs are maintained in the [ci-infra repository](https://github.com/gardener/ci-infra).
    Update the references for the end-to-end tests with the new `krte` image and for unit- and integration tests with the new `golang-test` image ([example](https://github.com/gardener/ci-infra/pull/4338)).
    As a courtesy, consider removing references to no longer maintained image variants and updating to newer images wherever possible ([example](https://github.com/gardener/ci-infra/pull/4352)).
 
 > [!NOTE]  
 > Go maintains a [strong backward compatibility promise](https://go.dev/blog/compat), even if a tool has been built for an older Go version, try running it with the latest version and update accordingly.
 
-4. Finally, update the Go version references inside this repository (mainly GitHub Actions workflows and image references) to the newer version ([example](https://github.com/gardener/gardener/pull/12753)).
+5. Finally, update the Go version references inside this repository (mainly GitHub Actions workflows and image references) to the newer version ([example](https://github.com/gardener/gardener/pull/12753)).
    In the [`go.mod`](../../go.mod) file, ensure that the language version directive and, if defined, the toolchain directive are set to the lowest supported Go version.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation dev-productivity
/kind enhancement

**What this PR does / why we need it**:

The `krte` image uses the `golang-test` image as a base. Therefore, the guide should instruct building the new `golang-test` variant before changing the `krte` variants.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
