### PR TITLE
[GEP-28] `gardenadm join`: Generate ETCD server/peer certificates for control plane nodes

### DIFF
--- a/pkg/component/etcd/etcd/constants/constants.go
+++ b/pkg/component/etcd/etcd/constants/constants.go
@@ -35,4 +35,9 @@ var (
 	// StaticPodPortEtcdEventsWrapper is the port exposed by the etcd-wrapper container in etcd-events when it runs as
 	// static pod.
 	StaticPodPortEtcdEventsWrapper int32 = 9096
+
+	// VolumeNameServerTLS is the name of the volume in the ETCD pod spec used for the server TLS.
+	VolumeNameServerTLS = "etcd-server-tls"
+	// VolumeNamePeerTLS is the name of the volume in the ETCD pod spec used for the peer TLS.
+	VolumeNamePeerTLS = "etcd-peer-server-tls"
 )

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -252,12 +252,12 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		controlPlaneNodeIP = e.values.StaticPod.ControlPlaneNodesIPAddresses[0]
 	}
 
-	etcdCASecret, serverSecret, clientSecret, err := GenerateClientServerCertificates(
+	etcdCASecret, serverSecret, clientSecret, err := GenerateServerAndClientCertificates(
 		ctx,
 		e.secretsManager,
 		e.values.Role,
-		e.clientServiceDNSNames(),
-		e.clientServiceIPAddresses(),
+		ClientServiceDNSNames(e.etcd.Name, e.namespace, e.values.StaticPod != nil),
+		controlPlaneNodeIP,
 	)
 	if err != nil {
 		return err
@@ -268,20 +268,26 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	//  PeerUrlTLS for all remaining clusters as well.
 	var peerUrlTLS *druidcorev1alpha1.TLSConfig
 	if e.values.HighAvailabilityEnabled {
-		if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx); err != nil {
-			return err
+		etcdPeerCASecret, found := e.secretsManager.Get(v1beta1constants.SecretNameCAETCDPeer)
+		if !found {
+			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
+		}
+
+		peerServerSecret, err := GeneratePeerCertificate(ctx, e.secretsManager, e.values.Role, e.peerServiceDNSNames(), controlPlaneNodeIP)
+		if err != nil {
+			return fmt.Errorf("failed to generate a peer certificate: %w", err)
 		}
 
 		peerUrlTLS = &druidcorev1alpha1.TLSConfig{
 			TLSCASecretRef: druidcorev1alpha1.SecretReference{
 				SecretReference: corev1.SecretReference{
-					Name:      etcdPeerCASecretName,
+					Name:      etcdPeerCASecret.Name,
 					Namespace: e.namespace,
 				},
 				DataKey: ptr.To(secretsutils.DataKeyCertificateBundle),
 			},
 			ServerTLSSecretRef: corev1.SecretReference{
-				Name:      peerServerSecretName,
+				Name:      peerServerSecret.Name,
 				Namespace: e.namespace,
 			},
 		}
@@ -874,40 +880,6 @@ func (e *etcd) Snapshot(ctx context.Context, httpClient rest.HTTPClient) error {
 	return err
 }
 
-func (e *etcd) clientServiceDNSNames() []string {
-	var domainNames []string
-	domainNames = append(domainNames, fmt.Sprintf("%s-local", e.etcd.Name))
-	domainNames = append(domainNames, kubernetesutils.DNSNamesForService(fmt.Sprintf("%s-client", e.etcd.Name), e.namespace)...)
-
-	// The peer service needs to be considered here since the etcd-backup-restore side-car
-	// connects to member pods via pod domain names (e.g. for defragmentation).
-	// See https://github.com/gardener/etcd-backup-restore/issues/494
-	domainNames = append(domainNames, kubernetesutils.DNSNamesForService(fmt.Sprintf("*.%s-peer", e.etcd.Name), e.namespace)...)
-
-	if e.values.RunsAsStaticPod {
-		domainNames = append(domainNames, "localhost")
-	}
-
-	return domainNames
-}
-
-func (e *etcd) clientServiceIPAddresses() []net.IP {
-	if !e.values.RunsAsStaticPod {
-		return nil
-	}
-	return []net.IP{
-		net.ParseIP("127.0.0.1"),
-		net.ParseIP("::1"),
-	}
-}
-
-func (e *etcd) peerServiceDNSNames() []string {
-	return append(
-		kubernetesutils.DNSNamesForService(fmt.Sprintf("%s-peer", e.etcd.Name), e.namespace),
-		kubernetesutils.DNSNamesForService(fmt.Sprintf("*.%s-peer", e.etcd.Name), e.namespace)...,
-	)
-}
-
 // Get retrieves the Etcd resource
 func (e *etcd) Get(ctx context.Context) (*druidcorev1alpha1.Etcd, error) {
 	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), e.etcd); err != nil {
@@ -1087,81 +1059,6 @@ func (e *etcd) computeFullSnapshotSchedule(existingEtcd *druidcorev1alpha1.Etcd)
 		fullSnapshotSchedule = existingEtcd.Spec.Backup.FullSnapshotSchedule
 	}
 	return fullSnapshotSchedule
-}
-
-func (e *etcd) handlePeerCertificates(ctx context.Context) (caSecretName, peerSecretName string, err error) {
-	// TODO(timuthy): Remove this once https://github.com/gardener/etcd-backup-restore/issues/538 is resolved.
-	if !e.values.HighAvailabilityEnabled {
-		return
-	}
-
-	return GeneratePeerCertificates(ctx, e.secretsManager, e.values.Role, e.peerServiceDNSNames(), nil)
-}
-
-// GeneratePeerCertificates generates the peer certificates for the etcd cluster.
-func GeneratePeerCertificates(
-	ctx context.Context,
-	secretsManager secretsmanager.Interface,
-	role string,
-	dnsNames []string,
-	ipAddresses []net.IP,
-) (string, string, error) {
-	etcdPeerCASecret, found := secretsManager.Get(v1beta1constants.SecretNameCAETCDPeer)
-	if !found {
-		return "", "", fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
-	}
-
-	peerServerSecret, err := secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                        secretNamePrefixPeerServer + role,
-		CommonName:                  "etcd-server",
-		DNSNames:                    dnsNames,
-		IPAddresses:                 ipAddresses,
-		CertType:                    secretsutils.ServerClientCert,
-		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return "", "", fmt.Errorf("failed to generate secret %q: %w", secretNamePrefixPeerServer+role, err)
-	}
-
-	return etcdPeerCASecret.Name, peerServerSecret.Name, nil
-}
-
-// GenerateClientServerCertificates generates client and server certificates for the etcd cluster.
-func GenerateClientServerCertificates(
-	ctx context.Context,
-	secretsManager secretsmanager.Interface,
-	role string,
-	dnsNames []string,
-	ipAddresses []net.IP,
-) (*corev1.Secret, *corev1.Secret, *corev1.Secret, error) {
-	etcdCASecret, found := secretsManager.Get(v1beta1constants.SecretNameCAETCD)
-	if !found {
-		return nil, nil, nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCD)
-	}
-
-	serverSecret, err := secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                        secretNamePrefixServer + role,
-		CommonName:                  "etcd-server",
-		DNSNames:                    dnsNames,
-		IPAddresses:                 ipAddresses,
-		CertType:                    secretsutils.ServerClientCert,
-		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to generate secret %q: %w", secretNamePrefixServer+role, err)
-	}
-
-	clientSecret, err := secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
-		Name:                        SecretNameClient,
-		CommonName:                  "etcd-client",
-		CertType:                    secretsutils.ClientCert,
-		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to generate secret %q: %w", SecretNameClient, err)
-	}
-
-	return etcdCASecret, serverSecret, clientSecret, nil
 }
 
 func (e *etcd) defaultPortOrEtcdEventsStaticPodPort(defaultPort, etcdEventsPortWhenRunningAsStaticPod int32) int32 {

--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -106,7 +106,7 @@ type Interface interface {
 	GetReplicas() *int32
 	// SetReplicas sets the Replicas field in the Values.
 	SetReplicas(*int32)
-	// SetStaticPodControlPlaneNodesIPAddresses sets the IP addresses of the control plane nodes when etcd is ran as
+	// SetStaticPodControlPlaneNodesIPAddresses sets the IP addresses of all control plane nodes when etcd is run as
 	// static pod.
 	SetStaticPodControlPlaneNodesIPAddresses(...net.IP)
 }
@@ -164,7 +164,7 @@ type Values struct {
 	PriorityClassName           string
 	HighAvailabilityEnabled     bool
 	TopologyAwareRoutingEnabled bool
-	StaticPod                   *StaticPodConfig
+	StaticPodConfig             *StaticPodConfig
 }
 
 // BackupConfig contains information for configuring the backup-restore sidecar so that it takes regularly backups of
@@ -241,22 +241,22 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 		metrics = druidcorev1alpha1.Extensive
 
-		if e.values.StaticPod == nil {
+		if e.values.StaticPodConfig == nil {
 			volumeClaimTemplate = e.values.Role + "-" + strings.TrimSuffix(e.etcd.Name, "-"+e.values.Role)
 		}
 	}
 
 	var controlPlaneNodeIP net.IP
-	if e.values.StaticPod != nil && len(e.values.StaticPod.ControlPlaneNodesIPAddresses) > 0 {
+	if e.values.StaticPodConfig != nil && len(e.values.StaticPodConfig.ControlPlaneNodesIPAddresses) > 0 {
 		// TODO(rfranzke): Handle multiple control plane nodes later on as part of GEP-28.
-		controlPlaneNodeIP = e.values.StaticPod.ControlPlaneNodesIPAddresses[0]
+		controlPlaneNodeIP = e.values.StaticPodConfig.ControlPlaneNodesIPAddresses[0]
 	}
 
 	etcdCASecret, serverSecret, clientSecret, err := GenerateServerAndClientCertificates(
 		ctx,
 		e.secretsManager,
 		e.values.Role,
-		ClientServiceDNSNames(e.etcd.Name, e.namespace, e.values.StaticPod != nil),
+		ClientServiceDNSNames(e.etcd.Name, e.namespace, e.values.StaticPodConfig != nil),
 		controlPlaneNodeIP,
 	)
 	if err != nil {
@@ -435,7 +435,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			}
 		}
 
-		if e.values.StaticPod != nil {
+		if e.values.StaticPodConfig != nil {
 			e.etcd.Spec.RunAsRoot = ptr.To(true)
 			metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, druidcorev1alpha1.DisableEtcdRuntimeComponentCreationAnnotation, "")
 		}
@@ -967,8 +967,8 @@ func (e *etcd) GetReplicas() *int32 { return e.values.Replicas }
 func (e *etcd) SetReplicas(replicas *int32) { e.values.Replicas = replicas }
 
 func (e *etcd) SetStaticPodControlPlaneNodesIPAddresses(ips ...net.IP) {
-	if e.values.StaticPod != nil {
-		e.values.StaticPod.ControlPlaneNodesIPAddresses = append(e.values.StaticPod.ControlPlaneNodesIPAddresses, ips...)
+	if e.values.StaticPodConfig != nil {
+		e.values.StaticPodConfig.ControlPlaneNodesIPAddresses = ips
 	}
 }
 
@@ -1062,7 +1062,7 @@ func (e *etcd) computeFullSnapshotSchedule(existingEtcd *druidcorev1alpha1.Etcd)
 }
 
 func (e *etcd) defaultPortOrEtcdEventsStaticPodPort(defaultPort, etcdEventsPortWhenRunningAsStaticPod int32) int32 {
-	if e.values.Role == v1beta1constants.ETCDRoleMain || e.values.StaticPod == nil {
+	if e.values.Role == v1beta1constants.ETCDRoleMain || e.values.StaticPodConfig == nil {
 		return defaultPort
 	}
 	return etcdEventsPortWhenRunningAsStaticPod

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Etcd", func() {
 			End:   "5678",
 		}
 		highAvailabilityEnabled bool
-		runAsStaticPod          bool
+		staticPodConfig         *StaticPodConfig
 		role                    string
 		caRotationPhase         gardencorev1beta1.CredentialsRotationPhase
 		autoscalingConfig       AutoscalingConfig
@@ -135,7 +135,7 @@ var _ = Describe("Etcd", func() {
 			peerServerSecretName *string,
 			topologyAwareRoutingEnabled bool,
 			runtimeKubernetesVersion *semver.Version,
-			runAsStaticPod bool,
+			staticPodConfig *StaticPodConfig,
 		) *druidcorev1alpha1.Etcd {
 			defragSchedule := defragmentationSchedule
 			if existingDefragmentationSchedule != "" {
@@ -373,7 +373,7 @@ var _ = Describe("Etcd", func() {
 				}
 			}
 
-			if runAsStaticPod {
+			if staticPodConfig != nil {
 				obj.Annotations["druid.gardener.cloud/disable-etcd-runtime-component-creation"] = ""
 				obj.Spec.RunAsRoot = ptr.To(true)
 
@@ -727,7 +727,7 @@ var _ = Describe("Etcd", func() {
 		backupConfig = nil
 		replicas = ptr.To[int32](1)
 		highAvailabilityEnabled = false
-		runAsStaticPod = false
+		staticPodConfig = nil
 		role = testRole
 	})
 
@@ -756,7 +756,7 @@ var _ = Describe("Etcd", func() {
 			MaintenanceTimeWindow:   maintenanceTimeWindow,
 			HighAvailabilityEnabled: highAvailabilityEnabled,
 			BackupConfig:            backupConfig,
-			RunsAsStaticPod:         runAsStaticPod,
+			StaticPod:               staticPodConfig,
 		})
 	})
 
@@ -806,7 +806,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -881,7 +881,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -961,7 +961,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1025,7 +1025,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)
 					expectedObj.Annotations = utils.MergeStringMaps(expectedObj.Annotations, map[string]string{
 						"foo": "bar",
@@ -1098,7 +1098,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1143,7 +1143,7 @@ var _ = Describe("Etcd", func() {
 						nil,
 						false,
 						nil,
-						runAsStaticPod,
+						staticPodConfig,
 					)))
 				}),
 				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1211,7 +1211,7 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false,
 							nil,
-							runAsStaticPod,
+							staticPodConfig,
 						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1271,7 +1271,7 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false,
 							nil,
-							runAsStaticPod,
+							staticPodConfig,
 						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1336,7 +1336,7 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false,
 							nil,
-							runAsStaticPod,
+							staticPodConfig,
 						)
 						expobj.Status.Etcd = &druidcorev1alpha1.CrossVersionObjectReference{}
 
@@ -1362,7 +1362,7 @@ var _ = Describe("Etcd", func() {
 
 		When("etcd should run as static pod", func() {
 			BeforeEach(func() {
-				runAsStaticPod = true
+				staticPodConfig = &StaticPodConfig{}
 			})
 
 			Describe("main etcd", func() {
@@ -1389,7 +1389,7 @@ var _ = Describe("Etcd", func() {
 								nil,
 								false,
 								nil,
-								runAsStaticPod,
+								staticPodConfig,
 							)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1441,7 +1441,7 @@ var _ = Describe("Etcd", func() {
 								nil,
 								false,
 								nil,
-								runAsStaticPod,
+								staticPodConfig,
 							)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1498,7 +1498,7 @@ var _ = Describe("Etcd", func() {
 							&peerServerSecretName,
 							false,
 							nil,
-							runAsStaticPod,
+							staticPodConfig,
 						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1815,7 +1815,7 @@ var _ = Describe("Etcd", func() {
 								nil,
 								true,
 								runtimeKubernetesVersion,
-								runAsStaticPod,
+								staticPodConfig,
 							)))
 						}),
 						c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1881,7 +1881,7 @@ var _ = Describe("Etcd", func() {
 					nil,
 					false,
 					nil,
-					runAsStaticPod,
+					staticPodConfig,
 				)
 				etcdObj.Name = etcdName
 				etcdObj.Spec.VolumeClaimTemplate = ptr.To(testRole + "-virtual-garden-etcd")
@@ -1952,7 +1952,7 @@ var _ = Describe("Etcd", func() {
 							nil,
 							false,
 							nil,
-							runAsStaticPod,
+							staticPodConfig,
 						)))
 					}),
 					c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: vpaName}, gomock.AssignableToTypeOf(&vpaautoscalingv1.VerticalPodAutoscaler{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -1590,6 +1591,7 @@ var _ = Describe("Etcd", func() {
 							"*.etcd-" + testRole + "-peer.shoot--test--test.svc",
 							"*.etcd-" + testRole + "-peer.shoot--test--test.svc.cluster.local",
 						},
+						IPAddresses:                 []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 						CertType:                    secretsutils.ServerClientCert,
 						SkipPublishingCACertificate: true,
 					}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
@@ -1617,6 +1619,7 @@ var _ = Describe("Etcd", func() {
 							"*.etcd-" + testRole + "-peer.shoot--test--test.svc",
 							"*.etcd-" + testRole + "-peer.shoot--test--test.svc.cluster.local",
 						},
+						IPAddresses:                 []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 						CertType:                    secretsutils.ServerClientCert,
 						SkipPublishingCACertificate: true,
 					}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD), secretsmanager.Rotate(secretsmanager.InPlace))

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -757,7 +757,7 @@ var _ = Describe("Etcd", func() {
 			MaintenanceTimeWindow:   maintenanceTimeWindow,
 			HighAvailabilityEnabled: highAvailabilityEnabled,
 			BackupConfig:            backupConfig,
-			StaticPod:               staticPodConfig,
+			StaticPodConfig:         staticPodConfig,
 		})
 	})
 

--- a/pkg/component/etcd/etcd/mock/mocks.go
+++ b/pkg/component/etcd/etcd/mock/mocks.go
@@ -11,6 +11,7 @@ package mock
 
 import (
 	context "context"
+	net "net"
 	reflect "reflect"
 
 	v1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
@@ -164,6 +165,22 @@ func (m *MockInterface) SetReplicas(arg0 *int32) {
 func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicas", reflect.TypeOf((*MockInterface)(nil).SetReplicas), arg0)
+}
+
+// SetStaticPodControlPlaneNodesIPAddresses mocks base method.
+func (m *MockInterface) SetStaticPodControlPlaneNodesIPAddresses(arg0 ...net.IP) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "SetStaticPodControlPlaneNodesIPAddresses", varargs...)
+}
+
+// SetStaticPodControlPlaneNodesIPAddresses indicates an expected call of SetStaticPodControlPlaneNodesIPAddresses.
+func (mr *MockInterfaceMockRecorder) SetStaticPodControlPlaneNodesIPAddresses(arg0 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStaticPodControlPlaneNodesIPAddresses", reflect.TypeOf((*MockInterface)(nil).SetStaticPodControlPlaneNodesIPAddresses), arg0...)
 }
 
 // Snapshot mocks base method.

--- a/pkg/component/etcd/etcd/tls.go
+++ b/pkg/component/etcd/etcd/tls.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+)
+
+// GenerateServerCertificate generates the server certificate for the etcd cluster.
+func GenerateServerCertificate(
+	ctx context.Context,
+	secretsManager secretsmanager.Interface,
+	role string,
+	dnsNames []string,
+	ip net.IP,
+) (
+	*corev1.Secret,
+	error,
+) {
+	return secretsManager.Generate(ctx,
+		&secretsutils.CertificateSecretConfig{
+			Name:                        secretNamePrefixServer + role + ipSuffix(ip),
+			CommonName:                  "etcd-server",
+			DNSNames:                    dnsNames,
+			IPAddresses:                 clientServiceIPAddresses(ip),
+			CertType:                    secretsutils.ServerClientCert,
+			SkipPublishingCACertificate: true,
+		},
+		secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD, secretsmanager.LoadMissingCAFromCluster(ctx)),
+		secretsmanager.Rotate(secretsmanager.InPlace),
+	)
+}
+
+// GenerateClientCertificate generates the client certificate for the etcd cluster.
+func GenerateClientCertificate(ctx context.Context, secretsManager secretsmanager.Interface) (*corev1.Secret, error) {
+	return secretsManager.Generate(ctx,
+		&secretsutils.CertificateSecretConfig{
+			Name:                        SecretNameClient,
+			CommonName:                  "etcd-client",
+			CertType:                    secretsutils.ClientCert,
+			SkipPublishingCACertificate: true,
+		},
+		secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD),
+		secretsmanager.Rotate(secretsmanager.InPlace),
+	)
+}
+
+// GenerateServerAndClientCertificates generates both client and server certificates for the etcd cluster.
+func GenerateServerAndClientCertificates(
+	ctx context.Context,
+	secretsManager secretsmanager.Interface,
+	role string,
+	dnsNames []string,
+	ip net.IP,
+) (
+	etcdCASecret *corev1.Secret,
+	serverSecret *corev1.Secret,
+	clientSecret *corev1.Secret,
+	err error,
+) {
+	var found bool
+	etcdCASecret, found = secretsManager.Get(v1beta1constants.SecretNameCAETCD)
+	if !found {
+		return nil, nil, nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCD)
+	}
+
+	serverSecret, err = GenerateServerCertificate(ctx, secretsManager, role, dnsNames, ip)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate server certificate: %w", err)
+	}
+
+	clientSecret, err = GenerateClientCertificate(ctx, secretsManager)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate client certificate: %w", err)
+	}
+
+	return etcdCASecret, serverSecret, clientSecret, nil
+}
+
+// GeneratePeerCertificate generates the peer certificate for the etcd cluster.
+func GeneratePeerCertificate(
+	ctx context.Context,
+	secretsManager secretsmanager.Interface,
+	role string,
+	dnsNames []string,
+	ip net.IP,
+) (
+	*corev1.Secret,
+	error,
+) {
+	return secretsManager.Generate(ctx,
+		&secretsutils.CertificateSecretConfig{
+			Name:                        secretNamePrefixPeerServer + role + ipSuffix(ip),
+			CommonName:                  "etcd-server",
+			DNSNames:                    dnsNames,
+			IPAddresses:                 clientServiceIPAddresses(ip),
+			CertType:                    secretsutils.ServerClientCert,
+			SkipPublishingCACertificate: true,
+		},
+		secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, secretsmanager.UseCurrentCA, secretsmanager.LoadMissingCAFromCluster(ctx)),
+		secretsmanager.Rotate(secretsmanager.InPlace),
+	)
+}
+
+func ipSuffix(ip net.IP) string {
+	if len(ip) == 0 {
+		return ""
+	}
+	return "-" + ip.String()
+}
+
+// ClientServiceDNSNames returns the DNS names for the ETCD.
+func ClientServiceDNSNames(name, namespace string, runsAsStaticPod bool) []string {
+	var domainNames []string
+	domainNames = append(domainNames, fmt.Sprintf("%s-local", name))
+	domainNames = append(domainNames, kubernetesutils.DNSNamesForService(fmt.Sprintf("%s-client", name), namespace)...)
+
+	// The peer service needs to be considered here since the etcd-backup-restore side-car
+	// connects to member pods via pod domain names (e.g. for defragmentation).
+	// See https://github.com/gardener/etcd-backup-restore/issues/494
+	domainNames = append(domainNames, kubernetesutils.DNSNamesForService(fmt.Sprintf("*.%s-peer", name), namespace)...)
+
+	if runsAsStaticPod {
+		domainNames = append(domainNames, "localhost")
+	}
+
+	return domainNames
+}
+
+func clientServiceIPAddresses(ip net.IP) []net.IP {
+	ips := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	if len(ip) > 0 {
+		ips = append(ips, ip)
+	}
+	return ips
+}
+
+func (e *etcd) peerServiceDNSNames() []string {
+	return append(
+		kubernetesutils.DNSNamesForService(fmt.Sprintf("%s-peer", e.etcd.Name), e.namespace),
+		kubernetesutils.DNSNamesForService(fmt.Sprintf("*.%s-peer", e.etcd.Name), e.namespace)...,
+	)
+}

--- a/pkg/component/etcd/etcd/tls_test.go
+++ b/pkg/component/etcd/etcd/tls_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd_test
+
+import (
+	"context"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/pkg/component/etcd/etcd"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+)
+
+var _ = Describe("TLS", func() {
+	var (
+		ctx        = context.Background()
+		namespace  = "test-namespace"
+		fakeClient client.Client
+		sm         secretsmanager.Interface
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		sm = fakesecretsmanager.New(fakeClient, namespace)
+	})
+
+	Describe("#GenerateServerCertificate", func() {
+		It("should generate a server certificate without IP", func() {
+			secret, err := GenerateServerCertificate(ctx, sm, testRole, []string{"etcd-main-local"}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Name).To(HavePrefix("etcd-server-" + testRole))
+			Expect(secret.Data).NotTo(BeEmpty())
+		})
+
+		It("should generate a server certificate with IP suffix", func() {
+			ip := net.ParseIP("10.0.0.1")
+			secret, err := GenerateServerCertificate(ctx, sm, testRole, []string{"etcd-main-local"}, ip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Name).To(HavePrefix("etcd-server-" + testRole + "-10.0.0.1"))
+		})
+
+		It("should not include IP suffix when IP is nil", func() {
+			secret, err := GenerateServerCertificate(ctx, sm, testRole, []string{"etcd-main-local"}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret.Name).To(HavePrefix("etcd-server-" + testRole))
+			Expect(secret.Name).NotTo(ContainSubstring("-10."))
+		})
+	})
+
+	Describe("#GenerateClientCertificate", func() {
+		It("should generate a client certificate", func() {
+			secret, err := GenerateClientCertificate(ctx, sm)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Name).To(HavePrefix(SecretNameClient))
+			Expect(secret.Data).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("#GenerateServerAndClientCertificates", func() {
+		When("etcd CA secret is present", func() {
+			BeforeEach(func() {
+				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.SecretNameCAETCD,
+					Namespace: namespace,
+				}})).To(Succeed())
+			})
+
+			It("should return CA, server, and client secrets", func() {
+				caSecret, serverSecret, clientSecret, err := GenerateServerAndClientCertificates(ctx, sm, testRole, []string{"etcd-main-local"}, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caSecret).NotTo(BeNil())
+				Expect(caSecret.Name).To(Equal(v1beta1constants.SecretNameCAETCD))
+				Expect(serverSecret).NotTo(BeNil())
+				Expect(clientSecret).NotTo(BeNil())
+			})
+		})
+
+		When("etcd CA secret is missing", func() {
+			It("should return an error", func() {
+				_, _, _, err := GenerateServerAndClientCertificates(ctx, sm, testRole, []string{"etcd-main-local"}, nil)
+				Expect(err).To(MatchError(ContainSubstring(v1beta1constants.SecretNameCAETCD)))
+			})
+		})
+	})
+
+	Describe("#GeneratePeerCertificate", func() {
+		It("should generate a peer certificate without IP", func() {
+			secret, err := GeneratePeerCertificate(ctx, sm, testRole, []string{"etcd-main-peer"}, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Name).To(HavePrefix("etcd-peer-server-" + testRole))
+			Expect(secret.Data).NotTo(BeEmpty())
+		})
+
+		It("should generate a peer certificate with IP suffix", func() {
+			ip := net.ParseIP("192.168.1.1")
+			secret, err := GeneratePeerCertificate(ctx, sm, testRole, []string{"etcd-main-peer"}, ip)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Name).To(HavePrefix("etcd-peer-server-" + testRole + "-192.168.1.1"))
+		})
+	})
+
+	Describe("#ClientServiceDNSNames", func() {
+		It("should return standard DNS names for a non-static-pod etcd", func() {
+			Expect(ClientServiceDNSNames("etcd-main", namespace, false)).To(And(
+				ContainElements(
+					"etcd-main-local",
+					"etcd-main-client",
+					"etcd-main-client."+namespace,
+					"etcd-main-client."+namespace+".svc",
+					"etcd-main-client."+namespace+".svc.cluster.local",
+				),
+				Not(ContainElement("localhost")),
+			))
+		})
+
+		It("should include localhost when running as static pod", func() {
+			Expect(ClientServiceDNSNames("etcd-main", namespace, true)).To(ContainElement("localhost"))
+		})
+
+		It("should include wildcard peer DNS names", func() {
+			Expect(ClientServiceDNSNames("etcd-main", namespace, false)).To(ContainElement("*.etcd-main-peer"))
+		})
+	})
+})

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -505,6 +505,11 @@ func (s *shootSystem) selfHostedShootResources() []client.Object {
 					Resources: []string{"nodes"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					APIGroups: []string{corev1.SchemeGroupVersion.Group},
+					Resources: []string{"secrets"},
+					Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
+				},
 			},
 		}
 		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
@@ -522,37 +527,7 @@ func (s *shootSystem) selfHostedShootResources() []client.Object {
 				Name:     v1beta1constants.ShootsGroup,
 			}},
 		}
-
-		role = &rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rbacName,
-				Namespace: metav1.NamespaceSystem,
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"secrets"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-			},
-		}
-		roleBinding = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rbacName,
-				Namespace: metav1.NamespaceSystem,
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     role.Name,
-			},
-			Subjects: []rbacv1.Subject{{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "Group",
-				Name:     v1beta1constants.ShootsGroup,
-			}},
-		}
 	)
 
-	return []client.Object{clusterRole, clusterRoleBinding, role, roleBinding}
+	return []client.Object{clusterRole, clusterRoleBinding}
 }

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -595,6 +595,11 @@ var _ = Describe("ShootSystem", func() {
 								Resources: []string{"nodes"},
 								Verbs:     []string{"get", "list", "watch"},
 							},
+							{
+								APIGroups: []string{""},
+								Resources: []string{"secrets"},
+								Verbs:     []string{"get", "list", "watch", "create", "patch", "update"},
+							},
 						},
 					}
 
@@ -614,42 +619,9 @@ var _ = Describe("ShootSystem", func() {
 						}},
 					}
 
-					expectedRole := &rbacv1.Role{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "gardener.cloud:gardenadm",
-							Namespace: "kube-system",
-						},
-						Rules: []rbacv1.PolicyRule{
-							{
-								APIGroups: []string{""},
-								Resources: []string{"secrets"},
-								Verbs:     []string{"get", "list", "watch"},
-							},
-						},
-					}
-
-					expectedRoleBinding := &rbacv1.RoleBinding{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "gardener.cloud:gardenadm",
-							Namespace: "kube-system",
-						},
-						RoleRef: rbacv1.RoleRef{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Role",
-							Name:     "gardener.cloud:gardenadm",
-						},
-						Subjects: []rbacv1.Subject{{
-							APIGroup: "rbac.authorization.k8s.io",
-							Kind:     "Group",
-							Name:     "gardener.cloud:system:shoots",
-						}},
-					}
-
 					Expect(managedResource).To(contain(
 						expectedClusterRole,
 						expectedClusterRoleBinding,
-						expectedRole,
-						expectedRoleBinding,
 					))
 				})
 			})

--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -75,3 +75,13 @@ func netIPNetSliceToStringSlice(in []net.IPNet) []string {
 	}
 	return out
 }
+
+// MachineIP returns the IP address of the current machine.
+func (b *GardenadmBotanist) MachineIP() (net.IP, error) {
+	// https://github.com/kubernetes/kubernetes/blob/ec9f0d55360f74337f9ef40879434a063821ff5b/pkg/kubelet/nodestatus/setters.go#L162-L178
+	addrs, _ := net.LookupIP(b.HostName)
+	for _, addr := range addrs {
+		return addr, nil
+	}
+	return nil, fmt.Errorf("no IP address found for node")
+}

--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/controller/networkpolicy"
@@ -76,12 +77,36 @@ func netIPNetSliceToStringSlice(in []net.IPNet) []string {
 	return out
 }
 
-// MachineIP returns the IP address of the current machine.
+// LookupIP is an alias for net.LookupIP that can be overridden in tests.
+var LookupIP = net.LookupIP
+
+// MachineIP returns the IP address of the current machine. It prefers addresses matching the primary IP family
+// (the first entry in .spec.networking.ipFamilies), falling back to any available address.
+// Similar to https://github.com/kubernetes/kubernetes/blob/ec9f0d55360f74337f9ef40879434a063821ff5b/pkg/kubelet/nodestatus/setters.go#L162-L178
 func (b *GardenadmBotanist) MachineIP() (net.IP, error) {
-	// https://github.com/kubernetes/kubernetes/blob/ec9f0d55360f74337f9ef40879434a063821ff5b/pkg/kubelet/nodestatus/setters.go#L162-L178
-	addrs, _ := net.LookupIP(b.HostName)
-	for _, addr := range addrs {
-		return addr, nil
+	var (
+		preferIPv6 = len(b.Shoot.GetInfo().Spec.Networking.IPFamilies) > 0 &&
+			b.Shoot.GetInfo().Spec.Networking.IPFamilies[0] == gardencorev1beta1.IPFamilyIPv6
+		fallback net.IP
+	)
+
+	addrs, err := LookupIP(b.HostName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup IPs for hostname %s: %w", b.HostName, err)
 	}
+
+	for _, addr := range addrs {
+		if isIPv6 := addr.To4() == nil; isIPv6 == preferIPv6 {
+			return addr, nil
+		}
+		if fallback == nil {
+			fallback = addr
+		}
+	}
+
+	if fallback != nil {
+		return fallback, nil
+	}
+
 	return nil, fmt.Errorf("no IP address found for node")
 }

--- a/pkg/gardenadm/botanist/network_test.go
+++ b/pkg/gardenadm/botanist/network_test.go
@@ -114,6 +114,24 @@ var _ = Describe("Network", func() {
 		})
 	})
 
+	Describe("#MachineIP", func() {
+		It("should return the IP address for a resolvable hostname", func() {
+			b.HostName = "localhost"
+
+			ip, err := b.MachineIP()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip).NotTo(BeNil())
+		})
+
+		It("should return an error when no IP address is found", func() {
+			b.HostName = "this-hostname-does-not-exist.invalid"
+
+			ip, err := b.MachineIP()
+			Expect(err).To(MatchError("no IP address found for node"))
+			Expect(ip).To(BeNil())
+		})
+	})
+
 	Describe("#ApplyNetworkPolicies", func() {
 		It("should apply the NetworkPolicies", func() {
 			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: map[string]string{"gardener.cloud/role": "shoot"}}, Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive}}

--- a/pkg/gardenadm/botanist/network_test.go
+++ b/pkg/gardenadm/botanist/network_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Network", func() {
@@ -115,16 +116,69 @@ var _ = Describe("Network", func() {
 	})
 
 	Describe("#MachineIP", func() {
-		It("should return the IP address for a resolvable hostname", func() {
-			b.HostName = "localhost"
+		var ipv4, ipv6 net.IP
+
+		BeforeEach(func() {
+			ipv4 = net.ParseIP("1.2.3.4").To4()
+			ipv6 = net.ParseIP("::1")
+			b.HostName = "some-host"
+		})
+
+		It("should return an IPv4 address when IPv4 is the primary IP family", func() {
+			b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+					},
+				},
+			})
+			DeferCleanup(test.WithVar(&LookupIP, func(_ string) ([]net.IP, error) {
+				return []net.IP{ipv6, ipv4}, nil
+			}))
 
 			ip, err := b.MachineIP()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ip).NotTo(BeNil())
+			Expect(ip.To4()).NotTo(BeNil(), "expected an IPv4 address")
+		})
+
+		It("should return an IPv6 address when IPv6 is the primary IP family", func() {
+			b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6},
+					},
+				},
+			})
+			DeferCleanup(test.WithVar(&LookupIP, func(_ string) ([]net.IP, error) {
+				return []net.IP{ipv4, ipv6}, nil
+			}))
+
+			ip, err := b.MachineIP()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip.To4()).To(BeNil(), "expected an IPv6 address")
+		})
+
+		It("should fall back to any available address when no address of the preferred family is found", func() {
+			b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: &gardencorev1beta1.Networking{
+						IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6},
+					},
+				},
+			})
+			DeferCleanup(test.WithVar(&LookupIP, func(_ string) ([]net.IP, error) {
+				return []net.IP{ipv4}, nil
+			}))
+
+			ip, err := b.MachineIP()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip.Equal(ipv4)).To(BeTrue())
 		})
 
 		It("should return an error when no IP address is found", func() {
-			b.HostName = "this-hostname-does-not-exist.invalid"
+			DeferCleanup(test.WithVar(&LookupIP, func(_ string) ([]net.IP, error) {
+				return nil, nil
+			}))
 
 			ip, err := b.MachineIP()
 			Expect(err).To(MatchError("no IP address found for node"))

--- a/pkg/gardenadm/cmd/join/join.go
+++ b/pkg/gardenadm/cmd/join/join.go
@@ -402,12 +402,15 @@ type etcdRoleToTLSSecrets map[string]etcdTLSSecrets
 
 func (e etcdRoleToTLSSecrets) writeToDisk(fs afero.Afero) error {
 	for role, tlsSecrets := range e {
-		dir := staticpodtranslator.HostPath(etcd.Name(role), etcdconstants.VolumeNameServerTLS)
-		if err := fs.MkdirAll(dir, os.ModeDir); err != nil {
-			return fmt.Errorf("failed creating directory %s: %w", dir, err)
-		}
+		for volumeName, secret := range map[string]*corev1.Secret{
+			etcdconstants.VolumeNameServerTLS: tlsSecrets.server,
+			etcdconstants.VolumeNamePeerTLS:   tlsSecrets.peer,
+		} {
+			dir := staticpodtranslator.HostPath(etcd.Name(role), volumeName)
+			if err := fs.MkdirAll(dir, os.ModeDir); err != nil {
+				return fmt.Errorf("failed creating directory %s: %w", dir, err)
+			}
 
-		for _, secret := range []*corev1.Secret{tlsSecrets.server, tlsSecrets.peer} {
 			for key, value := range secret.Data {
 				path := filepath.Join(dir, key)
 				if err := fs.WriteFile(path, value, 0640); err != nil {

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -134,7 +134,7 @@ func translateVolumes(ctx context.Context, c client.Client, pod *corev1.Pod, sou
 	)
 
 	for i, volume := range pod.Spec.Volumes {
-		hostPath := filepath.Join(string(filepath.Separator), "var", "lib", pod.Name, volume.Name)
+		hostPath := HostPath(pod.Name, volume.Name)
 
 		switch {
 		case volume.ConfigMap != nil:
@@ -191,4 +191,9 @@ func translateVolumes(ctx context.Context, c client.Client, pod *corev1.Pod, sou
 // translated.
 func StatefulSetVolumeClaimTemplateHostPath(volumeClaimTemplateName string) string {
 	return fmt.Sprintf("/var/lib/%s/data", volumeClaimTemplateName)
+}
+
+// HostPath returns the host path for the given pod name and volume name.
+func HostPath(podName, volumeName string) string {
+	return filepath.Join(string(filepath.Separator), "var", "lib", podName, volumeName)
 }

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -905,6 +905,12 @@ kind: Config
 		})
 	})
 
+	Describe("#HostPath", func() {
+		It("should return the expected path", func() {
+			Expect(HostPath("my-pod", "my-volume")).To(Equal("/var/lib/my-pod/my-volume"))
+		})
+	})
+
 	Describe("#StatefulSetVolumeClaimTemplateHostPath", func() {
 		It("should return the expected path", func() {
 			Expect(StatefulSetVolumeClaimTemplateHostPath("foo")).To(Equal("/var/lib/foo/data"))

--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -67,7 +67,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 	}
 
 	if b.Shoot.RunsControlPlane() {
-		values.StaticPod = &etcd.StaticPodConfig{}
+		values.StaticPodConfig = &etcd.StaticPodConfig{}
 	}
 
 	return NewEtcd(b.Logger, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.SecretsManager, values), nil


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
When running `gardenadm join --control-plane`, we are now generating machine-specific ETCD certificates with the machine IP part of the SANs (this is also already done for `gardenadm init`). The certificates are directly written to disk:

```
2026-02-27T10:02:06.296Z	INFO	Starting	{"flow": "join"}
2026-02-27T10:02:06.296Z	INFO	secretsmanager	Signing CA secret not found in internal store, trying to load it from cluster	{"signingCASecretName": "ca-etcd"}
2026-02-27T10:02:06.565Z	INFO	secretsmanager	Generated new secret	{"configName": "etcd-server-main-10.0.212.6", "secret": {"name":"etcd-server-main-10.0.212.6-e9eabcec","namespace":"kube-system"}}
2026-02-27T10:02:06.568Z	INFO	secretsmanager	Signing CA secret not found in internal store, trying to load it from cluster	{"signingCASecretName": "ca-etcd-peer"}
2026-02-27T10:02:07.186Z	INFO	secretsmanager	Generated new secret	{"configName": "etcd-peer-server-main-10.0.212.6", "secret": {"name":"etcd-peer-server-main-10.0.212.6-27d50a47","namespace":"kube-system"}}
2026-02-27T10:02:07.534Z	INFO	secretsmanager	Generated new secret	{"configName": "etcd-server-events-10.0.212.6", "secret": {"name":"etcd-server-events-10.0.212.6-c5ed639d","namespace":"kube-system"}}
2026-02-27T10:02:08.046Z	INFO	secretsmanager	Generated new secret	{"configName": "etcd-peer-server-events-10.0.212.6", "secret": {"name":"etcd-peer-server-events-10.0.212.6-b1927634","namespace":"kube-system"}}
2026-02-27T10:02:08.049Z	INFO	Succeeded	{"flow": "join", "task": "Generating ETCD certificates"}
2026-02-27T10:02:08.050Z	INFO	Succeeded	{"flow": "join", "task": "Writing ETCD files to disk"}
...
```

This leverages #14000 for loading the existing CAs from the cluster.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
