### PR TITLE
Use a static prefix in `{Admin,Viewer}KubeconfigRequest`

### DIFF
--- a/docs/usage/shoot/shoot_access.md
+++ b/docs/usage/shoot/shoot_access.md
@@ -10,7 +10,7 @@ After creation of a shoot cluster, end-users require a `kubeconfig` to access it
 
 The [`shoots/adminkubeconfig`](https://github.com/gardener/enhancements/tree/main/geps/0016-adminkubeconfig-subresource) subresource allows users to dynamically generate temporary `kubeconfig`s that can be used to access shoot cluster with `cluster-admin` privileges. The credentials associated with this `kubeconfig` are client certificates which have a very short validity and must be renewed before they expire (by calling the subresource endpoint again).
 
-The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with a random prefix added in front.
+The username associated with such `kubeconfig` will be the same which is used for authenticating to the Gardener API, with the prefix `gardener.cloud:admin:` added in front.
 If the user is considered Gardener system administrator, i.e. has the permissions to read all secrets in the Garden cluster, then the group `gardener.cloud:system:admins` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:admins`.
 The created `kubeconfig` will not be persisted anywhere.
 
@@ -118,9 +118,10 @@ v1 = client.CoreV1Api(shoot_api_client)
 
 ## `shoots/viewerkubeconfig` Subresource
 
-The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource) with two differences.
-One is that it returns a kubeconfig with read-only access for all APIs except the `core/v1.Secret` API and the resources which are specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot (see [this document](../security/etcd_encryption_config.md)).
-The other difference is the group associated with the `kubeconfig` - if the user is considered Gardener system viewer, i.e. has the permissions to read all projects in the Garden cluster, then the group `gardener.cloud:system:viewers` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:viewers`.
+The `shoots/viewerkubeconfig` subresource works similar to the [`shoots/adminkubeconfig`](#shootsadminkubeconfig-subresource) with the following differences:
+- The username has a `gardener.cloud:viewer:` prefix instead of `gardener.cloud:admin:`.
+- The returned kubeconfig grants users read-only access for all APIs. Exceptions apply to `Secret`s and resources specified in the `spec.kubernetes.kubeAPIServer.encryptionConfig` field of the Shoot (see [this document](../security/etcd_encryption_config.md)), which are not accessible doe to security reasons.
+- A different group is associated with the `kubeconfig` - if the user is considered Gardener system viewer, i.e. has the permissions to read all projects in the Garden cluster, then the group `gardener.cloud:system:viewers` is associated with the `kubeconfig`, otherwise the group `gardener.cloud:project:viewers`.
 
 In order to request such a `kubeconfig`, you can run almost the same code as above - the only difference is that you need to use the `viewerkubeconfig` subresource.
 For example, in bash this looks like this:

--- a/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig.go
@@ -47,6 +47,7 @@ func NewAdminKubeconfigREST(
 			return &authenticationv1alpha1.AdminKubeconfigRequest{}
 		},
 		userGroupsFunc: getAdminUserGroups,
+		userNamePrefix: "gardener.cloud:admin:",
 	}
 }
 

--- a/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -40,5 +40,6 @@ var _ = Describe("Admin Kubeconfig", func() {
 		},
 		ConsistOf("gardener.cloud:system:admins"),
 		ConsistOf("gardener.cloud:project:admins"),
+		"gardener.cloud:admin:",
 	)
 })

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
@@ -46,6 +45,7 @@ type KubeconfigREST struct {
 	gvk            schema.GroupVersionKind
 	newObjectFunc  func() runtime.Object
 	userGroupsFunc func(context.Context, user.Info, clientauthorizationv1.SubjectAccessReviewInterface) ([]string, error)
+	userNamePrefix string
 }
 
 var (
@@ -156,19 +156,13 @@ func (r *KubeconfigREST) Create(ctx context.Context, name string, obj runtime.Ob
 		kubeconfigRequest.Spec.ExpirationSeconds = r.maxExpirationSeconds
 	}
 
-	// generate a random user name prefix to avoid conflicts with (cluster)role bindings for existing users
-	userNamePrefix, err := utils.GenerateRandomString(10)
-	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to generate user name prefix: %w", err))
-	}
-
 	var (
 		validity = time.Duration(kubeconfigRequest.Spec.ExpirationSeconds) * time.Second
 		authName = fmt.Sprintf("%s--%s", shoot.Namespace, shoot.Name)
 		cpsc     = secrets.ControlPlaneSecretConfig{
 			Name: authName,
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				CommonName:   userNamePrefix + ":" + userInfo.GetName(),
+				CommonName:   r.userNamePrefix + userInfo.GetName(),
 				Organization: groups,
 				CertType:     secrets.ClientCert,
 				Validity:     &validity,

--- a/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/kubeconfig_test.go
@@ -44,6 +44,7 @@ func kubeconfigTests(
 	getKubeconfig func(runtime.Object) []byte,
 	systemOrganizationMatcher gomegatypes.GomegaMatcher,
 	projectOrganizationMatcher gomegatypes.GomegaMatcher,
+	userNamePrefix string,
 ) {
 	var (
 		ctx context.Context
@@ -332,7 +333,7 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 			cert, err := x509.ParseCertificate(certPem.Bytes)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(cert.Subject.CommonName).To(HaveSuffix(":" + userName))
+			Expect(cert.Subject.CommonName).To(Equal(userNamePrefix + userName))
 			Expect(cert.Subject.Organization).To(organizationMatcher)
 			Expect(cert.NotAfter.Unix()).To(Equal(getExpirationTimestamp(actual).Unix())) // certificates do not have nano seconds in them
 			Expect(cert.NotBefore.UTC()).To(Equal(secretsutils.AdjustToClockSkew(time.Unix(10, 0).UTC())))

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig.go
@@ -47,6 +47,7 @@ func NewViewerKubeconfigREST(
 			return &authenticationv1alpha1.ViewerKubeconfigRequest{}
 		},
 		userGroupsFunc: getViewerUserGroups,
+		userNamePrefix: "gardener.cloud:viewer:",
 	}
 }
 

--- a/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig_test.go
+++ b/pkg/apiserver/registry/core/shoot/storage/viewer_kubeconfig_test.go
@@ -40,5 +40,6 @@ var _ = Describe("Viewer Kubeconfig", func() {
 		},
 		ConsistOf("gardener.cloud:system:viewers"),
 		ConsistOf("gardener.cloud:project:viewers"),
+		"gardener.cloud:viewer:",
 	)
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Replaces the random user prefix in favor of a static `gardener.cloud:admin:` or `gardener.cloud:viewer:` prefix for generating kubeconfigs. See #14181 for more details.

**Which issue(s) this PR fixes**:
Fixes #14181

**Special notes for your reviewer**:

/cc @vlerenc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`AdminKubeconfigRequest` now uses the static username prefix `gardener.cloud:admin:`, and `ViewerKubeconfigRequest` uses `gardener.cloud:viewer:` to generate the username for the resulting kubeconfig. Previously, this prefix was randomized."
```
