### PR TITLE
dwd: remove resource limits

### DIFF
--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap.go
@@ -408,9 +408,6 @@ func (b *bootstrapper) getDeployment(serviceAccountName string, configMapName st
 								corev1.ResourceCPU:    resource.MustParse("200m"),
 								corev1.ResourceMemory: resource.MustParse("256Mi"),
 							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
-							},
 						},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.To(false),

--- a/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
+++ b/pkg/component/nodemanagement/dependencywatchdog/bootstrap_test.go
@@ -339,8 +339,6 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          limits:
-            memory: 512Mi
           requests:
             cpu: 200m
             memory: 256Mi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
According to the [Shoot Pod Autoscaling Best practices guide](https://github.com/gardener/gardener/blob/v1.117.1/docs/usage/autoscaling/shoot_pod_autoscaling_best_practices.md), it is not recommended to have resource limits.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The dependency-watchdog component no longer defines resource limits.
```
