### PR TITLE
Increase worker default timeout to 15min

### DIFF
--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -39,7 +39,7 @@ const (
 	DefaultSevereThreshold = 30 * time.Second
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait for a successful reconciliation
 	// of a Worker resource.
-	DefaultTimeout = 10 * time.Minute
+	DefaultTimeout = 15 * time.Minute
 )
 
 // TimeNow returns the current time. Exposed for testing.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
For shoots with many worker pools (> 100), the reconciliation of the `Worker` resource was observed to take nearly or even more than 10 mins in some cases.
As a consequence, the shoot reconciliation is retried before the `Worker` reconciliation is finished and the shoot reconciliation never succeeds.
Currently the timeout cannot be configured.
This PR proposes to increase the default timeout from `10` to `15` minutes as a quick fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase worker deployment/reconciliation timeout from 10 min to 15 min to avoid for shoots with high number of worker pools.
```
