### PR TITLE
Use k8s >=1.34 for EndpointSlice for Apiservices

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -64,6 +64,7 @@ rules:
   - resourcequotas
   - services
   - endpoints
+  - endpointslices
   verbs:
   - create
   - delete
@@ -244,6 +245,7 @@ rules:
   - resourcequotas
   - services
   - endpoints
+  - endpointslices
   verbs:
   - get
   - list

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -170,7 +170,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -276,7 +276,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -297,7 +297,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -231,7 +231,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	}
 
 	var endpointsOrEndpointSlice client.Object
-	if version.ConstraintK8sGreaterEqual133.Check(g.GetValues().TargetVersion) {
+	if version.ConstraintK8sGreaterEqual134.Check(g.GetValues().TargetVersion) {
 		endpointsOrEndpointSlice = g.endpointSlice(serviceRuntime.Spec.ClusterIP)
 	} else {
 		endpointsOrEndpointSlice = g.endpoints(serviceRuntime.Spec.ClusterIP)

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -544,7 +544,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				}},
 			},
 		}
-		if version.ConstraintK8sGreaterEqual133.Check(values.TargetVersion) {
+		if version.ConstraintK8sGreaterEqual134.Check(values.TargetVersion) {
 			endpointsOrEndpointSlice = &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gardener-apiserver",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Allow gardener admins to manage endpointslices in the virtual cluster, similar to https://github.com/gardener/gardener/pull/12211
Follow up after - https://github.com/gardener/gardener/pull/13820

https://github.com/gardener/gardener/pull/13820 Switched to endpoinslice but the support for endpointslices was added only in v1.34 for apiservices. - [ref](https://github.com/kubernetes/kubernetes/pull/129837)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
