### PR TITLE
[GEP-32] Add strategy for the `CloudprofileStatus`

### DIFF
--- a/pkg/api/core/validation/cloudprofile.go
+++ b/pkg/api/core/validation/cloudprofile.go
@@ -53,6 +53,13 @@ func ValidateCloudProfileUpdate(newProfile, oldProfile *core.CloudProfile) field
 	return allErrs
 }
 
+// ValidateCloudProfileStatusUpdate validates the status field of a cloudProfile object.
+func ValidateCloudProfileStatusUpdate(_, _ *core.CloudProfileStatus) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
 // ValidateCloudProfileSpecUpdate validates the spec update of a CloudProfile
 func ValidateCloudProfileSpecUpdate(new, old *core.CloudProfileSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/apiserver/registry/core/cloudprofile/storage/storage.go
+++ b/pkg/apiserver/registry/core/cloudprofile/storage/storage.go
@@ -82,7 +82,7 @@ var (
 	_ rest.Updater = &StatusREST{}
 )
 
-// New creats a new (empty) internal CloudProfile object.
+// New creates a new (empty) internal CloudProfile object.
 func (r *StatusREST) New() runtime.Object {
 	return &core.CloudProfile{}
 }
@@ -93,6 +93,7 @@ func (r *StatusREST) Destroy() {
 	// we don't destroy it here explicitly.
 }
 
+// Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
 }

--- a/pkg/apiserver/registry/core/cloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy.go
@@ -83,6 +83,7 @@ type cloudProfileStatusStrategy struct {
 	cloudProfileStrategy
 }
 
+// StatusStrategy defines the storage strategy for the status subresource of CloudProfiles.
 var StatusStrategy = cloudProfileStatusStrategy{Strategy}
 
 func (cloudProfileStatusStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj runtime.Object) {

--- a/pkg/apiserver/registry/core/cloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy.go
@@ -32,6 +32,7 @@ func (cloudProfileStrategy) NamespaceScoped() bool {
 
 func (cloudProfileStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	cloudProfile := obj.(*core.CloudProfile)
+	cloudProfile.Status = core.CloudProfileStatus{}
 
 	dropInactiveVersions(cloudProfile)
 }
@@ -55,6 +56,7 @@ func (cloudProfileStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj r
 	oldCloudProfile := oldObj.(*core.CloudProfile)
 	newCloudProfile := newObj.(*core.CloudProfile)
 
+	newCloudProfile.Status = oldCloudProfile.Status // can only be changed by cloudProfiles/status subresource.
 	gardenerutils.SyncArchitectureCapabilityFields(newCloudProfile.Spec, oldCloudProfile.Spec)
 }
 
@@ -75,6 +77,22 @@ func (cloudProfileStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (cloudProfileStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
 	return nil
+}
+
+type cloudProfileStatusStrategy struct {
+	cloudProfileStrategy
+}
+
+var StatusStrategy = cloudProfileStatusStrategy{Strategy}
+
+func (cloudProfileStatusStrategy) PrepareForUpdate(_ context.Context, newObj, oldObj runtime.Object) {
+	oldCloudProfile, newCloudProfile := oldObj.(*core.CloudProfile), newObj.(*core.CloudProfile)
+	newCloudProfile.Spec = oldCloudProfile.Spec
+}
+
+func (cloudProfileStatusStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	oldCloudProfile, newCloudProfile := oldObj.(*core.CloudProfile), newObj.(*core.CloudProfile)
+	return validation.ValidateCloudProfileStatusUpdate(&oldCloudProfile.Status, &newCloudProfile.Status)
 }
 
 func dropInactiveVersions(cloudProfile *core.CloudProfile) {

--- a/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy_test.go
@@ -329,12 +329,20 @@ var _ = Describe("Strategy", func() {
 			newCloudProfile = &core.CloudProfile{}
 		})
 
+		It("should allow updating the status", func() {
+			newCloudProfile.Status.Kubernetes = &core.KubernetesStatus{
+				Versions: []core.ExpirableVersionStatus{{Version: "foo"}},
+			}
+			strategy.PrepareForUpdate(ctx, newCloudProfile, oldCloudProfile)
+
+			Expect(newCloudProfile.Status.Kubernetes.Versions).To(ConsistOf(core.ExpirableVersionStatus{Version: "foo"}))
+		})
+
 		It("should not allow editing the spec", func() {
 			newCloudProfile.Spec.Type = "foo"
 			strategy.PrepareForUpdate(ctx, newCloudProfile, oldCloudProfile)
 
-			Expect(newCloudProfile.Status).To(Equal(oldCloudProfile.Status))
+			Expect(newCloudProfile.Spec).To(Equal(oldCloudProfile.Spec))
 		})
-
 	})
 })

--- a/pkg/apiserver/registry/core/rest/storage_core.go
+++ b/pkg/apiserver/registry/core/rest/storage_core.go
@@ -81,6 +81,7 @@ func (p StorageProvider) v1beta1Storage(restOptionsGetter generic.RESTOptionsGet
 
 	cloudprofileStorage := cloudprofilestore.NewStorage(restOptionsGetter)
 	storage["cloudprofiles"] = cloudprofileStorage.CloudProfile
+	storage["cloudprofiles/status"] = cloudprofileStorage.Status
 
 	namespacedcloudprofileStorage := namespacedcloudprofilestore.NewStorage(restOptionsGetter)
 	storage["namespacedcloudprofiles"] = namespacedcloudprofileStorage.NamespacedCloudProfile


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity usability
/kind api-change

**What this PR does / why we need it**:

This PR introduces the strategy for the newly added `cloudprofileStatus` as part of GEP-32.
Test suite got extended to also cover the new classifications.

**Which issue(s) this PR fixes:**  
Part of https://github.com/gardener/gardener/issues/12256

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
