### PR TITLE
[GEP-28] Garden cluster access for extensions in self-hosted shoot clusters 

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -396,8 +396,9 @@ func (g *garden) Start(ctx context.Context) error {
 						// Gardenlet does not have the required RBAC permissions for listing/watching the following
 						// resources on cluster level. Hence, we need to watch them individually with the help of a
 						// SingleObject cache.
-						&corev1.ConfigMap{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
-						&corev1.Secret{}:    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
+						&corev1.ConfigMap{}:      kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
+						&corev1.Secret{}:         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
+						&corev1.ServiceAccount{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
 					},
 					kubernetes.GardenScheme,
 				)(config, opts)

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -136,10 +136,11 @@ If no such objects exist, then it removes the finalizer and allows the deletion.
 This reconciler watches two resources in the garden cluster:
 
 - `ClusterRole`s labelled with `authorization.gardener.cloud/custom-extensions-permissions=true`
-- `ServiceAccount`s in seed namespaces matching the selector provided via the `authorization.gardener.cloud/extensions-serviceaccount-selector` annotation of such `ClusterRole`s.
+- `ServiceAccount`s in seed namespaces, the `garden` namespace, and project namespaces (`garden-*`) matching the selector provided via the `authorization.gardener.cloud/extensions-serviceaccount-selector` annotation of such `ClusterRole`s.
 
 Its core task is to maintain a `ClusterRoleBinding` resource referencing the respective `ClusterRole`.
-This gets bound to all `ServiceAccount`s in seed namespaces whose labels match the selector provided via the `authorization.gardener.cloud/extensions-serviceaccount-selector` annotation of such `ClusterRole`s.
+This gets bound to all extension `ServiceAccount`s whose labels match the selector provided via the `authorization.gardener.cloud/extensions-serviceaccount-selector` annotation of such `ClusterRole`s.
+`ServiceAccount`s are considered from seed namespaces (all names), the `garden` namespace, and project namespaces (`garden-*`), but only those whose name is prefixed with `extension-shoot--` in the latter two cases (i.e., extension clients of self-hosted shoot clusters).
 
 You can read more about the purpose of this reconciler in [this document](../extensions/garden-api-access.md#additional-permissions).
 

--- a/docs/extensions/garden-api-access.md
+++ b/docs/extensions/garden-api-access.md
@@ -171,7 +171,7 @@ rules:
 Note the label `authorization.gardener.cloud/extensions-serviceaccount-selector` which contains a label selector for `ServiceAccount`s.
 
 There is a controller part of `gardener-controller-manager` which takes care of maintaining the respective `ClusterRoleBinding` resources.
-It binds all `ServiceAccount`s in the seed namespaces in the garden cluster (i.e., all extension clients) whose labels match.
+It binds all extension `ServiceAccount`s in the garden cluster whose labels match: those in seed namespaces (all names), the `garden` namespace, and project namespaces (`garden-*`) — where the latter two are restricted to `ServiceAccount`s whose name is prefixed with `extension-shoot--` (i.e., extension clients of self-hosted shoot clusters).
 You can read more about this controller [here](../concepts/controller-manager.md#-extension-clusterrole--reconciler).
 
 #### Custom Permissions

--- a/extensions/pkg/controller/selfhostedshootexposure/controller.go
+++ b/extensions/pkg/controller/selfhostedshootexposure/controller.go
@@ -19,7 +19,7 @@ import (
 const (
 	// FinalizerName is the selfhostedshootexposure controller finalizer.
 	FinalizerName = "extensions.gardener.cloud/selfhostedshootexposure"
-	// ControllerName is the name of the controller
+	// ControllerName is the name of the controller.
 	ControllerName = "selfhostedshootexposure"
 )
 

--- a/pkg/admissioncontroller/gardenletidentity/shoot/identity.go
+++ b/pkg/admissioncontroller/gardenletidentity/shoot/identity.go
@@ -110,17 +110,17 @@ func getIdentityForServiceAccountsGroup(u user.Info) (namespace string, name str
 		return "", "", false, ""
 	}
 
-	// SA must be in the garden namespace or a project namespace (garden-<project>).
+	// The SA must be in the garden namespace or a project namespace (garden-<project>).
 	if saNamespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(saNamespace, gardenerutils.ProjectNamespacePrefix) {
 		return "", "", false, ""
 	}
 
-	// SA name must start with the extension-shoot-- prefix.
+	// The SA name must start with the extension-shoot-- prefix.
 	if !strings.HasPrefix(saName, v1beta1constants.ExtensionShootServiceAccountPrefix) {
 		return "", "", false, ""
 	}
 
-	// Parse: extension-shoot--<shoot-name>--<controller-installation-name>
+	// Parse: extension-shoot--<shoot-name>--<controller-installation-name>.
 	withoutPrefix := strings.TrimPrefix(saName, v1beta1constants.ExtensionShootServiceAccountPrefix)
 	shootName, _, found := strings.Cut(withoutPrefix, "--")
 	if !found || shootName == "" {

--- a/pkg/admissioncontroller/gardenletidentity/shoot/identity.go
+++ b/pkg/admissioncontroller/gardenletidentity/shoot/identity.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/admissioncontroller/gardenletidentity"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // FromUserInfoInterface returns the shoot namespace and name, a boolean indicating whether the provided user is an
@@ -103,8 +104,28 @@ func userTypeFromPrefix(prefix string) gardenletidentity.UserType {
 	return ""
 }
 
-func getIdentityForServiceAccountsGroup(_ user.Info) (namespace string, name string, isSelfHostedShoot bool, userType gardenletidentity.UserType) {
-	// TODO(rfranzke): Implement this function once the concept of how extensions running in self-hosted shoots
-	//  authenticate with the garden cluster gets clear.
-	return "", "", false, gardenletidentity.UserTypeExtension
+func getIdentityForServiceAccountsGroup(u user.Info) (namespace string, name string, isSelfHostedShoot bool, userType gardenletidentity.UserType) {
+	saNamespace, saName, err := serviceaccount.SplitUsername(u.GetName())
+	if err != nil {
+		return "", "", false, ""
+	}
+
+	// SA must be in the garden namespace or a project namespace (garden-<project>).
+	if saNamespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(saNamespace, gardenerutils.ProjectNamespacePrefix) {
+		return "", "", false, ""
+	}
+
+	// SA name must start with the extension-shoot-- prefix.
+	if !strings.HasPrefix(saName, v1beta1constants.ExtensionShootServiceAccountPrefix) {
+		return "", "", false, ""
+	}
+
+	// Parse: extension-shoot--<shoot-name>--<controller-installation-name>
+	withoutPrefix := strings.TrimPrefix(saName, v1beta1constants.ExtensionShootServiceAccountPrefix)
+	shootName, _, found := strings.Cut(withoutPrefix, "--")
+	if !found || shootName == "" {
+		return "", "", false, ""
+	}
+
+	return saNamespace, shootName, true, gardenletidentity.UserTypeExtension
 }

--- a/pkg/admissioncontroller/gardenletidentity/shoot/identity_test.go
+++ b/pkg/admissioncontroller/gardenletidentity/shoot/identity_test.go
@@ -34,7 +34,12 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but shoot group not present", &user.DefaultInfo{Name: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"bar"}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix and shoot group", &user.DefaultInfo{Name: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenlet),
 		Entry("gardenadm usertype", &user.DefaultInfo{Name: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenadm),
-		Entry("Extension ServiceAccount", &user.DefaultInfo{Name: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}}, "", "", false, gardenletidentity.UserTypeExtension),
+		Entry("Extension ServiceAccount in non-project namespace", &user.DefaultInfo{Name: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}}, "", "", false, gardenletidentity.UserType("")),
+		Entry("Extension ServiceAccount missing extension-shoot-- prefix", &user.DefaultInfo{Name: "system:serviceaccount:garden-my-project:extension-myshoot--myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden-my-project"}}, "", "", false, gardenletidentity.UserType("")),
+		Entry("Extension ServiceAccount with valid extension-shoot-- prefix in project namespace", &user.DefaultInfo{Name: "system:serviceaccount:garden-my-project:extension-shoot--myshoot--myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden-my-project"}}, "garden-my-project", "myshoot", true, gardenletidentity.UserTypeExtension),
+		Entry("Extension ServiceAccount with valid extension-shoot-- prefix in garden namespace", &user.DefaultInfo{Name: "system:serviceaccount:garden:extension-shoot--myshoot--myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden"}}, "garden", "myshoot", true, gardenletidentity.UserTypeExtension),
+		Entry("Extension ServiceAccount missing shoot name separator", &user.DefaultInfo{Name: "system:serviceaccount:garden-my-project:extension-shoot--myshoot", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden-my-project"}}, "", "", false, gardenletidentity.UserType("")),
+		Entry("Extension ServiceAccount with empty shoot name", &user.DefaultInfo{Name: "system:serviceaccount:garden-my-project:extension-shoot----myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden-my-project"}}, "", "", false, gardenletidentity.UserType("")),
 	)
 
 	DescribeTable("#FromAuthenticationV1UserInfo",
@@ -52,7 +57,9 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but shoot group not present", authenticationv1.UserInfo{Username: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"bar"}}, "", "", false, gardenletidentity.UserType("")),
 		Entry("user name prefix and shoot group", authenticationv1.UserInfo{Username: "gardener.cloud:system:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenlet),
 		Entry("gardenadm usertype", authenticationv1.UserInfo{Username: "gardener.cloud:gardenadm:shoot:foo:bar", Groups: []string{"gardener.cloud:system:shoots"}}, "foo", "bar", true, gardenletidentity.UserTypeGardenadm),
-		Entry("Extension ServiceAccount", authenticationv1.UserInfo{Username: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}, Extra: map[string]authenticationv1.ExtraValue{}}, "", "", false, gardenletidentity.UserTypeExtension),
+		Entry("Extension ServiceAccount in non-project namespace", authenticationv1.UserInfo{Username: "system:serviceaccount:foo:extension-bar", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"}, Extra: map[string]authenticationv1.ExtraValue{}}, "", "", false, gardenletidentity.UserType("")),
+		Entry("Extension ServiceAccount with valid extension-shoot-- prefix in project namespace", authenticationv1.UserInfo{Username: "system:serviceaccount:garden-my-project:extension-shoot--myshoot--myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden-my-project"}}, "garden-my-project", "myshoot", true, gardenletidentity.UserTypeExtension),
+		Entry("Extension ServiceAccount with valid extension-shoot-- prefix in garden namespace", authenticationv1.UserInfo{Username: "system:serviceaccount:garden:extension-shoot--myshoot--myext", Groups: []string{"system:serviceaccounts", "system:serviceaccounts:garden"}}, "garden", "myshoot", true, gardenletidentity.UserTypeExtension),
 	)
 
 	DescribeTable("#FromCertificateSigningRequest",

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
@@ -180,8 +180,8 @@ func (h *Handler) admitLease(gardenletShootInfo types.NamespacedName, userType g
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
 	}
 
-	// extension clients may only create leases in the shoot namespace and whose name is prefixed with
-	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace
+	// Extension clients may only create leases in the shoot namespace and whose name is prefixed with
+	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace.
 	if userType == gardenletidentity.UserTypeExtension {
 		if request.Namespace != gardenletShootInfo.Namespace {
 			return admission.Errored(http.StatusForbidden, fmt.Errorf("extension client can only create leases in the namespace for shoot %q", gardenletShootInfo))

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
@@ -45,6 +45,7 @@ var (
 	leaseResource                     = coordinationv1.Resource("leases")
 	projectResource                   = gardencorev1beta1.Resource("projects")
 	secretResource                    = corev1.Resource("secrets")
+	serviceAccountResource            = corev1.Resource("serviceaccounts")
 	shootResource                     = gardencorev1beta1.Resource("shoots")
 	shootStateResource                = gardencorev1beta1.Resource("shootstates")
 	workloadIdentityResource          = securityv1alpha1.Resource("workloadidentities")
@@ -86,6 +87,9 @@ func (h *Handler) Handle(ctx context.Context, request admission.Request) admissi
 
 	case secretResource:
 		return h.admitSecret(ctx, gardenletShootInfo, request)
+
+	case serviceAccountResource:
+		return h.admitServiceAccount(gardenletShootInfo, userType, request)
 
 	case shootStateResource:
 		return h.admitShootState(gardenletShootInfo, request)
@@ -189,6 +193,25 @@ func (h *Handler) admitLease(gardenletShootInfo types.NamespacedName, userType g
 	}
 
 	return h.admitCreateWithResourcePrefix(gardenletShootInfo, request)
+}
+
+func (h *Handler) admitServiceAccount(gardenletShootInfo types.NamespacedName, userType gardenletidentity.UserType, request admission.Request) admission.Response {
+	if request.Operation != admissionv1.Create {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
+	}
+
+	if userType == gardenletidentity.UserTypeExtension {
+		return admission.Errored(http.StatusForbidden, fmt.Errorf("extension client may not create ServiceAccounts"))
+	}
+
+	// Allow gardenlet to create service accounts for extensions in the shoot's project namespace.
+	// The SA name must be prefixed with extension-shoot--<shootName>-- to scope to this shoot.
+	if request.Namespace == gardenletShootInfo.Namespace &&
+		strings.HasPrefix(request.Name, v1beta1constants.ExtensionShootServiceAccountPrefix+gardenletShootInfo.Name+"--") {
+		return admission.Allowed("")
+	}
+
+	return admission.Errored(http.StatusForbidden, fmt.Errorf("object does not belong to shoot %s", gardenletShootInfo))
 }
 
 func (h *Handler) admitCreateWithResourcePrefix(gardenletShootInfo types.NamespacedName, request admission.Request) admission.Response {

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
@@ -82,7 +82,7 @@ func (h *Handler) Handle(ctx context.Context, request admission.Request) admissi
 		return h.admitCreateWithResourcePrefix(gardenletShootInfo, request)
 
 	case leaseResource:
-		return h.admitCreateWithResourcePrefix(gardenletShootInfo, request)
+		return h.admitLease(gardenletShootInfo, userType, request)
 
 	case secretResource:
 		return h.admitSecret(ctx, gardenletShootInfo, request)
@@ -169,6 +169,26 @@ func (h *Handler) admit(gardenletShootInfo, objectShootInfo types.NamespacedName
 	}
 
 	return admission.Errored(http.StatusForbidden, fmt.Errorf("object does not belong to shoot %s", gardenletShootInfo))
+}
+
+func (h *Handler) admitLease(gardenletShootInfo types.NamespacedName, userType gardenletidentity.UserType, request admission.Request) admission.Response {
+	if request.Operation != admissionv1.Create {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
+	}
+
+	// extension clients may only create leases in the shoot namespace and whose name is prefixed with
+	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace
+	if userType == gardenletidentity.UserTypeExtension {
+		if request.Namespace != gardenletShootInfo.Namespace {
+			return admission.Errored(http.StatusForbidden, fmt.Errorf("extension client can only create leases in the namespace for shoot %q", gardenletShootInfo))
+		}
+		if !strings.HasPrefix(request.Name, gardenletShootInfo.Name+"--") {
+			return admission.Errored(http.StatusForbidden, fmt.Errorf("extension client can only create leases with the shoot name %q as prefix", gardenletShootInfo.Name))
+		}
+		return admission.Allowed("")
+	}
+
+	return h.admitCreateWithResourcePrefix(gardenletShootInfo, request)
 }
 
 func (h *Handler) admitCreateWithResourcePrefix(gardenletShootInfo types.NamespacedName, request admission.Request) admission.Response {

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
@@ -48,10 +48,12 @@ var _ = Describe("handler", func() {
 		request admission.Request
 		encoder runtime.Encoder
 
-		shootNamespace string
-		shootName      string
-		gardenletUser  authenticationv1.UserInfo
-		gardenadmUser  authenticationv1.UserInfo
+		shootNamespace          string
+		shootName               string
+		extensionShootNamespace string
+		gardenletUser           authenticationv1.UserInfo
+		gardenadmUser           authenticationv1.UserInfo
+		extensionUser           authenticationv1.UserInfo
 
 		responseAllowed = admission.Response{
 			AdmissionResponse: admissionv1.AdmissionResponse{
@@ -76,6 +78,7 @@ var _ = Describe("handler", func() {
 
 		shootNamespace = "shoot-namespace"
 		shootName = "shoot-name"
+		extensionShootNamespace = "garden-project"
 		gardenletUser = authenticationv1.UserInfo{
 			Username: "gardener.cloud:system:shoot:" + shootNamespace + ":" + shootName,
 			Groups:   []string{"gardener.cloud:system:shoots"},
@@ -83,6 +86,10 @@ var _ = Describe("handler", func() {
 		gardenadmUser = authenticationv1.UserInfo{
 			Username: "gardener.cloud:gardenadm:shoot:" + shootNamespace + ":" + shootName,
 			Groups:   []string{"gardener.cloud:system:shoots"},
+		}
+		extensionUser = authenticationv1.UserInfo{
+			Username: "system:serviceaccount:" + extensionShootNamespace + ":extension-shoot--" + shootName + "--foo",
+			Groups:   []string{"system:serviceaccounts"},
 		}
 	})
 
@@ -422,6 +429,47 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 						request.Namespace = shootNamespace
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+					})
+				})
+
+				Context("extension client", func() {
+					BeforeEach(func() {
+						request.UserInfo = extensionUser
+						request.Operation = admissionv1.Create
+						request.Namespace = extensionShootNamespace
+						request.Name = shootName + "--provider-aws-leader-election"
+					})
+
+					It("should allow lease creation in shoot namespace with correct name prefix", func() {
+						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+					})
+
+					It("should forbid lease creation outside shoot namespace", func() {
+						request.Namespace = "other-namespace"
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("extension client can only create leases in the namespace for shoot \"%s/%s\"", extensionShootNamespace, shootName),
+								},
+							},
+						}))
+					})
+
+					It("should forbid lease creation when name does not have the shoot name as prefix", func() {
+						request.Name = "other-shoot--provider-aws-leader-election"
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("extension client can only create leases with the shoot name %q as prefix", shootName),
+								},
+							},
+						}))
 					})
 				})
 			})

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
@@ -567,6 +567,95 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 				})
 			})
 
+			When("requested for ServiceAccounts", func() {
+				BeforeEach(func() {
+					request.Name = "extension-shoot--" + shootName + "--provider-aws"
+					request.Namespace = shootNamespace
+					request.UserInfo = gardenletUser
+					request.Resource = metav1.GroupVersionResource{
+						Group:    corev1.SchemeGroupVersion.Group,
+						Resource: "serviceaccounts",
+					}
+				})
+
+				DescribeTable("should not allow the request because no allowed verb",
+					func(operation admissionv1.Operation) {
+						request.Operation = operation
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusBadRequest),
+									Message: fmt.Sprintf("unexpected operation: %q", operation),
+								},
+							},
+						}))
+					},
+
+					Entry("update", admissionv1.Update),
+					Entry("delete", admissionv1.Delete),
+				)
+
+				When("operation is create", func() {
+					BeforeEach(func() {
+						request.Operation = admissionv1.Create
+					})
+
+					Context("gardenlet client", func() {
+						It("should allow when service account is in the shoot's project namespace with the correct name prefix", func() {
+							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+						})
+
+						It("should forbid when service account name does not have the required prefix", func() {
+							request.Name = "not-prefixed-sa"
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("object does not belong to shoot %s/%s", shootNamespace, shootName),
+									},
+								},
+							}))
+						})
+
+						It("should forbid when service account is in a different namespace", func() {
+							request.Namespace = "other-namespace"
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("object does not belong to shoot %s/%s", shootNamespace, shootName),
+									},
+								},
+							}))
+						})
+					})
+
+					Context("extension client", func() {
+						BeforeEach(func() {
+							request.UserInfo = extensionUser
+						})
+
+						It("should forbid service account creation", func() {
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: "extension client may not create ServiceAccounts",
+									},
+								},
+							}))
+						})
+					})
+				})
+			})
+
 			Context("when requested for ShootStates", func() {
 				var name string
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -149,10 +149,7 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 			)
 
 		case leaseResource:
-			return requestAuthorizer.Check(graph.VertexTypeLease, attrs,
-				authwebhook.WithAllowedVerbs("get", "update", "patch", "list", "watch"),
-				authwebhook.WithAlwaysAllowedVerbs("create"),
-			)
+			return a.authorizeLease(requestAuthorizer, userType, shootNamespace, shootName, attrs)
 
 		case secretResource:
 			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
@@ -206,6 +203,29 @@ func (a *authorizer) authorizeEvent(log logr.Logger, attrs auth.Attributes) (aut
 	}
 
 	return auth.DecisionAllow, "", nil
+}
+
+func (a *authorizer) authorizeLease(requestAuthorizer *authwebhook.RequestAuthorizer, userType gardenletidentity.UserType, shootNamespace, shootName string, attrs auth.Attributes) (auth.Decision, string, error) {
+	// extension clients may only work with leases in the shoot namespace and whose name is prefixed with
+	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace
+	if userType == gardenletidentity.UserTypeExtension {
+		if attrs.GetNamespace() != shootNamespace {
+			return auth.DecisionNoOpinion, "lease object is not in shoot namespace", nil
+		}
+		// list/watch have no name; for all other verbs check the name prefix
+		if attrs.GetName() != "" && !strings.HasPrefix(attrs.GetName(), shootName+"--") {
+			return auth.DecisionNoOpinion, "lease object name does not have the shoot name as prefix", nil
+		}
+		if ok, reason := authwebhook.CheckVerb(requestAuthorizer.Log, attrs, "create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"); !ok {
+			return auth.DecisionNoOpinion, reason, nil
+		}
+		return auth.DecisionAllow, "", nil
+	}
+
+	return requestAuthorizer.Check(graph.VertexTypeLease, attrs,
+		authwebhook.WithAllowedVerbs("get", "update", "patch", "list", "watch"),
+		authwebhook.WithAlwaysAllowedVerbs("create"),
+	)
 }
 
 func (a *authorizer) authorizeSecret(ctx context.Context, requestAuthorizer *authwebhook.RequestAuthorizer, attrs auth.Attributes) (auth.Decision, string, error) {

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -158,8 +158,6 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 
 		case serviceAccountResource:
 			if userType == gardenletidentity.UserTypeExtension {
-				// We don't use CheckRead here, as it would also grant list and watch permissions, which gardenlet doesn't
-				// have. We want to grant the read-only subset of gardenlet's permissions.
 				return requestAuthorizer.Check(graph.VertexTypeServiceAccount, attrs,
 					authwebhook.WithAllowedVerbs("get"),
 				)
@@ -219,13 +217,13 @@ func (a *authorizer) authorizeEvent(log logr.Logger, attrs auth.Attributes) (aut
 }
 
 func (a *authorizer) authorizeLease(requestAuthorizer *authwebhook.RequestAuthorizer, userType gardenletidentity.UserType, shootNamespace, shootName string, attrs auth.Attributes) (auth.Decision, string, error) {
-	// extension clients may only work with leases in the shoot namespace and whose name is prefixed with
-	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace
+	// Extension clients may only work with leases in the shoot namespace and whose name is prefixed with
+	// the shoot name to avoid tampering with leases belonging to other shoots in the same project namespace.
 	if userType == gardenletidentity.UserTypeExtension {
 		if attrs.GetNamespace() != shootNamespace {
 			return auth.DecisionNoOpinion, "lease object is not in shoot namespace", nil
 		}
-		// list/watch have no name; for all other verbs check the name prefix
+		// List/watch have no name; for all other verbs check the name prefix.
 		if attrs.GetName() != "" && !strings.HasPrefix(attrs.GetName(), shootName+"--") {
 			return auth.DecisionNoOpinion, "lease object name does not have the shoot name as prefix", nil
 		}

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -26,6 +26,7 @@ import (
 	authwebhook "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
@@ -70,6 +71,7 @@ var (
 	projectResource                   = gardencorev1beta1.Resource("projects")
 	secretResource                    = corev1.Resource("secrets")
 	secretBindingResource             = gardencorev1beta1.Resource("secretbindings")
+	serviceAccountResource            = corev1.Resource("serviceaccounts")
 	shootResource                     = gardencorev1beta1.Resource("shoots")
 	shootStateResource                = gardencorev1beta1.Resource("shootstates")
 	workloadIdentityResource          = securityv1alpha1.Resource("workloadidentities")
@@ -154,6 +156,17 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 		case secretResource:
 			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
 
+		case serviceAccountResource:
+			if userType == gardenletidentity.UserTypeExtension {
+				// We don't use CheckRead here, as it would also grant list and watch permissions, which gardenlet doesn't
+				// have. We want to grant the read-only subset of gardenlet's permissions.
+				return requestAuthorizer.Check(graph.VertexTypeServiceAccount, attrs,
+					authwebhook.WithAllowedVerbs("get"),
+				)
+			}
+
+			return a.authorizeServiceAccount(requestAuthorizer, shootNamespace, shootName, attrs)
+
 		case shootResource:
 			// This allows the gardenlet to read its own Shoot resource even if it does not yet exist in the system.
 			// For other verbs, the graph-based authorization takes over.
@@ -224,6 +237,21 @@ func (a *authorizer) authorizeLease(requestAuthorizer *authwebhook.RequestAuthor
 
 	return requestAuthorizer.Check(graph.VertexTypeLease, attrs,
 		authwebhook.WithAllowedVerbs("get", "update", "patch", "list", "watch"),
+		authwebhook.WithAlwaysAllowedVerbs("create"),
+	)
+}
+
+func (a *authorizer) authorizeServiceAccount(requestAuthorizer *authwebhook.RequestAuthorizer, shootNamespace, shootName string, attrs auth.Attributes) (auth.Decision, string, error) {
+	// Allow all verbs for extension ServiceAccounts belonging to this shoot in the shoot's project namespace.
+	// The name must be prefixed with extension-shoot--<shootName>-- to scope to this shoot and prevent a
+	// gardenlet from accessing unrelated ServiceAccounts of other shoots sharing the same project namespace.
+	if attrs.GetNamespace() == shootNamespace &&
+		strings.HasPrefix(attrs.GetName(), v1beta1constants.ExtensionShootServiceAccountPrefix+shootName+"--") {
+		return auth.DecisionAllow, "", nil
+	}
+
+	return requestAuthorizer.Check(graph.VertexTypeServiceAccount, attrs,
+		authwebhook.WithAllowedVerbs("get", "patch", "update"),
 		authwebhook.WithAlwaysAllowedVerbs("create"),
 	)
 }

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -48,10 +48,12 @@ var _ = Describe("Shoot", func() {
 		fakeWithSelectorsChecker authorizerwebhook.WithSelectorsChecker
 		authorizer               auth.Authorizer
 
-		shootNamespace string
-		shootName      string
-		gardenletUser  user.Info
-		gardenadmUser  user.Info
+		shootNamespace          string
+		shootName               string
+		extensionShootNamespace string
+		gardenletUser           user.Info
+		gardenadmUser           user.Info
+		extensionUser           user.Info
 	)
 
 	BeforeEach(func() {
@@ -66,6 +68,7 @@ var _ = Describe("Shoot", func() {
 
 		shootNamespace = "shoot-namespace"
 		shootName = "shoot-name"
+		extensionShootNamespace = "garden-project"
 		gardenletUser = &user.DefaultInfo{
 			Name:   "gardener.cloud:system:shoot:" + shootNamespace + ":" + shootName,
 			Groups: []string{"gardener.cloud:system:shoots"},
@@ -73,6 +76,10 @@ var _ = Describe("Shoot", func() {
 		gardenadmUser = &user.DefaultInfo{
 			Name:   "gardener.cloud:gardenadm:shoot:" + shootNamespace + ":" + shootName,
 			Groups: []string{"gardener.cloud:system:shoots"},
+		}
+		extensionUser = &user.DefaultInfo{
+			Name:   "system:serviceaccount:" + extensionShootNamespace + ":extension-shoot--" + shootName + "--foo",
+			Groups: []string{"system:serviceaccounts"},
 		}
 	})
 
@@ -855,6 +862,67 @@ var _ = Describe("Shoot", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
 					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
+				})
+
+				Context("extension client", func() {
+					BeforeEach(func() {
+						attrs.User = extensionUser
+						attrs.Namespace = extensionShootNamespace
+						attrs.Name = shootName + "--provider-aws-leader-election"
+					})
+
+					DescribeTable("should allow when lease is in shoot namespace with correct name prefix and verb is allowed",
+						func(verb string) {
+							attrs.Verb = verb
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						},
+
+						Entry("create", "create"),
+						Entry("get", "get"),
+						Entry("update", "update"),
+					)
+
+					It("should allow list/watch without a name in the shoot namespace",
+						func() {
+							attrs.Verb = "list"
+							attrs.Name = ""
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						},
+					)
+
+					It("should have no opinion when lease name does not have the shoot name as prefix", func() {
+						attrs.Verb = "get"
+						attrs.Name = "other-shoot--provider-aws-leader-election"
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("lease object name does not have the shoot name as prefix"))
+					})
+
+					DescribeTable("should have no opinion when lease is outside shoot namespace",
+						func(verb string) {
+							attrs.Namespace = "other-namespace"
+							attrs.Verb = verb
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("lease object is not in shoot namespace"))
+						},
+
+						Entry("get", "get"),
+						Entry("create", "create"),
+						Entry("update", "update"),
+					)
 				})
 			})
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -1235,6 +1235,124 @@ var _ = Describe("Shoot", func() {
 				)
 			})
 
+			When("requested for ServiceAccounts", func() {
+				var (
+					name, namespace string
+					attrs           *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name, namespace = "foo", "bar"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						Namespace:       namespace,
+						APIGroup:        corev1.SchemeGroupVersion.Group,
+						Resource:        "serviceaccounts",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				It("should allow because path to shoot exists", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeServiceAccount, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because path to shoot does not exist", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeServiceAccount, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+
+				DescribeTable("should allow without consulting the graph because object is an extension SA of this shoot in the shoot's project namespace",
+					func(verb string) {
+						attrs.Namespace = shootNamespace
+						attrs.Name = "extension-shoot--" + shootName + "--provider-aws"
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("patch", "patch"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should fall through to graph check because SA name does not have the shoot's extension prefix (different shoot's SA)", func() {
+					attrs.Namespace = shootNamespace
+					attrs.Name = "extension-shoot--other-shoot--provider-aws"
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeServiceAccount, shootNamespace, "extension-shoot--other-shoot--provider-aws", graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+
+				Context("extension client", func() {
+					BeforeEach(func() {
+						attrs.User = extensionUser
+					})
+
+					It("should allow because path to shoot exists", func() {
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeServiceAccount, namespace, name, graphutils.VertexTypeShoot, extensionShootNamespace, shootName).Return(true)
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					})
+
+					It("should have no opinion because path to shoot does not exist", func() {
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeServiceAccount, namespace, name, graphutils.VertexTypeShoot, extensionShootNamespace, shootName).Return(false)
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
+					})
+
+					DescribeTable("should not have an opinion because verb is not allowed",
+						func(verb string) {
+							attrs.Verb = verb
+
+							decision, reason, err := authorizer.Authorize(ctx, attrs)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get]"))
+						},
+
+						Entry("create", "create"),
+						Entry("list", "list"),
+						Entry("watch", "watch"),
+						Entry("patch", "patch"),
+						Entry("update", "update"),
+						Entry("delete", "delete"),
+						Entry("deletecollection", "deletecollection"),
+					)
+				})
+			})
+
 			Context("when requested for Shoots", func() {
 				var (
 					name, namespace string

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -107,6 +107,10 @@ const (
 	// ExtensionGardenServiceAccountPrefix is the prefix of the default garden ServiceAccount generated for each
 	// ControllerInstallation.
 	ExtensionGardenServiceAccountPrefix = "extension-"
+	// ExtensionShootServiceAccountPrefix is the prefix for garden ServiceAccounts generated for extensions in
+	// self-hosted shoot clusters. The full name is extension-shoot--<shoot-name>--<controller-installation-name>.
+	// The ServiceAccount is located in the shoot's project namespace.
+	ExtensionShootServiceAccountPrefix = "extension-shoot--"
 
 	// ReferenceProtectionFinalizerName is the name of the finalizer used for the reference protection.
 	ReferenceProtectionFinalizerName = "gardener.cloud/reference-protection"

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ControllerName is the name of this controller.
@@ -81,9 +79,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 // project namespaces (`garden-*`) when their name is prefixed with `extension-shoot--`.
 func (r *Reconciler) ServiceAccountPredicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return strings.HasPrefix(obj.GetNamespace(), gardenerutils.SeedNamespaceNamePrefix) ||
-			((obj.GetNamespace() == v1beta1constants.GardenNamespace || strings.HasPrefix(obj.GetNamespace(), gardenerutils.ProjectNamespacePrefix)) &&
-				strings.HasPrefix(obj.GetName(), v1beta1constants.ExtensionShootServiceAccountPrefix))
+		return isExtensionServiceAccount(obj.GetName(), obj.GetNamespace())
 	})
 }
 

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add.go
@@ -77,10 +77,13 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Complete(r)
 }
 
-// ServiceAccountPredicate returns true when the namespace is prefixed with `seed-`.
+// ServiceAccountPredicate returns true for ServiceAccounts in seed namespaces (`seed-*`), the garden namespace, or
+// project namespaces (`garden-*`) when their name is prefixed with `extension-shoot--`.
 func (r *Reconciler) ServiceAccountPredicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return strings.HasPrefix(obj.GetNamespace(), gardenerutils.SeedNamespaceNamePrefix)
+		return strings.HasPrefix(obj.GetNamespace(), gardenerutils.SeedNamespaceNamePrefix) ||
+			((obj.GetNamespace() == v1beta1constants.GardenNamespace || strings.HasPrefix(obj.GetNamespace(), gardenerutils.ProjectNamespacePrefix)) &&
+				strings.HasPrefix(obj.GetName(), v1beta1constants.ExtensionShootServiceAccountPrefix))
 	})
 }
 

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/add_test.go
@@ -53,13 +53,37 @@ var _ = Describe("Add", func() {
 				Expect(f(&corev1.ConfigMap{})).To(BeFalse())
 			})
 
-			It("should return false because namespace is not prefixed with 'seed-'", func() {
+			It("should return false because namespace is not prefixed with 'seed-' or 'garden-'", func() {
 				serviceAccount.Namespace = "foo"
 				Expect(f(serviceAccount)).To(BeFalse())
 			})
 
-			It("should return true because object matches all conditions", func() {
+			It("should return true because namespace is prefixed with 'seed-'", func() {
 				Expect(f(serviceAccount)).To(BeTrue())
+			})
+
+			It("should return true because namespace is the garden namespace and name is an extension SA", func() {
+				serviceAccount.Namespace = "garden"
+				serviceAccount.Name = "extension-shoot--my-shoot--foo"
+				Expect(f(serviceAccount)).To(BeTrue())
+			})
+
+			It("should return false because namespace is the garden namespace but name is not an extension SA", func() {
+				serviceAccount.Namespace = "garden"
+				serviceAccount.Name = "non-extension-sa"
+				Expect(f(serviceAccount)).To(BeFalse())
+			})
+
+			It("should return true because namespace is a project namespace and name is an extension SA", func() {
+				serviceAccount.Namespace = "garden-my-project"
+				serviceAccount.Name = "extension-shoot--my-shoot--foo"
+				Expect(f(serviceAccount)).To(BeTrue())
+			})
+
+			It("should return false because namespace is a project namespace but name is not an extension SA", func() {
+				serviceAccount.Namespace = "garden-my-project"
+				serviceAccount.Name = "non-extension-sa"
+				Expect(f(serviceAccount)).To(BeFalse())
 			})
 		}
 

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
@@ -24,6 +24,18 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
+func isExtensionServiceAccount(name, namespace string) bool {
+	if strings.HasPrefix(namespace, gardenerutils.SeedNamespaceNamePrefix) {
+		return true
+	}
+
+	if !strings.HasPrefix(name, v1beta1constants.ExtensionShootServiceAccountPrefix) {
+		return false
+	}
+
+	return namespace == v1beta1constants.GardenNamespace || strings.HasPrefix(namespace, gardenerutils.ProjectNamespacePrefix)
+}
+
 // Reconciler reconciles ClusterRoles for additional extension permissions and creates ClusterRoleBindings for binding
 // extension service accounts to such ClusterRoles.
 type Reconciler struct {
@@ -86,9 +98,7 @@ func (r *Reconciler) computeSubjects(ctx context.Context, clusterRole *metav1.Pa
 
 	var subjects []rbacv1.Subject
 	for _, serviceAccount := range serviceAccountList.Items {
-		if strings.HasPrefix(serviceAccount.Namespace, gardenerutils.SeedNamespaceNamePrefix) ||
-			((serviceAccount.Namespace == v1beta1constants.GardenNamespace || strings.HasPrefix(serviceAccount.Namespace, gardenerutils.ProjectNamespacePrefix)) &&
-				strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix)) {
+		if isExtensionServiceAccount(serviceAccount.Name, serviceAccount.Namespace) {
 			subjects = append(subjects, rbacv1.Subject{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccount.Name,

--- a/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/extensionclusterrole/reconciler.go
@@ -19,6 +19,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -85,7 +86,9 @@ func (r *Reconciler) computeSubjects(ctx context.Context, clusterRole *metav1.Pa
 
 	var subjects []rbacv1.Subject
 	for _, serviceAccount := range serviceAccountList.Items {
-		if strings.HasPrefix(serviceAccount.GetNamespace(), gardenerutils.SeedNamespaceNamePrefix) {
+		if strings.HasPrefix(serviceAccount.Namespace, gardenerutils.SeedNamespaceNamePrefix) ||
+			((serviceAccount.Namespace == v1beta1constants.GardenNamespace || strings.HasPrefix(serviceAccount.Namespace, gardenerutils.ProjectNamespacePrefix)) &&
+				strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix)) {
 			subjects = append(subjects, rbacv1.Subject{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccount.Name,

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -173,7 +173,6 @@ func (b *GardenadmBotanist) ReconcileExtensionControllerInstallations(ctx contex
 			Identity:                  &shoot.Status.Gardener,
 			GardenNamespace:           b.Shoot.ControlPlaneNamespace,
 			BootstrapControlPlaneNode: bootstrapMode,
-			ForSelfHostedShoot:        true,
 			SelfHostedShootMeta: &types.NamespacedName{
 				Namespace: shoot.Namespace,
 				Name:      shoot.Name,

--- a/pkg/gardenadm/botanist/extensions.go
+++ b/pkg/gardenadm/botanist/extensions.go
@@ -163,16 +163,23 @@ func controllerRegistrationSliceToList(controllerRegistrations []*gardencorev1be
 // ReconcileExtensionControllerInstallations reconciles the ControllerInstallation resources necessary to deploy the
 // extension controllers.
 func (b *GardenadmBotanist) ReconcileExtensionControllerInstallations(ctx context.Context, bootstrapMode bool) error {
-	reconciler := controllerinstallation.Reconciler{
-		GardenClient:              b.GardenClient,
-		SeedClientSet:             b.SeedClientSet,
-		HelmRegistry:              oci.NewHelmRegistry(b.SeedClientSet.Client()),
-		Clock:                     b.Clock,
-		Identity:                  &b.Shoot.GetInfo().Status.Gardener,
-		GardenNamespace:           b.Shoot.ControlPlaneNamespace,
-		BootstrapControlPlaneNode: bootstrapMode,
-		ForSelfHostedShoot:        true,
-	}
+	var (
+		shoot      = b.Shoot.GetInfo()
+		reconciler = controllerinstallation.Reconciler{
+			GardenClient:              b.GardenClient,
+			SeedClientSet:             b.SeedClientSet,
+			HelmRegistry:              oci.NewHelmRegistry(b.SeedClientSet.Client()),
+			Clock:                     b.Clock,
+			Identity:                  &shoot.Status.Gardener,
+			GardenNamespace:           b.Shoot.ControlPlaneNamespace,
+			BootstrapControlPlaneNode: bootstrapMode,
+			ForSelfHostedShoot:        true,
+			SelfHostedShootMeta: &types.NamespacedName{
+				Namespace: shoot.Namespace,
+				Name:      shoot.Name,
+			},
+		}
+	)
 
 	for _, extension := range b.Extensions {
 		b.Logger.Info("Reconciling ControllerInstallation using gardenlet's reconciliation logic", "controllerInstallationName", extension.ControllerInstallation.Name)

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -135,6 +135,15 @@ func AddToManager(
 			return fmt.Errorf("failed adding TokenRequestorWorkloadIdentity controller: %w", err)
 		}
 
+		// TargetNamespace is intentionally left empty: the SA namespace is provided via the
+		// serviceaccount.resources.gardener.cloud/namespace annotation set by AccessSecret.Reconcile().
+		if err := (&tokenrequestor.Reconciler{
+			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
+			Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),
+		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding TokenRequestorServiceAccount controller: %w", err)
+		}
+
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -79,11 +79,8 @@ type Reconciler struct {
 	// to nodes even when they are not ready yet. Furthermore, the replicas are set to 1 and a usable port range is
 	// provided.
 	BootstrapControlPlaneNode bool
-	// ForSelfHostedShoot should be set to true if this reconciler is run in the context of a self-hosted shoot (e.g.,
-	// in gardenadm or in the shoot gardenlet).
-	ForSelfHostedShoot bool
-	// SelfHostedShootMeta holds the namespace and name of the self-hosted shoot. Required when ForSelfHostedShoot=true
-	// to construct the ServiceAccount name and namespace for extensions.
+	// SelfHostedShootMeta holds the namespace and name of the self-hosted shoot. When set, this reconciler runs in the
+	// context of a self-hosted shoot (e.g., in gardenadm or in the shoot gardenlet).
 	SelfHostedShootMeta *types.NamespacedName
 }
 
@@ -224,7 +221,7 @@ func (r *Reconciler) reconcile(
 	}
 
 	var gardenAccessSecret *gardenerutils.AccessSecret
-	if r.ForSelfHostedShoot && r.SelfHostedShootMeta != nil {
+	if r.SelfHostedShootMeta != nil {
 		gardenAccessSecret = gardenerutils.NewGardenAccessSecret("extension", namespace.Name).
 			WithServiceAccountName(extensionServiceAccountName(r.SelfHostedShootMeta.Name, controllerInstallation.Name)).
 			WithServiceAccountNamespace(r.SelfHostedShootMeta.Namespace).
@@ -467,7 +464,7 @@ func (r *Reconciler) delete(
 	conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionSuccessful", "Deletion of old resources succeeded.")
 
 	var gardenClusterServiceAccount *corev1.ServiceAccount
-	if r.ForSelfHostedShoot && r.SelfHostedShootMeta != nil {
+	if r.SelfHostedShootMeta != nil {
 		gardenClusterServiceAccount = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
 			Name:      extensionServiceAccountName(r.SelfHostedShootMeta.Name, controllerInstallation.Name),
 			Namespace: r.SelfHostedShootMeta.Namespace,
@@ -611,7 +608,7 @@ func objectEnablesGardenKubeconfig(o runtime.Object) bool {
 // MutateSpecForSelfHostedShootExtensions adapts host network, replicas, tolerations and usable ports range for
 // self-hosted shoot clusters if necessary.
 func (r *Reconciler) MutateSpecForSelfHostedShootExtensions(obj runtime.Object) error {
-	if !r.ForSelfHostedShoot {
+	if r.SelfHostedShootMeta == nil {
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -81,6 +82,9 @@ type Reconciler struct {
 	// ForSelfHostedShoot should be set to true if this reconciler is run in the context of a self-hosted shoot (e.g.,
 	// in gardenadm or in the shoot gardenlet).
 	ForSelfHostedShoot bool
+	// SelfHostedShootMeta holds the namespace and name of the self-hosted shoot. Required when ForSelfHostedShoot=true
+	// to construct the ServiceAccount name and namespace for extensions.
+	SelfHostedShootMeta *types.NamespacedName
 }
 
 // Reconcile reconciles ControllerInstallations and deploys them into the seed cluster or the self-hosted shoot cluster.
@@ -219,11 +223,19 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	var (
+	var gardenAccessSecret *gardenerutils.AccessSecret
+	if r.ForSelfHostedShoot && r.SelfHostedShootMeta != nil {
 		gardenAccessSecret = gardenerutils.NewGardenAccessSecret("extension", namespace.Name).
-					WithServiceAccountName(v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name).
-					WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
+			WithServiceAccountName(extensionServiceAccountName(r.SelfHostedShootMeta.Name, controllerInstallation.Name)).
+			WithServiceAccountNamespace(r.SelfHostedShootMeta.Namespace).
+			WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
+	} else {
+		gardenAccessSecret = gardenerutils.NewGardenAccessSecret("extension", namespace.Name).
+			WithServiceAccountName(v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name).
+			WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
+	}
 
+	var (
 		volumeProvider  string
 		volumeProviders []gardencorev1beta1.SeedVolumeProvider
 	)
@@ -454,10 +466,18 @@ func (r *Reconciler) delete(
 
 	conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionSuccessful", "Deletion of old resources succeeded.")
 
-	gardenClusterServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
-		Name:      v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name,
-		Namespace: gardenerutils.ComputeGardenNamespace(seed.Name),
-	}}
+	var gardenClusterServiceAccount *corev1.ServiceAccount
+	if r.ForSelfHostedShoot && r.SelfHostedShootMeta != nil {
+		gardenClusterServiceAccount = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+			Name:      extensionServiceAccountName(r.SelfHostedShootMeta.Name, controllerInstallation.Name),
+			Namespace: r.SelfHostedShootMeta.Namespace,
+		}}
+	} else {
+		gardenClusterServiceAccount = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+			Name:      v1beta1constants.ExtensionGardenServiceAccountPrefix + controllerInstallation.Name,
+			Namespace: gardenerutils.ComputeGardenNamespace(seed.Name),
+		}}
+	}
 	if err := r.GardenClient.Delete(gardenCtx, gardenClusterServiceAccount); client.IgnoreNotFound(err) != nil {
 		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ServiceAccount %q in garden cluster failed: %+v", client.ObjectKeyFromObject(gardenClusterServiceAccount), err))
 		return reconcile.Result{}, err
@@ -629,4 +649,10 @@ func (r *Reconciler) CalculateUsablePorts() ([]int, error) {
 		ports = append(ports, p)
 	}
 	return ports, nil
+}
+
+// extensionServiceAccountName returns the name of the garden ServiceAccount for an extension in a self-hosted shoot
+// cluster. The format is extension-shoot--<shoot-name>--<controller-installation-name>.
+func extensionServiceAccountName(shootName, controllerInstallationName string) string {
+	return v1beta1constants.ExtensionShootServiceAccountPrefix + shootName + "--" + controllerInstallationName
 }

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
@@ -53,8 +54,6 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should not change objects if not responsible for self-hosted shoots", func() {
-			reconciler.ForSelfHostedShoot = false
-
 			p := pod.DeepCopy()
 			Expect(reconciler.MutateSpecForSelfHostedShootExtensions(p)).To(Succeed())
 			Expect(p).To(Equal(pod))
@@ -137,7 +136,7 @@ var _ = Describe("Reconciler", func() {
 			)
 
 			BeforeEach(func() {
-				reconciler.ForSelfHostedShoot = true
+				reconciler.SelfHostedShootMeta = &types.NamespacedName{Namespace: "garden-my-project", Name: "my-shoot"}
 			})
 
 			When("BootstrapControlPlaneNode is true", func() {

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -746,9 +746,13 @@ func (r *Reconciler) newKubeAPIServer(
 				fmt.Sprintf("'%s' in request.groups || request.groups.exists(e, e.startsWith('%s%s'))", v1beta1constants.SeedsGroup, serviceaccount.ServiceAccountGroupPrefix, gardenerutils.SeedNamespaceNamePrefix),
 			),
 			newAuthorizationWebhook("shoot", kubeconfigShootAuthz,
-				// only intercept request from shoot gardenlets
-				// TODO(rfranzke): Also handle requests from ServiceAccounts of extensions running in the self-hosted shoot.
-				fmt.Sprintf("'%s' in request.groups", v1beta1constants.ShootsGroup),
+				// only intercept requests from shoot gardenlets and extension ServiceAccounts in garden/project namespaces
+				fmt.Sprintf("'%s' in request.groups || (request.groups.exists(e, e == '%s') && request.user.startsWith('%s') && request.user.contains(':%s'))",
+					v1beta1constants.ShootsGroup,
+					serviceaccount.AllServiceAccountsGroup,
+					serviceaccount.ServiceAccountUsernamePrefix,
+					v1beta1constants.ExtensionShootServiceAccountPrefix,
+				),
 			),
 		)
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -746,11 +746,12 @@ func (r *Reconciler) newKubeAPIServer(
 				fmt.Sprintf("'%s' in request.groups || request.groups.exists(e, e.startsWith('%s%s'))", v1beta1constants.SeedsGroup, serviceaccount.ServiceAccountGroupPrefix, gardenerutils.SeedNamespaceNamePrefix),
 			),
 			newAuthorizationWebhook("shoot", kubeconfigShootAuthz,
-				// only intercept requests from shoot gardenlets and extension ServiceAccounts in garden/project namespaces
-				fmt.Sprintf("'%s' in request.groups || (request.groups.exists(e, e == '%s') && request.user.startsWith('%s') && request.user.contains(':%s'))",
+				// Only intercept requests from shoot gardenlets and extension ServiceAccounts in garden/project namespaces.
+				// Extension SA usernames follow the format system:serviceaccount:<garden|garden-*>:extension-shoot--<shoot>--<ci>.
+				fmt.Sprintf("'%s' in request.groups || (request.groups.exists(e, e == '%s%s' || e.startsWith('%s%s')) && request.user.contains(':%s'))",
 					v1beta1constants.ShootsGroup,
-					serviceaccount.AllServiceAccountsGroup,
-					serviceaccount.ServiceAccountUsernamePrefix,
+					serviceaccount.ServiceAccountGroupPrefix, v1beta1constants.GardenNamespace,
+					serviceaccount.ServiceAccountGroupPrefix, gardenerutils.ProjectNamespacePrefix,
 					v1beta1constants.ExtensionShootServiceAccountPrefix,
 				),
 			),

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -321,6 +321,7 @@ type AccessSecret struct {
 	targetSecretName        string
 	targetSecretNamespace   string
 	serviceAccountLabels    map[string]string
+	serviceAccountNamespace string
 }
 
 // NewShootAccessSecret returns a new AccessSecret object and initializes it with an empty corev1.Secret object
@@ -367,6 +368,14 @@ func (s *AccessSecret) WithServiceAccountLabels(labels map[string]string) *Acces
 	return s
 }
 
+// WithServiceAccountNamespace overrides the namespace of the ServiceAccount to be created. If empty, the
+// TokenRequestor's TargetNamespace is used (or kube-system for shoot class). Use this when the ServiceAccount must
+// live in a different namespace than the TokenRequestor's default TargetNamespace.
+func (s *AccessSecret) WithServiceAccountNamespace(namespace string) *AccessSecret {
+	s.serviceAccountNamespace = namespace
+	return s
+}
+
 // WithTokenExpirationDuration sets the tokenExpirationDuration field of the AccessSecret.
 func (s *AccessSecret) WithTokenExpirationDuration(duration string) *AccessSecret {
 	s.tokenExpirationDuration = duration
@@ -397,6 +406,8 @@ func (s *AccessSecret) Reconcile(ctx context.Context, c client.Client) error {
 
 		if s.Class == resourcesv1alpha1.ResourceManagerClassShoot {
 			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountNamespace, metav1.NamespaceSystem)
+		} else if s.serviceAccountNamespace != "" {
+			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountNamespace, s.serviceAccountNamespace)
 		}
 
 		if s.serviceAccountLabels != nil {

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -536,6 +536,17 @@ var _ = Describe("Shoot", func() {
 					validate()
 					Expect(accessSecret.Secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/labels", `{"foo":"bar"}`))
 				})
+
+				It("should set ServiceAccount namespace from WithServiceAccountNamespace for garden class", func() {
+					accessSecret.WithServiceAccountNamespace("garden-my-project")
+					validate()
+					Expect(accessSecret.Secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/namespace", "garden-my-project"))
+				})
+
+				It("should not set ServiceAccount namespace annotation when WithServiceAccountNamespace is not called for garden class", func() {
+					validate()
+					Expect(accessSecret.Secret.Annotations).NotTo(HaveKey("serviceaccount.resources.gardener.cloud/namespace"))
+				})
 			})
 
 			Context("update", func() {

--- a/pkg/utils/graph/eventhandler_serviceaccount.go
+++ b/pkg/utils/graph/eventhandler_serviceaccount.go
@@ -98,7 +98,7 @@ func (g *graph) handleServiceAccountCreateOrUpdateForShoots(serviceAccount *core
 		return
 	}
 
-	// SA name: extension-shoot--<shootName>--<controllerInstallationName>
+	// SA name: extension-shoot--<shootName>--<controllerInstallationName>.
 	withoutPrefix := strings.TrimPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix)
 	shootName, _, found := strings.Cut(withoutPrefix, "--")
 	if !found || shootName == "" {

--- a/pkg/utils/graph/eventhandler_serviceaccount.go
+++ b/pkg/utils/graph/eventhandler_serviceaccount.go
@@ -14,6 +14,7 @@ import (
 	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 )
 
@@ -25,7 +26,8 @@ func (g *graph) setupServiceAccountWatch(_ context.Context, informer cache.Infor
 				return
 			}
 
-			if !strings.HasPrefix(serviceAccount.Name, gardenletbootstraputil.ServiceAccountNamePrefix) {
+			if !strings.HasPrefix(serviceAccount.Name, gardenletbootstraputil.ServiceAccountNamePrefix) &&
+				!strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix) {
 				return
 			}
 
@@ -57,7 +59,8 @@ func (g *graph) setupServiceAccountWatch(_ context.Context, informer cache.Infor
 				return
 			}
 
-			if !strings.HasPrefix(serviceAccount.Name, gardenletbootstraputil.ServiceAccountNamePrefix) {
+			if !strings.HasPrefix(serviceAccount.Name, gardenletbootstraputil.ServiceAccountNamePrefix) &&
+				!strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix) {
 				return
 			}
 
@@ -75,6 +78,11 @@ func (g *graph) handleServiceAccountCreateOrUpdate(serviceAccount *corev1.Servic
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
+	if g.forSelfHostedShoots {
+		g.handleServiceAccountCreateOrUpdateForShoots(serviceAccount)
+		return
+	}
+
 	g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeServiceAccount, serviceAccount.Namespace, serviceAccount.Name)
 
 	serviceAccountVertex := g.getOrCreateVertex(VertexTypeServiceAccount, serviceAccount.Namespace, serviceAccount.Name)
@@ -83,6 +91,25 @@ func (g *graph) handleServiceAccountCreateOrUpdate(serviceAccount *corev1.Servic
 		secretVertex := g.getOrCreateVertex(VertexTypeSecret, serviceAccount.Namespace, secret.Name)
 		g.addEdge(secretVertex, serviceAccountVertex)
 	}
+}
+
+func (g *graph) handleServiceAccountCreateOrUpdateForShoots(serviceAccount *corev1.ServiceAccount) {
+	if !strings.HasPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix) {
+		return
+	}
+
+	// SA name: extension-shoot--<shootName>--<controllerInstallationName>
+	withoutPrefix := strings.TrimPrefix(serviceAccount.Name, v1beta1constants.ExtensionShootServiceAccountPrefix)
+	shootName, _, found := strings.Cut(withoutPrefix, "--")
+	if !found || shootName == "" {
+		return
+	}
+
+	g.deleteAllOutgoingEdges(VertexTypeServiceAccount, serviceAccount.Namespace, serviceAccount.Name, VertexTypeShoot)
+
+	serviceAccountVertex := g.getOrCreateVertex(VertexTypeServiceAccount, serviceAccount.Namespace, serviceAccount.Name)
+	shootVertex := g.getOrCreateVertex(VertexTypeShoot, serviceAccount.Namespace, shootName)
+	g.addEdge(serviceAccountVertex, shootVertex)
 }
 
 func (g *graph) handleServiceAccountDelete(serviceAccount *corev1.ServiceAccount) {

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -75,6 +75,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 			resourceSetup{&gardencorev1beta1.BackupEntry{}, g.setupBackupEntryWatch},
 			resourceSetup{&certificatesv1.CertificateSigningRequest{}, g.setupCertificateSigningRequestWatch},
 			resourceSetup{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
+			resourceSetup{&corev1.ServiceAccount{}, g.setupServiceAccountWatch},
 			resourceSetup{&gardencorev1beta1.Shoot{}, g.setupShootWatch},
 			resourceSetup{&securityv1alpha1.CredentialsBinding{}, g.setupCredentialsBindingWatch},
 		)

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -31,6 +31,7 @@ import (
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -2518,6 +2519,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeInformerBackupEntry               *controllertest.FakeInformer
 		fakeInformerCertificateSigningRequest *controllertest.FakeInformer
 		fakeInformerGardenlet                 *controllertest.FakeInformer
+		fakeInformerServiceAccount            *controllertest.FakeInformer
 		fakeInformerShoot                     *controllertest.FakeInformer
 		fakeInformers                         *informertest.FakeInformers
 
@@ -2526,6 +2528,8 @@ var _ = Describe("graph for shoots", func() {
 
 		shootNamespace = "shoot-namespace"
 		shootName      = "shoot-name"
+
+		serviceAccount1 *corev1.ServiceAccount
 
 		backupBucket1                               *gardencorev1beta1.BackupBucket
 		backupBucket1SecretCredentialsRef           = corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "baz", Name: "secret1"}
@@ -2573,6 +2577,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeInformerBackupEntry = &controllertest.FakeInformer{}
 		fakeInformerCertificateSigningRequest = &controllertest.FakeInformer{}
 		fakeInformerGardenlet = &controllertest.FakeInformer{}
+		fakeInformerServiceAccount = &controllertest.FakeInformer{}
 		fakeInformerShoot = &controllertest.FakeInformer{}
 
 		fakeInformers = &informertest.FakeInformers{
@@ -2582,6 +2587,7 @@ var _ = Describe("graph for shoots", func() {
 				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupEntry"):            fakeInformerBackupEntry,
 				certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
 				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("Gardenlet"):         fakeInformerGardenlet,
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"):                    fakeInformerServiceAccount,
 				gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"):                  fakeInformerShoot,
 			},
 		}
@@ -2620,6 +2626,13 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 
 		gardenlet1 = &seedmanagementv1alpha1.Gardenlet{
 			ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-" + shootName, Namespace: shootNamespace},
+		}
+
+		serviceAccount1 = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: shootNamespace,
+				Name:      v1beta1constants.ExtensionShootServiceAccountPrefix + shootName + "--provider-aws",
+			},
 		}
 
 		namespace1 = &corev1.Namespace{
@@ -2862,6 +2875,20 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 		Expect(graph.graph.Nodes().Len()).To(BeZero())
 		Expect(graph.graph.Edges().Len()).To(BeZero())
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeFalse())
+	})
+
+	It("should behave as expected for corev1.ServiceAccount", func() {
+		By("Add")
+		fakeInformerServiceAccount.Add(serviceAccount1)
+		Expect(graph.graph.Nodes().Len()).To(Equal(2))
+		Expect(graph.graph.Edges().Len()).To(Equal(1))
+		Expect(graph.HasPathFrom(VertexTypeServiceAccount, serviceAccount1.Namespace, serviceAccount1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeTrue())
+
+		By("Delete")
+		fakeInformerServiceAccount.Delete(serviceAccount1)
+		Expect(graph.graph.Nodes().Len()).To(BeZero())
+		Expect(graph.graph.Edges().Len()).To(BeZero())
+		Expect(graph.HasPathFrom(VertexTypeServiceAccount, serviceAccount1.Namespace, serviceAccount1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeFalse())
 	})
 
 	It("should behave as expected for gardencorev1beta1.Shoot", func() {

--- a/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_suite_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
@@ -27,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/extensionclusterrole"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	gardenerenvtest "github.com/gardener/gardener/test/envtest"
 	"github.com/gardener/gardener/test/utils/namespacefinalizer"
 )
@@ -74,6 +76,14 @@ var _ = BeforeSuite(func() {
 	By("Create test client")
 	testClient, err = client.New(restConfig, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
+
+	By("Create garden namespace")
+	gardenNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "garden"}}
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	DeferCleanup(func() {
+		By("Delete garden namespace")
+		Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
 
 	By("Setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{

--- a/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_test.go
+++ b/test/integration/controllermanager/controllerregistration/extensionclusterrole/extensionclusterrole_test.go
@@ -29,6 +29,12 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 		nonSeedNamespace                *corev1.Namespace
 		serviceAccount1NonSeedNamespace *corev1.ServiceAccount
 
+		extensionSAGardenNamespace *corev1.ServiceAccount
+
+		projectNamespace               *corev1.Namespace
+		extensionSAProjectNamespace    *corev1.ServiceAccount
+		nonExtensionSAProjectNamespace *corev1.ServiceAccount
+
 		clusterRole        *rbacv1.ClusterRole
 		clusterRoleBinding *rbacv1.ClusterRoleBinding
 	)
@@ -149,6 +155,68 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 			}).Should(BeNotFoundError())
 		})
 
+		// Extension SA in the garden namespace (not garden-* project namespace).
+		extensionSAGardenNamespace = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-shoot--my-shoot--foo",
+				Namespace: "garden",
+				Labels:    map[string]string{testID: testRunID, "relevant": "true"},
+			},
+		}
+
+		By("Create extension ServiceAccount in garden namespace")
+		Expect(testClient.Create(ctx, extensionSAGardenNamespace)).To(Succeed())
+		log.Info("Created ServiceAccount for test", "serviceAccount", client.ObjectKeyFromObject(extensionSAGardenNamespace))
+
+		DeferCleanup(func() {
+			By("Delete extension ServiceAccount from garden namespace")
+			Expect(testClient.Delete(ctx, extensionSAGardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+		})
+
+		projectNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "garden-my-project",
+				Labels: map[string]string{testID: testRunID},
+			},
+		}
+		// Extension SA: prefixed with "extension-shoot--", should be included in binding subjects.
+		extensionSAProjectNamespace = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "extension-shoot--my-shoot--foo",
+				Namespace: projectNamespace.Name,
+				Labels:    map[string]string{testID: testRunID, "relevant": "true"},
+			},
+		}
+		// Non-extension SA: no "extension-shoot--" prefix, must be excluded even though labels match.
+		nonExtensionSAProjectNamespace = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "non-extension-sa",
+				Namespace: projectNamespace.Name,
+				Labels:    map[string]string{testID: testRunID, "relevant": "true"},
+			},
+		}
+
+		By("Create project Namespace and ServiceAccounts")
+		Expect(testClient.Create(ctx, projectNamespace)).To(Succeed())
+		log.Info("Created Namespace for test", "namespace", client.ObjectKeyFromObject(projectNamespace))
+
+		Expect(testClient.Create(ctx, extensionSAProjectNamespace)).To(Succeed())
+		log.Info("Created ServiceAccount for test", "serviceAccount", client.ObjectKeyFromObject(extensionSAProjectNamespace))
+
+		Expect(testClient.Create(ctx, nonExtensionSAProjectNamespace)).To(Succeed())
+		log.Info("Created ServiceAccount for test", "serviceAccount", client.ObjectKeyFromObject(nonExtensionSAProjectNamespace))
+
+		DeferCleanup(func() {
+			By("Delete ServiceAccounts and project Namespace")
+			Expect(testClient.Delete(ctx, extensionSAProjectNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, nonExtensionSAProjectNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, projectNamespace)).To(Or(Succeed(), BeNotFoundError()))
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(projectNamespace), &corev1.Namespace{})
+			}).Should(BeNotFoundError())
+		})
+
 		clusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testRunID,
@@ -216,6 +284,16 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 		Expect(clusterRoleBinding.Subjects).To(HaveExactElements(
 			rbacv1.Subject{
 				Kind:      "ServiceAccount",
+				Name:      extensionSAGardenNamespace.Name,
+				Namespace: extensionSAGardenNamespace.Namespace,
+			},
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      extensionSAProjectNamespace.Name,
+				Namespace: projectNamespace.Name,
+			},
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
 				Name:      serviceAccount1SeedNamespace1.Name,
 				Namespace: seedNamespace1.Name,
 			},
@@ -262,6 +340,16 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 			}).Should(HaveExactElements(
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
+					Name:      extensionSAGardenNamespace.Name,
+					Namespace: extensionSAGardenNamespace.Namespace,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      extensionSAProjectNamespace.Name,
+					Namespace: projectNamespace.Name,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
 					Name:      serviceAccount3SeedNamespace1.Name,
 					Namespace: seedNamespace1.Name,
 				},
@@ -289,6 +377,16 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
 				return clusterRoleBinding.Subjects
 			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      extensionSAGardenNamespace.Name,
+					Namespace: extensionSAGardenNamespace.Namespace,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      extensionSAProjectNamespace.Name,
+					Namespace: projectNamespace.Name,
+				},
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
 					Name:      serviceAccount3SeedNamespace1.Name,
@@ -342,6 +440,16 @@ var _ = Describe("ExtensionClusterRole controller tests", func() {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(clusterRoleBinding), clusterRoleBinding)).To(Succeed())
 				return clusterRoleBinding.Subjects
 			}).Should(HaveExactElements(
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      extensionSAGardenNamespace.Name,
+					Namespace: extensionSAGardenNamespace.Namespace,
+				},
+				rbacv1.Subject{
+					Kind:      "ServiceAccount",
+					Name:      extensionSAProjectNamespace.Name,
+					Namespace: projectNamespace.Name,
+				},
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
 					Name:      serviceAccount1SeedNamespace1.Name,

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -569,7 +569,6 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				selfHostedControllerInstall = &gardencorev1beta1.ControllerInstallation{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "install-sh-",
-						Annotations:  map[string]string{"security.gardener.cloud/pod-security-enforce": "privileged"},
 						// Intentionally no testID label so the test manager does not watch this object.
 					},
 				}
@@ -604,7 +603,6 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					Identity:              identity,
 					GardenClusterIdentity: gardenClusterIdentity,
 					GardenNamespace:       v1beta1constants.GardenNamespace,
-					ForSelfHostedShoot:    true,
 					SelfHostedShootMeta: &types.NamespacedName{
 						Namespace: projectNamespace.Name,
 						Name:      "my-shoot",

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -16,13 +16,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -525,6 +530,99 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				Expect(testClient.Update(ctx, controllerDeployment)).To(Succeed())
 
 				test()
+			})
+		})
+
+		When("reconciler is configured for a self-hosted shoot", func() {
+			var (
+				projectNamespace               *corev1.Namespace
+				selfHostedControllerDeployment *gardencorev1.ControllerDeployment
+				selfHostedControllerInstall    *gardencorev1beta1.ControllerInstallation
+			)
+
+			BeforeEach(func() {
+				projectNamespace = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "garden-",
+					},
+				}
+				Expect(testClient.Create(ctx, projectNamespace)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, projectNamespace))).To(Succeed())
+				})
+
+				selfHostedControllerDeployment = &gardencorev1.ControllerDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "deploy-sh-",
+						// Intentionally no testID label so the test manager does not watch this object.
+					},
+					Helm: &gardencorev1.HelmControllerDeployment{
+						RawChart: chartWithGardenKubeconfig,
+					},
+					InjectGardenKubeconfig: ptr.To(true),
+				}
+				Expect(testClient.Create(ctx, selfHostedControllerDeployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedControllerDeployment))).To(Succeed())
+				})
+
+				selfHostedControllerInstall = &gardencorev1beta1.ControllerInstallation{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "install-sh-",
+						Annotations:  map[string]string{"security.gardener.cloud/pod-security-enforce": "privileged"},
+						// Intentionally no testID label so the test manager does not watch this object.
+					},
+				}
+			})
+
+			JustBeforeEach(func() {
+				selfHostedControllerInstall.Spec.SeedRef = &corev1.ObjectReference{Name: seed.Name}
+				selfHostedControllerInstall.Spec.RegistrationRef = corev1.ObjectReference{Name: controllerRegistration.Name}
+				selfHostedControllerInstall.Spec.DeploymentRef = &corev1.ObjectReference{Name: selfHostedControllerDeployment.Name}
+				Expect(testClient.Create(ctx, selfHostedControllerInstall)).To(Succeed())
+				log.Info("Created self-hosted ControllerInstallation", "controllerInstallation", client.ObjectKeyFromObject(selfHostedControllerInstall))
+
+				DeferCleanup(func() {
+					By("Remove finalizer from self-hosted ControllerInstallation to allow deletion")
+					patch := client.MergeFrom(selfHostedControllerInstall.DeepCopy())
+					selfHostedControllerInstall.Finalizers = nil
+					Expect(client.IgnoreNotFound(testClient.Patch(ctx, selfHostedControllerInstall, patch))).To(Succeed())
+
+					By("Delete self-hosted ControllerInstallation")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedControllerInstall))).To(Succeed())
+				})
+			})
+
+			It("should create the garden access secret with the self-hosted shoot SA name and namespace annotation", func() {
+				r := &controllerinstallation.Reconciler{
+					GardenClient:          testClient,
+					GardenConfig:          restConfig,
+					SeedClientSet:         testClientSet,
+					HelmRegistry:          fakeRegistry,
+					Clock:                 clock.RealClock{},
+					Config:                gardenletconfigv1alpha1.GardenletConfiguration{Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{ControllerInstallation: &gardenletconfigv1alpha1.ControllerInstallationControllerConfiguration{ConcurrentSyncs: ptr.To(5)}}},
+					Identity:              identity,
+					GardenClusterIdentity: gardenClusterIdentity,
+					GardenNamespace:       v1beta1constants.GardenNamespace,
+					ForSelfHostedShoot:    true,
+					SelfHostedShootMeta: &types.NamespacedName{
+						Namespace: projectNamespace.Name,
+						Name:      "my-shoot",
+					},
+				}
+
+				By("Reconcile the self-hosted ControllerInstallation")
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: selfHostedControllerInstall.Name}})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Ensure garden access secret has self-hosted shoot SA name and namespace annotation")
+				secret := &corev1.Secret{}
+				extensionNamespace := "extension-" + selfHostedControllerInstall.Name
+				Expect(testClient.Get(ctx, client.ObjectKey{Namespace: extensionNamespace, Name: "garden-access-extension"}, secret)).To(Succeed())
+				Expect(secret.Annotations).To(And(
+					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/name", v1beta1constants.ExtensionShootServiceAccountPrefix+"my-shoot--"+selfHostedControllerInstall.Name),
+					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/namespace", projectNamespace.Name),
+				))
 			})
 		})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area control-plane
/area security
/kind enhancement

**What this PR does / why we need it**:

Extensions installed via a `ControllerInstallation` on a regular seed cluster already receive garden cluster access through gardenlet's `TokenRequestor` controller. For self-hosted shoot clusters (#2906), there is no dedicated seed — the shoot's own nodes are the "seed". Extensions running there need the same garden cluster access, but via a different mechanism: `ServiceAccount`s created in the shoot's project namespace (`garden-<project>`) or the `garden` namespace itself, named `extension-shoot--<shoot>--<controller-installation>`.

This PR wires up the full end-to-end flow:

1. **Prefactors** (`AccessSecret`, `ExtensionShootServiceAccountPrefix`): adds the `WithServiceAccountNamespace` option so the `TokenRequestor` can target a SA namespace that differs from its own configured `TargetNamespace`, and introduces the shared naming constant.

2. **`gardenlet` — `ControllerInstallation` reconciler**: extends the self-hosted shoot path to construct the correct `extension-shoot--<shoot>--<ci>` SA name and annotate the access secret with the target namespace so the `TokenRequestorServiceAccount` controller picks it up.

3. **`gardenlet` — `TokenRequestorServiceAccount` controller**: registers the garden-class token requestor for self-hosted shoot gardenlets, requesting tokens for the per-extension SA in the project namespace.

4. **`admissioncontroller` — identity extraction**: `getIdentityForServiceAccountsGroup` parses `extension-shoot--<shoot>--<ci>` SAs in project/garden namespaces and returns a fully populated `Identity` with `UserTypeExtension`.

5. **`admissioncontroller` — shoot restriction handler**: allows gardenlet to CREATE extension SAs (name-prefixed); blocks extensions from creating SAs themselves; preserves graph-based SA reads for extensions.

6. **`admissioncontroller` — shoot authorizer**: scopes extension client `Lease` access to the shoot's project namespace with a `<shoot-name>--` name prefix for per-shoot isolation; scopes `CertificateSigningRequest` access to `get` only (via graph path), similar to how it works for seeds.

7. **`admissioncontroller` — `gardener-operator` webhook**: extends the CEL match condition to intercept extension SA usernames (containing `extension-shoot--`) so they reach the shoot authorizer, not just gardenlet identities.

8. **`graph`**: adds `ServiceAccount → Shoot` edges for `extension-shoot--` prefixed SAs in self-hosted shoot mode so the graph-based authorizer can evaluate requests from extension clients.

9. **`gardener-controller-manager` — `extensionclusterrole` controller**: extends the `ServiceAccountPredicate` watch filter and `computeSubjects` to include extension SAs in project namespaces and the `garden` namespace, so operator-defined `ClusterRole`s with custom extension permissions apply uniformly to self-hosted shoot extensions.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:

- The SA naming scheme `extension-shoot--<shoot-name>--<controller-installation-name>` is the key invariant throughout. The double-dash `--` separator is load-bearing: it is used to split the parts during identity extraction.
- The `TokenRequestor`'s `TargetNamespace` is intentionally left empty for the self-hosted shoot case; the namespace is provided per-secret via the `serviceaccount.resources.gardener.cloud/namespace` annotation.
- Lease isolation uses the `<shoot-name>--` name prefix rather than namespace-scoping because the project namespace is shared across multiple shoots.
- The `extensionclusterrole` controller now handles both `seed-*` SAs (existing) and project-namespace / `garden`-namespace extension SAs (new), with a name-prefix guard for the latter.

**Release note**:
```feature operator
NONE
```