### PR TITLE
[release-v1.136] Use k8s >=1.34 for EndpointSlice for Apiservices

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -64,6 +64,7 @@ rules:
   - resourcequotas
   - services
   - endpoints
+  - endpointslices
   verbs:
   - create
   - delete
@@ -244,6 +245,7 @@ rules:
   - resourcequotas
   - services
   - endpoints
+  - endpointslices
   verbs:
   - get
   - list

--- a/pkg/component/garden/system/virtual/virtual.go
+++ b/pkg/component/garden/system/virtual/virtual.go
@@ -170,7 +170,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -276,7 +276,7 @@ func (g *gardenSystem) computeResourcesData() (map[string][]byte, error) {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/component/garden/system/virtual/virtual_test.go
+++ b/pkg/component/garden/system/virtual/virtual_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 				},
 				{
@@ -297,7 +297,7 @@ var _ = Describe("Virtual", func() {
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints"},
+					Resources: []string{"events", "namespaces", "resourcequotas", "services", "endpoints", "endpointslices"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -234,6 +234,9 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	if version.ConstraintK8sGreaterEqual134.Check(g.GetValues().TargetVersion) {
 		endpointsResources = []client.Object{g.endpointSlice(serviceRuntime.Spec.ClusterIP)}
 	} else if version.ConstraintK8sGreaterEqual133.Check(g.GetValues().TargetVersion) {
+		// For Kubernetes 1.33, we create both Endpoints and EndpointSlice resources. This is required so we can safely
+		// switch to EndpointSlices only in 1.34. Otherwise, there can be unwanted downtime of the Gardener API server if
+		// some issue occurs during the process of removing the Endpoints and creating the EndpointSlice in one go.
 		endpointsResources = []client.Object{g.endpoints(serviceRuntime.Spec.ClusterIP), g.endpointSlice(serviceRuntime.Spec.ClusterIP)}
 	} else {
 		endpointsResources = []client.Object{g.endpoints(serviceRuntime.Spec.ClusterIP)}

--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -231,7 +231,7 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	}
 
 	var endpointsOrEndpointSlice client.Object
-	if version.ConstraintK8sGreaterEqual133.Check(g.GetValues().TargetVersion) {
+	if version.ConstraintK8sGreaterEqual134.Check(g.GetValues().TargetVersion) {
 		endpointsOrEndpointSlice = g.endpointSlice(serviceRuntime.Spec.ClusterIP)
 	} else {
 		endpointsOrEndpointSlice = g.endpoints(serviceRuntime.Spec.ClusterIP)

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -544,7 +544,7 @@ var _ = Describe("GardenerAPIServer", func() {
 				}},
 			},
 		}
-		if version.ConstraintK8sGreaterEqual133.Check(values.TargetVersion) {
+		if version.ConstraintK8sGreaterEqual134.Check(values.TargetVersion) {
 			endpointsOrEndpointSlice = &discoveryv1.EndpointSlice{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gardener-apiserver",

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			}
 		}
 		serviceVirtual                   *corev1.Service
-		endpointsOrEndpointSlice         client.Object
+		endpointsResources               []client.Object
 		clusterRole                      *rbacv1.ClusterRole
 		clusterRoleBinding               *rbacv1.ClusterRoleBinding
 		clusterRoleBindingAuthDelegation *rbacv1.ClusterRoleBinding
@@ -544,46 +544,50 @@ var _ = Describe("GardenerAPIServer", func() {
 				}},
 			},
 		}
+		endpointSlice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-apiserver",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app":                        "gardener",
+					"role":                       "apiserver",
+					"kubernetes.io/service-name": "gardener-apiserver",
+				},
+			},
+			AddressType: "IPv4",
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     ptr.To(int32(443)),
+				Protocol: ptr.To(corev1.ProtocolTCP),
+			}},
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{clusterIP},
+			}},
+		}
+		endpoints := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-apiserver",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "apiserver",
+				},
+			},
+			Subsets: []corev1.EndpointSubset{{
+				Ports: []corev1.EndpointPort{{
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP: clusterIP,
+				}},
+			}},
+		}
 		if version.ConstraintK8sGreaterEqual134.Check(values.TargetVersion) {
-			endpointsOrEndpointSlice = &discoveryv1.EndpointSlice{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-apiserver",
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"app":                        "gardener",
-						"role":                       "apiserver",
-						"kubernetes.io/service-name": "gardener-apiserver",
-					},
-				},
-				AddressType: "IPv4",
-				Ports: []discoveryv1.EndpointPort{{
-					Port:     ptr.To(int32(443)),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discoveryv1.Endpoint{{
-					Addresses: []string{clusterIP},
-				}},
-			}
+			endpointsResources = []client.Object{endpointSlice}
+		} else if version.ConstraintK8sGreaterEqual133.Check(values.TargetVersion) {
+			endpointsResources = []client.Object{endpoints, endpointSlice}
 		} else {
-			endpointsOrEndpointSlice = &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-apiserver",
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"app":  "gardener",
-						"role": "apiserver",
-					},
-				},
-				Subsets: []corev1.EndpointSubset{{
-					Ports: []corev1.EndpointPort{{
-						Port:     443,
-						Protocol: corev1.ProtocolTCP,
-					}},
-					Addresses: []corev1.EndpointAddress{{
-						IP: clusterIP,
-					}},
-				}},
-			}
+			endpointsResources = []client.Object{endpoints}
 		}
 		clusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1384,7 +1388,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-					Expect(managedResourceVirtual).To(consistOf(
+					expectedVirtualObjects := []client.Object{
 						apiServiceFor("core.gardener.cloud", "v1"),
 						apiServiceFor("core.gardener.cloud", "v1beta1"),
 						apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1"),
@@ -1392,12 +1396,13 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 						apiServiceFor("settings.gardener.cloud", "v1alpha1"),
 						apiServiceFor("security.gardener.cloud", "v1alpha1"),
 						serviceVirtual,
-						endpointsOrEndpointSlice,
 						clusterRole,
 						clusterRoleBinding,
 						clusterRoleBindingAuthDelegation,
 						roleBindingAuthReader,
-					))
+					}
+					expectedVirtualObjects = append(expectedVirtualObjects, endpointsResources...)
+					Expect(managedResourceVirtual).To(consistOf(expectedVirtualObjects...))
 					Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))


### PR DESCRIPTION
cherry-pick of #14033

This PR adds both `endpoints` and `endpointslices` for k8s version 1.33. This is required so we can safely switch to endpoitnslices in 1.34. Otherwise, there can be unwanted downtime of the Gardener APIserver if some issue occurs during the process of removing the endpoints and creating the endpointslice in one go.

/cc @timuthy 

```noteworthy operator
For Kubernetes virtual clusters `>= 1.33`, we now deploy both `Endpoints` and `EndpointSlice` resources for the APIService connection between virtual-garden-kube-apiserver and gardener-apiserver.
```