### PR TITLE
[extensions] Set `servicePort` in `ServiceReference` for `ModeService`

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
         - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
+        - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
         - --webhook-config-mode={{ .Values.webhookConfig.mode }}
 {{- if eq .Values.webhookConfig.mode "url" }}
         - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}

--- a/charts/gardener/admission-local/charts/runtime/templates/service.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
   selector:
 {{ include "labels" . | indent 4 }}
   ports:
-  - port: 443
+  - port: {{ .Values.webhookConfig.servicePort }}
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
   {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}

--- a/charts/gardener/admission-local/charts/runtime/values.yaml
+++ b/charts/gardener/admission-local/charts/runtime/values.yaml
@@ -18,6 +18,7 @@ vpa:
 webhookConfig:
   mode: url
   serverPort: 10250
+  servicePort: 443
 service:
   topologyAwareRouting:
     enabled: false

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -368,6 +368,7 @@ func BuildClientConfigFor(webhookPath string, namespace, componentName string, d
 			Namespace: namespace,
 			Name:      PrefixedName(componentName, doNotPrefixComponentName),
 			Path:      &path,
+			Port:      ptr.To(int32(servicePort)), // #nosec: G115 - Port is validated on Kubernetes level
 		}
 	}
 

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -201,6 +201,7 @@ var _ = Describe("Registration", func() {
 								Name:      "gardener-extension-" + providerName,
 								Namespace: namespace,
 								Path:      ptr.To("/" + path),
+								Port:      ptr.To(int32(servicePort)),
 							}
 						}
 

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Certificates tests", func() {
 						Name:      "gardener-extension-" + extensionName,
 						Namespace: extensionNamespace.Name,
 						Path:      ptr.To("/" + seedWebhookPath),
-						Port:      ptr.To[int32](443),
+						Port:      ptr.To[int32](12345),
 					},
 				},
 				Rules: []admissionregistrationv1.RuleWithOperations{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
- `Port` field was introduced with Kubernetes v1.15 (https://github.com/kubernetes/kubernetes/pull/74855) which didn't exit at the point
- This webhook registration code was introduced with https://github.com/gardener-attic/gardener-extensions/pull/218
- We were using `k8s.io/api@1.13.4` at this point in time: https://github.com/gardener-attic/gardener-extensions/blob/ef83a2368cdf11d11720bd198f5cba0161b48187/Gopkg.toml#L26-L28

**Special notes for your reviewer**:
/cc @databus23 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
When using `ModeService` in the extension webhook library, the specified service port is now properly propagated when constructing the `admissionregistrationv1.WebhookClientConfig` for `{Validating,Mutating}WebhookConfiguration`s (previously, it was not specified at all and defaulted to `443` by Kubernetes). Make sure to specify `--webhook-config-service-port` to prevent falling back to the `--webhook-config-server-port` (if configured).
```
