### PR TITLE
Set default reconciliation timeout for all extension controllers

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -16,6 +16,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -62,6 +63,10 @@ func Add(mgr manager.Manager, args AddArgs) error {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
+
 	c, err := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -17,6 +17,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -62,6 +63,10 @@ func Add(mgr manager.Manager, args AddArgs) error {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
+
 	c, err := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).

--- a/extensions/pkg/controller/bastion/controller.go
+++ b/extensions/pkg/controller/bastion/controller.go
@@ -13,6 +13,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -56,6 +57,9 @@ func Add(mgr manager.Manager, args AddArgs) error {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).

--- a/extensions/pkg/controller/bastion/controller.go
+++ b/extensions/pkg/controller/bastion/controller.go
@@ -5,6 +5,8 @@
 package bastion
 
 import (
+	"time"
+
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -13,7 +15,6 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -58,7 +59,7 @@ func Add(mgr manager.Manager, args AddArgs) error {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
 	if args.ControllerOptions.ReconciliationTimeout == 0 {
-		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+		args.ControllerOptions.ReconciliationTimeout = 20 * time.Minute
 	}
 	return builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -18,6 +18,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -64,6 +65,10 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 
 func add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -17,6 +17,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -57,6 +58,10 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/dnsrecord/controller.go
+++ b/extensions/pkg/controller/dnsrecord/controller.go
@@ -17,6 +17,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -65,6 +66,10 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // Add creates a new dnsrecord controller and adds it to the given Manager.
 func Add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/extension/controller.go
+++ b/extensions/pkg/controller/extension/controller.go
@@ -19,6 +19,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -69,6 +70,10 @@ func add(mgr manager.Manager, args AddArgs) error {
 	predicates := []predicate.Predicate{predicateutils.HasType(args.Type)}
 	predicates = append(predicates, predicateutils.HasClass(args.ExtensionClasses...))
 	predicates = append(predicates, args.Predicates...)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/utils"
@@ -184,6 +185,10 @@ func add(mgr manager.Manager, args AddArgs, actuator HealthCheckActuator) error 
 
 	// add type predicate to only watch registered resource (e.g. ControlPlane) with a certain type (e.g. aws)
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	log.Log.Info("Registering health check controller", "kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "conditionTypes", args.registeredExtension.healthConditionTypes, "syncPeriod", args.SyncPeriod.Duration.String())
 

--- a/extensions/pkg/controller/heartbeat/controller.go
+++ b/extensions/pkg/controller/heartbeat/controller.go
@@ -61,6 +61,10 @@ type AddArgs struct {
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.MaxConcurrentReconciles = 1
 
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
+
 	return builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -19,6 +19,7 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -70,6 +71,10 @@ func Add(mgr manager.Manager, args AddArgs) error {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout // TODO(vpnachev): Is this enough?
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -6,6 +6,7 @@ package infrastructure
 
 import (
 	"context"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,7 +20,6 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -73,7 +73,7 @@ func add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
 
 	if args.ControllerOptions.ReconciliationTimeout == 0 {
-		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout // TODO(vpnachev): Is this enough?
+		args.ControllerOptions.ReconciliationTimeout = 20 * time.Minute
 	}
 
 	c, err := builder.

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -17,6 +17,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -62,6 +63,10 @@ func Add(mgr manager.Manager, args AddArgs) error {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -15,6 +15,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 )
 
@@ -47,6 +48,10 @@ type AddArgs struct {
 // Add adds an operatingsystemconfig controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Types...)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	return builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -23,6 +23,7 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -66,6 +67,10 @@ func DefaultPredicates(ctx context.Context, mgr manager.Manager, ignoreOperation
 // and Start it when the Manager is Started.
 func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
+
+	if args.ControllerOptions.ReconciliationTimeout == 0 {
+		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+	}
 
 	c, err := builder.
 		ControllerManagedBy(mgr).

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -7,6 +7,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
@@ -23,7 +24,6 @@ import (
 
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -69,7 +69,7 @@ func Add(ctx context.Context, mgr manager.Manager, args AddArgs) error {
 	predicates := predicateutils.AddTypeAndClassPredicates(args.Predicates, args.ExtensionClasses, args.Type)
 
 	if args.ControllerOptions.ReconciliationTimeout == 0 {
-		args.ControllerOptions.ReconciliationTimeout = controllerutils.DefaultReconciliationTimeout
+		args.ControllerOptions.ReconciliationTimeout = 20 * time.Minute
 	}
 
 	c, err := builder.


### PR DESCRIPTION
**How to categorize this PR?**
/area quality ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Set default reconciliation timeout of 3 minutes for all extension controllers.
This will ensure that there will be no long-running reconciliation loops, e.g. for hours.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @kon-angelo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
⚠️ A default reconciliation timeout of 3 minutes has been set for the extension controllers:
- github.com/gardener/gardener/extensions/pkg/controller/backupbucket
- github.com/gardener/gardener/extensions/pkg/controller/backupentry
- github.com/gardener/gardener/extensions/pkg/controller/containerruntime
- github.com/gardener/gardener/extensions/pkg/controller/controlplane
- github.com/gardener/gardener/extensions/pkg/controller/dnsrecord
- github.com/gardener/gardener/extensions/pkg/controller/extension
- github.com/gardener/gardener/extensions/pkg/controller/healthcheck
- github.com/gardener/gardener/extensions/pkg/controller/heartbeat
- github.com/gardener/gardener/extensions/pkg/controller/network
- github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig
A default reconciliation timeout of 20 minutes has been set for the extension controllers:
- github.com/gardener/gardener/extensions/pkg/controller/bastion
- github.com/gardener/gardener/extensions/pkg/controller/infrastructure
- github.com/gardener/gardener/extensions/pkg/controller/worker
Extension developers can define own reconciliation timeout via the `sigs.k8s.io/controller-runtime/pkg/controller.Options` provided to the respective controller.
```
