### PR TITLE
chore: Configure VPA responsibles

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -809,6 +809,10 @@ images:
           confidentiality_requirement: 'low'
           integrity_requirement: 'high'
           availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/vertical-pod-autoscaler-maintainers'
   - name: vpa-recommender
     sourceRepository: github.com/kubernetes/autoscaler
     repository: registry.k8s.io/autoscaling/vpa-recommender
@@ -822,6 +826,10 @@ images:
           confidentiality_requirement: 'low'
           integrity_requirement: 'high'
           availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/vertical-pod-autoscaler-maintainers'
   - name: vpa-updater
     sourceRepository: github.com/kubernetes/autoscaler
     repository: registry.k8s.io/autoscaling/vpa-updater
@@ -835,6 +843,10 @@ images:
           confidentiality_requirement: 'low'
           integrity_requirement: 'high'
           availability_requirement: 'high'
+      - name: 'cloud.gardener.cnudie/responsibles'
+        value:
+          - type: 'githubTeam'
+            teamname: 'gardener/vertical-pod-autoscaler-maintainers'
   # Horizontal cluster-proportional-autoscaler
   - name: cluster-proportional-autoscaler
     sourceRepository: https://github.com/kubernetes-sigs/cluster-proportional-autoscaler


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener/pull/10948. Otherwise, OCM/ODG machinery doesn't properly assign responsible people for the VPA images.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
