### PR TITLE
Fix creation of tags in `golang-test` build

### DIFF
--- a/.github/workflows/golang-test-build.yaml
+++ b/.github/workflows/golang-test-build.yaml
@@ -20,11 +20,11 @@ jobs:
       date: ${{ steps.metadata.outputs.date }}
       short-sha: ${{ steps.metadata.outputs.short-sha }}
     steps:
-      - name: Generate metadata
+      - name: Generate date
         id: metadata
-        run: |
-          echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
-          echo "short-sha=${GITHUB_SHA:0:7} >> $GITHUB_OUTPUT
+        run: echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+      - name: Generate short-sha
+        run: echo "short-sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
   generate-matrix:
     name: Generate Matrix

--- a/.github/workflows/golang-test-images.yaml
+++ b/.github/workflows/golang-test-images.yaml
@@ -33,5 +33,3 @@ jobs:
           }
           MATRIX_EOF
           EOF
-
-


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
PR #14156 has a bug 😅 
The build terminates with an error which is fixed in this PR.
```
Run echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
  echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
  echo "short-sha=${GITHUB_SHA:0:7} >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/1b753aa7-bf65-4807-bfd8-8a733d357800.sh: line 2: unexpected EOF while looking for matching `"'
Error: Process completed with exit code 2.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
