### PR TITLE
IaaS API Calls MCM metric fix

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
@@ -446,14 +446,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_cloud_api_requests_total{name=\"${controlloop}\"}[1m])",
+          "expr": "rate(mcm_cloud_api_requests_total[2m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{provider}} / {{service}} ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "rate(mcm_cloud_api_requests_failed_total{name=\"${controlloop}\"}[1m])",
+          "expr": "rate(mcm_cloud_api_requests_failed_total[2m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Error: {{provider}} / {{service}} ({{pod}})",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/machine-controller-manager/mcm-dashboard.json
@@ -143,7 +143,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"machine-controller-manager-(.+)\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"machine-controller-manager-(.+)\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Current ({{pod}})",
@@ -414,7 +414,7 @@
       "dashLength": 10,
       "dashes": false,
       "decimals": null,
-      "description": "Average per Second rate over 1m of IaaS provider api calls split by services. \n\nShows also the rate of failed iaas calls if at least one failed.",
+      "description": "Rate of IaaS provider API calls split by services. \n\nShows also the rate of failed IaaS provider API calls if at least one failed.",
       "fill": 0,
       "gridPos": {
         "h": 6,
@@ -446,14 +446,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_cloud_api_requests_total[2m])",
+          "expr": "rate(mcm_cloud_api_requests_total[$__rate_interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{provider}} / {{service}} ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "rate(mcm_cloud_api_requests_failed_total[2m])",
+          "expr": "rate(mcm_cloud_api_requests_failed_total[$__rate_interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Error: {{provider}} / {{service}} ({{pod}})",
@@ -876,7 +876,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "description": "Average per second rate over 5m of workqueue item adds.",
+      "description": "Rate of workqueue item adds.",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -908,7 +908,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_workqueue_adds_total{name=\"${controlloop}\"}[5m])",
+          "expr": "rate(mcm_workqueue_adds_total{name=\"${controlloop}\"}[$__rate_interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",
@@ -961,7 +961,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "description": "Average per second rate over 5m of workqueue item retries.",
+      "description": "Rate of workqueue item retries.",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -993,7 +993,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mcm_workqueue_retries_total{name=\"${controlloop}\"}[5m])",
+          "expr": "rate(mcm_workqueue_retries_total{name=\"${controlloop}\"}[$__rate_interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "${controlloop} ({{pod}})",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This PR is continuation of #13810 , where IaaS API Calls was not showing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Continuation PR for #13810 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
