### PR TITLE
Update getting_started_locally.md

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -57,7 +57,7 @@ The local registry can now be accessed either via `localhost:5001` or `registry.
 The storage directories of the registries are mounted to the host machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 
-It may also be necessary to mark the repository in Docker as an insecure repository to ensure that Docker establishes the connection via HTTP. This can be achieved by adding the repository accordingly in the `/etc/docker/daemon.json` file:
+It may also be necessary to mark the registry in Docker as an insecure registry to ensure that Docker establishes the connection via HTTP. This can be achieved by adding the registry accordingly in the `/etc/docker/daemon.json` file:
 ```json
 { "insecure-registries":["registry.local.gardener.cloud:5001"] }
 ``` 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -62,7 +62,6 @@ It may also be necessary to mark the registry in Docker as an insecure registry 
 { "insecure-registries":["registry.local.gardener.cloud:5001"] }
 ``` 
 
-
 The command also deploys a default [calico](https://github.com/projectcalico/calico) installation as the cluster's CNI implementation with `NetworkPolicy` support (the default `kindnet` CNI doesn't provide `NetworkPolicy` support).
 Furthermore, it deploys the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) in order to support HPA and VPA on the seed cluster.
 

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -57,6 +57,12 @@ The local registry can now be accessed either via `localhost:5001` or `registry.
 The storage directories of the registries are mounted to the host machine under `dev/local-registry`.
 With this, mirrored images don't have to be pulled again after recreating the cluster.
 
+It may also be necessary to mark the repository in Docker as an insecure repository to ensure that Docker establishes the connection via HTTP. This can be achieved by adding the repository accordingly in the `/etc/docker/daemon.json` file:
+```json
+{ "insecure-registries":["registry.local.gardener.cloud:5001"] }
+``` 
+
+
 The command also deploys a default [calico](https://github.com/projectcalico/calico) installation as the cluster's CNI implementation with `NetworkPolicy` support (the default `kindnet` CNI doesn't provide `NetworkPolicy` support).
 Furthermore, it deploys the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) in order to support HPA and VPA on the seed cluster.
 


### PR DESCRIPTION
Added additional instructions to the documentation in order to mark the docker registry on `registry.local.gardener.cloud:5001`  as insecure. This prevents issues that Docker is trying to reach "https://registry.local.gardener.cloud:5001" instead of "https://registry.local.gardener.cloud:5001".

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Users which following the getting started steps might get the following error while running `make gardener-up`

``` 
Build [local-skaffold/gardener-extension-provider-local-node] failed: could not push image "registry.local.gardener.cloud:5001/local-skaffold_gardener-extension-provider-local-node:v1.137.0-dev-92aacf78bc21bb2872012862338c9fc550892dcfb8a4ef45daaaa1de25cbae6a": failed to do request: Head "https://registry.local.gardener.cloud:5001/v2/local-skaffold_gardener-extension-provider-local-node/blobs/sha256:44afd72d0dc30edcfc0f01cf56dc20bf2c53935b121fdb85601f0c82d63235b5": dial tcp 127.0.0.1:5001: connect: connection refused
``` 
The error is because docker is trying to access the registry via https (default). To make docker use http it is important to add the registry to the insecure-registries of docker. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:

```
doc user
```
