### PR TITLE
Set path for systemd cluster inputs

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logging.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logging.go
@@ -44,6 +44,7 @@ func generateClusterInputs() []*fluentbitv1alpha2.ClusterInput {
 					Tag:           getContainerdTag(),
 					ReadFromTail:  "on",
 					SystemdFilter: []string{"_SYSTEMD_UNIT=containerd.service"},
+					Path:          "/var/log/journal",
 				},
 			},
 		},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logging_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logging_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Logging", func() {
 								Tag:           "systemd.containerd",
 								ReadFromTail:  "on",
 								SystemdFilter: []string{"_SYSTEMD_UNIT=containerd.service"},
+								Path:          "/var/log/journal",
 							},
 						},
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging.go
@@ -43,6 +43,7 @@ func generateClusterInputs() []*fluentbitv1alpha2.ClusterInput {
 				Tag:           getKubeletTag(),
 				ReadFromTail:  "on",
 				SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet.service"},
+				Path:          "/var/log/journal",
 			},
 		},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/logging_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Logging", func() {
 								Tag:           "systemd.kubelet",
 								ReadFromTail:  "on",
 								SystemdFilter: []string{"_SYSTEMD_UNIT=kubelet.service"},
+								Path:          "/var/log/journal",
 							},
 						},
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging.go
@@ -40,6 +40,7 @@ func generateClusterInputs() []*fluentbitv1alpha2.ClusterInput {
 				Tag:           getGardenerNodeAgentTag(),
 				ReadFromTail:  "on",
 				SystemdFilter: []string{"_SYSTEMD_UNIT=gardener-node-agent.service"},
+				Path:          "/var/log/journal",
 			},
 		},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/logging_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Logging", func() {
 								Tag:           "systemd.gardener-node-agent",
 								ReadFromTail:  "on",
 								SystemdFilter: []string{"_SYSTEMD_UNIT=gardener-node-agent.service"},
+								Path:          "/var/log/journal",
 							},
 						},
 					},


### PR DESCRIPTION
/area logging
/kind bug

This PR fixes a bug where the cluster input logging configuration was lacking path attribute, preventing collecting system logs from seed clusters. The path attribute is required for the cluster input to work properly.

```bugfix operator
Systemd logs are now collected from seed clusters as expected.
```
