### PR TITLE
Fix version in deprecation notice of provider-extensions setup

### DIFF
--- a/docs/deployment/getting_started_locally_with_extensions.md
+++ b/docs/deployment/getting_started_locally_with_extensions.md
@@ -3,5 +3,5 @@
 > [!CAUTION]
 > This scenario does not work anymore. It is replaced by the [`getting started remotely`](getting_started_remotely.md) scenario.
 > 
-> All its content is removed from the repository. If you own a running setup, please check out [Gardener@v1.136.0](https://github.com/gardener/gardener/releases/tag/v1.136.0) or earlier to delete it.
+> All its content is removed from the repository. If you own a running setup, please check out [Gardener@v1.137.0](https://github.com/gardener/gardener/releases/tag/v1.137.0) or earlier to delete it.
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
`provider-extension` setup will be removed in Gardener v1.138.0 (see PR #13994).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
