### PR TITLE
fix: reduce coredns mem limit to protect nodes

### DIFF
--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -507,7 +507,7 @@ import custom/*.server
 									corev1.ResourceMemory: resource.MustParse("15Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("1500Mi"),
+									corev1.ResourceMemory: resource.MustParse("1000Mi"),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -350,7 +350,7 @@ spec:
           timeoutSeconds: 2
         resources:
           limits:
-            memory: 1500Mi
+            memory: 1000Mi
           requests:
             cpu: 50m
             memory: 15Mi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
- Reduces memory limit for CoreDNS from 1500MiB to 1000MiB
- The [official formula for CoreDNS scaling](https://coredns.io/2018/11/15/scaling-coredns-in-kubernetes-clusters/) suggests the limit to be `(pods+services)/1000+54`
- However, looking at one of the larger shoot deployments with 6000+ pods and 2500+ services we see a memory consumption of close to 250 MiB / instance
- The official limit would be only around 64 MiB und would cause OOMs
- However, the existing limit of 1500 MiB seems way off when comparing with the formula numbers
- So, as a we reduce the limit to 1000 MiB in order to have any meaningful node protection while still being 4x the average memory usage of large clusters.

**Which issue(s) this PR fixes**:
- Addresses general limits reconsideration / removal of Gardener components.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Memory limit of CoreDNS has been reduced to 1000 MiB (from 1500) to provide meaningful node protection.
```
