### PR TITLE
Switch building `golang-test` image to a Github workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,13 +23,14 @@
       // Generic detection for pod-like image specifications.
       customType: 'regex',
       managerFilePatterns: [
+        '/^.github/workflows/.+\\.yaml$/',
         '/^example/.+\\.yaml$/',
         '/^hack/.+\\.yaml$/',
         '/^\\.test-defs/.+\\.yaml$/',
         '/^charts/.+\\.yaml$/',
       ],
       matchStrings: [
-        'image: ["|\']?(?<depName>.*?):(?<currentValue>.*?)["|\']?\\s',
+        '["|\']?image["|\']?: ["|\']?(?<depName>.*?):(?<currentValue>.*?)["|\']?\\s',
       ],
       datasourceTemplate: 'docker',
     },

--- a/.github/workflows/golang-test-build-test.yaml
+++ b/.github/workflows/golang-test-build-test.yaml
@@ -1,0 +1,47 @@
+name: Test golang-test Build
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/golang-test-build.yaml
+      - .github/workflows/golang-test-images.yaml
+      - hack/tools/image/**
+      - hack/tools.mk
+      - go.mod
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    if: ${{ github.repository == 'gardener/gardener' }}
+    uses: ./.github/workflows/golang-test-images.yaml
+
+  build-golang-test:
+    name: Build golang-test
+    if: ${{ github.repository == 'gardener/gardener' }}
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build golang-test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./hack/tools/image/Dockerfile
+          target: golang-test
+          build-args: |
+            image=${{ matrix.images.image }}
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/golang-test-build.yaml
+++ b/.github/workflows/golang-test-build.yaml
@@ -1,0 +1,61 @@
+name: Build and Push golang-test Image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/golang-test-build.yaml
+      - .github/workflows/golang-test-images.yaml
+      - hack/tools/image/**
+      - hack/tools.mk
+      - go.mod
+
+jobs:
+  prepare-metadata:
+    name: Prepare Metadata
+    if: ${{ github.repository == 'gardener/gardener' }}
+    runs-on: ubuntu-latest
+    outputs:
+      date: ${{ steps.metadata.outputs.date }}
+      short-sha: ${{ steps.metadata.outputs.short-sha }}
+    steps:
+      - name: Generate metadata
+        id: metadata
+        run: |
+          echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "short-sha=${GITHUB_SHA:0:7} >> $GITHUB_OUTPUT
+
+  generate-matrix:
+    name: Generate Matrix
+    if: ${{ github.repository == 'gardener/gardener' }}
+    uses: ./.github/workflows/golang-test-images.yaml
+
+  oci-images:
+    name: Build OCI-Images
+    if: ${{ github.repository == 'gardener/gardener' }}
+    needs:
+      - prepare-metadata
+      - generate-matrix
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    secrets: inherit
+    uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    with:
+      name: golang-test
+      version: ${{ matrix.images.version }}
+      dockerfile: ./hack/tools/image/Dockerfile
+      build-args: |
+        image=${{ matrix.images.image }}
+      target: golang-test
+      commit-objects-artefact: ""
+      oci-registry: europe-docker.pkg.dev/gardener-project/releases/ci-infra
+      oci-repository: golang-test
+      oci-platforms: linux/amd64,linux/arm64
+      ocm-labels: ""
+      extra-tags: v${{ needs.prepare-metadata.outputs.date }}-${{ needs.prepare-metadata.outputs.short-sha }}-${{ matrix.images.version }}
+      push: always

--- a/.github/workflows/golang-test-images.yaml
+++ b/.github/workflows/golang-test-images.yaml
@@ -1,0 +1,37 @@
+name: Golang Test Images
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "Matrix configuration for golang-test images"
+        value: ${{ jobs.generate-matrix.outputs.matrix }}
+
+jobs:
+  generate-matrix:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          cat <<'EOF' >> $GITHUB_OUTPUT
+          matrix<<MATRIX_EOF
+          {
+            "images": [
+              {
+                "version": "1.25",
+                "image": "golang:1.25.7-bookworm"
+              },
+              {
+                "version": "1.26",
+                "image": "golang:1.26.0-bookworm"
+              }
+            ]
+          }
+          MATRIX_EOF
+          EOF
+
+

--- a/docs/development/dependencies.md
+++ b/docs/development/dependencies.md
@@ -74,8 +74,8 @@ Once a new Go version is released, please consider the guidance below for updati
 
 1. Check the [release notes](https://go.dev/doc/devel/release) to see whether there are any relevant changes that might be useful or affect us in another way.
 
-2. Maintain the image variants of the [`golang-test`](../../hack/tools/image) image used for unit- and integration testing as well as being the base image for `krte` (see next step) in the [`hack/tools/image/variants.yaml`](../../hack/tools/image/variants.yaml) file.
-   Remove older Go versions [if they are no longer supported](https://endoflife.date/go) and add the new version ([example](https://github.com/gardener/gardener/pull/12770)).  
+2. Maintain the image variants of the [`golang-test`](../../hack/tools/image) image used for unit- and integration testing as well as being the base image for `krte` (see next step) in the [`.github/workflows/golang-test-images.yaml`](../../.github/workflows/golang-test-images.yaml) file.
+   Remove older Go versions [if they are no longer supported](https://endoflife.date/go) and add the new version.  
    Check the registry to see when the new image variant is available:  
    [europe-docker.pkg.dev/gardener-project/releases/ci-infra/golang-test](https://console.cloud.google.com/artifacts/docker/gardener-project/europe/releases/ci-infra%2Fgolang-test)
 

--- a/hack/tools/image/Dockerfile
+++ b/hack/tools/image/Dockerfile
@@ -13,8 +13,6 @@ RUN echo "Installing Packages ..." \
 
 # builder
 FROM base AS builder
-ARG GOPROXY=https://proxy.golang.org,direct
-ENV GOPROXY=$GOPROXY
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 RUN make create-tools-bin TOOLS_BIN_DIR=hack/tools/bin && \

--- a/hack/tools/image/variants.yaml
+++ b/hack/tools/image/variants.yaml
@@ -1,9 +1,0 @@
-# Debian versions of golang images should be `bookworm`.
-# The Kubernetes upstream `krte` images uses the same version, and we should keep this in sync.
-# - https://github.com/kubernetes/test-infra/blob/master/images/krte/Dockerfile
-# - https://github.com/gardener/ci-infra/blob/master/images/krte
-variants:
-  "1.25":
-    image: golang:1.25.7-bookworm
-  "1.26":
-    image: golang:1.26.0-bookworm


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`golang-test` image is currently build using our `image-builder` tool. This tool uses `kaniko` which is not maintained anymore (see .
Thus, we would like to start building the image with a Github workflow as we do it for other images. This also harmonizes the process a bit.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/ci-infra/issues/5484

**Special notes for your reviewer**:
/cc @LucaBernstein 

Please merge after https://github.com/gardener/ci-infra/pull/5524 has been merged.
/hold

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
