### PR TITLE
fix: drop limits on apiserver-proxy

### DIFF
--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -330,9 +330,6 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 										corev1.ResourceCPU:    resource.MustParse("20m"),
 										corev1.ResourceMemory: resource.MustParse("20Mi"),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("200Mi"),
-									},
 								},
 								SecurityContext: &corev1.SecurityContext{
 									AllowPrivilegeEscalation: ptr.To(false),
@@ -357,9 +354,6 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("5m"),
 										corev1.ResourceMemory: resource.MustParse("15Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("90Mi"),
 									},
 								},
 								SecurityContext: &corev1.SecurityContext{
@@ -387,9 +381,6 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:    resource.MustParse("5m"),
 										corev1.ResourceMemory: resource.MustParse("30Mi"),
-									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("1Gi"),
 									},
 								},
 								SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -634,9 +634,6 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "sidecar",
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("90Mi"),
-								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("15Mi"),
@@ -687,9 +684,6 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 								TimeoutSeconds:      1,
 							},
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
-								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("5m"),
 									corev1.ResourceMemory: resource.MustParse("30Mi"),
@@ -722,9 +716,6 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "setup",
 							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("200Mi"),
-								},
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("20m"),
 									corev1.ResourceMemory: resource.MustParse("20Mi"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
- Drops useless resource limits on apiserver-proxy as discussed in the community
- OOM killing apiserver-proxy can be more disruptive to shoot connectivity than having it run with higher memory allocation

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource limits are dropped from apiserver-proxy to increase shoot connectivity.
```
