### PR TITLE
gardenadm: Properly disable the `vpa-in-place-updates` webhook

### DIFF
--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -49,7 +49,7 @@ func runtimeGardenerResourceManagerDefaultValues() resourcemanager.Values {
 			}},
 		},
 		PodTopologySpreadConstraintsEnabled: false,
-		VPAInPlaceUpdatesEnabled:            true,
+		VPAInPlaceUpdatesEnabled:            false,
 		Replicas:                            ptr.To[int32](2),
 		ResourceClass:                       ptr.To(v1beta1constants.SeedResourceManagerClass),
 		ResponsibilityMode:                  resourcemanager.ForRuntime,

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ResourceManager", func() {
 					}},
 				},
 				PodTopologySpreadConstraintsEnabled: false,
-				VPAInPlaceUpdatesEnabled:            true,
+				VPAInPlaceUpdatesEnabled:            false,
 				Replicas:                            ptr.To[int32](2),
 				ResourceClass:                       ptr.To("seed"),
 				ResponsibilityMode:                  resourcemanager.ForRuntime,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind flake
/kind bug
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/14145 we disabled in the `VPAInPlaceUpdates` feature gate for gardenadm because:
1. enabling the `vpa-in-place-updates` webhook is not needed as gardenadm at the moment does not deploy the VPA components
2. enabling the `vpa-in-place-updates` webhook causes issues with the init flow. The issue is described more in https://github.com/gardener/gardener/pull/14145.
3. we aim to remove the `vpa-in-place-updates` webhook when the `VPAInPlaceUpdates` feature gate is promoted to GA

However, for the runtime gardener-resource-manager for gardenadm the webhook is still enabled.
The gardenadm botanist creates a new runtime GRM in https://github.com/gardener/gardener/blob/d6effc0a1157493cf38ab5b32874bce80541ff2f/pkg/gardenadm/botanist/botanist.go#L163. In https://github.com/gardener/gardener/blob/355bb0e79c32b2114d49e547bdddd764f5a6f7b7/pkg/gardenadm/botanist/resource_manager.go#L24, the `VPAInPlaceUpdatesEnabled` value is `false` because we disable the feature gate for gardenadm. However, in https://github.com/gardener/gardener/blob/dae93c7caec00afd50ed39ad8c54b9d16bef94e2/pkg/component/shared/resourcemanager.go#L76-L79 the default values are merged with the provided values. The default value for `VPAInPlaceUpdatesEnabled` is true - https://github.com/gardener/gardener/blob/dae93c7caec00afd50ed39ad8c54b9d16bef94e2/pkg/component/shared/resourcemanager.go#L52. This overwrites the provided value for `VPAInPlaceUpdatesEnabled=false` as the field is of type bool as its default value is anyways false.

To fix this, this PR sets `VPAInPlaceUpdatesEnabled=false` in the default runtime GRM values.

Before:
```
root@machine-0:/# k get mutatingwebhookconfigurations gardener-resource-manager -o json | jq -r '.webhooks[].name'
projected-token-mount.resources.gardener.cloud
high-availability-config.resources.gardener.cloud
vpa-in-place-updates.resources.gardener.cloud
```

After:

```
root@machine-0:/# k get mutatingwebhookconfigurations gardener-resource-manager -o json | jq -r '.webhooks[].name'
projected-token-mount.resources.gardener.cloud
high-availability-config.resources.gardener.cloud
```

This issue also prevents the `VPAInPlaceUpdates` feature gate to be disabled.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14145

**Special notes for your reviewer**:
This should also fix `pull-gardener-e2e-kind-gardenadm` flakes like https://github.com/gardener/gardener/pull/14165#issuecomment-3996118858.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
