### PR TITLE
operator: set dashboard apiServerCaData from SNI TLS secret ca.crt

### DIFF
--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1216,6 +1216,24 @@ func (r *Reconciler) deployGardenerDashboard(ctx context.Context, dashboard gard
 			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
 		}
 		dashboard.SetAPIServerCABundle(ptr.To(utils.EncodeBase64(caSecret.Data[secretsutils.DataKeyCertificateBundle])))
+	} else {
+		tlsSecretName := garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.SNI.SecretName
+		if tlsSecretName == nil {
+			tlsSecret, err := gardenerutils.GetRequiredGardenWildcardCertificate(ctx, r.RuntimeClientSet.Client(), r.GardenNamespace)
+			if err != nil {
+				return fmt.Errorf("failed getting SNI TLS secret for dashboard API server CA bundle: %w", err)
+			}
+			tlsSecretName = &tlsSecret.Name
+		}
+
+		tlsSecret := &corev1.Secret{}
+		if err := r.RuntimeClientSet.Client().Get(ctx, client.ObjectKey{Name: *tlsSecretName, Namespace: r.GardenNamespace}, tlsSecret); err != nil {
+			return fmt.Errorf("failed getting SNI TLS secret %q for dashboard API server CA bundle: %w", *tlsSecretName, err)
+		}
+
+		if caData, ok := tlsSecret.Data[secretsutils.DataKeyCertificateCA]; ok {
+			dashboard.SetAPIServerCABundle(ptr.To(utils.EncodeBase64(caData)))
+		}
 	}
 
 	return component.OpWait(dashboard).Deploy(ctx)


### PR DESCRIPTION
## What this PR does / why we need it
For SNI-based garden API server endpoints signed by private CAs, dashboard terminal sessions can fail with x509 unknown authority because terminal kubeconfig has no CA data.

This PR sets dashboard apiServerCaData from the SNI TLS secret ca.crt when available, so terminal-generated kubeconfigs include the CA bundle.

## Which issue(s) this PR fixes
Fixes #14215

## Special notes for your reviewer
- Non-SNI behavior remains unchanged.
- For SNI, this uses the configured server certificate secret (or wildcard fallback) and reads ca.crt if present.