### PR TITLE
Return error code in worker healthcheck func

### DIFF
--- a/pkg/component/extensions/worker/worker.go
+++ b/pkg/component/extensions/worker/worker.go
@@ -452,7 +452,7 @@ func (w *worker) checkWorkerStatusMachineDeploymentsUpdated(o client.Object) err
 	}
 
 	if obj.Status.LastError != nil && obj.Status.LastError.LastUpdateTime != nil && (w.machineDeploymentsLastUpdateTime == nil || obj.Status.LastError.LastUpdateTime.After(w.machineDeploymentsLastUpdateTime.Time)) {
-		return errors.New(obj.Status.LastError.Description)
+		return v1beta1helper.NewErrorWithCodes(errors.New(obj.Status.LastError.Description), obj.Status.LastError.Codes...)
 	}
 
 	if obj.Status.MachineDeploymentsLastUpdateTime != nil && (w.machineDeploymentsLastUpdateTime == nil || obj.Status.MachineDeploymentsLastUpdateTime.After(w.machineDeploymentsLastUpdateTime.Time)) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR return error code form worker status in its health check function, so when the reconciliation fails in `WaitUntilWorkerStatusMachineDeploymentsUpdated`,  errors can be properly classified.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
