### PR TITLE
Add startup probe to gardener-metrics-exporter

### DIFF
--- a/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
@@ -82,7 +82,8 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								PeriodSeconds: 5,
+								PeriodSeconds:       5,
+								InitialDelaySeconds: 120, // Wait for informer cache to be synced
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/deployment.go
@@ -82,8 +82,19 @@ func (g *gardenerMetricsExporter) deployment(secretGenericTokenKubeconfig, secre
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								PeriodSeconds:       5,
-								InitialDelaySeconds: 120, // Wait for informer cache to be synced
+								PeriodSeconds: 5,
+							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/",
+										Port:   intstr.FromInt32(probePort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								// Wait for 2 minutes to allow the informer cache to sync
+								PeriodSeconds:    5,
+								FailureThreshold: 24,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -685,7 +685,8 @@ func deployment(namespace string, testValues Values) *appsv1.Deployment {
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								PeriodSeconds: 5,
+								PeriodSeconds:       5,
+								InitialDelaySeconds: 120,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
+++ b/pkg/component/observability/monitoring/gardenermetricsexporter/gardener_metrics_exporter_test.go
@@ -685,8 +685,19 @@ func deployment(namespace string, testValues Values) *appsv1.Deployment {
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								PeriodSeconds:       5,
-								InitialDelaySeconds: 120,
+								PeriodSeconds: 5,
+							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/",
+										Port:   intstr.FromInt32(2718),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								// Wait for 2 minutes to allow the informer cache to sync
+								PeriodSeconds:    5,
+								FailureThreshold: 24,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The gardener-metrics-exporter's liveness probe only succeeds after its informer cache has been synchronized. This might cause the termination of the container during startup on large landscapes. This PR adds a startup probe with a maximum delay of 120 seconds to give enough time to sync the cache.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @vicwicker @istvanballok @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add startup probe to gardener-metrics-exporter
```
