### PR TITLE
Add `delete-on-invalid-update` annotation to referenced resources

### DIFF
--- a/pkg/gardenlet/operation/botanist/resources_test.go
+++ b/pkg/gardenlet/operation/botanist/resources_test.go
@@ -180,8 +180,9 @@ var _ = Describe("Resources", func() {
 				[]client.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "ref-" + secret.Name,
-							Namespace: controlPlaneNamespace,
+							Name:        "ref-" + secret.Name,
+							Namespace:   controlPlaneNamespace,
+							Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 						},
 						Type: secret.Type,
 						Data: secret.Data,

--- a/pkg/utils/gardener/resources.go
+++ b/pkg/utils/gardener/resources.go
@@ -17,6 +17,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	securityv1alpha1constants "github.com/gardener/gardener/pkg/apis/security/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -58,7 +59,11 @@ func PrepareReferencedResourcesForSeedCopy(ctx context.Context, cl client.Client
 		unstructuredObj.SetName(v1beta1constants.ReferencedResourcesPrefix + unstructuredObj.GetName())
 
 		// We don't want to keep user-defined annotations or labels when copying the resource to the seed.
-		unstructuredObj.SetAnnotations(nil)
+		// Set the annotation to trigger deletion of the resource in case an invalid update is applied, such as changing an immutable field of a Secret or ConfigMap while keeping the resource name the same.
+		// Users can do this by deleting and re-creating the resource with the same name; therefore, the resource will be deleted and re-created.
+		unstructuredObj.SetAnnotations(map[string]string{
+			resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+		})
 		unstructuredObj.SetLabels(nil)
 
 		unstructuredObjs = append(unstructuredObjs, unstructuredObj)

--- a/pkg/utils/gardener/resources_test.go
+++ b/pkg/utils/gardener/resources_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
@@ -137,7 +138,7 @@ var _ = Describe("Resources", func() {
 
 			for _, unstructuredObj := range unstructuredObjs {
 				Expect(unstructuredObj.GetNamespace()).To(Equal(targetNamespace), unstructuredObj.GetName()+" should have target namespace "+targetNamespace)
-				Expect(unstructuredObj.GetAnnotations()).To(BeEmpty(), unstructuredObj.GetName()+" should have no annotations")
+				Expect(unstructuredObj.GetAnnotations()).To(Equal(map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"}), unstructuredObj.GetName()+" should have resources.gardener.cloud/delete-on-invalid-update annotation")
 				Expect(unstructuredObj.GetLabels()).To(BeEmpty(), unstructuredObj.GetName()+" should have no labels")
 				Expect(unstructuredObj.GetFinalizers()).To(BeEmpty(), unstructuredObj.GetName()+" should have no finalizers")
 				Expect(unstructuredObj.Object).To(HaveKey("data"), unstructuredObj.GetName()+" should have data field")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds `resources.gardener.cloud/delete-on-invalid-update` annotation on referenced Secrets/ConfigMaps when copying to seed, enabling automatic recreation on immutable field changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
