### PR TITLE
Use correct Kubernetes version for certification docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please find more information regarding the concepts and a detailed description o
 ## K8s Conformance Test Coverage <img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" alt="certified kubernetes logo" width="50" align="right"/>
 
 Gardener takes part in the [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/) to attest its compatibility with the K8s conformance testsuite.
-Currently, Gardener is certified for K8s versions up to v1.34, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=113:114).
+Currently, Gardener is certified for K8s versions up to v1.34, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=109:110).
 
 Continuous conformance test results of the latest stable Gardener release are uploaded regularly to the CNCF test grid:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please find more information regarding the concepts and a detailed description o
 ## K8s Conformance Test Coverage <img src="https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" alt="certified kubernetes logo" width="50" align="right"/>
 
 Gardener takes part in the [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/) to attest its compatibility with the K8s conformance testsuite.
-Currently, Gardener is certified for K8s versions up to v1.33, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=113:114).
+Currently, Gardener is certified for K8s versions up to v1.34, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit#gid=0&range=113:114).
 
 Continuous conformance test results of the latest stable Gardener release are uploaded regularly to the CNCF test grid:
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
I believe the correct k8s version that Gardener is certified is 1.34 not 1.33... based on the [conformance spreadsheet](https://docs.google.com/spreadsheets/d/1uF9BoDzzisHSQemXHIKegMhuythuq_GL3N1mlUUK2h0/edit?gid=0#gid=0&range=113:114)

See also https://github.com/gardener/gardener/pull/13866 

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/area documentation
/kind task

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
