### PR TITLE
Add both endpoint and endpointslices for k8s v1.33

### DIFF
--- a/pkg/component/gardener/apiserver/apiserver.go
+++ b/pkg/component/gardener/apiserver/apiserver.go
@@ -234,6 +234,9 @@ func (g *gardenerAPIServer) Deploy(ctx context.Context) error {
 	if version.ConstraintK8sGreaterEqual134.Check(g.GetValues().TargetVersion) {
 		endpointsResources = []client.Object{g.endpointSlice(serviceRuntime.Spec.ClusterIP)}
 	} else if version.ConstraintK8sGreaterEqual133.Check(g.GetValues().TargetVersion) {
+		// For Kubernetes 1.33, we create both Endpoints and EndpointSlice resources. This is required so we can safely
+		// switch to EndpointSlices only in 1.34. Otherwise, there can be unwanted downtime of the Gardener API server if
+		// some issue occurs during the process of removing the Endpoints and creating the EndpointSlice in one go.
 		endpointsResources = []client.Object{g.endpoints(serviceRuntime.Spec.ClusterIP), g.endpointSlice(serviceRuntime.Spec.ClusterIP)}
 	} else {
 		endpointsResources = []client.Object{g.endpoints(serviceRuntime.Spec.ClusterIP)}

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GardenerAPIServer", func() {
 			}
 		}
 		serviceVirtual                   *corev1.Service
-		endpointsOrEndpointSlice         client.Object
+		endpointsResources               []client.Object
 		clusterRole                      *rbacv1.ClusterRole
 		clusterRoleBinding               *rbacv1.ClusterRoleBinding
 		clusterRoleBindingAuthDelegation *rbacv1.ClusterRoleBinding
@@ -544,46 +544,50 @@ var _ = Describe("GardenerAPIServer", func() {
 				}},
 			},
 		}
+		endpointSlice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-apiserver",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app":                        "gardener",
+					"role":                       "apiserver",
+					"kubernetes.io/service-name": "gardener-apiserver",
+				},
+			},
+			AddressType: "IPv4",
+			Ports: []discoveryv1.EndpointPort{{
+				Port:     ptr.To(int32(443)),
+				Protocol: ptr.To(corev1.ProtocolTCP),
+			}},
+			Endpoints: []discoveryv1.Endpoint{{
+				Addresses: []string{clusterIP},
+			}},
+		}
+		endpoints := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-apiserver",
+				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "apiserver",
+				},
+			},
+			Subsets: []corev1.EndpointSubset{{
+				Ports: []corev1.EndpointPort{{
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				}},
+				Addresses: []corev1.EndpointAddress{{
+					IP: clusterIP,
+				}},
+			}},
+		}
 		if version.ConstraintK8sGreaterEqual134.Check(values.TargetVersion) {
-			endpointsOrEndpointSlice = &discoveryv1.EndpointSlice{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-apiserver",
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"app":                        "gardener",
-						"role":                       "apiserver",
-						"kubernetes.io/service-name": "gardener-apiserver",
-					},
-				},
-				AddressType: "IPv4",
-				Ports: []discoveryv1.EndpointPort{{
-					Port:     ptr.To(int32(443)),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discoveryv1.Endpoint{{
-					Addresses: []string{clusterIP},
-				}},
-			}
+			endpointsResources = []client.Object{endpointSlice}
+		} else if version.ConstraintK8sGreaterEqual133.Check(values.TargetVersion) {
+			endpointsResources = []client.Object{endpoints, endpointSlice}
 		} else {
-			endpointsOrEndpointSlice = &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gardener-apiserver",
-					Namespace: "kube-system",
-					Labels: map[string]string{
-						"app":  "gardener",
-						"role": "apiserver",
-					},
-				},
-				Subsets: []corev1.EndpointSubset{{
-					Ports: []corev1.EndpointPort{{
-						Port:     443,
-						Protocol: corev1.ProtocolTCP,
-					}},
-					Addresses: []corev1.EndpointAddress{{
-						IP: clusterIP,
-					}},
-				}},
-			}
+			endpointsResources = []client.Object{endpoints}
 		}
 		clusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1384,7 +1388,7 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 					Expect(managedResourceSecretRuntime.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretRuntime.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
-					Expect(managedResourceVirtual).To(consistOf(
+					expectedVirtualObjects := []client.Object{
 						apiServiceFor("core.gardener.cloud", "v1"),
 						apiServiceFor("core.gardener.cloud", "v1beta1"),
 						apiServiceFor("seedmanagement.gardener.cloud", "v1alpha1"),
@@ -1392,12 +1396,13 @@ kubeConfigFile: /etc/kubernetes/admission-kubeconfigs/validatingadmissionwebhook
 						apiServiceFor("settings.gardener.cloud", "v1alpha1"),
 						apiServiceFor("security.gardener.cloud", "v1alpha1"),
 						serviceVirtual,
-						endpointsOrEndpointSlice,
 						clusterRole,
 						clusterRoleBinding,
 						clusterRoleBindingAuthDelegation,
 						roleBindingAuthReader,
-					))
+					}
+					expectedVirtualObjects = append(expectedVirtualObjects, endpointsResources...)
+					Expect(managedResourceVirtual).To(consistOf(expectedVirtualObjects...))
 					Expect(managedResourceSecretVirtual.Type).To(Equal(corev1.SecretTypeOpaque))
 					Expect(managedResourceSecretVirtual.Immutable).To(Equal(ptr.To(true)))
 					Expect(managedResourceSecretVirtual.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
This PR adds both endpoints and endpointslices for k8s version 1.33. This is required so we can safely switch to endpointslices in 1.34. Otherwise, there can be unwanted downtime of the Gardener APIserver if some issue occurs during the process of removing the endpoints and creating the endpointslice in one go.



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
