### PR TITLE
fix: allow Debian version numbers when parsing containerd version in GNA

### DIFF
--- a/pkg/nodeagent/containerd/containerd_suite_test.go
+++ b/pkg/nodeagent/containerd/containerd_suite_test.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package containerd_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/nodeagent/features"
+)
+
+func TestOperatingSystemConfig(t *testing.T) {
+	features.RegisterFeatureGates()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Containerd Client Suite")
+}

--- a/pkg/nodeagent/containerd/containerd_suite_test.go
+++ b/pkg/nodeagent/containerd/containerd_suite_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/gardener/gardener/pkg/nodeagent/features"
 )
 
-func TestOperatingSystemConfig(t *testing.T) {
+func TestContainerd(t *testing.T) {
 	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Containerd Client Suite")
+	RunSpecs(t, "NodeAgent Containerd Suite")
 }

--- a/pkg/nodeagent/containerd/containerdclient.go
+++ b/pkg/nodeagent/containerd/containerdclient.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	containerd "github.com/containerd/containerd/v2/client"
@@ -60,7 +61,23 @@ func versionGreaterThanEqual(ctx context.Context, client Client, s *semver.Versi
 		return false, err
 	}
 
-	v, err := semver.NewVersion(containerdVersion.Version)
+	// on some Debian based distros, internal build info can spill over to the patch version of containerd
+	// e.g. the version could be 1.7.23~ds2
+	// this is not valid semver and therefore, we need to strip any ~ and what follows from the patch
+	// we also strip any pre-release or build info from the version string as these might also not be
+	// semver compliant with certain Debian builds of containerd
+	sanitizedVersion := strings.Split(containerdVersion.Version, ".")
+	if len(sanitizedVersion) < 3 {
+		return false, fmt.Errorf("containerd version %s is not semver compliant and does not consist of <major>.<minor>.<patch>", containerdVersion.Version)
+	}
+
+	for _, c := range []string{"-", "+", "~"} {
+		if before, _, found := strings.Cut(sanitizedVersion[2], c); found {
+			sanitizedVersion[2] = before
+		}
+	}
+
+	v, err := semver.NewVersion(strings.Join(sanitizedVersion[:3], "."))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/nodeagent/containerd/containerdclient_test.go
+++ b/pkg/nodeagent/containerd/containerdclient_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package containerd_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	containerd "github.com/gardener/gardener/pkg/nodeagent/containerd"
+	fakecontainerd "github.com/gardener/gardener/pkg/nodeagent/containerd/fake"
+)
+
+var _ = Describe("Containerd Client version tests", func() {
+
+	var (
+		ctx    context.Context
+		client *fakecontainerd.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = fakecontainerd.NewClient()
+	})
+
+	DescribeTable("containerd version greater or equal 2.2", func(version string, result bool) {
+		client.SetFakeContainerdVersion(version)
+		r, err := containerd.VersionGreaterThanEqual22(ctx, client)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(r).To(Equal(result))
+	},
+		Entry("should detect 1.7.23 is lower", "1.7.23", false),
+		Entry("should properly parse 1.7.23~ds2 which is and lower", "1.7.23~ds2", false),
+		Entry("should detect 2.2.0 is greater or equal", "2.2.0", true),
+		Entry("should properly parse 2.3.0~ds2 which is greater or equal", "2.3.0~ds2", true),
+		Entry("should detect 2.3.0-foo+bar is greater or equal", "2.3.0-foo+bar", true),
+		Entry("should allow and parse the invalid 2.3.0-foo~ds2+bar~ds1", "2.3.0-foo~ds2+bar~ds1", true),
+		Entry("should allow and parse the invalid 2.3.0-foo+123.45", "2.3.0-foo+123.45", true),
+		Entry("should allow and parse the invalid 2.3.0-foo123.45", "2.3.0-foo+123.45", true),
+	)
+})

--- a/pkg/nodeagent/containerd/fake/containerdclient.go
+++ b/pkg/nodeagent/containerd/fake/containerdclient.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/Masterminds/semver/v3"
 	containerd "github.com/containerd/containerd/v2/client"
 )
 
@@ -41,7 +40,6 @@ func (f Client) Version(_ context.Context) (containerd.Version, error) {
 
 // SetFakeContainerdVersion sets the version of the (fake) containerd to the desired value
 func (f *Client) SetFakeContainerdVersion(version string) {
-	semver.MustParse(version)
 	f.version = version
 }
 

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -81,7 +81,7 @@ func CheckVersionMeetsConstraint(version, constraint string) (bool, error) {
 // Normalize returns the normalized version string by removing the leading 'v' and any suffixes like '-rc1', '-beta2', etc.
 func Normalize(version string) string {
 	v := strings.ReplaceAll(version, "v", "")
-	idx := strings.IndexAny(v, "-+")
+	idx := strings.IndexAny(v, "-+~")
 	if idx != -1 {
 		v = v[:idx]
 	}

--- a/pkg/utils/version/version_test.go
+++ b/pkg/utils/version/version_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Version", func() {
 		Entry("handles both suffix and metadata", "1.2.3-rc1+build123", "1.2.3"),
 		Entry("returns unchanged version without 'v', suffix, or metadata", "1.2.3", "1.2.3"),
 		Entry("handles empty version string", "", ""),
+		Entry("removes Debian style suffix '~ds1'", "1.2.3~ds1", "1.2.3"),
 	)
 
 	DescribeTable("#CheckVersionMeetsConstraint",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind regression
/kind bug

**What this PR does / why we need it**:
With PR #13826 Gardener Node Agent (GNA) will query containerd for its version to determine how the CNI bin_dir needs to be configured. This is done by obtaining the version string from containerd and parsing it into a semver object.

Certain containerd builds (mainly on Debian based distros) can have internal build information and package version numbers embedded into the containerd binary itself. This can result in containerd returning `1.7.23~ds2` as its version number which is not semver compliant. 

```
# ctr version
...
Server:
  Version:  1.7.23~ds2
  Revision: 1.7.23~ds2-1gl2~bp1592
  UUID: 5239156f-7dc0-42c5-a988-065548c6ff95
```

Also, version numbers like "1.7.23-ds2_1592.12" have been seen in the wild, which are also not semver compliant. As a result, GNA will fail parsing these numbers into a semver version object and will fail reconciling a node.

To fix this, after the version number is retrieved from containerd it is sanitized by removing the pre-release and build info fields from the patch version as well as any potential occurrence of a Debian build identifier, i.e. `-`, `+` or `~` will be right-trimmed from the patch field of the version number string before it gets parsed into a semver object.

**Which issue(s) this PR fixes**:

Fixes this error that will appear on clusters running a containerd with a version of e.g. `1.7.23~ds2`:

```
Feb 26 19:03:46 shoot--abc--123 gardener-node-agent[0815]: {"level":"error","ts":"2026-02-26T19:03:46.233Z","msg":"Reconciler error","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-default-abc","reconcileID":"95d01f2f-158e-4347-8f2a-f4774c133458","error":"failed reconciling containerd configuration: failed to ensure containerd config: failed to determine containerd version: invalid semantic version","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296"}
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A regression in Gardener Node Agent that can occur on Debian based OS images and that prevents it to successfully reconcile nodes that run a containerd version that contains - according to semver - invalid characters in its version number was fixed.
```
