### PR TITLE
Add concurrency flag to gosec for parallel scanning

### DIFF
--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -12,6 +12,7 @@ report_fname='gosec-report.sarif'
 gosec_report="false"
 gosec_report_parse_flags=""
 exclude_dirs="hack"
+concurrency="${GOSEC_CONCURRENCY:-4}"
 
 parse_flags() {
   while test $# -gt 1; do
@@ -27,6 +28,9 @@ parse_flags() {
         ;;
       --exclude-dirs)
         shift; exclude_dirs="$1"
+        ;;
+      --concurrency)
+        shift; concurrency="$1"
         ;;
       *)
         echo "Unknown argument: $1"
@@ -54,4 +58,4 @@ fi
 # Thus, generated code is excluded from gosec scan.
 # Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
 # is excluded too. It does not contain productive code anyway.
-gosec -exclude-generated $(echo "$exclude_dirs" | awk -v RS=',' '{printf "-exclude-dir %s ", $1}') $gosec_report_parse_flags ./...
+gosec -concurrency="$concurrency" -exclude-generated $(echo "$exclude_dirs" | awk -v RS=',' '{printf "-exclude-dir %s ", $1}') $gosec_report_parse_flags ./...


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind enhancement

**What this PR does / why we need it**:
Adds configurable concurrency to gosec via `-concurrency` flag (default: 4 workers). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
