### PR TITLE
cloudprofile: Fix regression when validating machine image versions

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -181,7 +181,7 @@ func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVe
 	allErrs := field.ErrorList{}
 
 	// NOTE: Lifecycle classifications treat nil classifications as default, which differs in old classification.
-	// Keep skipping old classifications if they nil.
+	// Keep skipping old classifications if they are nil.
 	if (version.Classification != nil || len(version.Lifecycle) > 0) && helper.VersionIsSupported(version) {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -180,7 +180,9 @@ func validateCloudProfileKubernetesSettings(kubernetes core.KubernetesSettings, 
 func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if helper.VersionIsSupported(version) {
+	// NOTE: Lifecycle classifications treat nil classifications as default, which differs in old classification.
+	// Keep skipping old classifications if they nil.
+	if (version.Classification != nil || len(version.Lifecycle) > 0) && helper.VersionIsSupported(version) {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {
 			// check is already performed by caller, avoid duplicate error

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1044,7 +1044,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
-				It("allow nil classification with same semver, but different flavor", func() {
+				It("should allow nil classification with same semver, but different flavor", func() {
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
 						{
 							Name: machineImageName,

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -1044,6 +1044,35 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
+				It("allow nil classification with same semver, but different flavor", func() {
+					cloudProfile.Spec.MachineImages = []core.MachineImage{
+						{
+							Name: machineImageName,
+							Versions: []core.MachineImageVersion{
+								{
+									ExpirableVersion: core.ExpirableVersion{
+										Version:        "3.4.6",
+										Classification: &supportedClassification,
+									},
+									CRI:           []core.CRI{{Name: "containerd"}},
+									Architectures: []string{"amd64"},
+								},
+								{
+									ExpirableVersion: core.ExpirableVersion{
+										Version: "3.4.6-flavor",
+									},
+									CRI:           []core.CRI{{Name: "containerd"}},
+									Architectures: []string{"amd64"},
+								},
+							},
+							UpdateStrategy: &updateStrategyMajor,
+						},
+					}
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
 				It("should forbid duplicate names in list of machine images", func() {
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
 						{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind regression

**What this PR does / why we need it**:

This PR addresses a change introduced in #10982 that changed how nil classifications are handled and validated, causing them to default to “supported”.

This fix restores the previous behavior when validating old classifications, to skip it when they `nil`.

**Which issue(s) this PR fixes**:
Fixes #14047 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
