### PR TITLE
[GEP-35] Victoria-Operator: Prefer Explicit Set of Verbs instead of Wildcard

### DIFF
--- a/pkg/component/observability/logging/victoria/operator/victoria_operator.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator.go
@@ -312,7 +312,7 @@ func (v *victoriaOperator) clusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"vlsingles", "vlsingles/finalizers", "vlsingles/status",
 				},
-				Verbs: []string{"*"},
+				Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
 				APIGroups: []string{"coordination.k8s.io"},

--- a/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator_test.go
@@ -315,7 +315,7 @@ var _ = Describe("VictoriaOperator", func() {
 					Resources: []string{
 						"vlsingles", "vlsingles/finalizers", "vlsingles/status",
 					},
-					Verbs: []string{"*"},
+					Verbs: []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 				},
 				{
 					APIGroups: []string{"coordination.k8s.io"},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind cleanup

**What this PR does / why we need it**:
Simple change to comply with rules that prefer explicit set of verbs instead of the use of a wildcard.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
