### PR TITLE
Fix cache sync timeouts in `gardener-resource-manager`

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -86,6 +86,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, sourceCluster, targetClus
 					predicateutils.IsDeleting(),
 				),
 			)),
+			// Only react on secret updates to minimize the handler calls during start up.
+			// Since the controller-runtime has started to wait for all handler syncs, cache sync timeouts blocked the GRM from starting.
+			// See https://github.com/kubernetes-sigs/controller-runtime/pull/3406 for more information.
+			builder.WithPredicates(predicateutils.ForEventTypes(predicateutils.Update)),
 		).
 		Complete(reconcilerutils.OperationAnnotationWrapper(
 			mgr,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
After upgrading to `controller-runtime:v0.23.1` in #13982, we observed GRM startup issues in clusters with many secrets (> 80,000).

```
{"level":"error","ts":"2026-03-03T10:20:40.168Z","msg":"Could not wait for Cache to sync","controller":"managedresource","controllerGroup":"resources.gardener.cloud","controllerKind":"ManagedResource","source":"kind source: *v1.Secret","error":"failed to wait for managedresource caches to sync kind source: *v1.Secret: timed out waiting for cache to be synced for Kind *v1.Secret","stacktrace":"[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).startEventSourcesAndQueueLocked.func1.2.1](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).startEventSourcesAndQueueLocked.func1.2.1)\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:383"}
```

It turned out that the `controller-runtime` has started to wait for all event handler to sync (see https://github.com/kubernetes-sigs/controller-runtime/pull/3406), causing a significant delay with complex mapping functions. If the invocation of said mapper functions take longer than `2 minutes` (default cache sync timeout), the GRM instance aborts the startup procedure, resulting in crash loops.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR only fixes the expensive mapping function that blocks GRM startups, it does not solve the issue in general or in a sustainable manner. ~We will follow up with a discussion with the `controller-runtime` maintainer and ask for making https://github.com/kubernetes-sigs/controller-runtime/pull/3406 an optional feature.~ See https://github.com/kubernetes-sigs/controller-runtime/issues/3466 for further discussions.

/cc @voelzmo @dguendisch @adenitiu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issues has been fixed causing `gardener-resource-manager` crash loops in large clusters.
```
