### PR TITLE
extensions-healthcheck: skip cluster lookup for seed class

### DIFF
--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -47,6 +47,7 @@ type GetExtensionObjectListFunc = func() client.ObjectList
 // PreCheckFunc checks whether the health check shall be performed based on the given object.
 // For shoot extensions, the object is a cluster resource *extensions.Cluster.
 // For garden extensions, the object is *operatorv1alpha1.Garden.
+// For seed extensions, the object is nil.
 type PreCheckFunc = func(context.Context, client.Client, client.Object, any) bool
 
 // ErrorCodeCheckFunc checks if the given error is user specific and return respective Gardener ErrorCodes.

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -224,23 +224,14 @@ func isGardenExtensionClass(extensionClasses []extensionsv1alpha1.ExtensionClass
 	return len(extensionClasses) == 1 && extensionClasses[0] == extensionsv1alpha1.ExtensionClassGarden
 }
 
+func isShootExtensionClass(class extensionsv1alpha1.ExtensionClass) bool {
+	return class == extensionsv1alpha1.ExtensionClassShoot
+}
+
 func classesHaveClusterObject(extensionClasses []extensionsv1alpha1.ExtensionClass) bool {
 	// backwards compatibility for shoot extension
 	if len(extensionClasses) == 0 {
 		return true
 	}
-	return slices.ContainsFunc(extensionClasses, classHasClusterObject)
-}
-
-func classHasClusterObject(extensionClass extensionsv1alpha1.ExtensionClass) bool {
-	switch extensionClass {
-	case extensionsv1alpha1.ExtensionClassGarden:
-		return false
-	case extensionsv1alpha1.ExtensionClassSeed:
-		return false
-	case extensionsv1alpha1.ExtensionClassShoot:
-		return true
-	default:
-		return false
-	}
+	return slices.ContainsFunc(extensionClasses, isShootExtensionClass)
 }

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -6,6 +6,7 @@ package healthcheck
 
 import (
 	"fmt"
+	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -196,7 +197,7 @@ func add(mgr manager.Manager, args AddArgs, actuator HealthCheckActuator) error 
 			builder.WithPredicates(predicates...),
 		)
 
-	if isGardenExtensionClass(args.ExtensionClasses) {
+	if !classesHaveClusterObject(args.ExtensionClasses) {
 		return builder.
 			Complete(NewReconciler(mgr, actuator, *args.registeredExtension, args.SyncPeriod, args.ExtensionClasses))
 	}
@@ -221,4 +222,25 @@ func getHealthCheckTypes(healthChecks []ConditionTypeToHealthCheck) []string {
 
 func isGardenExtensionClass(extensionClasses []extensionsv1alpha1.ExtensionClass) bool {
 	return len(extensionClasses) == 1 && extensionClasses[0] == extensionsv1alpha1.ExtensionClassGarden
+}
+
+func classesHaveClusterObject(extensionClasses []extensionsv1alpha1.ExtensionClass) bool {
+	// backwards compatibility for shoot extension
+	if len(extensionClasses) == 0 {
+		return true
+	}
+	return slices.ContainsFunc(extensionClasses, classHasClusterObject)
+}
+
+func classHasClusterObject(extensionClass extensionsv1alpha1.ExtensionClass) bool {
+	switch extensionClass {
+	case extensionsv1alpha1.ExtensionClassGarden:
+		return false
+	case extensionsv1alpha1.ExtensionClassSeed:
+		return false
+	case extensionsv1alpha1.ExtensionClassShoot:
+		return true
+	default:
+		return false
+	}
 }

--- a/extensions/pkg/controller/healthcheck/controller_test.go
+++ b/extensions/pkg/controller/healthcheck/controller_test.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+var _ = Describe("controller", func() {
+	Describe("#classesHaveClusterObject", func() {
+		It("should return true if extension classes contain shoot", func() {
+			Expect(classesHaveClusterObject([]extensionsv1alpha1.ExtensionClass{extensionsv1alpha1.ExtensionClassShoot})).To(BeTrue())
+		})
+
+		It("should return true if extension classes is empty", func() {
+			Expect(classesHaveClusterObject(nil)).To(BeTrue())
+		})
+
+		It("should return false if extension classes are seed and garden", func() {
+			Expect(classesHaveClusterObject([]extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassGarden,
+				extensionsv1alpha1.ExtensionClassSeed,
+			})).To(BeFalse())
+		})
+	})
+})

--- a/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
@@ -274,6 +274,9 @@ func (a *Actuator) getPreCheckFuncObject(ctx context.Context, request types.Name
 		}
 		return garden, nil
 	}
+	if !classesHaveClusterObject(a.extensionClasses) {
+		return nil, nil
+	}
 	cluster, err := extensionscontroller.GetCluster(ctx, a.sourceClient, request.Namespace)
 	if err != nil {
 		return nil, err

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -22,6 +22,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/api/extensions"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/api/extensions/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -102,7 +103,8 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		extension.GetExtensionStatus().SetConditions(newConditions)
 	}
 
-	if !isGardenExtensionClass(r.extensionClasses) {
+	extClass := extensionsv1alpha1helper.GetExtensionClassOrDefault(extension.GetExtensionSpec().GetExtensionClass())
+	if classHasClusterObject(extClass) {
 		cluster, err := extensionscontroller.GetCluster(ctx, r.client, acc.GetNamespace())
 		if err != nil {
 			return reconcile.Result{}, err

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -104,7 +104,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	extClass := extensionsv1alpha1helper.GetExtensionClassOrDefault(extension.GetExtensionSpec().GetExtensionClass())
-	if classHasClusterObject(extClass) {
+	if isShootExtensionClass(extClass) {
 		cluster, err := extensionscontroller.GetCluster(ctx, r.client, acc.GetNamespace())
 		if err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Support healthcheck reconciler for extension of class **seed**.

**Which issue(s) this PR fixes**:
Fixes #14161

**Special notes for your reviewer**:
/cc @theoddora @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The healthcheck controller now supports the seed extension class.
```
