### PR TITLE
chore: Add Kubernetes 1.35 to the list of supported Kubernetes versions

### DIFF
--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -13,6 +13,7 @@ Currently, Gardener supports the following Kubernetes versions:
 | [`v1.32`](https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/) | [`v1.113.0`](https://github.com/gardener/gardener/releases/tag/v1.113.0) | `2025-02-24`  | `2026-04-24`    |
 | [`v1.33`](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/) | [`v1.122.0`](https://github.com/gardener/gardener/releases/tag/v1.122.0) | `2025-06-27`  | `2026-08-27`    |
 | [`v1.34`](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/) | [`v1.132.0`](https://github.com/gardener/gardener/releases/tag/v1.132.0) | `2025-11-13`  | `2027-01-13`    |
+| [`v1.35`](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/) | [`v1.136.0`](https://github.com/gardener/gardener/releases/tag/v1.136.0) | `2026-02-14`  | `2027-04-14`    |
 
 > [!NOTE]  
 > Gardener supports Kubernetes versions for at least 14 months after their initial support date.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
I followed the instructions in https://github.com/gardener/gardener/blob/7e4475add34c3e45b89859e832f5defcab536b7d/docs/development/new-kubernetes-version.md#L208-L209.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/13845

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
