### PR TITLE
Fix panic of shoot care controller

### DIFF
--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -297,7 +297,7 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.EncryptedResources = v1beta1helper.GetShootEncryptedResourcesInStatus(shootStatus)
 
 	shoot.EncryptionProviderToUse = v1beta1helper.GetEncryptionProviderType(shoot.GetInfo().Spec.Kubernetes.KubeAPIServer)
-	if shootStatus.Credentials != nil {
+	if shootStatus.Credentials != nil && shootStatus.Credentials.EncryptionAtRest != nil {
 		shoot.UsedEncryptionProvider = shootStatus.Credentials.EncryptionAtRest.Provider.Type
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
When we rolled out g/g 1.136 in our landscape we noticed that the shoot-care controller panics for some clusters until they are reconciled for the first time with an updated gardenlet. This can happen for shoots that have performed a credential rotation in the past, so their `.status.credentials.rotation` is set, but `.status.credentials.encryptionAtRest` is still nil - at least in the seed-local `Cluster` object.

**Which issue(s) this PR fixes**:
Bug introduced with https://github.com/gardener/gardener/pull/13732
This panic:

```
{
    "log": {
        "controller": "shoot-care",
        "level": "error",
        "msg": "Observed a panic",
        "name": "a-cluster-name",
        "namespace": "garden-ca240c0722-1a2b2",
        "panic": "runtime error: invalid memory address or nil pointer dereference",
        "panicGoValue": "\"invalid memory address or nil pointer dereference\"",
        "reconcileID": "c8734fdd-f7d9-4ab0-91a3-6f5d3a41db54",
        "stacktrace": "k8s.io/apimachinery/pkg/util/runtime.logPanic\n\tk8s.io/apimachinery@v0.34.3/pkg/util/runtime/runtime.go:142\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:198\nruntime.gopanic\n\truntime/panic.go:783\nruntime.panicmem\n\truntime/panic.go:262\nruntime.sigpanic\n\truntime/signal_unix.go:925\ngithub.com/gardener/gardener/pkg/gardenlet/operation/shoot.(*Builder).Build\n\tgithub.com/gardener/gardener/pkg/gardenlet/operation/shoot/shoot.go:301\ngithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care.init.func5.(*Builder).WithShootFromCluster.10\n\tgithub.com/gardener/gardener/pkg/gardenlet/operation/operation.go:185\ngithub.com/gardener/gardener/pkg/gardenlet/operation.(*Builder).Build\n\tgithub.com/gardener/gardener/pkg/gardenlet/operation/operation.go:280\ngithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care.init.func5\n\tgithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care/types.go:175\ngithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care.(*Reconciler).Reconcile\n\tgithub.com/gardener/gardener/pkg/gardenlet/controller/shoot/care/reconciler.go:144\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296",
        "ts": "2026-02-24T14:24:01.268Z"
    },
    "logtag": "F"
}
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed the shoot-care controller panic for clusters where `.status.credentials.rotation` exists but `.status.credentials.encryptionAtRest` is nil.
```
