### PR TITLE
Parallelise deployment of `MachineDeployment`s

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -28,13 +28,13 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
-// maxConcurrentMachineTasks defines the maximum number of machine-related tasks that can run concurrently.
+// MaxConcurrentMachineTasks defines the maximum number of machine-related tasks that can run concurrently.
 // A value of 50 was chosen because using more parallel tasks brings a marginal speed increase and risks
 // running into client-side rate limits which could slow down the operations.
 // Once client-side rate limits are dropped this number can be re-evaluated.
 // See also https://github.com/kubernetes-sigs/controller-runtime/pull/3119 for the removal of client-side
 // rate limits in controller-runtime.
-const maxConcurrentMachineTasks = 50
+const MaxConcurrentMachineTasks = 50
 
 type genericActuator struct {
 	delegateFactory    DelegateFactory

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -124,9 +124,8 @@ func markAllMachinesForcefulDeletion(ctx context.Context, log logr.Logger, cl cl
 
 	var tasks = make([]flow.TaskFn, 0, len(existingMachines.Items))
 	for _, machine := range existingMachines.Items {
-		m := machine
 		tasks = append(tasks, func(ctx context.Context) error {
-			return markMachineForcefulDeletion(ctx, cl, &m)
+			return markMachineForcefulDeletion(ctx, cl, &machine)
 		})
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -13,6 +13,7 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -121,7 +122,7 @@ func markAllMachinesForcefulDeletion(ctx context.Context, log logr.Logger, cl cl
 		return err
 	}
 
-	var tasks []flow.TaskFn
+	var tasks = make([]flow.TaskFn, 0, len(existingMachines.Items))
 	for _, machine := range existingMachines.Items {
 		m := machine
 		tasks = append(tasks, func(ctx context.Context) error {
@@ -138,16 +139,13 @@ func markAllMachinesForcefulDeletion(ctx context.Context, log logr.Logger, cl cl
 
 // markMachineForcefulDeletion labels a machine object to become forcefully deleted.
 func markMachineForcefulDeletion(ctx context.Context, cl client.Client, machine *machinev1alpha1.Machine) error {
-	if machine.Labels == nil {
-		machine.Labels = map[string]string{}
-	}
-
 	if val, ok := machine.Labels[forceDeletionLabelKey]; ok && val == forceDeletionLabelValue {
 		return nil
 	}
 
-	machine.Labels[forceDeletionLabelKey] = forceDeletionLabelValue
-	return cl.Update(ctx, machine)
+	patch := client.MergeFrom(machine.DeepCopy())
+	metav1.SetMetaDataLabel(&machine.ObjectMeta, forceDeletionLabelKey, forceDeletionLabelValue)
+	return cl.Patch(ctx, machine, patch)
 }
 
 func (a *genericActuator) waitUntilCredentialsSecretAcquiredOrReleased(ctx context.Context, acquired bool, worker *extensionsv1alpha1.Worker) error {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -185,6 +185,14 @@ func deployMachineDeployments(
 	clusterAutoscalerUsed bool,
 ) error {
 	log.Info("Deploying machine deployments")
+
+	// If the Shoot is hibernated, then mark all machines for forceful deletion to avoid respecting of PDBs/SLAs.
+	if extensionscontroller.IsHibernationEnabled(cluster) {
+		if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
+			return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)
+		}
+	}
+
 	for _, deployment := range wantedMachineDeployments {
 		var (
 			labels                    = map[string]string{extensionsworkercontroller.LabelKeyMachineDeploymentName: deployment.Name}
@@ -210,12 +218,8 @@ func deployMachineDeployments(
 
 			switch {
 			// If the Shoot is hibernated then the machine deployment's replicas should be zero.
-			// Also mark all machines for forceful deletion to avoid respecting of PDBs/SLAs in case of cluster hibernation.
 			case extensionscontroller.IsHibernationEnabled(cluster):
 				machineDeployment.Spec.Replicas = 0
-				if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
-					return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)
-				}
 			// If the cluster autoscaler is not enabled then min=max (as per API validation), hence
 			// we can use either min or max.
 			case !clusterAutoscalerUsed:

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -207,7 +207,7 @@ func deployMachineDeployments(
 		})
 	}
 
-	return flow.ParallelN(maxConcurrentMachineTasks, taskFns...)(ctx)
+	return flow.ParallelN(MaxConcurrentMachineTasks, taskFns...)(ctx)
 }
 
 func deployMachineDeployment(

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -188,7 +188,7 @@ func deployMachineDeployments(
 	log.Info("Deploying machine deployments")
 
 	// If the Shoot is hibernated, then mark all machines for forceful deletion to avoid respecting of PDBs/SLAs.
-	var isHibernated = extensionscontroller.IsHibernationEnabled(cluster)
+	isHibernated := extensionscontroller.IsHibernationEnabled(cluster)
 	if isHibernated {
 		if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
 			return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
@@ -187,110 +188,132 @@ func deployMachineDeployments(
 	log.Info("Deploying machine deployments")
 
 	// If the Shoot is hibernated, then mark all machines for forceful deletion to avoid respecting of PDBs/SLAs.
-	if extensionscontroller.IsHibernationEnabled(cluster) {
+	var isHibernated = extensionscontroller.IsHibernationEnabled(cluster)
+	if isHibernated {
 		if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
 			return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)
 		}
 	}
 
+	var taskFns = make([]flow.TaskFn, 0, len(wantedMachineDeployments))
 	for _, deployment := range wantedMachineDeployments {
 		var (
-			labels                    = map[string]string{extensionsworkercontroller.LabelKeyMachineDeploymentName: deployment.Name}
 			existingMachineDeployment = getExistingMachineDeployment(existingMachineDeployments, deployment.Name)
+			shootIsAwake              = shootIsAwake(extensionscontroller.IsHibernationEnabled(cluster), existingMachineDeployments)
 		)
 
-		machineDeployment := &machinev1alpha1.MachineDeployment{
+		taskFns = append(taskFns, func(ctx context.Context) error {
+			return deployMachineDeployment(ctx, log, cl, worker, deployment, existingMachineDeployment, clusterAutoscalerUsed, isHibernated, shootIsAwake)
+		})
+	}
+
+	return flow.ParallelN(maxConcurrentMachineTasks, taskFns...)(ctx)
+}
+
+func deployMachineDeployment(
+	ctx context.Context,
+	log logr.Logger,
+	cl client.Client,
+	worker *extensionsv1alpha1.Worker,
+	deployment extensionsworkercontroller.MachineDeployment,
+	existingMachineDeployment *machinev1alpha1.MachineDeployment,
+	clusterAutoscalerUsed bool,
+	isHibernationEnabled bool,
+	shootIsAwake bool,
+) error {
+	var labels = map[string]string{extensionsworkercontroller.LabelKeyMachineDeploymentName: deployment.Name}
+
+	machineDeployment := &machinev1alpha1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment.Name,
+			Namespace: worker.Namespace,
+		},
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, cl, machineDeployment, func() error {
+		metav1.SetMetaDataLabel(&machineDeployment.ObjectMeta, v1beta1constants.LabelWorkerPool, deployment.PoolName)
+		for k, v := range deployment.ClusterAutoscalerAnnotations {
+			if v == "" {
+				delete(machineDeployment.GetAnnotations(), k)
+			} else {
+				metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
+			}
+		}
+
+		switch {
+		// If the Shoot is hibernated then the machine deployment's replicas should be zero.
+		case isHibernationEnabled:
+			machineDeployment.Spec.Replicas = 0
+		// If the cluster autoscaler is not enabled then min=max (as per API validation), hence
+		// we can use either min or max.
+		case !clusterAutoscalerUsed:
+			machineDeployment.Spec.Replicas = deployment.Minimum
+		// If the machine deployment does not yet exist we set replicas to min so that the cluster
+		// autoscaler can scale them as required.
+		case existingMachineDeployment == nil:
+			if deployment.State != nil {
+				// During restoration the actual replica count is in the State.Replicas
+				// If wanted deployment has no corresponding existing deployment, but has State, then we are in restoration process
+				machineDeployment.Spec.Replicas = deployment.State.Replicas
+			} else {
+				machineDeployment.Spec.Replicas = deployment.Minimum
+			}
+		// If the Shoot was hibernated and is now woken up we set replicas to min so that the cluster
+		// autoscaler can scale them as required.
+		case shootIsAwake:
+			machineDeployment.Spec.Replicas = deployment.Minimum
+		// If the shoot worker pool minimum was updated and if the current machine deployment replica
+		// count is less than minimum, we update the machine deployment replica count to updated minimum.
+		case machineDeployment.Spec.Replicas < deployment.Minimum:
+			machineDeployment.Spec.Replicas = deployment.Minimum
+		// If the shoot worker pool maximum was updated and if the current machine deployment replica
+		// count is greater than maximum, we update the machine deployment replica count to updated maximum.
+		case machineDeployment.Spec.Replicas > deployment.Maximum:
+			machineDeployment.Spec.Replicas = deployment.Maximum
+		}
+
+		// machineDeployment.Spec.Replicas is not explicitly set for default switch case,
+		// as it would have been already set by the client.Get() call in getAndCreateOrMergePatch().
+		// This is done to avoid overwriting the machineDeployment.Spec.Replicas value
+		// which is fetched from the client.Get() call in getAndCreateOrMergePatch()
+		// and hence causing unnecessary updates to the machineDeployment.Spec.Replicas
+		machineDeployment.Spec.RevisionHistoryLimit = ptr.To[int32](0)
+		machineDeployment.Spec.MinReadySeconds = 500
+		machineDeployment.Spec.Strategy = deployment.Strategy
+		machineDeployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: labels,
+		}
+		machineDeployment.Spec.Template = machinev1alpha1.MachineTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      deployment.Name,
-				Namespace: worker.Namespace,
+				Labels: getMachineLabels(deployment.Strategy, labels, worker.Name),
+			},
+			Spec: machinev1alpha1.MachineSpec{
+				Class: machinev1alpha1.ClassSpec{
+					Kind: "MachineClass",
+					Name: deployment.ClassName,
+				},
+				NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: deployment.Annotations,
+						Labels:      deployment.Labels,
+					},
+					Spec: corev1.NodeSpec{
+						Taints: deployment.Taints,
+					},
+				},
+				MachineConfiguration: deployment.MachineConfiguration,
 			},
 		}
-
-		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, cl, machineDeployment, func() error {
-			metav1.SetMetaDataLabel(&machineDeployment.ObjectMeta, v1beta1constants.LabelWorkerPool, deployment.PoolName)
-			for k, v := range deployment.ClusterAutoscalerAnnotations {
-				if v == "" {
-					delete(machineDeployment.GetAnnotations(), k)
-				} else {
-					metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
-				}
+		if existingMachineDeployment != nil && existingMachineDeployment.Spec.Template.Annotations != nil {
+			for k, v := range existingMachineDeployment.Spec.Template.Annotations {
+				metav1.SetMetaDataAnnotation(&machineDeployment.Spec.Template.ObjectMeta, k, v)
 			}
-
-			switch {
-			// If the Shoot is hibernated then the machine deployment's replicas should be zero.
-			case extensionscontroller.IsHibernationEnabled(cluster):
-				machineDeployment.Spec.Replicas = 0
-			// If the cluster autoscaler is not enabled then min=max (as per API validation), hence
-			// we can use either min or max.
-			case !clusterAutoscalerUsed:
-				machineDeployment.Spec.Replicas = deployment.Minimum
-			// If the machine deployment does not yet exist we set replicas to min so that the cluster
-			// autoscaler can scale them as required.
-			case existingMachineDeployment == nil:
-				if deployment.State != nil {
-					// During restoration the actual replica count is in the State.Replicas
-					// If wanted deployment has no corresponding existing deployment, but has State, then we are in restoration process
-					machineDeployment.Spec.Replicas = deployment.State.Replicas
-				} else {
-					machineDeployment.Spec.Replicas = deployment.Minimum
-				}
-			// If the Shoot was hibernated and is now woken up we set replicas to min so that the cluster
-			// autoscaler can scale them as required.
-			case shootIsAwake(extensionscontroller.IsHibernationEnabled(cluster), existingMachineDeployments):
-				machineDeployment.Spec.Replicas = deployment.Minimum
-			// If the shoot worker pool minimum was updated and if the current machine deployment replica
-			// count is less than minimum, we update the machine deployment replica count to updated minimum.
-			case machineDeployment.Spec.Replicas < deployment.Minimum:
-				machineDeployment.Spec.Replicas = deployment.Minimum
-			// If the shoot worker pool maximum was updated and if the current machine deployment replica
-			// count is greater than maximum, we update the machine deployment replica count to updated maximum.
-			case machineDeployment.Spec.Replicas > deployment.Maximum:
-				machineDeployment.Spec.Replicas = deployment.Maximum
-			}
-
-			// machineDeployment.Spec.Replicas is not explicitly set for default switch case,
-			// as it would have been already set by the client.Get() call in getAndCreateOrMergePatch().
-			// This is done to avoid overwriting the machineDeployment.Spec.Replicas value
-			// which is fetched from the client.Get() call in getAndCreateOrMergePatch()
-			// and hence causing unnecessary updates to the machineDeployment.Spec.Replicas
-			machineDeployment.Spec.RevisionHistoryLimit = ptr.To[int32](0)
-			machineDeployment.Spec.MinReadySeconds = 500
-			machineDeployment.Spec.Strategy = deployment.Strategy
-			machineDeployment.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: labels,
-			}
-			machineDeployment.Spec.Template = machinev1alpha1.MachineTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: getMachineLabels(deployment.Strategy, labels, worker.Name),
-				},
-				Spec: machinev1alpha1.MachineSpec{
-					Class: machinev1alpha1.ClassSpec{
-						Kind: "MachineClass",
-						Name: deployment.ClassName,
-					},
-					NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Annotations: deployment.Annotations,
-							Labels:      deployment.Labels,
-						},
-						Spec: corev1.NodeSpec{
-							Taints: deployment.Taints,
-						},
-					},
-					MachineConfiguration: deployment.MachineConfiguration,
-				},
-			}
-			if existingMachineDeployment != nil && existingMachineDeployment.Spec.Template.Annotations != nil {
-				for k, v := range existingMachineDeployment.Spec.Template.Annotations {
-					metav1.SetMetaDataAnnotation(&machineDeployment.Spec.Template.ObjectMeta, k, v)
-				}
-			}
-
-			log.Info("Deploying machine deployment", "machineDeploymentName", machineDeployment.Name, "replicas", machineDeployment.Spec.Replicas)
-			return nil
-		}); err != nil {
-			return err
 		}
+
+		log.Info("Deploying machine deployment", "machineDeployment", client.ObjectKeyFromObject(machineDeployment), "replicas", machineDeployment.Spec.Replicas)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("could not deploy machine deployment '%s': %w", client.ObjectKeyFromObject(machineDeployment), err)
 	}
 
 	return nil

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
@@ -21,8 +23,11 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 )
 
 var _ = Describe("ActuatorReconcile", func() {
@@ -37,15 +42,129 @@ var _ = Describe("ActuatorReconcile", func() {
 			testDeployment             *machinev1alpha1.MachineDeployment
 			returnedDeployment         machinev1alpha1.MachineDeployment
 			wantedMachineDeployments   extensionsworkercontroller.MachineDeployments
+			testDeploymentObjectKey    client.ObjectKey
 			caUsed                     bool
 		)
+
+		buildWantedMachineDeployment := func(suffix string, strategyType machinev1alpha1.MachineDeploymentStrategyType, taints []corev1.Taint) extensionsworkercontroller.MachineDeployment {
+			md := extensionsworkercontroller.MachineDeployment{
+				Name:      "machine-deployment" + suffix,
+				PoolName:  "pool" + suffix,
+				ClassName: "test-machine-class-" + suffix,
+				Labels: map[string]string{
+					"worker.gardener.cloud/name": worker.Name,
+					"worker.gardener.cloud/pool": "pool" + suffix,
+				},
+				Annotations: map[string]string{
+					"node-annotation-1": "ann-value1",
+				},
+				ClusterAutoscalerAnnotations: map[string]string{
+					"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "0.3",
+					"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+					"autoscaler.gardener.cloud/scale-down-unneeded-time":             "10m",
+					"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+					"autoscaler.gardener.cloud/max-node-provision-time":              "",
+				},
+				Minimum: 2,
+				Maximum: 10,
+				Taints:  taints,
+			}
+
+			if strategyType == machinev1alpha1.RollingUpdateMachineDeploymentStrategyType {
+				md.Strategy = machinev1alpha1.MachineDeploymentStrategy{
+					Type: machinev1alpha1.RollingUpdateMachineDeploymentStrategyType,
+					RollingUpdate: &machinev1alpha1.RollingUpdateMachineDeployment{
+						UpdateConfiguration: machinev1alpha1.UpdateConfiguration{
+							MaxSurge:       ptr.To(intstr.FromInt32(1)),
+							MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						},
+					},
+				}
+			}
+
+			if strategyType == machinev1alpha1.InPlaceUpdateMachineDeploymentStrategyType {
+				md.Strategy = machinev1alpha1.MachineDeploymentStrategy{
+					Type: machinev1alpha1.InPlaceUpdateMachineDeploymentStrategyType,
+					InPlaceUpdate: &machinev1alpha1.InPlaceUpdateMachineDeployment{
+						UpdateConfiguration: machinev1alpha1.UpdateConfiguration{
+							MaxSurge:       ptr.To(intstr.FromInt32(1)),
+							MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						},
+					},
+				}
+			}
+
+			return md
+		}
+
+		buildExpectedMachineDeployment := func(namespace string, replicas int32, resourceVersion string, machineDeployment extensionsworkercontroller.MachineDeployment) *machinev1alpha1.MachineDeployment {
+			templateLabels := map[string]string{
+				"name": machineDeployment.Name,
+			}
+
+			if machineDeployment.Strategy.Type == machinev1alpha1.InPlaceUpdateMachineDeploymentStrategyType {
+				templateLabels = utils.MergeStringMaps(templateLabels, map[string]string{
+					v1beta1constants.LabelWorkerName: "worker",
+				})
+			}
+
+			md := &machinev1alpha1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      machineDeployment.Name,
+					Labels: map[string]string{
+						"worker.gardener.cloud/pool": machineDeployment.PoolName,
+					},
+					ResourceVersion: resourceVersion,
+				},
+				Spec: machinev1alpha1.MachineDeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"name": machineDeployment.Name,
+						},
+					},
+					Strategy:             machineDeployment.Strategy,
+					Replicas:             replicas,
+					MinReadySeconds:      500,
+					RevisionHistoryLimit: ptr.To[int32](0),
+					Template: machinev1alpha1.MachineTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: templateLabels,
+						},
+						Spec: machinev1alpha1.MachineSpec{
+							Class: machinev1alpha1.ClassSpec{
+								Kind: "MachineClass",
+								Name: machineDeployment.ClassName,
+							},
+							NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels:      machineDeployment.Labels,
+									Annotations: machineDeployment.Annotations,
+								},
+								Spec: corev1.NodeSpec{
+									Taints: machineDeployment.Taints,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			for k, v := range machineDeployment.ClusterAutoscalerAnnotations {
+				if v != "" {
+					metav1.SetMetaDataAnnotation(&md.ObjectMeta, k, v)
+				}
+			}
+
+			return md
+		}
 
 		BeforeEach(func() {
 			// Starting with controller-runtime v0.22.0, the default object tracker does not work with resources which include
 			// structs directly as pointer, e.g. *MachineConfiguration in Machine resource. Hence, use the old one instead.
 			seedClient = fakeclient.NewClientBuilder().
 				WithScheme(kubernetes.SeedScheme).
-				WithStatusSubresource(&extensionsv1alpha1.Worker{}, &machinev1alpha1.MachineDeployment{}).
+				WithStatusSubresource(&machinev1alpha1.MachineDeployment{}).
 				WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).
 				Build()
 
@@ -66,39 +185,12 @@ var _ = Describe("ActuatorReconcile", func() {
 					},
 				},
 			}
-			Expect(seedClient.Create(ctx, worker)).To(Succeed())
 
-			testDeployment = &machinev1alpha1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-deployment1",
-					Namespace: worker.Namespace,
-					Labels: map[string]string{
-						"worker.gardener.cloud/name": worker.Name,
-						"worker.gardener.cloud/pool": "pool1",
-					},
-					Annotations: map[string]string{
-						"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "0.3",
-						"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
-						"autoscaler.gardener.cloud/scale-down-unneeded-time":             "10m",
-						"autoscaler.gardener.cloud/scale-down-unready-time":              "",
-						"autoscaler.gardener.cloud/max-node-provision-time":              "",
-					},
-				},
-			}
-
-			Expect(seedClient.Create(ctx, testDeployment)).To(Succeed())
-			wantedMachineDeployment := extensionsworkercontroller.MachineDeployment{
-				Name:                         testDeployment.Name,
-				PoolName:                     testDeployment.Labels["worker.gardener.cloud/pool"],
-				Labels:                       testDeployment.Labels,
-				ClusterAutoscalerAnnotations: testDeployment.Annotations,
-			}
+			wantedMachineDeployment := buildWantedMachineDeployment("1", machinev1alpha1.RollingUpdateMachineDeploymentStrategyType, nil)
+			testDeploymentObjectKey = client.ObjectKey{Namespace: "namespace", Name: wantedMachineDeployment.Name}
 			wantedMachineDeployments = []extensionsworkercontroller.MachineDeployment{wantedMachineDeployment}
 
-			DeferCleanup(func() {
-				Expect(seedClient.Delete(ctx, worker)).To(Succeed())
-				Expect(seedClient.Delete(ctx, testDeployment)).To(Succeed())
-			})
+			caUsed = true
 
 			cluster = &extensionscontroller.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -110,112 +202,240 @@ var _ = Describe("ActuatorReconcile", func() {
 			}
 		})
 
-		It("should remove cluster autoscaler annotations with no values", func() {
+		testReplicaCount := func(setup func(), expectedReplicas int) {
+			if setup != nil {
+				setup()
+			}
+
 			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Annotations).To(Equal(map[string]string{
-				"autoscaler.gardener.cloud/scale-down-utilization-threshold": "0.3",
-				"autoscaler.gardener.cloud/scale-down-unneeded-time":         "10m",
-			}))
-		})
+			Expect(seedClient.Get(ctx, testDeploymentObjectKey, &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(expectedReplicas)))
+		}
 
-		It("should remove all cluster autoscaler annotations", func() {
-			testDeployment.Annotations = map[string]string{
-				"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
-				"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
-				"autoscaler.gardener.cloud/scale-down-unneeded-time":             "",
-				"autoscaler.gardener.cloud/scale-down-unready-time":              "",
-				"autoscaler.gardener.cloud/max-node-provision-time":              "",
-			}
-			wantedMachineDeployments[0].ClusterAutoscalerAnnotations = testDeployment.Annotations
+		testMachineDeployments := func(wantedMachineDeployments extensionsworkercontroller.MachineDeployments, expectedMachineDeployments []*machinev1alpha1.MachineDeployment) {
 			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Annotations).To(BeNil())
+			for _, expectedMachineDeployment := range expectedMachineDeployments {
+				returnedDeployment := &machinev1alpha1.MachineDeployment{}
+				Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(expectedMachineDeployment), returnedDeployment)).To(Succeed(), expectedMachineDeployment.Name+" should be retrieved successfully")
+				Expect(returnedDeployment).To(Equal(expectedMachineDeployment), "should be equal to expected machine deployment "+expectedMachineDeployment.Name)
+			}
+		}
+
+		When("there are no existing MachineDeployments", func() {
+			It("should correctly deploy multiple machine deployments", func() {
+				wantedMachineDeployments = append(wantedMachineDeployments,
+					buildWantedMachineDeployment("2", machinev1alpha1.InPlaceUpdateMachineDeploymentStrategyType,
+						[]corev1.Taint{
+							{
+								Key:    "taint-key-2",
+								Value:  "taint-value-2",
+								Effect: corev1.TaintEffectNoExecute,
+							},
+						},
+					),
+				)
+
+				expectedMachineDeployments := []*machinev1alpha1.MachineDeployment{
+					buildExpectedMachineDeployment("namespace", 2, "1", wantedMachineDeployments[0]),
+					buildExpectedMachineDeployment("namespace", 2, "1", wantedMachineDeployments[1]),
+				}
+
+				testMachineDeployments(wantedMachineDeployments, expectedMachineDeployments)
+			})
+
+			DescribeTable("verify replica count", testReplicaCount,
+				Entry("should use replicas from state when restoring machine deployment", func() {
+					wantedMachineDeployments[0].State = &shootstate.MachineDeploymentState{
+						Replicas: 5,
+					}
+				}, 5),
+				Entry("should use min replicas when restoring machine deployment without cluster autoscaler", func() {
+					wantedMachineDeployments[0].State = &shootstate.MachineDeploymentState{
+						Replicas: 5,
+					}
+					wantedMachineDeployments[0].Maximum = wantedMachineDeployments[0].Minimum
+					caUsed = false
+				}, 2),
+				Entry("should use min replicas when creating a machine deployment", nil, 2),
+				Entry("should use min replicas when creating a machine deployment without cluster autoscaler", func() {
+					wantedMachineDeployments[0].Maximum = wantedMachineDeployments[0].Minimum
+					caUsed = false
+				}, 2),
+			)
 		})
 
-		It("should not remove non-CA annotation and update CA annotations", func() {
-			// Set non CA annotation
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			metav1.SetMetaDataAnnotation(&returnedDeployment.ObjectMeta, "non-ca-annotation", "")
-			Expect(seedClient.Update(ctx, &returnedDeployment)).To(Succeed())
-			// Update existing CA annotation value and remove another CA annotation
-			wantedMachineDeployments[0].ClusterAutoscalerAnnotations = map[string]string{
-				"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
-				"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
-				"autoscaler.gardener.cloud/scale-down-unneeded-time":             "20m",
-				"autoscaler.gardener.cloud/scale-down-unready-time":              "",
-				"autoscaler.gardener.cloud/max-node-provision-time":              "",
-			}
-			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
-			Expect(err).NotTo(HaveOccurred())
+		When("there are existing MachineDeployments", func() {
+			BeforeEach(func() {
+				testDeployment = &machinev1alpha1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wantedMachineDeployments[0].Name,
+						Namespace: worker.Namespace,
+						Labels: map[string]string{
+							"worker.gardener.cloud/pool": "pool1",
+						},
+						Annotations: map[string]string{
+							"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "0.3",
+							"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+							"autoscaler.gardener.cloud/scale-down-unneeded-time":             "10m",
+							"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+							"autoscaler.gardener.cloud/max-node-provision-time":              "",
+						},
+					},
+					Spec: machinev1alpha1.MachineDeploymentSpec{
+						Replicas: 4,
+					},
+				}
+				Expect(seedClient.Create(ctx, testDeployment)).To(Succeed())
 
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(worker), worker)).To(Succeed())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.ObjectMeta.Annotations).To(Equal(map[string]string{
-				"non-ca-annotation": "",
-				"autoscaler.gardener.cloud/scale-down-unneeded-time": "20m",
-			}))
-		})
+				Expect(seedClient.List(ctx, &existingMachineDeployments)).To(Succeed())
+			})
 
-		It("should not modify replicas of the existing machine deployment if they're within acceptable range", func() {
-			wantedMachineDeployments[0].Minimum = 2
-			wantedMachineDeployments[0].Maximum = 5
-			testDeployment.Spec.Replicas = 4
-			Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
-			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
-				Items: []machinev1alpha1.MachineDeployment{
-					*testDeployment,
-				},
-			}
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(4)))
-			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(4)))
-		})
+			It("should remove all cluster autoscaler annotations", func() {
+				wantedMachineDeployments[0].ClusterAutoscalerAnnotations = map[string]string{
+					"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
+					"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+					"autoscaler.gardener.cloud/scale-down-unneeded-time":             "",
+					"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+					"autoscaler.gardener.cloud/max-node-provision-time":              "",
+				}
 
-		It("should modify replicas of the existing machine deployment to the Minimum", func() {
-			wantedMachineDeployments[0].Minimum = 2
-			wantedMachineDeployments[0].Maximum = 5
-			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
-				Items: []machinev1alpha1.MachineDeployment{
-					*testDeployment,
-				},
-			}
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(0)))
-			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(wantedMachineDeployments[0].Minimum))
-		})
+				err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, false)
+				Expect(err).NotTo(HaveOccurred())
 
-		It("should set deployment replicas to 0 when marked for hibernation", func() {
-			wantedMachineDeployments[0].Minimum = 0
-			wantedMachineDeployments[0].Maximum = 3
-			testDeployment.Spec.Replicas = 2
-			Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
-			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
-				Items: []machinev1alpha1.MachineDeployment{
-					*testDeployment,
-				},
-			}
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(2)))
-			cluster.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: ptr.To(true)}
-			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
-			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(0)))
+				Expect(seedClient.Get(ctx, testDeploymentObjectKey, &returnedDeployment)).To(Succeed())
+				Expect(returnedDeployment.Annotations).To(BeNil())
+			})
+
+			It("should not remove non-CA annotation and update CA annotations", func() {
+				metav1.SetMetaDataAnnotation(&testDeployment.ObjectMeta, "non-ca-annotation", "")
+				Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
+				Expect(seedClient.List(ctx, &existingMachineDeployments)).To(Succeed())
+
+				wantedMachineDeployments[0].ClusterAutoscalerAnnotations = map[string]string{
+					"autoscaler.gardener.cloud/scale-down-utilization-threshold":     "",
+					"autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold": "",
+					"autoscaler.gardener.cloud/scale-down-unneeded-time":             "20m",
+					"autoscaler.gardener.cloud/scale-down-unready-time":              "",
+					"autoscaler.gardener.cloud/max-node-provision-time":              "",
+				}
+				err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(seedClient.Get(ctx, testDeploymentObjectKey, &returnedDeployment)).To(Succeed())
+				Expect(returnedDeployment.ObjectMeta.Annotations).To(And(HaveKeyWithValue("non-ca-annotation", ""), HaveKeyWithValue("autoscaler.gardener.cloud/scale-down-unneeded-time", "20m")))
+			})
+
+			It("should correctly deploy multiple machine deployments", func() {
+				wantedMachineDeployments = append(wantedMachineDeployments,
+					buildWantedMachineDeployment("2", machinev1alpha1.InPlaceUpdateMachineDeploymentStrategyType,
+						[]corev1.Taint{
+							{
+								Key:    "taint-key-2",
+								Value:  "taint-value-2",
+								Effect: corev1.TaintEffectNoExecute,
+							},
+						},
+					),
+				)
+
+				expectedMachineDeployments := []*machinev1alpha1.MachineDeployment{
+					buildExpectedMachineDeployment("namespace", 4, "2", wantedMachineDeployments[0]),
+					buildExpectedMachineDeployment("namespace", 2, "1", wantedMachineDeployments[1]),
+				}
+
+				testMachineDeployments(wantedMachineDeployments, expectedMachineDeployments)
+			})
+
+			DescribeTable("verify replica count", testReplicaCount,
+				Entry("should keep existing replicas when restoring machine deployment", func() {
+					wantedMachineDeployments[0].State = &shootstate.MachineDeploymentState{
+						Replicas: 4,
+					}
+				}, 4),
+				Entry("should set replicas to min when restoring machine deployment without cluster autoscaler", func() {
+					wantedMachineDeployments[0].State = &shootstate.MachineDeploymentState{
+						Replicas: 5,
+					}
+					wantedMachineDeployments[0].Maximum = wantedMachineDeployments[0].Minimum
+					caUsed = false
+				}, 2),
+				Entry("should not modify replicas of the existing machine deployment if they're within acceptable range", nil, 4),
+				Entry("should set replicas to min when deploying a machine deployment without cluster autoscaler", func() {
+					wantedMachineDeployments[0].Maximum = wantedMachineDeployments[0].Minimum
+					caUsed = false
+				}, 2),
+				Entry("should set deployment replicas to 0 when marked for hibernation", func() {
+					cluster.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+						Enabled: ptr.To(true),
+					}
+				}, 0),
+				Entry("should set replicas to min when cluster autoscaler is not used", func() {
+					wantedMachineDeployments[0].Maximum = wantedMachineDeployments[0].Minimum
+					caUsed = false
+				}, 2),
+				Entry("should modify replicas of the existing machine deployment to the minimum", func() {
+					testDeployment.Spec.Replicas = 1
+					Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
+					Expect(seedClient.List(ctx, &existingMachineDeployments)).To(Succeed())
+				}, 2),
+				Entry("should set replicas to max when replicas are above maximum", func() {
+					testDeployment.Spec.Replicas = 15
+					Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
+					Expect(seedClient.List(ctx, &existingMachineDeployments)).To(Succeed())
+				}, 10),
+			)
+
+			It("should mark all machines for forceful deletion when shoot is hibernated", func() {
+				machine1 := &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-1",
+						Namespace: worker.Namespace,
+					},
+				}
+				machine2 := &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-2",
+						Namespace: worker.Namespace,
+						Labels: map[string]string{
+							"worker.gardener.cloud/name": worker.Name,
+						},
+					},
+				}
+				machine3 := &machinev1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-3",
+						Namespace: worker.Namespace,
+						Labels: map[string]string{
+							"worker.gardener.cloud/name": worker.Name,
+							"force-deletion":             "True",
+						},
+					},
+				}
+
+				for _, machine := range []*machinev1alpha1.Machine{machine1, machine2, machine3} {
+					Expect(seedClient.Create(ctx, machine)).To(Succeed(), machine.Name+" should be created successfully")
+				}
+
+				cluster.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
+					Enabled: ptr.To(true),
+				}
+
+				err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, machine := range []*machinev1alpha1.Machine{machine1, machine2, machine3} {
+					var returnedMachine machinev1alpha1.Machine
+					Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(machine), &returnedMachine)).To(Succeed(), machine.Name+" should be retrieved successfully")
+					Expect(returnedMachine.Labels).To(HaveKeyWithValue("force-deletion", "True"), machine.Name+" should have `force-deletion: True` annotation")
+				}
+			})
 		})
 	})
+
 	Describe("#updateWorkerStatusInPlaceUpdateWorkerPoolHash", func() {
 		var (
 			ctx        context.Context

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -172,7 +172,7 @@ func restoreMachineSetsAndMachines(ctx context.Context, log logr.Logger, cl clie
 		}
 	}
 
-	return flow.ParallelN(maxConcurrentMachineTasks, taskFns...)(ctx)
+	return flow.ParallelN(MaxConcurrentMachineTasks, taskFns...)(ctx)
 }
 
 func removeWantedDeploymentWithoutState(wantedMachineDeployments extensionsworkercontroller.MachineDeployments) extensionsworkercontroller.MachineDeployments {

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -147,11 +147,6 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		return nil, err
 	}
 
-	seedChartApplier, err := kubernetesclient.NewChartApplierForConfig(d.restConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	return NewWorkerDelegate(
 		ctx,
 		logf.FromContext(ctx),
@@ -159,7 +154,6 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		d.restConfig,
 		d.decoder,
 		d.scheme,
-		seedChartApplier,
 		serverVersion.GitVersion,
 		worker,
 		cluster,
@@ -179,7 +173,6 @@ type workerDelegate struct {
 	decoder        runtime.Decoder
 	scheme         *runtime.Scheme
 
-	seedChartApplier    kubernetesclient.ChartApplier
 	podExecutor         kubernetesclient.PodExecutor
 	serverVersion       string
 	cloudProfileConfig  *api.CloudProfileConfig
@@ -199,7 +192,6 @@ func NewWorkerDelegate(
 	restConfig *rest.Config,
 	decoder runtime.Decoder,
 	scheme *runtime.Scheme,
-	seedChartApplier kubernetesclient.ChartApplier,
 	serverVersion string,
 	worker *extensionsv1alpha1.Worker,
 	cluster *extensionscontroller.Cluster,
@@ -244,7 +236,6 @@ func NewWorkerDelegate(
 		runtimeClient:      runtimeClient,
 		providerClient:     providerClient,
 		decoder:            decoder,
-		seedChartApplier:   seedChartApplier,
 		podExecutor:        podExecutor,
 		serverVersion:      serverVersion,
 		cloudProfileConfig: config,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/area scalability
/area performance
/kind enhancement

**What this PR does / why we need it**:
This PR parallelises the deployment of `MachineDeployment`s across 50 go routines.
This is needed to speed up the reconciliation of the `Worker` resource in cases where there is high latency between the provider extension and the `Seed`'s kube-apiserver.

Along the way, I also modified the function that is used to mark `Machine`s to be forcefully deleted to use `Patch` instead of `Update` as it was also called by the `deployMachineDeployments` func when the `Shoot` is hibernated, and I also moved it outside of the for loop that deploys each `MachineDeployment` so that it is executed only once. I do not immediately see any issue with the latter, however, it was added a long time ago in the for loop so I'm not sure if there was any concrete reason for it to be there - only thing that comes to mind is to not be called if there are no `MachineDeployment`s, however that should technically never happen if the shoot is not workerless.

Same as https://github.com/gardener/gardener/pull/14219 I opted to not expose the configuration of the number of parallel deployments. Running across 50 workers seems fine and already greatly reduces the total deployment time.

**Which issue(s) this PR fixes**:
Part of #14137

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
During `Shoot` reconciliation `MachineDeployment`s are now deployed in parallel. This should speed up the reconciliation of the `Worker` resource.
```
```other operator
`Patch` is now used to label all `Machine`s with `force-deletion: True` instead of `Update` when the `Shoot` is being hibernated or deleted. Additionally, the function used to do this during the reconciliation of the `Worker` resource is now only executed once instead of for each `MachineDeployment`.
```