### PR TITLE
[GEP-34] Fine-Tune Batch Size and Update Migration Script

### DIFF
--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -185,7 +185,14 @@ func ensureOtelColPipelineConfiguration(collector *otelv1beta1.OpenTelemetryColl
 	collector.Spec.Config.Processors = &otelv1beta1.AnyConfig{
 		Object: map[string]any{
 			"batch": map[string]any{
-				"timeout": "10s",
+				"send_batch_size":     2000,
+				"send_batch_max_size": 4000,
+				"timeout":             "10s",
+			},
+			"memory_limiter": map[string]any{
+				"check_interval":  "1s",
+				"limit_mib":       3000,
+				"spike_limit_mib": 600,
 			},
 			"resource/vali": map[string]any{
 				"attributes": []any{
@@ -217,6 +224,15 @@ func ensureOtelColPipelineConfiguration(collector *otelv1beta1.OpenTelemetryColl
 				"exporter": false,
 				"job":      false,
 			},
+			"sending_queue": map[string]any{
+				"queue_size": 16777216,
+				"sizer":      "bytes",
+				"batch": map[string]any{
+					"flush_timeout": "1s",
+					"max_size":      4194304,
+					"sizer":         "bytes",
+				},
+			},
 		},
 		"debug/logs": map[string]any{
 			"verbosity": "basic",
@@ -226,7 +242,7 @@ func ensureOtelColPipelineConfiguration(collector *otelv1beta1.OpenTelemetryColl
 	collector.Spec.Config.Service.Pipelines = map[string]*otelv1beta1.Pipeline{
 		"logs/vali": {
 			Receivers:  []string{"otlp"},
-			Processors: []string{"resource/vali", "attributes/vali", "batch"},
+			Processors: []string{"memory_limiter", "resource/vali", "attributes/vali", "batch"},
 			Exporters:  []string{"loki", "debug/logs"},
 		},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -140,7 +140,8 @@ receivers:
 
 processors:
   batch:
-    send_batch_max_size: 8192
+    send_batch_size: 2000
+    send_batch_max_size: 4000
     timeout: 10s
 
   memory_limiter:
@@ -219,11 +220,11 @@ service:
   pipelines:
     logs/journal:
       receivers: [journald/journal]
-      processors: [batch, memory_limiter, resource/journal]
+      processors: [memory_limiter, resource/journal, batch]
       exporters: [otlp]
     logs/pods:
       receivers: [filelog/pods]
-      processors: [batch, memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels]
+      processors: [memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
       exporters: [otlp]
 `)),
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -56,7 +56,8 @@ receivers:
 
 processors:
   batch:
-    send_batch_max_size: 8192
+    send_batch_size: 2000
+    send_batch_max_size: 4000
     timeout: 10s
 
   memory_limiter:
@@ -135,9 +136,9 @@ service:
   pipelines:
     logs/journal:
       receivers: [journald/journal]
-      processors: [batch, memory_limiter, resource/journal]
+      processors: [memory_limiter, resource/journal, batch]
       exporters: [otlp]
     logs/pods:
       receivers: [filelog/pods]
-      processors: [batch, memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels]
+      processors: [memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
       exporters: [otlp]

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -364,7 +364,8 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Processors: &otelv1beta1.AnyConfig{
 					Object: map[string]any{
 						"batch": map[string]any{
-							"send_batch_max_size": 8192,
+							"send_batch_size":     2000,
+							"send_batch_max_size": 4000,
 							"timeout":             "10s",
 						},
 						"memory_limiter": map[string]any{
@@ -450,6 +451,15 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								"exporter": false,
 								"job":      false,
 							},
+							"sending_queue": map[string]any{
+								"queue_size": 16777216,
+								"sizer":      "bytes",
+								"batch": map[string]any{
+									"flush_timeout": "1s",
+									"max_size":      4194304,
+									"sizer":         "bytes",
+								},
+							},
 						},
 						"debug/logs": map[string]any{
 							"verbosity": "basic",
@@ -489,10 +499,10 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								"otlp",
 							},
 							Processors: []string{
-								"batch",
 								"memory_limiter",
 								"resource/vali",
 								"attributes/vali",
+								"batch",
 							},
 						},
 					},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -372,7 +372,8 @@ var _ = Describe("OpenTelemetry Collector", func() {
 								// When fetching the object from the apiserver, since there's no type information regarding this field.
 								// the deserializer will interpret it as a `float64`. By setting the value to `float64` here, we ensure that
 								// when this object is compared to the fetched one, the types match.
-								"send_batch_max_size": float64(8192),
+								"send_batch_size":     float64(2000),
+								"send_batch_max_size": float64(4000),
 								"timeout":             "10s",
 							},
 							"memory_limiter": map[string]any{
@@ -458,6 +459,15 @@ var _ = Describe("OpenTelemetry Collector", func() {
 									"exporter": false,
 									"job":      false,
 								},
+								"sending_queue": map[string]any{
+									"queue_size": float64(16777216),
+									"sizer":      "bytes",
+									"batch": map[string]any{
+										"flush_timeout": "1s",
+										"max_size":      float64(4194304),
+										"sizer":         "bytes",
+									},
+								},
 							},
 							"debug/logs": map[string]any{
 								"verbosity": "basic",
@@ -496,7 +506,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 							"logs/vali": {
 								Exporters:  []string{"loki", "debug/logs"},
 								Receivers:  []string{"otlp"},
-								Processors: []string{"batch", "memory_limiter", "resource/vali", "attributes/vali"},
+								Processors: []string{"memory_limiter", "resource/vali", "attributes/vali", "batch"},
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
In a [previous PR](https://github.com/gardener/gardener/pull/14108) the batch processor was updated and a `memory_limiter` processor was included to the collectors.
However, it was found that there are cases where the batch limit is too big and has to be limited to an even lower number.
For additional safety, batching and limiting of the query and batch size is added to the `loki` exporter itself as well.
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Additional finetuning to the `Collector` configuration has been applied for improved memory usage.
```
