### PR TITLE
fix(ci): Prevent trailing newline in additional release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
     with:
       release-commit-target: branch
       github-tag-template: '${version}'
-      github-additional-tag-templates: |
+      github-additional-tag-templates: |-
         pkg/apis/${version}
       next-version: ${{ inputs.next-version }}
       slack-channel-id: C9CEBQPGE # #sap-tech-gardener


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/etcd-druid/pull/1228.

Currently, our release pipeline failed with:
```
To https://github.com/gardener/gardener
 * [new tag]               HEAD -> pkg/apis/v1.137.0
error: saw empty tag in github-additional-tag-templates input
```

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/13536

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
