### PR TITLE
Fix Renovate `postUpgradeTasks` by wrapping the `make generate` call under `bash` call

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -113,7 +113,7 @@
       ],
       postUpgradeTasks: {
         commands: [
-          'PATH="$PATH:$(go env GOROOT)/bin" make generate MODE=sequential',
+          '/bin/bash -c "PATH=$PATH:$(go env GOROOT)/bin make generate MODE=sequential"',
         ],
         executionMode: 'branch',
       },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Due to Renovate's command invocation, having an env var at the beginning does not work. See: https://github.com/gardener/gardener/pull/14078#issuecomment-3909146969

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @marc1404 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
