### PR TITLE
[GEP-34] OpenTelemetry Collector Memory Usage Optimisation

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -66,7 +66,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 Environment=KUBECONFIG=/var/lib/opentelemetry-collector/kubeconfig
-ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=1600MiB"
 ExecStart=/opt/bin/opentelemetry-collector --config=` + PathConfig
 
 			otelDaemonUnit := extensionsv1alpha1.Unit{
@@ -140,7 +140,12 @@ receivers:
 
 processors:
   batch:
+    send_batch_max_size: 8192
     timeout: 10s
+
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 2000
 
   # Include resource attributes from the Kubernetes environment.
   # The Shoot KAPI server is queried for pods in the kube-system namespace
@@ -214,11 +219,11 @@ service:
   pipelines:
     logs/journal:
       receivers: [journald/journal]
-      processors: [resource/journal, batch]
+      processors: [batch, memory_limiter, resource/journal]
       exporters: [otlp]
     logs/pods:
       receivers: [filelog/pods]
-      processors: [k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
+      processors: [batch, memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels]
       exporters: [otlp]
 `)),
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -56,7 +56,12 @@ receivers:
 
 processors:
   batch:
+    send_batch_max_size: 8192
     timeout: 10s
+
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: {{ .memoryLimitMiB }}
 
   # Include resource attributes from the Kubernetes environment.
   # The Shoot KAPI server is queried for pods in the kube-system namespace
@@ -130,9 +135,9 @@ service:
   pipelines:
     logs/journal:
       receivers: [journald/journal]
-      processors: [resource/journal, batch]
+      processors: [batch, memory_limiter, resource/journal]
       exporters: [otlp]
     logs/pods:
       receivers: [filelog/pods]
-      processors: [k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
+      processors: [batch, memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels]
       exporters: [otlp]

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -364,7 +364,13 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Processors: &otelv1beta1.AnyConfig{
 					Object: map[string]any{
 						"batch": map[string]any{
-							"timeout": "10s",
+							"send_batch_max_size": 8192,
+							"timeout":             "10s",
+						},
+						"memory_limiter": map[string]any{
+							"check_interval":  "1s",
+							"limit_mib":       3000,
+							"spike_limit_mib": 600,
 						},
 						"resource/vali": map[string]any{
 							"attributes": []any{
@@ -483,9 +489,10 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								"otlp",
 							},
 							Processors: []string{
+								"batch",
+								"memory_limiter",
 								"resource/vali",
 								"attributes/vali",
-								"batch",
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Previously there was no upper limit for how big the batches that the collector sends can be.
However gRPC has a hard limit set on the maximum message size of 4MB. If there happens to be a spike in the messages for one moment of time, the batch size could blow up to a size bigger than 4MB, leading to issues such as:
```
caller:internal/queue_sender.go:42 dropped_items:11625 error:interrupted due to shutdown: HTTP 500 "Internal Server Error": rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4608592 vs. 4194304) level:error msg:Exporting failed. Dropping data. otelcol.component.id:loki otelcol.component.kind:exporter otelcol.signal:logs resource:map[service.instance.id:b5103812-b1c0-46f5-81d1-4118882a3983 service.name:otelcol service.version:0.0.0] stacktrace:go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewQueueSender.func1
	/go/pkg/mod/go.opentelemetry.io/collector/exporter/exporterhelper@v0.136.0/internal/queue_sender.go:42
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queuebatch.(*disabledBatcher[...]).Consume
	/go/pkg/mod/go.opentelemetry.io/collector/exporter/exporterhelper@v0.136.0/internal/queuebatch/disabled_batcher.go:23
go.opentelemetry.io/collector/exporter/exporterhelper/internal/queue.(*asyncQueue[...]).Start.func1
	/go/pkg/mod/go.opentelemetry.i... <truncated 105 bytes>
```

This PR also includes the usage of a [memory_limiter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor) processor that will make sure that the collector does not use more memory than expected.
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue with the maximum batch size that the `OpenTelemetry Collector` instances can send.
```
