### PR TITLE
Promote `VPAInPlaceUpdates` feature gate to `Beta`

### DIFF
--- a/cmd/gardenadm/app/app.go
+++ b/cmd/gardenadm/app/app.go
@@ -8,8 +8,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/bootstrap"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd/connect"
@@ -33,6 +35,11 @@ func NewCommand() *cobra.Command {
 		Use:   Name,
 		Short: Name + " bootstraps and manages self-hosted shoot clusters in the Gardener project.",
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			// TODO(vitanovs): Clean up once VPAInPlaceUpdates gets promoted to GA.
+			// Disable the feature gate as there are no VPA components that manage VPA resources and
+			// there is no reason for the GRM webhook, introduced by the gate, to be deployed.
+			utilruntime.Must(features.DefaultFeatureGate.Set("VPAInPlaceUpdates=false"))
+
 			if err := opts.Validate(); err != nil {
 				return err
 			}

--- a/cmd/gardenadm/app/app.go
+++ b/cmd/gardenadm/app/app.go
@@ -38,6 +38,13 @@ func NewCommand() *cobra.Command {
 			// TODO(vitanovs): Clean up once VPAInPlaceUpdates gets promoted to GA.
 			// Disable the feature gate as there are no VPA components that manage VPA resources and
 			// there is no reason for the GRM webhook, introduced by the gate, to be deployed.
+			//
+			// Further more, upon invocation, the GRM's /webhooks/vpa-in-place-updates endpoint,
+			// introduced by the webhook, fails to verify the request certificate with the following error message:
+			//
+			// "x509: certificate is valid for machine-0, not gardener-resource-manager.kube-system.svc"
+			//
+			// indicating that the gardenadm's initialization flow introduces a side effect when redeplying the GRM.
 			utilruntime.Must(features.DefaultFeatureGate.Set("VPAInPlaceUpdates=false"))
 
 			if err := opts.Validate(); err != nil {

--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -13,7 +13,6 @@ spec:
     featureGates:
       DefaultSeccompProfile: true
       IstioTLSTermination: true
-      VPAInPlaceUpdates: true
       VPNBondingModeRoundRobin: true
       PrometheusHealthChecks: true
       VictoriaLogsBackend: true

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,7 +29,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
 | UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` |         |
-| VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` |         |
+| VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.136` |
+| VPAInPlaceUpdates              | `true`  | `Beta`  | `1.137` |         |
 | VictoriaLogsBackend            | `false` | `Alpha` | `1.137` |         |
 | CustomDNSServerInNodeLocalDNS  | `true`  | `Beta`  | `1.133` |         |
 | VPNBondingModeRoundRobin       | `false` | `Alpha` | `1.135` |         |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -29,8 +29,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
 | UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` |         |
-| VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.136` |
-| VPAInPlaceUpdates              | `true`  | `Beta`  | `1.137` |         |
+| VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |
+| VPAInPlaceUpdates              | `true`  | `Beta`  | `1.138` |         |
 | VictoriaLogsBackend            | `false` | `Alpha` | `1.137` |         |
 | CustomDNSServerInNodeLocalDNS  | `true`  | `Beta`  | `1.133` |         |
 | VPNBondingModeRoundRobin       | `false` | `Alpha` | `1.135` |         |

--- a/docs/operations/enabling-in-place-resource-updates.md
+++ b/docs/operations/enabling-in-place-resource-updates.md
@@ -30,6 +30,8 @@ vpa-in-place-updates.resources.gardener.cloud/skip
 
 ### gardenlet
 
+> With Gardener [v1.137](https://github.com/gardener/gardener/releases/tag/v1.137.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
+
 To enable the _mutating_ [resource manager](../concepts/resource-manager.md) webhook, the `VPAInPlaceUpdates` feature gate must be set to `true`:
 
 ```yaml
@@ -52,6 +54,8 @@ To make use of the _mutating_ resource manager webhook, the `Shoot`'s [Vertical 
 To make use of the _mutating_ resource manager webhook, the `Seed`'s [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler) deployment must __not have__ the `InPlaceOrRecreate` feature gate __disabled__. Follow the [in-place resource updates](../usage/autoscaling/in-place-resource-updates.md#seed) guide for more details about the Vertical Pod Autoscaler components setup.
 
 ### Gardener Operator
+
+> With Gardener [v1.137](https://github.com/gardener/gardener/releases/tag/v1.137.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
 
 To enable the _mutating_ [resource manager](../concepts/resource-manager.md) webhook, the `VPAInPlaceUpdates` feature gate must be set to `true`:
 

--- a/docs/operations/enabling-in-place-resource-updates.md
+++ b/docs/operations/enabling-in-place-resource-updates.md
@@ -30,7 +30,7 @@ vpa-in-place-updates.resources.gardener.cloud/skip
 
 ### gardenlet
 
-> With Gardener [v1.137](https://github.com/gardener/gardener/releases/tag/v1.137.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
+> With Gardener [v1.138](https://github.com/gardener/gardener/releases/tag/v1.138.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
 
 To enable the _mutating_ [resource manager](../concepts/resource-manager.md) webhook, the `VPAInPlaceUpdates` feature gate must be set to `true`:
 
@@ -55,7 +55,7 @@ To make use of the _mutating_ resource manager webhook, the `Seed`'s [Vertical P
 
 ### Gardener Operator
 
-> With Gardener [v1.137](https://github.com/gardener/gardener/releases/tag/v1.137.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
+> With Gardener [v1.138](https://github.com/gardener/gardener/releases/tag/v1.138.0), the `VPAInPlaceUpdates` feature gate got promoted to `Beta` and is now __enabled by default__.
 
 To enable the _mutating_ [resource manager](../concepts/resource-manager.md) webhook, the `VPAInPlaceUpdates` feature gate must be set to `true`:
 

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -41,7 +41,6 @@ config:
     IstioTLSTermination: true
     UseUnifiedHTTPProxyPort: true
     VictoriaLogsBackend: true
-    VPAInPlaceUpdates: true
     VPNBondingModeRoundRobin: true
     PrometheusHealthChecks: true
   logging:

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -337,7 +337,7 @@ var _ = Describe("ResourceManager", func() {
 			DefaultSeccompProfileEnabled:              false,
 			EndpointSliceHintsEnabled:                 false,
 			PodTopologySpreadConstraintsEnabled:       true,
-			VPAInPlaceUpdatesEnabled:                  false,
+			VPAInPlaceUpdatesEnabled:                  true,
 			LogLevel:                                  "info",
 			LogFormat:                                 "json",
 			Zones:                                     []string{"a", "b"},

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -468,6 +468,9 @@ var _ = Describe("ResourceManager", func() {
 						AuthorizeWithSelectors: ptr.To(true),
 						MachineNamespace:       cfg.MachineNamespace,
 					},
+					VPAInPlaceUpdates: resourcemanagerconfigv1alpha1.VPAInPlaceUpdatesConfig{
+						Enabled: true,
+					},
 				},
 			}
 
@@ -1596,10 +1599,42 @@ webhooks:
     resources:
     - pods
   sideEffects: None
+  timeoutSeconds: 10`
+			}
+			out += `
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    url: https://gardener-resource-manager.` + deployNamespace + `:443/webhooks/vpa-in-place-updates
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vpa-in-place-updates.resources.gardener.cloud
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - kube-system
+      - kubernetes-dashboard
+  objectSelector:
+    matchExpressions:
+    - key: vpa-in-place-updates.resources.gardener.cloud/skip
+      operator: DoesNotExist
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - autoscaling.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - verticalpodautoscalers
+  sideEffects: None
   timeoutSeconds: 10
 `
-			}
-
 			return out
 		}
 

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -49,7 +49,7 @@ func runtimeGardenerResourceManagerDefaultValues() resourcemanager.Values {
 			}},
 		},
 		PodTopologySpreadConstraintsEnabled: false,
-		VPAInPlaceUpdatesEnabled:            false,
+		VPAInPlaceUpdatesEnabled:            true,
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
 		ResponsibilityMode:                  resourcemanager.ForRuntime,

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ResourceManager", func() {
 					}},
 				},
 				PodTopologySpreadConstraintsEnabled: false,
-				VPAInPlaceUpdatesEnabled:            false,
+				VPAInPlaceUpdatesEnabled:            true,
 				Replicas:                            ptr.To[int32](2),
 				ResourceClass:                       ptr.To("seed"),
 				ResponsibilityMode:                  resourcemanager.ForRuntime,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,6 +87,7 @@ const (
 	// to perform in-place Pod resource updates.
 	// owner: @vitanovs @ialidzhikov
 	// alpha: v1.133.0
+	// beta: v1.137.0
 	VPAInPlaceUpdates featuregate.Feature = "VPAInPlaceUpdates"
 
 	// CustomDNSServerInNodeLocalDNS enables custom server block support for NodeLocalDNS in the custom CoreDNS configuration of Shoot clusters.
@@ -140,7 +141,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	OpenTelemetryCollector:         {Default: true, PreRelease: featuregate.Beta},
 	VictoriaLogsBackend:            {Default: false, PreRelease: featuregate.Alpha},
 	UseUnifiedHTTPProxyPort:        {Default: false, PreRelease: featuregate.Alpha},
-	VPAInPlaceUpdates:              {Default: false, PreRelease: featuregate.Alpha},
+	VPAInPlaceUpdates:              {Default: true, PreRelease: featuregate.Beta},
 	CustomDNSServerInNodeLocalDNS:  {Default: true, PreRelease: featuregate.Beta},
 	VPNBondingModeRoundRobin:       {Default: false, PreRelease: featuregate.Alpha},
 	PrometheusHealthChecks:         {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,7 +87,7 @@ const (
 	// to perform in-place Pod resource updates.
 	// owner: @vitanovs @ialidzhikov
 	// alpha: v1.133.0
-	// beta: v1.137.0
+	// beta: v1.138.0
 	VPAInPlaceUpdates featuregate.Feature = "VPAInPlaceUpdates"
 
 	// CustomDNSServerInNodeLocalDNS enables custom server block support for NodeLocalDNS in the custom CoreDNS configuration of Shoot clusters.

--- a/pkg/gardenadm/botanist/resource_manager.go
+++ b/pkg/gardenadm/botanist/resource_manager.go
@@ -21,5 +21,6 @@ func (b *GardenadmBotanist) NewRuntimeGardenerResourceManager() (resourcemanager
 		PriorityClassName:                    v1beta1constants.PriorityClassNameShootControlPlane400,
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
 		SystemComponentTolerations:           gardenerutils.ExtractSystemComponentsTolerations(b.Shoot.GetInfo().Spec.Provider.Workers),
+		VPAInPlaceUpdatesEnabled:             features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
 	})
 }

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -981,7 +981,6 @@ deploy:
           nodeToleration.defaultUnreachableTolerationSeconds: "60"
           replicaCount: 2
           config.featureGates.IstioTLSTermination: true
-          config.featureGates.VPAInPlaceUpdates: true
           config.featureGates.PrometheusHealthChecks: true
           config.featureGates.VictoriaLogsBackend: true
         createNamespace: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR promotes the `VPAInPlaceUpdates` feature gate from `Alpha` to `Beta`, starting from Gardener `v1.138.0`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12955

<!--
**Special notes for your reviewer**:
-->

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `VPAInPlaceUpdates` feature gate has been promoted to Beta and is enabled by default.
```
