### PR TITLE
Correct the version of the `VersionClassificationLifecycle` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,7 +34,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | CustomDNSServerInNodeLocalDNS  | `true`  | `Beta`  | `1.133` |         |
 | VPNBondingModeRoundRobin       | `false` | `Alpha` | `1.135` |         |
 | PrometheusHealthChecks         | `false` | `Alpha` | `1.135` |         |
-| VersionClassificationLifecycle | `false` | `Alpha` | `1.136` |         |
+| VersionClassificationLifecycle | `false` | `Alpha` | `1.137` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -52,7 +52,7 @@ const (
 	// VersionClassificationLifecycle enables the features introduced by GEP-0032,
 	// including lifecycle-based classification for Kubernetes and machine image versions.
 	// owner: @rapsnx
-	// alpha: v1.136.0
+	// alpha: v1.137.0
 	VersionClassificationLifecycle featuregate.Feature = "VersionClassificationLifecycle"
 
 	// DoNotCopyBackupCredentials disables the copying of Shoot infrastructure credentials as backup credentials when the Shoot is used as a ManagedSeed.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/12543 was released with v1.137, not v1.136.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/12543

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
