### PR TITLE
Fix extension scrape configuration in the seed Prometheus

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
@@ -58,7 +58,7 @@ func CentralPodMonitors() []*monitoringv1.PodMonitor {
 						},
 						{
 							SourceLabels: []monitoringv1.LabelName{
-								"__tmp_kubernetes_pod_ipv4",
+								"__tmp_kubernetes_pod_ip_ipv4",
 								"__tmp_kubernetes_pod_ip_ipv6_with_brackets",
 								"__meta_kubernetes_pod_annotation_prometheus_io_port",
 							},

--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors.go
@@ -57,11 +57,15 @@ func CentralPodMonitors() []*monitoringv1.PodMonitor {
 							TargetLabel:  "__tmp_kubernetes_pod_ip_ipv6_with_brackets",
 						},
 						{
-							SourceLabels: []monitoringv1.LabelName{"__tmp_kubernetes_pod_ipv4", "__tmp_kubernetes_pod_ip_ipv6_with_brackets", "__meta_kubernetes_pod_annotation_prometheus_io_port"},
-							Regex:        `(.*);(.*);(.+)`,
-							Action:       "replace",
-							Replacement:  ptr.To(`$1$2:$3`),
-							TargetLabel:  "__address__",
+							SourceLabels: []monitoringv1.LabelName{
+								"__tmp_kubernetes_pod_ipv4",
+								"__tmp_kubernetes_pod_ip_ipv6_with_brackets",
+								"__meta_kubernetes_pod_annotation_prometheus_io_port",
+							},
+							Regex:       `(.*);(.*);(.+)`,
+							Action:      "replace",
+							Replacement: ptr.To(`$1$2:$3`),
+							TargetLabel: "__address__",
 						},
 						{
 							Action: "labelmap",

--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
@@ -57,7 +57,7 @@ var _ = Describe("PodMonitors", func() {
 								},
 								{
 									SourceLabels: []monitoringv1.LabelName{
-										"__tmp_kubernetes_pod_ipv4",
+										"__tmp_kubernetes_pod_ip_ipv4",
 										"__tmp_kubernetes_pod_ip_ipv6_with_brackets",
 										"__meta_kubernetes_pod_annotation_prometheus_io_port",
 									},

--- a/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
+++ b/pkg/component/observability/monitoring/prometheus/seed/podmonitors_test.go
@@ -56,11 +56,15 @@ var _ = Describe("PodMonitors", func() {
 									TargetLabel:  "__tmp_kubernetes_pod_ip_ipv6_with_brackets",
 								},
 								{
-									SourceLabels: []monitoringv1.LabelName{"__tmp_kubernetes_pod_ipv4", "__tmp_kubernetes_pod_ip_ipv6_with_brackets", "__meta_kubernetes_pod_annotation_prometheus_io_port"},
-									Regex:        `(.*);(.*);(.+)`,
-									Action:       "replace",
-									Replacement:  ptr.To(`$1$2:$3`),
-									TargetLabel:  "__address__",
+									SourceLabels: []monitoringv1.LabelName{
+										"__tmp_kubernetes_pod_ipv4",
+										"__tmp_kubernetes_pod_ip_ipv6_with_brackets",
+										"__meta_kubernetes_pod_annotation_prometheus_io_port",
+									},
+									Regex:       `(.*);(.*);(.+)`,
+									Action:      "replace",
+									Replacement: ptr.To(`$1$2:$3`),
+									TargetLabel: "__address__",
 								},
 								{
 									Action: "labelmap",


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind regression

**What this PR does / why we need it**:

During the development of [PR#13341](https://github.com/gardener/gardener/pull/13341), a bug in the extension scrape configuration in the seed Prometheus was detected. The scrape configuration was not working on IPv6, and commit https://github.com/gardener/gardener/pull/13341/changes/7cd355eaa626e924c40ca67da8adb51959e06f4f fixed this. Unfortunately, a typo in such commit introduced a new bug when the scrape configuration uses IPv4. The `__address__` label is replaced by using an IPv4 IP label that doesn't exist due to the typo, which results in `http://:<port>` as scrape address. 

Such an issue was not detected in the local setup or during pull request validation because extensions in those environments expose metrics on 8080, and scraping `http://:8080` resolves to `http://localhost:8080`. By coincidence, Prometheus exposes metrics on 8080, so it scrapes itself and not the extensions. Hence, the corresponding jobs were up and imported metrics, and that is why this regression was not detected earlier.

This PR fixes this typo and, with that, scraping the extensions works again.

**Special notes for your reviewer**:

/cc @istvanballok 

**Release note**:

```bugfix operator
A bug is fixed in the extension scrape configuration in the seed Prometheus, where the scrape address was not correctly configured on IPv4 setups.
```
