### PR TITLE
[GEP-28] `gardenadm connect`: Enable `networkpolicy` controller in `gardenlet`

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -492,6 +492,7 @@ func (g *garden) Start(ctx context.Context) error {
 	if err := controllerutils.AddAllRunnables(g.mgr, runnables...); err != nil {
 		return err
 	}
+
 	var shoot *gardencorev1beta1.Shoot
 	if gardenlet.IsResponsibleForSelfHostedShoot() {
 		shoot = &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: g.selfHostedShootInfo.Meta.Name, Namespace: g.selfHostedShootInfo.Meta.Namespace}}

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -492,10 +492,10 @@ func (g *garden) Start(ctx context.Context) error {
 	if err := controllerutils.AddAllRunnables(g.mgr, runnables...); err != nil {
 		return err
 	}
-
+	var shoot *gardencorev1beta1.Shoot
 	if gardenlet.IsResponsibleForSelfHostedShoot() {
+		shoot = &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: g.selfHostedShootInfo.Meta.Name, Namespace: g.selfHostedShootInfo.Meta.Namespace}}
 		if err := retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-			shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: g.selfHostedShootInfo.Meta.Name, Namespace: g.selfHostedShootInfo.Meta.Namespace}}
 			if err := gardenCluster.GetClient().Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return retry.SevereError(err)
@@ -520,6 +520,7 @@ func (g *garden) Start(ctx context.Context) error {
 		shootClientMap,
 		g.config,
 		g.healthManager,
+		shoot,
 	); err != nil {
 		return fmt.Errorf("failed adding controllers to manager: %w", err)
 	}

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -40,6 +41,7 @@ import (
 )
 
 // AddToManager adds all gardenlet controllers to the given manager.
+// shootCluster is only needed to be non-nil when running in self-hosted shoot mode.
 func AddToManager(
 	ctx context.Context,
 	mgr manager.Manager,
@@ -49,6 +51,7 @@ func AddToManager(
 	shootClientMap clientmap.ClientMap,
 	cfg *gardenletconfigv1alpha1.GardenletConfiguration,
 	healthManager healthz.Manager,
+	shootCluster *gardencorev1beta1.Shoot,
 ) error {
 	identity, err := gardenerutils.DetermineIdentity()
 	if err != nil {
@@ -80,6 +83,8 @@ func AddToManager(
 	if err != nil {
 		return fmt.Errorf("failed creating seed clientset: %w", err)
 	}
+
+	seedNetworks := getSeedNetworks(cfg, shootCluster)
 
 	if gardenletutils.IsResponsibleForSelfHostedShoot() {
 		mgr.GetLogger().Info("Running in self-hosted shoot, registering minimal set of controllers")
@@ -114,6 +119,10 @@ func AddToManager(
 			Config: *cfg.Controllers.ShootState,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding ShootState controller: %w", err)
+		}
+
+		if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, seedNetworks, nil); err != nil {
+			return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
 		}
 
 		if err := vpaevictionrequirements.AddToManager(ctx, mgr, gardenletCancel, *cfg.Controllers.VPAEvictionRequirements, seedCluster); err != nil {
@@ -166,7 +175,7 @@ func AddToManager(
 		return fmt.Errorf("failed adding ManagedSeed controller: %w", err)
 	}
 
-	if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, cfg.SeedConfig.Spec.Networks, nil); err != nil {
+	if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, seedNetworks, nil); err != nil {
 		return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
 	}
 
@@ -197,4 +206,16 @@ func AddToManager(
 	}
 
 	return nil
+}
+
+func getSeedNetworks(cfg *gardenletconfigv1alpha1.GardenletConfiguration, shoot *gardencorev1beta1.Shoot) gardencorev1beta1.SeedNetworks {
+	if shoot != nil {
+		return gardencorev1beta1.SeedNetworks{
+			Nodes:      shoot.Spec.Networking.Nodes,
+			Pods:       ptr.Deref(shoot.Spec.Networking.Pods, ""),
+			Services:   ptr.Deref(shoot.Spec.Networking.Services, ""),
+			IPFamilies: shoot.Spec.Networking.IPFamilies,
+		}
+	}
+	return cfg.SeedConfig.Spec.Networks
 }

--- a/pkg/gardenlet/controller/networkpolicy/add.go
+++ b/pkg/gardenlet/controller/networkpolicy/add.go
@@ -50,7 +50,20 @@ func AddToManager(
 		return fmt.Errorf("failed checking whether the seed is the garden cluster: %w", err)
 	}
 	if seedIsGarden {
-		return nil // When the seed is the garden cluster at the same time, the gardener-operator runs this controller.
+		// When the seed is the garden cluster, the gardener-operator runs this controller.
+		return nil
+	}
+
+	if !gardenletutils.IsResponsibleForSelfHostedShoot() {
+		seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+		if err != nil {
+			return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
+		}
+		if seedIsSelfHostedShoot {
+			// When the seed is a self-hosted shoot cluster, the gardenlet responsible for the self-hosted shoot in the
+			// kube-system namespace runs this controller.
+			return nil
+		}
 	}
 
 	var nodes []string
@@ -83,25 +96,43 @@ func AddToManager(
 		return err
 	}
 
-	// At this point, the seed is not the garden cluster at the same time. However, this could change during the runtime
-	// of gardenlet. If so, gardener-operator will take over responsibility of the NetworkPolicy management and will run
-	// this controller. Since there is no way to stop a controller after it started, we cancel the manager context in
-	// case the seed is registered as garden during runtime. This way, gardenlet will restart and not add the controller
-	// again.
+	// At this point, the seed is not the garden cluster. However, this could change during the runtime of gardenlet.
+	// If so, gardener-operator will take over responsibility of the NetworkPolicy management and will run this
+	// controller.
+	// Similarly, the seed is not a self-hosted shoot cluster (at least not detectable right now, maybe because it was
+	// not yet connected to Gardener, i.e., a gardenlet deployment in the kube-system namespace does not exist, but this
+	// could change during the runtime of gardenlet). If so, the gardenlet in the kube-system namespace will take over
+	// responsibility of the NetworkPolicy management and will run this controller.
+	// Since there is no way to stop a controller after it started, we cancel the manager context in such cases. This
+	// way, gardenlet will restart and not add the controller again.
 	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		wait.Until(func() {
 			seedIsGarden, err = gardenletutils.SeedIsGarden(ctx, seedCluster.GetClient())
 			if err != nil {
-				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster at the same time")
+				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster")
 				return
 			}
-			if !seedIsGarden {
+			if seedIsGarden {
+				mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been registered as garden cluster. " +
+					"This effectively stops the NetworkPolicy controller (gardener-operator takes over now).")
+				gardenletCancel()
 				return
 			}
 
-			mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been registered as garden cluster. " +
-				"This effectively stops the NetworkPolicy controller (gardener-operator takes over now).")
-			gardenletCancel()
+			if !gardenletutils.IsResponsibleForSelfHostedShoot() {
+				seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+				if err != nil {
+					mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is a self-hosted shoot cluster")
+					return
+				}
+				if seedIsSelfHostedShoot {
+					mgr.GetLogger().Info("Terminating gardenlet since seed cluster has been detect to be a self-hosted " +
+						"shoot cluster. This effectively stops the NetworkPolicy controller (gardenlet in the " +
+						"kube-system namespace takes over now).")
+					gardenletCancel()
+					return
+				}
+			}
 		}, SeedIsGardenCheckInterval, ctx.Done())
 		return nil
 	}))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind quality

**What this PR does / why we need it**:

This PR enables the `networkpolicy` controller in the `gardenlet` for SHSC's.

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
