### PR TITLE
feat: Add packet loss panel to VPN Seed Server (HA) dashboard

### DIFF
--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -748,6 +748,8 @@ func (v *vpnSeedServer) deployScrapeConfig(ctx context.Context) error {
 			"openvpn_server_route_last_reference_time_seconds",
 			"openvpn_status_update_time_seconds",
 			"openvpn_up",
+			"openvpn_netstat_Tcp_OutSegs",
+			"openvpn_netstat_Tcp_RetransSegs",
 		}
 	}
 

--- a/pkg/component/networking/vpn/seedserver/seedserver_test.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver_test.go
@@ -595,6 +595,8 @@ var _ = Describe("VpnSeedServer", func() {
 					"openvpn_server_route_last_reference_time_seconds",
 					"openvpn_status_update_time_seconds",
 					"openvpn_up",
+					"openvpn_netstat_Tcp_OutSegs",
+					"openvpn_netstat_Tcp_RetransSegs",
 				}
 			}
 

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/vpn-seed-server/ha-vpn/vpn-seed-server-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/vpn-seed-server/ha-vpn/vpn-seed-server-dashboard.json
@@ -57,7 +57,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -167,7 +167,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -277,7 +277,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -387,7 +387,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -489,7 +489,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -553,6 +553,110 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Packet loss approximated by tcp segments retransmitted / segments sent.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "hiddenSeries": false,
+      "id": 31,
+      "interval": "1m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.45",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(openvpn_netstat_Tcp_RetransSegs[$__rate_interval]) / rate(openvpn_netstat_Tcp_OutSegs[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "1m",
+          "intervalFactor": 1,
+          "legendFormat": "Packet loss of {{service}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VPN Seed Servers Packet Loss",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2117",
+          "decimals": null,
+          "format": "percentunit",
+          "label": "Packet Loss",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2118",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "cacheTimeout": null,
       "datasource": null,
       "description": "Traffic sent to clients by OpenVPN server instance (reflects only values of current running server instances)",
@@ -579,7 +683,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 30
+        "y": 36
       },
       "hideTimeOverride": true,
       "id": 19,
@@ -601,7 +705,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "targets": [
         {
           "exemplar": true,
@@ -646,7 +750,7 @@
         "h": 6,
         "w": 5,
         "x": 5,
-        "y": 30
+        "y": 36
       },
       "hideTimeOverride": true,
       "id": 30,
@@ -668,7 +772,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "targets": [
         {
           "exemplar": true,
@@ -765,7 +869,7 @@
         "h": 13,
         "w": 14,
         "x": 10,
-        "y": 30
+        "y": 36
       },
       "id": 4,
       "links": [],
@@ -778,7 +882,7 @@
           }
         ]
       },
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "targets": [
         {
           "exemplar": true,
@@ -948,7 +1052,7 @@
         "h": 7,
         "w": 5,
         "x": 0,
-        "y": 36
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 21,
@@ -969,7 +1073,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1052,7 +1156,7 @@
         "h": 7,
         "w": 5,
         "x": 5,
-        "y": 36
+        "y": 42
       },
       "hiddenSeries": false,
       "id": 22,
@@ -1073,7 +1177,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
+      "pluginVersion": "7.5.45",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
- With the upcoming [round-robin bonding feature](https://github.com/gardener/gardener/blob/master/pkg/features/features.go#L138), more observability for VPN server is warranted to detect possible network degradation due to packet loss.
- This PR builds on top of [vpn2 release 0.47](https://github.com/gardener/gardener/pull/14086) that exports additional metrics for packet loss via the OpenVPN exporter
- A new panel is added on the "Reversed VPN OpenVPN Server (HA)" dashboard.

Here is a screenshot preview that shows simulated packet loss on vpn-seed-server-0:

<img width="2476" height="689" alt="image" src="https://github.com/user-attachments/assets/21069e9f-6d09-4c89-adea-5ba5b50998b9" />

- The new panel can help for RCA in case of HA VPN issues if any of the VPN server nodes have become degraded.

**Special notes for your reviewer**:
- Should be merged after the [vpn2 v0.47 update](https://github.com/gardener/gardener/pull/14086)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The "Reversed VPN OpenVPN Server (HA)" dashboard now shows packet loss statistics.
```
