### PR TITLE
[release-v1.135] [GEP-34] OpenTelemetry Collector Memory Usage Optimisation

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -56,7 +56,13 @@ receivers:
 
 processors:
   batch:
+    send_batch_size: 2000
+    send_batch_max_size: 4000
     timeout: 10s
+
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: {{ .memoryLimitMiB }}
 
   # Include resource attributes from the Kubernetes environment.
   # The Shoot KAPI server is queried for pods in the kube-system namespace
@@ -130,9 +136,9 @@ service:
   pipelines:
     logs/journal:
       receivers: [journald/journal]
-      processors: [resource/journal, batch]
+      processors: [memory_limiter, resource/journal, batch]
       exporters: [otlp]
     logs/pods:
       receivers: [filelog/pods]
-      processors: [k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
+      processors: [memory_limiter, k8sattributes, filter/drop_non_gardener, resource/pod_labels, batch]
       exporters: [otlp]

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -354,7 +354,14 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 				Processors: &otelv1beta1.AnyConfig{
 					Object: map[string]any{
 						"batch": map[string]any{
-							"timeout": "10s",
+							"send_batch_size":     2000,
+							"send_batch_max_size": 4000,
+							"timeout":             "10s",
+						},
+						"memory_limiter": map[string]any{
+							"check_interval":  "1s",
+							"limit_mib":       3000,
+							"spike_limit_mib": 600,
 						},
 						"resource/vali": map[string]any{
 							"attributes": []any{
@@ -391,6 +398,15 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 					Object: map[string]any{
 						"loki": map[string]any{
 							"endpoint": lokiEndpoint,
+							"sending_queue": map[string]any{
+								"queue_size": 16777216,
+								"sizer":      "bytes",
+								"batch": map[string]any{
+									"flush_timeout": "1s",
+									"max_size":      4194304,
+									"sizer":         "bytes",
+								},
+							},
 						},
 					},
 				},
@@ -427,6 +443,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 								"otlp",
 							},
 							Processors: []string{
+								"memory_limiter",
 								"resource/vali",
 								"batch",
 							},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Backport of:
- https://github.com/gardener/gardener/pull/14108
- https://github.com/gardener/gardener/pull/14127

For version v1.135. Sadly, there were merge conflicts, so a manual backport was required.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue with the maximum batch size that the `OpenTelemetry Collector` instances can send.
```

```bugfix operator
Additional finetuning to the `Collector` configuration has been applied for improved memory usage.
```

