### PR TITLE
Speed up restoration of `Machine`s and `MachineSet`s

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -29,7 +29,12 @@ import (
 )
 
 // maxConcurrentMachineTasks defines the maximum number of machine-related tasks that can run concurrently.
-const maxConcurrentMachineTasks = 10
+// A value of 50 was chosen because using more parallel tasks brings a marginal speed increase and risks
+// running into client-side rate limits which could slow down the operations.
+// Once client-side rate limits are dropped this number can be re-evaluated.
+// See also https://github.com/kubernetes-sigs/controller-runtime/pull/3119 for the removal of client-side
+// rate limits in controller-runtime.
+const maxConcurrentMachineTasks = 50
 
 type genericActuator struct {
 	delegateFactory    DelegateFactory

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -28,6 +28,9 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
+// maxConcurrentMachineTasks defines the maximum number of machine-related tasks that can run concurrently.
+const maxConcurrentMachineTasks = 10
+
 type genericActuator struct {
 	delegateFactory    DelegateFactory
 	gardenReader       client.Reader

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -10,7 +10,6 @@ import (
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -152,11 +151,11 @@ func addStateToMachineDeployment(
 func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl client.Client, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
 	log.Info("Deploying Machines and MachineSets")
 
-	taskFns := []flow.TaskFn{}
+	var taskFns []flow.TaskFn
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
 		for _, machineSet := range wantedMachineDeployment.State.MachineSets {
 			taskFns = append(taskFns, func(ctx context.Context) error {
-				if err := createIfNotExists(ctx, cl, &machineSet); err != nil {
+				if err := client.IgnoreAlreadyExists(cl.Create(ctx, &machineSet)); err != nil {
 					return fmt.Errorf("could not restore MachineSet '%s': %w", client.ObjectKeyFromObject(&machineSet), err)
 				}
 				return nil
@@ -165,7 +164,7 @@ func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl clie
 
 		for _, machine := range wantedMachineDeployment.State.Machines {
 			taskFns = append(taskFns, func(ctx context.Context) error {
-				if err := createIfNotExists(ctx, cl, &machine); err != nil {
+				if err := client.IgnoreAlreadyExists(cl.Create(ctx, &machine)); err != nil {
 					return fmt.Errorf("could not restore Machine '%s': %w", client.ObjectKeyFromObject(&machine), err)
 				}
 				return nil
@@ -174,17 +173,6 @@ func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl clie
 	}
 
 	return flow.ParallelN(maxConcurrentMachineTasks, taskFns...)(ctx)
-}
-
-func createIfNotExists(ctx context.Context, cl client.Client, obj client.Object) error {
-	err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)
-	if apierrors.IsNotFound(err) {
-		// Ignore AlreadyExists error which could happen if the client's cache
-		// was not yet updated with the recently created Object.
-		return client.IgnoreAlreadyExists(cl.Create(ctx, obj))
-	}
-
-	return err
 }
 
 func removeWantedDeploymentWithoutState(wantedMachineDeployments extensionsworkercontroller.MachineDeployments) extensionsworkercontroller.MachineDeployments {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -20,6 +20,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 )
 
@@ -150,23 +151,38 @@ func addStateToMachineDeployment(
 
 func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl client.Client, wantedMachineDeployments extensionsworkercontroller.MachineDeployments) error {
 	log.Info("Deploying Machines and MachineSets")
+
+	taskFns := []flow.TaskFn{}
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
 		for _, machineSet := range wantedMachineDeployment.State.MachineSets {
-			if err := cl.Create(ctx, &machineSet); client.IgnoreAlreadyExists(err) != nil {
-				return err
-			}
+			taskFns = append(taskFns, func(ctx context.Context) error {
+				if err := createIfNotExists(ctx, cl, &machineSet); err != nil {
+					return fmt.Errorf("could not restore MachineSet '%s': %w", client.ObjectKeyFromObject(&machineSet), err)
+				}
+				return nil
+			})
 		}
 
 		for _, machine := range wantedMachineDeployment.State.Machines {
-			if err := cl.Create(ctx, &machine); err != nil {
-				if !apierrors.IsAlreadyExists(err) {
-					return err
+			taskFns = append(taskFns, func(ctx context.Context) error {
+				if err := createIfNotExists(ctx, cl, &machine); err != nil {
+					return fmt.Errorf("could not restore Machine '%s': %w", client.ObjectKeyFromObject(&machine), err)
 				}
-			}
+				return nil
+			})
 		}
 	}
 
-	return nil
+	return flow.ParallelN(maxConcurrentMachineTasks, taskFns...)(ctx)
+}
+
+func createIfNotExists(ctx context.Context, cl client.Client, obj client.Object) error {
+	err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	if apierrors.IsNotFound(err) {
+		return cl.Create(ctx, obj)
+	}
+
+	return err
 }
 
 func removeWantedDeploymentWithoutState(wantedMachineDeployments extensionsworkercontroller.MachineDeployments) extensionsworkercontroller.MachineDeployments {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -179,7 +179,9 @@ func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl clie
 func createIfNotExists(ctx context.Context, cl client.Client, obj client.Object) error {
 	err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 	if apierrors.IsNotFound(err) {
-		return cl.Create(ctx, obj)
+		// Ignore AlreadyExists error which could happen if the client's cache
+		// was not yet updated with the recently created Object.
+		return client.IgnoreAlreadyExists(cl.Create(ctx, obj))
 	}
 
 	return err

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore_test.go
@@ -156,4 +156,105 @@ var _ = Describe("ActuatorRestore", func() {
 			})
 		})
 	})
+
+	Describe("#restoreMachineSetsAndMachines", func() {
+		var (
+			ctx            = context.Background()
+			log            = logr.Discard()
+			fakeSeedClient client.Client
+
+			machineDeployments extensionsworkercontroller.MachineDeployments
+			expectedMachineSet machinev1alpha1.MachineSet
+			expectedMachine1   machinev1alpha1.Machine
+			expectedMachine2   machinev1alpha1.Machine
+		)
+
+		BeforeEach(func() {
+			fakeSeedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			expectedMachineSet = machinev1alpha1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machineset",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"name": "pool1",
+					},
+				},
+			}
+
+			expectedMachine1 = machinev1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"node": "node-name-one",
+					},
+				},
+			}
+
+			expectedMachine2 = machinev1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-two",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"node": "node-name-two",
+					},
+				},
+			}
+
+			machineDeployments = extensionsworkercontroller.MachineDeployments{
+				{
+					State: &shootstate.MachineDeploymentState{
+						Replicas: 2,
+						MachineSets: []machinev1alpha1.MachineSet{
+							expectedMachineSet,
+						},
+						Machines: []machinev1alpha1.Machine{
+							expectedMachine1,
+							expectedMachine2,
+						},
+					},
+				},
+			}
+		})
+
+		test := func() {
+			Expect(restoreMachineSetsAndMachines(ctx, log, fakeSeedClient, machineDeployments)).To(Succeed())
+
+			var actualMachineSet machinev1alpha1.MachineSet
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(&expectedMachineSet), &actualMachineSet)).To(Succeed())
+			expectedMachineSet.ResourceVersion = "1"
+			Expect(actualMachineSet).To(Equal(expectedMachineSet))
+
+			for _, expectedMachine := range []machinev1alpha1.Machine{expectedMachine1, expectedMachine2} {
+				var actualMachine machinev1alpha1.Machine
+				Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(&expectedMachine), &actualMachine)).To(Succeed(), expectedMachine.Name+" should be retrieved successfully")
+				expectedMachine.ResourceVersion = "1"
+				Expect(actualMachine).To(Equal(expectedMachine), "actual should be equal to expected Machine"+expectedMachine.Name)
+			}
+		}
+
+		When("MachineSets and Machines do not exist", func() {
+			It("should deploy MachineSets and Machines present in the MachineDeployments' state", func() {
+				test()
+			})
+		})
+
+		When("MachineSet and Machines already exist", func() {
+			BeforeEach(func() {
+				expectedMachineSet.Labels = map[string]string{"foo": "bar"}
+				Expect(fakeSeedClient.Create(ctx, &expectedMachineSet)).To(Succeed())
+
+				expectedMachine1.Labels = map[string]string{"foo": "bar"}
+				expectedMachine2.Labels = map[string]string{"foo": "bar"}
+				for _, expectedMachine := range []machinev1alpha1.Machine{expectedMachine1, expectedMachine2} {
+					Expect(fakeSeedClient.Create(ctx, &expectedMachine)).To(Succeed(), expectedMachine.Name+" should be created successfully")
+				}
+			})
+
+			It("should not re-deploy MachineSets and Machines present in the MachineDeployments' state", func() {
+				test()
+			})
+		})
+	})
 })

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -10,18 +10,13 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Actuator", func() {
@@ -211,93 +206,5 @@ var _ = Describe("Actuator", func() {
 			Entry("should be stuck - machine set does not have matching matching class", []machinev1alpha1.MachineSet{machineSetOtherMachineClass}, machineDeployments, true),
 			Entry("should be stuck - no machine set with matching owner reference", []machinev1alpha1.MachineSet{machineSetOtherOwner}, machineDeployments, true),
 		)
-	})
-
-	Describe("#restoreMachineSetsAndMachines", func() {
-		var (
-			ctx    = context.TODO()
-			logger = log.Log.WithName("test")
-
-			mockCtrl   *gomock.Controller
-			mockClient *mockclient.MockClient
-
-			a *genericActuator
-
-			machineDeployments worker.MachineDeployments
-			expectedMachineSet machinev1alpha1.MachineSet
-			expectedMachine1   machinev1alpha1.Machine
-			expectedMachine2   machinev1alpha1.Machine
-
-			alreadyExistsError = apierrors.NewAlreadyExists(schema.GroupResource{Resource: "Machines"}, "machine")
-		)
-
-		BeforeEach(func() {
-			mockCtrl = gomock.NewController(GinkgoT())
-			mockClient = mockclient.NewMockClient(mockCtrl)
-
-			a = &genericActuator{seedClient: mockClient}
-
-			expectedMachineSet = machinev1alpha1.MachineSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machineset",
-					Namespace: "test-ns",
-				},
-			}
-
-			expectedMachine1 = machinev1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"node": "node-name-one",
-					},
-				},
-			}
-
-			expectedMachine2 = machinev1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-two",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						"node": "node-name-two",
-					},
-				},
-			}
-
-			machineDeployments = worker.MachineDeployments{
-				{
-					State: &shootstate.MachineDeploymentState{
-						Replicas: 2,
-						MachineSets: []machinev1alpha1.MachineSet{
-							expectedMachineSet,
-						},
-						Machines: []machinev1alpha1.Machine{
-							expectedMachine1,
-							expectedMachine2,
-						},
-					},
-				},
-			}
-		})
-
-		AfterEach(func() {
-			mockCtrl.Finish()
-		})
-
-		It("should deploy machinesets and machines present in the machine deployments' state", func() {
-			mockClient.EXPECT().Create(ctx, &expectedMachineSet)
-			mockClient.EXPECT().Create(ctx, &expectedMachine1)
-			mockClient.EXPECT().Create(ctx, &expectedMachine2)
-
-			Expect(restoreMachineSetsAndMachines(ctx, logger, a.seedClient, machineDeployments)).To(Succeed())
-		})
-
-		It("should not return error if machineset and machines already exist", func() {
-			mockClient.EXPECT().Create(ctx, &expectedMachineSet).Return(alreadyExistsError)
-			mockClient.EXPECT().Create(ctx, &expectedMachine1).Return(alreadyExistsError)
-			mockClient.EXPECT().Create(ctx, &expectedMachine2).Return(alreadyExistsError)
-
-			Expect(restoreMachineSetsAndMachines(ctx, logger, a.seedClient, machineDeployments)).To(Succeed())
-		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane-migration
/area performance
/area scalability
/kind enhancement

**What this PR does / why we need it**:
There could be high latency (200~300ms) between a `Seed`'s workers and its control plane when the workers are running in a separate region. E.g. control plane is in eu-west, whereas workers are in asia-pacific.
This PR speeds up the restoration of `Machines` and `MachineSets` during the `restore` phase of control plane migration in such cases by parallelising the API calls across 10 routines.
I decided to limit it to 10 because I'm afraid of hitting client rate limits and throttling API calls of other controllers in the provider extensions. 
I'm still wondering whether the number of parallel routines should be exposed as a configuration option.

Additionally, to prevent extra calls to the kube-apiserver, the restoration logic will now try to `Get` `Machine`s and `MachineSet`s to check if they exist before attempting to `Create` them.

For more information check #14137

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14137

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
During the `restore` phase of control plane migration, `Machines` and `MachineSets` are now deployed in parallel across 10 go routines. Additionally, the restoration logic now checks if a `Machine` or `MachineSet` already exists, and if that is the case, it does not attempt to create it. This should speed up the restoration of the `Worker` resource.
```
