### PR TITLE
Rename test CLI flags for gardener and k8s

### DIFF
--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -14,6 +14,6 @@ spec:
     go test -timeout=0 ./test/testmachinery/system/complete_reconcile
     --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color --verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
-    -version=$GARDENER_VERSION
+    -gardener-version=$GARDENER_VERSION
 
   image: golang:1.25.7

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -18,6 +18,6 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE
-    -version=$K8S_VERSION
-    -version-worker-pools=$K8S_VERSION_WORKER_POOLS
+    -k8s-version-control-plane=$K8S_VERSION
+    -k8s-version-worker-pools=$K8S_VERSION_WORKER_POOLS
   image: golang:1.25.7

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -54,14 +54,13 @@ test
    │  └── shoot
    └── system     # suites that are used for building a full test flow
       ├── complete_reconcile
-      ├── managed_seed_creation
-      ├── managed_seed_deletion
       ├── shoot_cp_migration
       ├── shoot_creation
       ├── shoot_deletion
       ├── shoot_hibernation
       ├── shoot_hibernation_wakeup
-      └── shoot_update
+      ├── shoot_kubernetes_update
+      └── shoot_machine_image_update
 ```
 
 A suite can be executed by running the suite definition with ginkgo's `focus` and `skip` flags 
@@ -290,12 +289,12 @@ If there is no available newer version, this test is a noop.
 **Example Run**
 
 ```console
-go test  -timeout=0 ./test/testmachinery/system/shoot_update \
+go test  -timeout=0 ./test/testmachinery/system/shoot_kubernetes_update \
   --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
   -project-namespace=$PROJECT_NAMESPACE \
-  -version=$K8S_VERSION
+  -k8s-version-control-plane=$K8S_VERSION
 ```
 
 #### Gardener Full Reconcile Test
@@ -309,7 +308,7 @@ go test  -timeout=0 ./test/testmachinery/system/complete_reconcile \
   --v -ginkgo.v -ginkgo.show-node-events \
   -kubecfg=$HOME/.kube/config \
   -project-namespace=$PROJECT_NAMESPACE \
-  -gardenerVersion=$GARDENER_VERSION # needed to validate the last acted gardener version of a shoot
+  -gardener-version=$GARDENER_VERSION # needed to validate the last acted gardener version of a shoot
 ```
 
 ## Container Images

--- a/test/testmachinery/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/testmachinery/system/complete_reconcile/gardener_reconcile_test.go
@@ -28,7 +28,7 @@ import (
 	shootoperation "github.com/gardener/gardener/test/utils/shoots/operation"
 )
 
-var gardenerVersion = flag.String("version", "", "current gardener version")
+var gardenerVersion = flag.String("gardener-version", "", "current gardener version")
 
 const ReconcileShootsTimeout = 1 * time.Hour
 

--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
@@ -40,8 +40,8 @@ import (
 )
 
 var (
-	newControlPlaneKubernetesVersion = flag.String("version", "", "the version to use for .spec.kubernetes.version and .spec.provider.workers[].kubernetes.version (only when nil or equal to .spec.kubernetes.version)")
-	newWorkerPoolKubernetesVersion   = flag.String("version-worker-pools", "", "the version to use for .spec.provider.workers[].kubernetes.version (only when not equal to .spec.kubernetes.version)")
+	newControlPlaneKubernetesVersion = flag.String("k8s-version-control-plane", "", "the version to use for .spec.kubernetes.version and .spec.provider.workers[].kubernetes.version (only when nil or equal to .spec.kubernetes.version)")
+	newWorkerPoolKubernetesVersion   = flag.String("k8s-version-worker-pools", "", "the version to use for .spec.provider.workers[].kubernetes.version (only when not equal to .spec.kubernetes.version)")
 )
 
 const UpdateKubernetesVersionTimeout = 45 * time.Minute


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/13708, the newly added dependency `github.com/VictoriaMetrics/operator/api v0.66.1` registers a global `-version` flag. When the test in `kubernetes_update_test.go` also tries to define a -version flag, it panics because flags cannot be redefined:
```
/var/folders/ml/d26c2f8j5z5c1t34t9wm9d2w0000gn/T/go-build791038995/b001/shoot_kubernetes_update.test flag redefined: version
panic: /var/folders/ml/d26c2f8j5z5c1t34t9wm9d2w0000gn/T/go-build791038995/b001/shoot_kubernetes_update.test flag redefined: version
```

The suggested fix in https://github.com/vitessio/vitess/issues/10714 of resetting the flags at start can't be used in gardener cause we rely on flags registered by Ginkgo and other dependencies.

**TLDR;**
This PR renames the `-version` flag to avoid a flag redefinition panic when running tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
