### PR TITLE
Scheduler: skip reporting conflict errors

### DIFF
--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -90,6 +90,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *Reconciler) reportFailedScheduling(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot, err error) {
+	// Conflict errors are likely to occur during scheduling but will be retried by the controller.
+	// Skip reporting the event and updating the status, the error will still be logged.
+	if apierrors.IsConflict(err) {
+		return
+	}
+
 	description := "Failed to schedule Shoot: " + err.Error()
 	r.reportEvent(shoot, corev1.EventTypeWarning, gardencorev1beta1.ShootEventSchedulingFailed, gardencorev1beta1.EventActionReconcile, description)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

The scheduler frequently encounters conflict errors, but it will recover automatically due to exponential backoff, e.g.:

```
Events:
  Type     Reason                Age    From              Message
  ----     ------                ----   ----              -------
  Warning  SchedulingFailed      8m29s  shoot-scheduler   Failed to schedule Shoot: Operation cannot be fulfilled on shoots.core.gardener.cloud "local": the object has been modified; please apply your changes to the latest version and try again
  Normal   SchedulingSuccessful  8m29s  shoot-scheduler   Scheduled to seed "local"
  Normal   Reconciling           8m27s  shoot-controller  Reconciling Shoot cluster
```

This PR makes the scheduler skip reporting of conflict errors to prevent confusion.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
