### PR TITLE
Update codegen in sequential in CI

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -40,15 +40,6 @@ source "${CODE_GEN_DIR}/kube_codegen.sh"
 
 rm -f $(go env GOPATH)/bin/*-gen
 
-# Pre-build generator binaries to avoid race conditions when running in parallel
-echo "> Pre-building code generator binaries..."
-go install k8s.io/code-generator/cmd/conversion-gen
-go install k8s.io/code-generator/cmd/deepcopy-gen
-go install k8s.io/code-generator/cmd/defaulter-gen
-go install k8s.io/code-generator/cmd/client-gen
-go install k8s.io/code-generator/cmd/lister-gen
-go install k8s.io/code-generator/cmd/informer-gen
-
 CURRENT_DIR=$(dirname $0)
 PROJECT_ROOT="${CURRENT_DIR}"/..
 export PROJECT_ROOT


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug



**What this PR does / why we need it**:
Update codegen in sequential in CI - 

Default to sequential mode in CI to avoid race conditions with go install. kube_codegen.sh functions (gen_helpers, gen_client) internally run 'go install' for code generators. When running in parallel, multiple processes race to write the same binaries, causing "already exists and is not an object file" errors.

CI links - 
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-unit/2025841607978258432
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14109/pull-gardener-unit/2025840024980819968

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
