### PR TITLE
Ensure shoot opentelemetry collectors pipeline migration

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -146,8 +146,7 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 
 			otelCollectorRegistry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
-			var otelCollectorManagedResources map[string][]byte
-			otelCollectorManagedResources, err = otelCollectorRegistry.AddAllAndSerialize(migratedOtelCollectorManagedResourceObjects...)
+			otelCollectorManagedResources, err := otelCollectorRegistry.AddAllAndSerialize(migratedOtelCollectorManagedResourceObjects...)
 			if err != nil {
 				return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", otelCollectorKey, err)
 			}

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -102,6 +102,12 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 				return nil
 			}
 
+			// Cast to OpenTelemetryCollector type
+			otelCollectorTyped, ok := otelCollector.(*otelv1beta1.OpenTelemetryCollector)
+			if !ok {
+				return fmt.Errorf("failed to cast object to OpenTelemetryCollector")
+			}
+
 			// Check if the annotations are present.
 			annotations := otelCollector.GetAnnotations()
 			if annotations == nil {
@@ -109,13 +115,11 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 			}
 
 			var (
-				needsUpdate                = false
 				expectedNamespaceSelectors = `[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]`
 			)
 
 			// Check NetworkingPodLabelSelectorNamespaceAlias annotation
 			if val, exists := annotations[resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias]; !exists || val != v1beta1constants.LabelNetworkPolicyShootNamespaceAlias {
-				needsUpdate = true
 				log.Info("Annotation missing or incorrect, will patch",
 					"annotation", resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias,
 					"expected", v1beta1constants.LabelNetworkPolicyShootNamespaceAlias,
@@ -126,7 +130,6 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 
 			// Check NetworkingNamespaceSelectors annotation
 			if val, exists := annotations[resourcesv1alpha1.NetworkingNamespaceSelectors]; !exists || val != expectedNamespaceSelectors {
-				needsUpdate = true
 				log.Info("Annotation missing or incorrect, will patch",
 					"annotation", resourcesv1alpha1.NetworkingNamespaceSelectors,
 					"expected", expectedNamespaceSelectors,
@@ -135,36 +138,113 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 				annotations[resourcesv1alpha1.NetworkingNamespaceSelectors] = expectedNamespaceSelectors
 			}
 
-			// Perform patch if needed
-			if needsUpdate {
-				otelCollector.SetAnnotations(annotations)
-				migratedOtelCollectorManagedResourceObjects = append(migratedOtelCollectorManagedResourceObjects, otelCollector)
+			// patch the OpenTelemetry Collector pipeline configuration
+			ensureOtelColPipelineConfiguration(otelCollectorTyped, log)
 
-				otelCollectorRegistry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+			otelCollector.SetAnnotations(annotations)
+			migratedOtelCollectorManagedResourceObjects = append(migratedOtelCollectorManagedResourceObjects, otelCollector)
 
-				var otelCollectorManagedResources map[string][]byte
-				otelCollectorManagedResources, err = otelCollectorRegistry.AddAllAndSerialize(migratedOtelCollectorManagedResourceObjects...)
-				if err != nil {
-					return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", otelCollectorKey, err)
-				}
-				if err = managedresources.CreateForSeedWithLabels(ctx, seedClient, otelCollectorManagedResource.Namespace, otelCollectorManagedResource.Name, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, otelCollectorManagedResources); err != nil {
-					return fmt.Errorf("failed updating ManagedResource %q: %w", otelCollectorKey, err)
-				}
+			otelCollectorRegistry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
-				twoMinutes := 2 * time.Minute
-				timeoutSeedCtx, cancelSeedCtx := context.WithTimeout(ctx, twoMinutes)
-				defer cancelSeedCtx()
-				if err = managedresources.WaitUntilHealthy(timeoutSeedCtx, seedClient, otelCollectorManagedResource.Namespace, otelCollectorManagedResource.Name); err != nil {
-					return fmt.Errorf("waiting for ManagedResource %q to become healthy failed: %w", otelCollectorKey, err)
-				}
-
-				log.Info("Successfully migrated collector annotations", "collector", otelCollector.GetName())
-			} else {
-				log.Info("Collector already has correct annotations, skipping migration", "collector", otelCollector.GetName())
+			var otelCollectorManagedResources map[string][]byte
+			otelCollectorManagedResources, err = otelCollectorRegistry.AddAllAndSerialize(migratedOtelCollectorManagedResourceObjects...)
+			if err != nil {
+				return fmt.Errorf("failed serializing objects for ManagedResource %q: %w", otelCollectorKey, err)
 			}
+			if err = managedresources.CreateForSeedWithLabels(ctx, seedClient, otelCollectorManagedResource.Namespace, otelCollectorManagedResource.Name, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, otelCollectorManagedResources); err != nil {
+				return fmt.Errorf("failed updating ManagedResource %q: %w", otelCollectorKey, err)
+			}
+
+			twoMinutes := 2 * time.Minute
+			timeoutSeedCtx, cancelSeedCtx := context.WithTimeout(ctx, twoMinutes)
+			defer cancelSeedCtx()
+			if err = managedresources.WaitUntilHealthy(timeoutSeedCtx, seedClient, otelCollectorManagedResource.Namespace, otelCollectorManagedResource.Name); err != nil {
+				return fmt.Errorf("waiting for ManagedResource %q to become healthy failed: %w", otelCollectorKey, err)
+			}
+			log.Info("Successfully migrated collector annotations", "collector", otelCollector.GetName())
 
 			return nil
 		})
 	}
 	return flow.Parallel(tasks...)(ctx)
+}
+
+// ensureOtelColPipelineConfiguration ensures the OpenTelemetry Collector has the required pipeline configuration.
+// Always applies the expected configuration.
+func ensureOtelColPipelineConfiguration(collector *otelv1beta1.OpenTelemetryCollector, log logr.Logger) {
+	log.Info("Applying otelcol pipeline configuration", "collector", collector.Name)
+
+	// Set receivers configuration
+	if collector.Spec.Config.Receivers.Object == nil {
+		collector.Spec.Config.Receivers.Object = make(map[string]any)
+	}
+	collector.Spec.Config.Receivers.Object["otlp"] = map[string]any{
+		"protocols": map[string]any{
+			"grpc": map[string]any{
+				"endpoint": "[::]:4317",
+			},
+		},
+	}
+
+	// Set processors configuration
+	if collector.Spec.Config.Processors == nil {
+		collector.Spec.Config.Processors = &otelv1beta1.AnyConfig{Object: make(map[string]any)}
+	}
+	if collector.Spec.Config.Processors.Object == nil {
+		collector.Spec.Config.Processors.Object = make(map[string]any)
+	}
+
+	collector.Spec.Config.Processors.Object["batch"] = map[string]any{
+		"timeout": "10s",
+	}
+
+	collector.Spec.Config.Processors.Object["resource/vali"] = map[string]any{
+		"attributes": []any{
+			map[string]any{"action": "insert", "from_attribute": "k8s.node.name", "key": "nodename"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.pod.name", "key": "pod_name"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.container.name", "key": "container_name"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.namespace.name", "key": "namespace_name"},
+			map[string]any{"action": "insert", "key": "loki.resource.labels", "value": "job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role"},
+			map[string]any{"action": "insert", "key": "loki.format", "value": "raw"},
+		},
+	}
+
+	collector.Spec.Config.Processors.Object["attributes/vali"] = map[string]any{
+		"actions": []any{
+			map[string]any{"action": "insert", "from_attribute": "k8s.node.name", "key": "nodename"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.pod.name", "key": "pod_name"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.container.name", "key": "container_name"},
+			map[string]any{"action": "insert", "from_attribute": "k8s.namespace.name", "key": "namespace_name"},
+			map[string]any{"action": "upsert", "key": "loki.attribute.labels", "value": "priority, level, process.command, process.pid, host.name, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role"},
+			map[string]any{"action": "insert", "key": "loki.format", "value": "raw"},
+		},
+	}
+
+	// Set exporters configuration
+	if collector.Spec.Config.Exporters.Object == nil {
+		collector.Spec.Config.Exporters.Object = make(map[string]any)
+	}
+
+	collector.Spec.Config.Exporters.Object["loki"] = map[string]any{
+		"endpoint": "http://logging:3100/vali/api/v1/push",
+		"default_labels_enabled": map[string]any{
+			"exporter": false,
+			"job":      false,
+		},
+	}
+
+	collector.Spec.Config.Exporters.Object["debug/logs"] = map[string]any{
+		"verbosity": "basic",
+	}
+
+	// Set service pipelines configuration
+	if collector.Spec.Config.Service.Pipelines == nil {
+		collector.Spec.Config.Service.Pipelines = make(map[string]*otelv1beta1.Pipeline)
+	}
+
+	collector.Spec.Config.Service.Pipelines["logs/vali"] = &otelv1beta1.Pipeline{
+		Receivers:  []string{"otlp"},
+		Processors: []string{"resource/vali", "attributes/vali", "batch"},
+		Exporters:  []string{"loki", "debug/logs"},
+	}
 }

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -155,8 +155,7 @@ func migrateOTelCollectorAnnotations(ctx context.Context, seedClient client.Clie
 				return fmt.Errorf("failed updating ManagedResource %q: %w", otelCollectorKey, err)
 			}
 
-			twoMinutes := 2 * time.Minute
-			timeoutSeedCtx, cancelSeedCtx := context.WithTimeout(ctx, twoMinutes)
+			timeoutSeedCtx, cancelSeedCtx := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancelSeedCtx()
 			if err = managedresources.WaitUntilHealthy(timeoutSeedCtx, seedClient, otelCollectorManagedResource.Namespace, otelCollectorManagedResource.Name); err != nil {
 				return fmt.Errorf("waiting for ManagedResource %q to become healthy failed: %w", otelCollectorKey, err)


### PR DESCRIPTION
/area logging
/kind enhancement

This PR extends the migration of opentelemetry collector pipelines in shoot control planes.
It ensures that the collector pipeline is migrated in the expected content:

```yaml
config:
    exporters:
      debug/logs:
        verbosity: basic
      loki:
        default_labels_enabled:
          exporter: false
          job: false
        endpoint: http://logging:3100/vali/api/v1/push
    processors:
      attributes/vali:
        actions:
          - action: insert
            from_attribute: k8s.node.name
            key: nodename
          - action: insert
            from_attribute: k8s.pod.name
            key: pod_name
          - action: insert
            from_attribute: k8s.container.name
            key: container_name
          - action: insert
            from_attribute: k8s.namespace.name
            key: namespace_name
          - action: upsert
            key: loki.attribute.labels
            value: priority, level, process.command, process.pid, host.name, host.id, service.name, service.namespace, job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role
          - action: insert
            key: loki.format
            value: raw
      batch:
        timeout: 10s
      resource/vali:
        attributes:
          - action: insert
            from_attribute: k8s.node.name
            key: nodename
          - action: insert
            from_attribute: k8s.pod.name
            key: pod_name
          - action: insert
            from_attribute: k8s.container.name
            key: container_name
          - action: insert
            from_attribute: k8s.namespace.name
            key: namespace_name
          - action: insert
            key: loki.resource.labels
            value: job, unit, nodename, origin, pod_name, container_name, namespace_name, gardener_cloud_role
          - action: insert
            key: loki.format
            value: raw
    receivers:
      otlp:
        protocols:
          grpc:
            endpoint: '[::]:4317'
    service:
      pipelines:
        logs/vali:
          exporters:
            - loki
            - debug/logs
```

This is required to ensure that the collector pipeline is migrated in the expected content and that the migration does not cause any issues with the existing collector pipeline and fluent-bit configuration.

```other operator
Upon gardenlet start all existing opentelemetry collector pipelines in shoot control planes will be migrated to the expected content.
```
