### PR TITLE
Support sequential format runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ endif
 
 .PHONY: format
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
-	@./hack/format.sh ./charts ./cmd ./extensions ./pkg ./plugin ./test ./hack
+	@MODE=$(MODE) ./hack/format.sh ./charts ./cmd ./extensions ./pkg ./plugin ./test ./hack
 	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -l -w .
 
 .PHONY: sast

--- a/hack/format.sh
+++ b/hack/format.sh
@@ -15,4 +15,10 @@ echo "> Format Import Order"
 
 goimports_reviser_opts=${GOIMPORTS_REVISER_OPTIONS:-""}
 
-printf '%s\n' "$@" | parallel --will-cite goimports-reviser ${goimports_reviser_opts} -recursive {}
+if [[ "$MODE" == "sequential" ]]; then
+  for p in "$@" ; do
+    goimports-reviser $goimports_reviser_opts -recursive $p
+  done
+else
+  printf '%s\n' "$@" | parallel --will-cite goimports-reviser ${goimports_reviser_opts} -recursive {}
+fi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery dev-productivity
/kind bug

**What this PR does / why we need it**:
This is necessary for environments (e.g., CI, Renovate), where no GNU `parallel` command is available.
Also relevant for depending projects delegating the format run to this `format.sh` script.

Introduced by: https://github.com/gardener/gardener/pull/13800/changes#diff-ce344763d725ee329ff5c03a26946b15eaf960973f11b90b762aea034388c73cR18

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @acumino @oliver-goetz @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
`make format` target supports sequential run (again) by passing `MODE=sequential`.
```
