### PR TITLE
[GEP-28] `gardener-node-agent`: Serialized `OperatingSystemConfig` reconciliation

### DIFF
--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -88,6 +88,34 @@ After all these steps are complete, the controller maintains two annotations on 
 - `worker.gardener.cloud/kubernetes-version`, describing the version of the installed `kubelet`.
 - `checksum/cloud-config-data`, describing the checksum of the applied `OperatingSystemConfig` (used in future reconciliations to determine whether it needs to reconcile, and to report that this node is up-to-date).
 
+#### Serial Reconciliation
+
+For certain critical nodes that should never be updated in parallel (e.g., control plane nodes for self-hosted shoot clusters), the controller supports a **serial reconciliation** mode.
+This ensures that only one `gardener-node-agent` instance at a time can reconcile the `OperatingSystemConfig`, preventing simultaneous updates that could potentially disrupt cluster operations.
+It is particularly relevant for control plane nodes since they run critical components like `etcd` or `kube-apiserver` as static pods, and we want them to get updated one at a time.
+
+##### How It Works
+
+Serial reconciliation is enabled by setting the `reconciliation.osc.node-agent.gardener.cloud/serial` annotation to `"true"` on the `Secret` containing the `OperatingSystemConfig`.
+When this annotation is present, the controller uses a leader election mechanism based on Kubernetes `Lease` objects to coordinate reconciliation across multiple `gardener-node-agent` instances:
+
+1. **Lease Acquisition**: Before starting reconciliation, each `gardener-node-agent` instance attempts to acquire a `Lease` object with the same name as the `Secret` (in the `kube-system` namespace). The `Lease` is owned by the `Secret` via an `OwnerReference`.
+2. **Reconciliation with Lock**: Only the instance that successfully acquires the `Lease` proceeds with reconciliation. The `Lease` has a duration of 10 minutes and is renewed in the beginning of the reconciliation process.
+3. **Lock Release**: After successful reconciliation, the instance releases the `Lease` by clearing its holder identity, making it available for other instances to acquire.
+4. **Waiting for Lock**: Instances that fail to acquire the `Lease` (because another instance holds it) will requeue their reconciliation and wait. The controller watches the `Lease` object and automatically requeues when it detects the `Lease` has been released.
+5. **Lease Expiry Handling**: If a `Lease` holder fails to renew the `Lease` before it expires, other instances can detect this and attempt to acquire the `Lease` to proceed with reconciliation.
+
+##### Behavior Changes
+
+When serial reconciliation is enabled:
+
+- The [jitter delay mechanism](resource-manager.md#node-agent-reconciliation-delay-controller) (which normally staggers reconciliations to reduce API server load) is bypassed, as the leader election mechanism provides sufficient coordination.
+- Accordingly, 'Update' events on the `Secret` are processed immediately rather than with a random delay.
+- The controller uses a dedicated cache for the leader election `Lease` object to minimize unnecessary network I/O.
+
+> [!NOTE]
+> Nodes with serial reconciliation enabled are excluded from the [Agent Reconciliation Delay Controller](resource-manager.md#agent-reconciliation-delay-controller) in the `gardener-resource-manager`, as the serialization mechanism provides its own coordination.
+
 ### [Token Controller](../../pkg/nodeagent/controller/token)
 
 This controller watches the access token `Secret`s in the `kube-system` namespace configured via the `gardener-node-agent`'s component configuration (`.controllers.token.syncConfigs[]` field).

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -874,6 +874,10 @@ The highest possible value is `1800`.
 
 The controller adds the `node-agent.gardener.cloud/reconciliation-delay` annotation to nodes whose value is read by the [node-agent](node-agent.md)s.
 
+> [!NOTE]
+> Nodes which should never be updated in parallel and are marked for 'serial reconciliation' (e.g., control plane nodes for self-hosted shoot clusters) are excluded by this controller.
+> Read more about it [here](node-agent.md#serial-reconciliation).
+
 ## Webhooks
 
 ### Mutating Webhooks

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -1077,6 +1077,12 @@ const (
 	// should wait with reconciliation of the operating system config (to prevent too many node-agents from restarting
 	// kubelet or other critical units at the same time).
 	AnnotationNodeAgentReconciliationDelay = "node-agent.gardener.cloud/reconciliation-delay"
+	// AnnotationNodeAgentSerialOSCReconciliation is an annotation key on the gardener-node-agent Secret containing
+	// the OperatingSystemConfig that should be reconciled. When set, gardener-node-agent instances watching this Secret
+	// will try to lock the resource (by writing a Lease object with the same name as the Secret).
+	// If they have the lock, they reconcile and release the Lease at the end. If they don't have the lock, they
+	// wait until it is removed again.
+	AnnotationNodeAgentSerialOSCReconciliation = "reconciliation.osc.node-agent.gardener.cloud/serial"
 	// NodeAgentsGroup is the identity group for gardener-node-agents when authenticating to the API server.
 	NodeAgentsGroup = "gardener.cloud:node-agents"
 	// NodeAgentUserNamePrefix is the identity username prefix for gardener-node-agent when authenticating to the API server.

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -74,6 +74,8 @@ func WaitUntilObjectReadyWithHealthFunction(
 		namespace = obj.GetNamespace()
 	)
 
+	log = log.WithValues("object", client.ObjectKeyFromObject(obj), "kind", kind)
+
 	// If the object has been reconciled successfully before we triggered a new reconciliation and our cache
 	// is not updated fast enough with our reconciliation trigger (i.e. adding the reconcile annotation), we might
 	// falsy return early from waiting for the object to be ready (as the last state already was "ready").

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -65,7 +65,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		Watches(
 			&corev1.Node{},
 			handler.EnqueueRequestsFromMapFunc(r.NodeToSecretMapper()),
-			builder.WithPredicates(r.NodeReadyForUpdate()),
+			builder.WithPredicates(r.NodeReadyForInPlaceUpdate()),
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
@@ -155,11 +155,11 @@ func (r *Reconciler) NodeToSecretMapper() handler.MapFunc {
 	}
 }
 
-// NodeReadyForUpdate returns a predicate that returns
+// NodeReadyForInPlaceUpdate returns a predicate that returns
 // - true for Create event if the new node has the InPlaceUpdate condition with the reason ReadyForUpdate.
 // - true for Update event if the new node has the InPlaceUpdate condition with the reason ReadyForUpdate and old node doesn't.
 // - false for Delete and Generic events.
-func (r *Reconciler) NodeReadyForUpdate() predicate.Predicate {
+func (r *Reconciler) NodeReadyForInPlaceUpdate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			node, ok := e.Object.(*corev1.Node)

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -7,23 +7,31 @@ package operatingsystemconfig
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/spf13/afero"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -41,6 +49,9 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
+	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorder(ControllerName)
 	}
@@ -54,12 +65,13 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		r.Extractor = registry.NewExtractor()
 	}
 
-	return builder.
+	log := mgr.GetLogger().WithValues("controller", ControllerName)
+	controller := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
 		Watches(
 			&corev1.Secret{},
-			r.EnqueueWithJitterDelay(ctx, mgr.GetLogger().WithValues("controller", ControllerName).WithName("reconciliation-delayer")),
+			r.EnqueueWithJitterDelay(ctx, log.WithName("reconciliation-delayer")),
 			builder.WithPredicates(r.SecretPredicate(), predicateutils.ForEventTypes(predicateutils.Create, predicateutils.Update)),
 		).
 		Watches(
@@ -70,8 +82,43 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) erro
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 			ReconciliationTimeout:   controllerutils.DefaultReconciliationTimeout,
-		}).
-		Complete(r)
+		})
+
+	if r.NodeName != "" {
+		// In case the OperatingSystemConfig reconciliation is serial, we require another Lease object for leader election
+		// among the responsible gardener-node-agent instances. We don't use the Lease cache from the mgr because this is
+		// already restricted in `cmd/gardener-node-agent/app.go` to the health check Lease object of the Node the
+		// gardener-node-agent is responsible for.
+		// It is not possible to add another field selector for the leader election Lease (multiple field selectors are
+		// AND-ed). Completely lifting the field selector for Leases in the mgr would result in too many unrelated update
+		// calls for all gardener-node-agent instances (and thus, increased network I/O).
+		log.Info("Setting up cluster object for serial reconciliation leader election Lease cache")
+		cluster, err := cluster.New(mgr.GetConfig(), func(opts *cluster.Options) {
+			opts.Scheme = mgr.GetScheme()
+			opts.Logger = log.WithName("serial-reconciliation-leader-election-cluster")
+			opts.Cache.ByObject = map[client.Object]cache.ByObject{&coordinationv1.Lease{}: {
+				Namespaces: map[string]cache.Config{metav1.NamespaceSystem: {}},
+				Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: r.Config.SecretName}),
+			}}
+		})
+		if err != nil {
+			return fmt.Errorf("could not instantiate cluster for serial reconciliation leader election Lease cache: %w", err)
+		}
+		if err := mgr.Add(cluster); err != nil {
+			return fmt.Errorf("could not add cluster for serial reconciliation leader election Lease cache to manager: %w", err)
+		}
+		if r.LeaseClient == nil {
+			r.LeaseClient = cluster.GetClient()
+		}
+
+		controller = controller.WatchesRawSource(source.Kind[client.Object](cluster.GetCache(),
+			&coordinationv1.Lease{},
+			handler.EnqueueRequestsFromMapFunc(r.LeaseToSecretMapper()),
+			predicateutils.HasName(r.Config.SecretName), r.LeasePredicate(ctx, log.WithName("leader-election-lease-predicate")),
+		))
+	}
+
+	return controller.Complete(r)
 }
 
 // SecretPredicate returns the predicate for Secret events.
@@ -96,6 +143,55 @@ func (r *Reconciler) SecretPredicate() predicate.Predicate {
 	}
 }
 
+// LeasePredicate returns the predicate for Lease events. It only reacts on 'Update' events and returns true when both
+// of the following conditions are met:
+// - Lease was just released by another instance (i.e., it is free to be claimed)
+// - Node is not up-to-date with the latest OperatingSystemConfig
+func (r *Reconciler) LeasePredicate(ctx context.Context, log logr.Logger) predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldLease, ok := e.ObjectOld.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			newLease, ok := e.ObjectNew.(*coordinationv1.Lease)
+			if !ok {
+				return false
+			}
+
+			leaseReleasedByOtherInstances := func() bool {
+				return ptr.Deref(oldLease.Spec.HolderIdentity, "") != r.HostName &&
+					newLease.Spec.HolderIdentity == nil
+			}
+
+			nodeIsUpToDate := func() bool {
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: newLease.GetName(), Namespace: newLease.GetNamespace()}}
+				if err := r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+					log.Error(err, "Failed to get secret containing OperatingSystemConfig, assuming node is outdated")
+					return false
+				}
+
+				node, _, err := r.getNode(ctx)
+				if err != nil {
+					log.Error(err, "Failed to get node, assuming it is outdated")
+					return false
+				}
+				if node == nil {
+					return false
+				}
+
+				return secret.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumDownloadedOperatingSystemConfig] == node.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig]
+			}
+
+			return leaseReleasedByOtherInstances() && !nodeIsUpToDate()
+		},
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+	}
+}
+
 func reconcileRequest(obj client.Object) reconcile.Request {
 	return reconcile.Request{NamespacedName: types.NamespacedName{
 		Name:      obj.GetName(),
@@ -103,8 +199,9 @@ func reconcileRequest(obj client.Object) reconcile.Request {
 	}}
 }
 
-// EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random jitter duration for 'update'
-// events. 'Create' events are enqueued immediately.
+// EnqueueWithJitterDelay returns handler.Funcs which enqueues the object with a random jitter duration for 'Update'
+// events. 'Create' events are enqueued immediately. If the reconciliation is serial, also 'Update' events are enqueued
+// immediately.
 func (r *Reconciler) EnqueueWithJitterDelay(ctx context.Context, log logr.Logger) handler.EventHandler {
 	delay := delayer{
 		log:    log,
@@ -129,12 +226,24 @@ func (r *Reconciler) EnqueueWithJitterDelay(ctx context.Context, log logr.Logger
 				return
 			}
 
+			if serialReconciliation(newSecret) {
+				q.Add(reconcileRequest(evt.ObjectNew))
+				return
+			}
+
 			if !bytes.Equal(oldSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig], newSecret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig]) {
 				duration := delay.fetch(ctx, r.NodeName)
 				log.Info("Enqueued secret with operating system config with a jitter period", "duration", duration)
 				q.AddAfter(reconcileRequest(evt.ObjectNew), duration)
 			}
 		},
+	}
+}
+
+// LeaseToSecretMapper returns a mapper that returns requests for a secret based on a leader election Lease.
+func (r *Reconciler) LeaseToSecretMapper() handler.MapFunc {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}}}
 	}
 }
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/add_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Add", func() {
 		)
 
 		BeforeEach(func() {
-			p = (&Reconciler{}).NodeReadyForUpdate()
+			p = (&Reconciler{}).NodeReadyForInPlaceUpdate()
 
 			node = &corev1.Node{
 				Status: corev1.NodeStatus{

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -108,9 +109,13 @@ func init() {
 // Reconciler decodes the OperatingSystemConfig resources from secrets and applies the systemd units and files to the
 // node.
 type Reconciler struct {
-	Client           client.Client
+	Client client.Client
+	// LeaseClient is a cached client just for the leader election Lease in case the OperatingSystemConfig
+	// reconciliation is serialed.
+	LeaseClient      client.Client
 	ContainerdClient nodeagentcontainerd.Client
 	Config           nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig
+	Clock            clock.Clock
 	ConfigDir        string
 	Recorder         events.EventRecorder
 	DBus             dbus.DBus
@@ -152,7 +157,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if nodeCreated {
-		log.Info("Node registered by kubelet. Restarting myself (gardener-node-agent unit) to start lease controller and watch my own node only. Canceling the context to initiate graceful shutdown")
+		log.Info("Node registered by kubelet. Restarting myself (gardener-node-agent unit) to start Lease controller and watch my own node only. Canceling the context to initiate graceful shutdown")
 		r.CancelContext()
 		return reconcile.Result{}, nil
 	}
@@ -179,9 +184,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
+	serialReconciliationLease := newLeaderElectorForSecret(log, r.LeaseClient, r.Clock, secret, r.HostName)
+
 	if node != nil && node.Annotations[nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig] == oscChecksum {
 		log.Info("Configuration on this node is up to date, nothing to be done")
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, serialReconciliationLease.release(ctx)
+	}
+
+	if serialReconciliation(secret) {
+		log.Info("OperatingSystemConfig reconciliation is serial")
+
+		if err := serialReconciliationLease.reload(ctx); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to reload Lease for serial reconciliation leader election: %w", err)
+		}
+
+		if serialReconciliationLease.acquiredByAnotherInstance() {
+			if serialReconciliationLease.renewedInTime() {
+				requeueAfter := serialReconciliationLease.durationUntilLeaseExpires()
+				serialReconciliationLease.logger().Info("Lease was acquired by another instance, exiting early and requeue when Lease expires", "requeueAfter", requeueAfter)
+				return reconcile.Result{RequeueAfter: requeueAfter}, nil
+			}
+
+			serialReconciliationLease.logger().Info("Lease was acquired by another instance, but it was not renewed in time")
+		}
+
+		if err := serialReconciliationLease.tryAcquireOrRenew(ctx); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed acquiring or renewing lease: %w", err)
+		}
+
+		log.Info("Lease acquired, starting reconciliation")
 	}
 
 	log.Info("Applying containerd configuration")
@@ -344,8 +375,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	patch := client.MergeFrom(node.DeepCopy())
 	metav1.SetMetaDataLabel(&node.ObjectMeta, v1beta1constants.LabelWorkerKubernetesVersion, r.Config.KubernetesVersion.String())
 	metav1.SetMetaDataAnnotation(&node.ObjectMeta, nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig, oscChecksum)
+	if err := r.Client.Patch(ctx, node, patch); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed patching Node annotations after OSC was applied: %w", err)
+	}
 
-	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, r.Client.Patch(ctx, node, patch)
+	return reconcile.Result{RequeueAfter: r.Config.SyncPeriod.Duration}, serialReconciliationLease.release(ctx)
 }
 
 func (r *Reconciler) getNode(ctx context.Context) (*corev1.Node, bool, error) {

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -111,7 +111,7 @@ func init() {
 type Reconciler struct {
 	Client client.Client
 	// LeaseClient is a cached client just for the leader election Lease in case the OperatingSystemConfig
-	// reconciliation is serialed.
+	// reconciliation is serialised.
 	LeaseClient      client.Client
 	ContainerdClient nodeagentcontainerd.Client
 	Config           nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -126,7 +126,8 @@ type Reconciler struct {
 	// actual OSC, or not reconcile them at all.
 	SkipWritingStateFiles bool
 
-	// Channel and TokenSecretSyncConfigs are used by the reconciler to trigger events for the token reconciler during an in-place service-account-key rotation.
+	// Channel and TokenSecretSyncConfigs are used by the reconciler to trigger events for the token reconciler during
+	// an in-place service-account-key rotation.
 	Channel                chan event.TypedGenericEvent[*corev1.Secret]
 	TokenSecretSyncConfigs []nodeagentconfigv1alpha1.TokenSecretSyncConfig
 }

--- a/pkg/nodeagent/controller/operatingsystemconfig/serial.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/serial.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+func serialReconciliation(secret *corev1.Secret) bool {
+	return secret.Annotations[v1beta1constants.AnnotationNodeAgentSerialOSCReconciliation] == "true"
+}
+
+type leaderElector struct {
+	log    logr.Logger
+	client client.Client
+	clock  clock.Clock
+
+	identity string
+	lease    *coordinationv1.Lease
+}
+
+func newLeaderElectorForSecret(log logr.Logger, c client.Client, clock clock.Clock, secret *corev1.Secret, identity string) *leaderElector {
+	var (
+		logger = log.WithName("leader-elector")
+		lease  *coordinationv1.Lease
+	)
+
+	if serialReconciliation(secret) {
+		ownerRef := metav1.NewControllerRef(secret, corev1.SchemeGroupVersion.WithKind("Secret"))
+		lease = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secret.Name,
+				Namespace:       secret.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		}
+		logger = logger.WithValues("lease", client.ObjectKeyFromObject(lease))
+	}
+
+	return &leaderElector{
+		log:      logger,
+		client:   c,
+		clock:    clock,
+		identity: identity,
+		lease:    lease,
+	}
+}
+
+func (l *leaderElector) logger() logr.Logger {
+	log := l.log
+
+	if l.lease.Spec.HolderIdentity != nil {
+		log = log.WithValues("holderIdentity", *l.lease.Spec.HolderIdentity)
+	}
+	if l.lease.Spec.AcquireTime != nil {
+		log = log.WithValues("acquireTime", l.lease.Spec.AcquireTime.String())
+	}
+	if l.lease.Spec.RenewTime != nil {
+		log = log.WithValues("acquireTime", l.lease.Spec.RenewTime.String())
+	}
+	if l.lease.Spec.LeaseDurationSeconds != nil {
+		log = log.WithValues("leaseDuration", l.leaseDuration().String())
+	}
+
+	return log
+}
+
+func (l *leaderElector) acquiredByMe() bool {
+	return ptr.Deref(l.lease.Spec.HolderIdentity, "") == l.identity
+}
+
+func (l *leaderElector) acquiredByAnotherInstance() bool {
+	holder := ptr.Deref(l.lease.Spec.HolderIdentity, "")
+	return holder != "" && !l.acquiredByMe()
+}
+
+func (l *leaderElector) leaseDuration() time.Duration {
+	return time.Duration(ptr.Deref(l.lease.Spec.LeaseDurationSeconds, 0)) * time.Second
+}
+
+func (l *leaderElector) renewedInTime() bool {
+	if ptr.Deref(l.lease.Spec.LeaseDurationSeconds, 0) < 0 || l.lease.Spec.RenewTime == nil {
+		return false
+	}
+	return l.lease.Spec.RenewTime.Add(l.leaseDuration()).UTC().After(l.clock.Now().UTC())
+}
+
+func (l *leaderElector) durationUntilLeaseExpires() time.Duration {
+	if ptr.Deref(l.lease.Spec.LeaseDurationSeconds, 0) < 0 || l.lease.Spec.RenewTime == nil {
+		return 0
+	}
+	return l.lease.Spec.RenewTime.UTC().Add(l.leaseDuration()).UTC().Sub(l.clock.Now().UTC())
+}
+
+func (l *leaderElector) reload(ctx context.Context) error {
+	return client.IgnoreNotFound(l.client.Get(ctx, client.ObjectKeyFromObject(l.lease), l.lease))
+}
+
+func (l *leaderElector) tryAcquireOrRenew(ctx context.Context) error {
+	l.log.Info("Try to acquire or renew Lease")
+
+	setLeaseSpec := func() {
+		if !l.acquiredByMe() {
+			l.lease.Spec.HolderIdentity = &l.identity
+			l.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			l.lease.Spec.AcquireTime = &metav1.MicroTime{Time: l.clock.Now().UTC()}
+		}
+		l.lease.Spec.RenewTime = &metav1.MicroTime{Time: l.clock.Now().UTC()}
+	}
+
+	if l.lease.ResourceVersion == "" {
+		l.log.Info("Lease does not exist, try creating it")
+		setLeaseSpec()
+		return l.client.Create(ctx, l.lease)
+	}
+
+	l.log.Info("Lease exists, try updating it")
+	setLeaseSpec()
+	return l.client.Update(ctx, l.lease)
+}
+
+func (l *leaderElector) release(ctx context.Context) error {
+	if l.lease == nil || !l.acquiredByMe() {
+		return nil
+	}
+
+	l.log.Info("Releasing Lease")
+	l.lease.Spec.HolderIdentity = nil
+	l.lease.Spec.LeaseDurationSeconds = nil
+	l.lease.Spec.AcquireTime = nil
+	l.lease.Spec.RenewTime = nil
+	return l.client.Update(ctx, l.lease)
+}

--- a/pkg/nodeagent/controller/operatingsystemconfig/serial_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/serial_test.go
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+)
+
+var _ = Describe("#serialReconciliation", func() {
+	It("should return true when annotation is 'true'", func() {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.AnnotationNodeAgentSerialOSCReconciliation: "true"}}}
+		Expect(serialReconciliation(s)).To(BeTrue())
+	})
+
+	It("should return false when annotation is absent", func() {
+		Expect(serialReconciliation(&corev1.Secret{})).To(BeFalse())
+	})
+
+	It("should return false when annotation is 'false'", func() {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.AnnotationNodeAgentSerialOSCReconciliation: "false"}}}
+		Expect(serialReconciliation(s)).To(BeFalse())
+	})
+
+	It("should return false when annotation is empty string", func() {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.AnnotationNodeAgentSerialOSCReconciliation: ""}}}
+		Expect(serialReconciliation(s)).To(BeFalse())
+	})
+})
+
+var _ = Describe("#newLeaderElectorForSecret", func() {
+	var (
+		log        = logr.Discard()
+		fakeClient client.Client
+		fakeClock  clock.Clock
+		identity   = "test-identity"
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		fakeClock = testclock.NewFakeClock(time.Now())
+	})
+
+	It("should return leaderElector with nil lease when annotation is not set", func() {
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}}
+
+		le := newLeaderElectorForSecret(log, fakeClient, fakeClock, secret, identity)
+		Expect(le).NotTo(BeNil())
+		Expect(le.lease).To(BeNil())
+		Expect(le.identity).To(Equal(identity))
+	})
+
+	It("should return leaderElector with correct lease when annotation is 'true'", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-secret",
+				Namespace: "test-namespace",
+				UID:       "test-uid",
+				Annotations: map[string]string{
+					v1beta1constants.AnnotationNodeAgentSerialOSCReconciliation: "true",
+				},
+			},
+		}
+
+		le := newLeaderElectorForSecret(log, fakeClient, fakeClock, secret, identity)
+		Expect(le).NotTo(BeNil())
+		Expect(le.identity).To(Equal(identity))
+		Expect(le.lease).NotTo(BeNil())
+		Expect(le.lease.Name).To(Equal("test-secret"))
+		Expect(le.lease.Namespace).To(Equal("test-namespace"))
+		Expect(le.lease.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
+			APIVersion:         "v1",
+			Kind:               "Secret",
+			Name:               "test-secret",
+			UID:                "test-uid",
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(true),
+		}))
+	})
+})
+
+var _ = Describe("leaderElector", func() {
+	var (
+		ctx        context.Context
+		now        time.Time
+		clk        *testclock.FakeClock
+		fakeClient client.Client
+		le         *leaderElector
+		identity   = "test-node"
+		lease      *coordinationv1.Lease
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		now = time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		clk = testclock.NewFakeClock(now)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		lease = &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: "test-lease", Namespace: "test-ns"}}
+		le = &leaderElector{log: logr.Discard(), client: fakeClient, clock: clk, identity: identity, lease: lease}
+	})
+
+	Describe("#acquiredByMe", func() {
+		It("should return true when HolderIdentity matches identity", func() {
+			le.lease.Spec.HolderIdentity = ptr.To(identity)
+			Expect(le.acquiredByMe()).To(BeTrue())
+		})
+
+		It("should return false when HolderIdentity is nil", func() {
+			Expect(le.acquiredByMe()).To(BeFalse())
+		})
+
+		It("should return false when HolderIdentity is another identity", func() {
+			le.lease.Spec.HolderIdentity = ptr.To("other")
+			Expect(le.acquiredByMe()).To(BeFalse())
+		})
+
+		It("should return false when HolderIdentity is empty string", func() {
+			le.lease.Spec.HolderIdentity = ptr.To("")
+			Expect(le.acquiredByMe()).To(BeFalse())
+		})
+	})
+
+	Describe("#acquiredByAnotherInstance", func() {
+		It("should return false when HolderIdentity is nil", func() {
+			Expect(le.acquiredByAnotherInstance()).To(BeFalse())
+		})
+
+		It("should return false when HolderIdentity is empty", func() {
+			le.lease.Spec.HolderIdentity = ptr.To("")
+			Expect(le.acquiredByAnotherInstance()).To(BeFalse())
+		})
+
+		It("should return false when HolderIdentity is own identity", func() {
+			le.lease.Spec.HolderIdentity = ptr.To(identity)
+			Expect(le.acquiredByAnotherInstance()).To(BeFalse())
+		})
+
+		It("should return true when HolderIdentity is a different non-empty identity", func() {
+			le.lease.Spec.HolderIdentity = ptr.To("other")
+			Expect(le.acquiredByAnotherInstance()).To(BeTrue())
+		})
+	})
+
+	Describe("#leaseDuration", func() {
+		It("should return zero when LeaseDurationSeconds is nil", func() {
+			Expect(le.leaseDuration()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return zero when LeaseDurationSeconds is 0", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](0)
+			Expect(le.leaseDuration()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return the correct duration", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			Expect(le.leaseDuration()).To(Equal(600 * time.Second))
+		})
+	})
+
+	Describe("#renewedInTime", func() {
+		It("should return false when LeaseDurationSeconds is nil", func() {
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now}
+			Expect(le.renewedInTime()).To(BeFalse())
+		})
+
+		It("should return false when LeaseDurationSeconds is negative", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](-1)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now}
+			Expect(le.renewedInTime()).To(BeFalse())
+		})
+
+		It("should return false when RenewTime is nil", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			Expect(le.renewedInTime()).To(BeFalse())
+		})
+
+		It("should return true when within lease duration", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now.Add(-300 * time.Second)}
+			Expect(le.renewedInTime()).To(BeTrue())
+		})
+
+		It("should return false when lease has expired", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now.Add(-700 * time.Second)}
+			Expect(le.renewedInTime()).To(BeFalse())
+		})
+
+		It("should return false when renewTime+duration exactly equals now", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now.Add(-600 * time.Second)}
+			Expect(le.renewedInTime()).To(BeFalse())
+		})
+	})
+
+	Describe("#durationUntilLeaseExpires", func() {
+		It("should return zero when LeaseDurationSeconds is nil", func() {
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now}
+			Expect(le.durationUntilLeaseExpires()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return zero when LeaseDurationSeconds is negative", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](-1)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now}
+			Expect(le.durationUntilLeaseExpires()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return zero when RenewTime is nil", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			Expect(le.durationUntilLeaseExpires()).To(Equal(time.Duration(0)))
+		})
+
+		It("should return the remaining duration when lease has not expired", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now.Add(-100 * time.Second)}
+			Expect(le.durationUntilLeaseExpires()).To(Equal(500 * time.Second))
+		})
+
+		It("should return a negative duration when lease has already expired", func() {
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.RenewTime = &metav1.MicroTime{Time: now.Add(-700 * time.Second)}
+			Expect(le.durationUntilLeaseExpires()).To(BeNumerically("<", 0))
+		})
+	})
+
+	Describe("#reload", func() {
+		It("should reload an existing lease", func() {
+			existing := &coordinationv1.Lease{
+				ObjectMeta: metav1.ObjectMeta{Name: lease.Name, Namespace: lease.Namespace},
+				Spec:       coordinationv1.LeaseSpec{HolderIdentity: ptr.To("some-holder")},
+			}
+			Expect(fakeClient.Create(ctx, existing)).To(Succeed())
+			Expect(le.reload(ctx)).To(Succeed())
+			Expect(le.lease.Spec.HolderIdentity).To(Equal(ptr.To("some-holder")))
+		})
+
+		It("should not error when lease does not exist (IgnoreNotFound)", func() {
+			Expect(le.reload(ctx)).To(Succeed())
+			Expect(le.lease.Spec.HolderIdentity).To(BeNil())
+		})
+	})
+
+	Describe("#tryAcquireOrRenew", func() {
+		When("lease does not yet exist", func() {
+			It("should create lease with holder identity, duration and timings", func() {
+				Expect(le.tryAcquireOrRenew(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+				Expect(lease.Spec.HolderIdentity).To(Equal(ptr.To(identity)))
+				Expect(lease.Spec.LeaseDurationSeconds).To(PointTo(Equal(int32(600))))
+				Expect(lease.Spec.AcquireTime).NotTo(BeNil())
+				Expect(lease.Spec.AcquireTime.UTC()).To(Equal(now.UTC()))
+				Expect(lease.Spec.RenewTime).NotTo(BeNil())
+				Expect(lease.Spec.RenewTime.UTC()).To(Equal(now.UTC()))
+			})
+
+			It("should not overwrite AcquireTime when already the holder", func() {
+				acquireTime := now.Add(-5 * time.Minute)
+				le.lease.Spec.HolderIdentity = ptr.To(identity)
+				le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+				le.lease.Spec.AcquireTime = &metav1.MicroTime{Time: acquireTime}
+
+				Expect(le.tryAcquireOrRenew(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+				Expect(lease.Spec.AcquireTime.UTC()).To(Equal(acquireTime.UTC()))
+				Expect(lease.Spec.RenewTime.UTC()).To(Equal(now.UTC()))
+			})
+
+			It("should reset AcquireTime when taking over from another holder", func() {
+				le.lease.Spec.HolderIdentity = ptr.To("other")
+				le.lease.Spec.AcquireTime = &metav1.MicroTime{Time: now.Add(-10 * time.Minute)}
+
+				Expect(le.tryAcquireOrRenew(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+				Expect(lease.Spec.HolderIdentity).To(Equal(ptr.To(identity)))
+				Expect(lease.Spec.AcquireTime.UTC()).To(Equal(now.UTC()))
+				Expect(lease.Spec.RenewTime.UTC()).To(Equal(now.UTC()))
+			})
+		})
+
+		When("lease already exists", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Create(ctx, lease)).To(Succeed())
+			})
+
+			It("should update the lease with holder identity and timings", func() {
+				Expect(le.tryAcquireOrRenew(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+				Expect(lease.Spec.HolderIdentity).To(Equal(ptr.To(identity)))
+				Expect(lease.Spec.LeaseDurationSeconds).To(PointTo(Equal(int32(600))))
+				Expect(lease.Spec.AcquireTime.UTC()).To(Equal(now.UTC()))
+				Expect(lease.Spec.RenewTime.UTC()).To(Equal(now.UTC()))
+			})
+
+			It("should only update RenewTime when already the holder", func() {
+				acquireTime := now.Add(-5 * time.Minute)
+				le.lease.Spec.HolderIdentity = ptr.To(identity)
+				le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+				le.lease.Spec.AcquireTime = &metav1.MicroTime{Time: acquireTime}
+				Expect(fakeClient.Update(ctx, le.lease)).To(Succeed())
+
+				Expect(le.tryAcquireOrRenew(ctx)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+				Expect(lease.Spec.AcquireTime.UTC()).To(Equal(acquireTime.UTC()))
+				Expect(lease.Spec.RenewTime.UTC()).To(Equal(now.UTC()))
+			})
+		})
+	})
+
+	Describe("#release", func() {
+		It("should do nothing when lease is nil", func() {
+			le.lease = nil
+			Expect(le.release(ctx)).To(Succeed())
+		})
+
+		It("should do nothing when not the holder", func() {
+			le.lease.Spec.HolderIdentity = ptr.To("other")
+			Expect(fakeClient.Create(ctx, le.lease)).To(Succeed())
+
+			Expect(le.release(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			Expect(lease.Spec.HolderIdentity).To(Equal(ptr.To("other")))
+		})
+
+		It("should clear all lease spec fields when the current holder releases", func() {
+			t := metav1.NewMicroTime(now)
+			le.lease.Spec.HolderIdentity = ptr.To(identity)
+			le.lease.Spec.LeaseDurationSeconds = ptr.To[int32](600)
+			le.lease.Spec.AcquireTime = &t
+			le.lease.Spec.RenewTime = &t
+			Expect(fakeClient.Create(ctx, le.lease)).To(Succeed())
+
+			Expect(le.release(ctx)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			Expect(lease.Spec.HolderIdentity).To(BeNil())
+			Expect(lease.Spec.LeaseDurationSeconds).To(BeNil())
+			Expect(lease.Spec.AcquireTime).To(BeNil())
+			Expect(lease.Spec.RenewTime).To(BeNil())
+		})
+	})
+})

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -404,7 +404,6 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 				ExtensionUnits: []extensionsv1alpha1.Unit{unit3, unit4, unit8, unit9, existingUnitDropIn},
 			},
 		}
-
 	})
 
 	JustBeforeEach(func() {

--- a/test/integration/nodeagent/operatingsystemconfig/serial_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/serial_test.go
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package operatingsystemconfig_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/gardener/pkg/api/indexer"
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	fakecontainerdclient "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
+	"github.com/gardener/gardener/pkg/nodeagent/controller/operatingsystemconfig"
+	fakedbus "github.com/gardener/gardener/pkg/nodeagent/dbus/fake"
+	fakeregistry "github.com/gardener/gardener/pkg/nodeagent/registry/fake"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/test"
+)
+
+var _ = Describe("OperatingSystemConfig controller serial reconciliation tests", func() {
+	var (
+		fakeDBus *fakedbus.DBus
+		fakeFS   afero.Afero
+
+		oscSecretName = testRunID
+
+		operatingSystemConfig *extensionsv1alpha1.OperatingSystemConfig
+		oscRaw                []byte
+		oscSecret             *corev1.Secret
+
+		imageMountDirectory                string
+		pathBootstrapTokenFile             = filepath.Join("/", "var", "lib", "gardener-node-agent", "credentials", "bootstrap-token")
+		pathKubeletBootstrapKubeconfigFile = filepath.Join("/", "var", "lib", "kubelet", "kubeconfig-bootstrap")
+
+		hostName1, hostName2, hostName3 = "host1", "host2", "host3"
+		remainingHosts                  = func(leaders ...string) []string {
+			var (
+				allHosts  = sets.New(hostName1, hostName2, hostName3)
+				leaderSet = sets.New(leaders...).Intersection(allHosts)
+			)
+
+			return sets.List(allHosts.Difference(leaderSet))
+		}
+	)
+
+	BeforeEach(func() {
+		fakeDBus = fakedbus.New()
+		fakeFS = afero.Afero{Fs: afero.NewMemMapFs()}
+		mgrClient = testClient
+
+		var err error
+		imageMountDirectory, err = fakeFS.TempDir("", "fake-node-agent-")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { Expect(fakeFS.RemoveAll(imageMountDirectory)).To(Succeed()) })
+
+		DeferCleanup(test.WithVars(
+			&operatingsystemconfig.RequeueAfterRestart, time.Second,
+			&operatingsystemconfig.Exec, func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+				return []byte(""), nil
+			},
+		))
+
+		operatingSystemConfig = &extensionsv1alpha1.OperatingSystemConfig{
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				Files: []extensionsv1alpha1.File{
+					{
+						Path:        "/example/file/" + hostName1,
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "", Data: "data"}},
+						Permissions: ptr.To[uint32](0777),
+						HostName:    &hostName1,
+					},
+					{
+						Path:        "/example/file/" + hostName2,
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "", Data: "data"}},
+						Permissions: ptr.To[uint32](0777),
+						HostName:    &hostName2,
+					},
+					{
+						Path:        "/example/file/" + hostName3,
+						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "", Data: "data"}},
+						Permissions: ptr.To[uint32](0777),
+						HostName:    &hostName3,
+					},
+				},
+			},
+		}
+
+		oscRaw, err = runtime.Encode(codec, operatingSystemConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		oscSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oscSecretName,
+				Namespace: metav1.NamespaceSystem,
+				Labels:    map[string]string{testID: testRunID},
+				Annotations: map[string]string{
+					"checksum/data-script":                                utils.ComputeSHA256Hex(oscRaw),
+					"reconciliation.osc.node-agent.gardener.cloud/serial": "true",
+				},
+			},
+			Data: map[string][]byte{"osc.yaml": oscRaw},
+		}
+
+		By("Create bootstrap token file")
+		_, err = fakeFS.Create(pathBootstrapTokenFile)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(fakeFS.Remove(pathBootstrapTokenFile)).To(Or(Succeed(), MatchError(afero.ErrFileNotFound)))
+		})
+
+		By("Create kubelet bootstrap kubeconfig file")
+		_, err = fakeFS.Create(pathKubeletBootstrapKubeconfigFile)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(fakeFS.Remove(pathKubeletBootstrapKubeconfigFile)).To(Or(Succeed(), MatchError(afero.ErrFileNotFound)))
+		})
+
+		slowFakeFs := afero.Afero{Fs: &slowFs{Fs: fakeFS.Fs}}
+		By("Create and start new controller instance for " + hostName1)
+		startNewOperatingSystemConfigControllerInstance(hostName1, oscSecretName, fakeDBus, slowFakeFs, imageMountDirectory)
+		By("Create and start new controller instance for " + hostName2)
+		startNewOperatingSystemConfigControllerInstance(hostName2, oscSecretName, fakeDBus, slowFakeFs, imageMountDirectory)
+		By("Create and start new controller instance for " + hostName3)
+		startNewOperatingSystemConfigControllerInstance(hostName3, oscSecretName, fakeDBus, slowFakeFs, imageMountDirectory)
+	})
+
+	It("should ensure that one node is updated at a time", func() {
+		By("Create Secret containing the operating system config")
+		Expect(testClient.Create(ctx, oscSecret)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, oscSecret)).To(Succeed())
+		})
+
+		lease := &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: oscSecret.Name, Namespace: oscSecret.Namespace}}
+
+		By("Wait until first leader is elected")
+		var leader1 string
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			g.Expect(lease.Spec.HolderIdentity).NotTo(BeNil())
+			leader1 = *lease.Spec.HolderIdentity
+		}).To(Succeed())
+
+		By("Ensure first leader has reconciled while others haven't")
+		Eventually(func(g Gomega) {
+			exists, err := fakeFS.Exists("/example/file/" + leader1)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(exists).To(BeTrue())
+		}).Should(Succeed())
+		for _, remainder := range remainingHosts(leader1) {
+			test.AssertNoFileOnDisk(fakeFS, "/example/file/"+remainder)
+		}
+
+		By("Wait until second leader is elected")
+		var leader2 string
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			g.Expect(lease.Spec.HolderIdentity).NotTo(BeNil())
+			leader2 = *lease.Spec.HolderIdentity
+			g.Expect(leader2).NotTo(Equal(leader1))
+		}).To(Succeed())
+
+		By("Ensure second leader has reconciled while others haven't")
+		Eventually(func(g Gomega) {
+			exists, err := fakeFS.Exists("/example/file/" + leader2)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(exists).To(BeTrue())
+		}).Should(Succeed())
+		for _, remainder := range remainingHosts(leader1, leader2) {
+			test.AssertNoFileOnDisk(fakeFS, "/example/file/"+remainder)
+		}
+
+		By("Wait until third leader is elected")
+		var leader3 string
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			g.Expect(lease.Spec.HolderIdentity).NotTo(BeNil())
+			leader3 = *lease.Spec.HolderIdentity
+			g.Expect(leader3).NotTo(Or(Equal(leader1), Equal(leader2)))
+		}).To(Succeed())
+
+		By("Ensure third leader has reconciled")
+		Eventually(func(g Gomega) {
+			exists, err := fakeFS.Exists("/example/file/" + leader3)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(exists).To(BeTrue())
+		}).Should(Succeed())
+		Expect(remainingHosts(leader1, leader2, leader3)).To(BeEmpty())
+
+		By("Ensure nobody claims the Lease again since the work is done")
+		Eventually(func(g Gomega) *string { // wait until Lease is released
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			return lease.Spec.HolderIdentity
+		}).Should(BeNil())
+
+		Consistently(func(g Gomega) *string { // ensure Lease is not acquired again
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(lease), lease)).To(Succeed())
+			return lease.Spec.HolderIdentity
+		}).To(BeNil())
+	})
+})
+
+func startNewOperatingSystemConfigControllerInstance(hostName, oscSecretName string, fakeDBus *fakedbus.DBus, fakeFS afero.Afero, imageMountDirectory string) {
+	GinkgoHelper()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hostName,
+			Labels: map[string]string{
+				testID:                   testRunID,
+				"kubernetes.io/hostname": hostName,
+			},
+		},
+	}
+	By("Create Node")
+	Expect(testClient.Create(ctx, node)).To(Succeed())
+	DeferCleanup(func() {
+		By("Delete Node")
+		Expect(testClient.Delete(ctx, node)).To(Succeed())
+	})
+
+	By("Setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Logger:  log.WithName(hostName),
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			DefaultLabelSelector: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(indexer.AddPodNodeName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+
+	By("Register controller")
+	Expect((&operatingsystemconfig.Reconciler{
+		Config: nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig{
+			SyncPeriod:        &metav1.Duration{Duration: time.Hour},
+			SecretName:        oscSecretName,
+			KubernetesVersion: semver.MustParse("1.2.3"),
+		},
+		ConfigDir:             "/var/lib/gardener-node-agent",
+		DBus:                  fakeDBus,
+		FS:                    fakeFS,
+		HostName:              hostName,
+		NodeName:              node.Name,
+		Extractor:             fakeregistry.NewExtractor(fakeFS, imageMountDirectory),
+		CancelContext:         (&cancelFuncEnsurer{}).cancel,
+		ContainerdClient:      fakecontainerdclient.NewClient(),
+		SkipWritingStateFiles: true,
+	}).AddToManager(ctx, mgr)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+}
+
+// slowFs makes "WriteFile" slower for the purpose of this integration test. This is to make the test reliably able to
+// observe leader changes on the Lease object for the reconciliation coordination.
+type slowFs struct {
+	afero.Fs
+}
+
+func (fs *slowFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	time.Sleep(2 * time.Second)
+	return fs.Fs.OpenFile(name, flag, perm)
+}


### PR DESCRIPTION
**How to categorize this PR?**
/area os
/area robustness
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR introduces coordinated rollout handling for `OperatingSystemConfig` reconciliation performed by the `gardener-node-agent`. It adds a serial processing mechanism to ensure that nodes reconcile in a controlled sequence instead of concurrently. This is motivated by GEP-28 where we want control plane nodes to update serially, one at a time (to prevent bringing down multiple control plane pods at a time, potentially violating ETCD quorum).

Key changes:
- Implement serial reconciliation logic for `Secret`s containing `OperatingSystemConfig` resources (when annotated with `reconciliation.osc.node-agent.gardener.cloud/serial=true`)
- Adapt the Node Agent Reconciliation Delay controller to respect rollout coordination.
- Adjust the Node Agent Authorizer webhook to align with the new reconciliation flow.
- Add comprehensive integration and unit tests for serial coordination and related components.
- Update documentation for new node-agent and resource-manager concepts.

These changes improve reliability and predictability of node updates and are required groundwork for coordinated node lifecycle handling.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
- Core logic is in the new serial coordination implementation and its integration into the reconciler.
- Webhook authorization changes are required to keep permission checks consistent with serialized rollout semantics.
- Tests intentionally cover ordering guarantees and edge cases such as already up-to-date nodes.

**Release note**:
```feature developer
`gardener-node-agent` can optionally coordinate `OperatingSystemConfig` reconciliation amongst other instances. This is helpful if you want to ensure that only one instance reconciles at a time. Read all about it [here](https://gardener.cloud/docs/gardener/concepts/node-agent/#serial-reconciliation).
```