### PR TITLE
Set a timeout of 1d to upstream kube-apiservers when L7 load-balancing is active

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -118,10 +118,11 @@ spec:
                           end
                         end
 
-                        -- Route timeouts to upstream have to be disabled. Otherwise, watches would be terminated after 15 seconds.
+                        -- Route timeouts to upstream have a high timeout of 1d. This allows long sessions but, also prevents
+                        -- leaking connections like forgotten kubectl port-forward or exec commands.
                         -- See https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts
-                        request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "0")
-                        request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "0")
+                        request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "86400000")
+                        request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "86400000")
                       end
               - name: envoy.filters.http.router
                 typed_config:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/apiserver-tls-termination-envoyfilter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/apiserver-tls-termination-envoyfilter.yaml
@@ -67,9 +67,10 @@ spec:
                   end
                 end
 
-                -- Route timeouts to upstream have to be disabled. Otherwise, watches would be terminated after 15 seconds.
+                -- Route timeouts to upstream have a high timeout of 1d. This allows long sessions but, also prevents
+                -- leaking connections like forgotten kubectl port-forward or exec commands.
                 -- See https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts
-                request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "0")
-                request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "0")
+                request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "86400000")
+                request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "86400000")
               end
 {{ end -}}

--- a/pkg/component/networking/istio/test_charts/apiserver_tls_termination.yaml
+++ b/pkg/component/networking/istio/test_charts/apiserver_tls_termination.yaml
@@ -68,8 +68,9 @@ spec:
                   end
                 end
 
-                -- Route timeouts to upstream have to be disabled. Otherwise, watches would be terminated after 15 seconds.
+                -- Route timeouts to upstream have a high timeout of 1d. This allows long sessions but, also prevents
+                -- leaking connections like forgotten kubectl port-forward or exec commands.
                 -- See https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts
-                request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "0")
-                request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "0")
+                request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "86400000")
+                request_handle:headers():add("x-envoy-upstream-rq-per-try-timeout-ms", "86400000")
               end


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Envoy route timeouts are set to a high timeout of 1 day. Before, they have been disabled.
With the new setting we don't disturb long kubectl port-forward and exec session, but we prevent that forgotten sessions increase the number of open connections over the time.

**Which issue(s) this PR fixes**:
Part of #8810

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When L7 load-balancing is active, connections to kube-apiservers have a timeout of 1 day now.
```
