### PR TITLE
Add missing commit hash in image tag and update renovate rule for `golang-test` image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -356,7 +356,7 @@
         'minor',
       ],
       matchFileNames: [
-        'hack/tools/image/variants\\.yaml',
+        '\\.github/workflows/golang-test-images\\.yaml',
       ],
       enabled: false,
     },

--- a/.github/workflows/golang-test-build.yaml
+++ b/.github/workflows/golang-test-build.yaml
@@ -17,13 +17,14 @@ jobs:
     if: ${{ github.repository == 'gardener/gardener' }}
     runs-on: ubuntu-latest
     outputs:
-      date: ${{ steps.metadata.outputs.date }}
-      short-sha: ${{ steps.metadata.outputs.short-sha }}
+      date: ${{ steps.date.outputs.date }}
+      short-sha: ${{ steps.short-sha.outputs.short-sha }}
     steps:
       - name: Generate date
-        id: metadata
+        id: date
         run: echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
       - name: Generate short-sha
+        id: short-sha
         run: echo "short-sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
   generate-matrix:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
The tag of `golang-test` image does not include the commit hash. This is fixed here.
It also ensures that renovate performs only patch updates for the images. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
