### PR TITLE
Guard dashboard addon installation for empty `.spec.addons`

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubernetesdashboard.go
+++ b/pkg/gardenlet/operation/botanist/kubernetesdashboard.go
@@ -37,7 +37,7 @@ func (b *Botanist) DefaultKubernetesDashboard() (kubernetesdashboard.Interface, 
 		values.APIServerHost = ptr.To(b.outOfClusterAPIServerFQDN())
 	}
 
-	if b.Shoot.GetInfo().Spec.Addons != nil && b.Shoot.GetInfo().Spec.Addons.KubernetesDashboard.AuthenticationMode != nil {
+	if b.Shoot.GetInfo().Spec.Addons != nil && b.Shoot.GetInfo().Spec.Addons.KubernetesDashboard != nil && b.Shoot.GetInfo().Spec.Addons.KubernetesDashboard.AuthenticationMode != nil {
 		values.AuthenticationMode = *b.Shoot.GetInfo().Spec.Addons.KubernetesDashboard.AuthenticationMode
 	}
 

--- a/pkg/gardenlet/operation/botanist/kubernetesdashboard_test.go
+++ b/pkg/gardenlet/operation/botanist/kubernetesdashboard_test.go
@@ -63,6 +63,18 @@ var _ = Describe("Kubernetes Dashboard", func() {
 			botanist.Shoot.SetInfo(shoot)
 		})
 
+		Context("For a Shoot with empty .spec.addons", func() {
+			BeforeEach(func() {
+				shoot.Spec.Addons = &gardencorev1beta1.Addons{}
+			})
+
+			It("should successfully create a Kubernetes Dashboard interface", func() {
+				kubernetesDashboard, err := botanist.DefaultKubernetesDashboard()
+				Expect(kubernetesDashboard).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 		It("should successfully create a Kubernetes Dashboard interface", func() {
 			kubernetesDashboard, err := botanist.DefaultKubernetesDashboard()
 			Expect(kubernetesDashboard).NotTo(BeNil())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
When the Shoot spec has en empty `.spec.addons` struct, gardenlet runs into a nil pointer at
```
github.com/gardener/gardener/pkg/gardenlet/operation/botanist.(*Botanist).DefaultKubernetesDashboard(0x140007916b8)
    	pkg/gardenlet/operation/botanist/kubernetesdashboard.go:40 +0x5cc
```

because it isn't guarded against `.spec.addons` being present, but not `.spec.addons.kubernetesDashboard`.

The nginx addon already has a similar guard: https://github.com/gardener/gardener/blob/03ea93a92a32ba91e7ebb1fad80225e35bf4f1e6/pkg/gardenlet/operation/botanist/nginxingress.go#L34

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue which lead to a nil pointer in gardenlet when a Shoot had an empty `.spec.addons` structure defined is now fixed.
```
