### PR TITLE
[resource-manager] Fix GVR construction for non-`apps/v1` resources in progressing health controller

### DIFF
--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -83,18 +82,17 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 		"certificates":  &certv1alpha1.Certificate{},
 		"issuers":       &certv1alpha1.Issuer{},
 	} {
-		gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
+		gvk, err := apiutil.GVKForObject(obj, r.TargetClient.Scheme())
 		if err != nil {
 			return fmt.Errorf("cannot determine GVK for object %T: %w", obj, err)
 		}
-		gvr := schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: resource}
 
-		if _, err := targetCluster.GetRESTMapper().KindFor(gvr); err != nil {
+		if _, err = targetCluster.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
 			if !meta.IsNoMatchError(err) {
 				return err
 			}
-			c.GetLogger().Info("Resource is not available/enabled API of the target cluster, skip adding watches", "gvr", gvr)
 
+			c.GetLogger().Info("Resource is not available/enabled API of the target cluster, skip adding watches", "gvk", gvk)
 			continue
 		}
 

--- a/pkg/resourcemanager/controller/health/progressing/add.go
+++ b/pkg/resourcemanager/controller/health/progressing/add.go
@@ -6,6 +6,7 @@ package progressing
 
 import (
 	"context"
+	"fmt"
 
 	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/go-logr/logr"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -81,7 +83,11 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, sour
 		"certificates":  &certv1alpha1.Certificate{},
 		"issuers":       &certv1alpha1.Issuer{},
 	} {
-		gvr := schema.GroupVersionResource{Group: appsv1.SchemeGroupVersion.Group, Version: appsv1.SchemeGroupVersion.Version, Resource: resource}
+		gvk, err := apiutil.GVKForObject(obj, mgr.GetScheme())
+		if err != nil {
+			return fmt.Errorf("cannot determine GVK for object %T: %w", obj, err)
+		}
+		gvr := schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: resource}
 
 		if _, err := targetCluster.GetRESTMapper().KindFor(gvr); err != nil {
 			if !meta.IsNoMatchError(err) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

 /area control-plane                                                                                                                                                                                                                
  /kind bug     

**What this PR does / why we need it**:
The progressing health controller watches several resource types to trigger re-evaluation of the `Progressing` condition. When setting up these watches, a `GroupVersionResource` is constructed to check whether the resource is available in the target cluster's API. However, the GVR was always built using `appsv1.SchemeGroupVersion` (group `apps`, version `v1`) — even for `Prometheus`, `Alertmanager` (group `monitoring.coreos.com`, version `v1`) and `Certificate`, `Issuer` (group `cert.gardener.cloud`, version `v1alpha1`).

As a result, the REST mapper lookup for those four resource types always returned a no-match error, causing their watches to be silently skipped. The controller would never react to changes in those resources.

The fix derives the group and version dynamically from each object's registered GVK via `apiutil.GVKForObject`, so the correct GVR is used for every resource type.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```