### PR TITLE
Switch to OIDC Federation Service instead of GitHub App

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,8 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
     with:
       mode: ${{ inputs.mode }}
-      version-commit-callback-action-path:
     permissions:
-      contents: read
+      id-token: write
 
   tests:
     runs-on: ${{ github.repository_owner == 'gardener' && 'ubuntu-latest-large' || 'ubuntu-latest' }}

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -13,7 +13,7 @@ jobs:
       mode: snapshot
     secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
 
@@ -22,7 +22,6 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
-    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,9 @@ jobs:
   build:
     if: ${{ github.repository == 'gardener/gardener' && startsWith(github.ref, 'refs/heads/release-v') }}
     uses: ./.github/workflows/build.yaml
+    secrets: inherit
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: write
     with:
@@ -32,7 +33,6 @@ jobs:
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}
-      next-version-callback-action-path:
       slack-channel-id: C9CEBQPGE # #sap-tech-gardener
       assets: |
         - name: gardenadm-darwin-amd64


### PR DESCRIPTION
**How to categorize this PR?**

/area delivery
/kind enhancement

**What this PR does / why we need it**:

Currently, the [Gardener GitHub-Actions App](https://github.com/apps/gardener-github-actions) is used to provide more privileged access than available via the default `GITHUB_TOKEN`, for example to circumvent branch protection rules (GitHub Apps can be configured as bypassers) or cross repository privileges. To prevent sharing the GitHub App secret with each and every repository/workflow which requires usage of it, the [GitHub OIDC Federation Service](https://github.com/gardener/github-oidc-federation) has been developed. In essence, it holds the credentials for a central GitHub App and creates short-lived access tokens with a configured scope based on a centrally configured OIDC configuration. See related changes which have been necessary for this repository:

- https://github.com/gardener/.github-oidc/commit/5127a4b9c94b5a498a322e34821d68b41176f1ab

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
