### PR TITLE
Deactivate scaling memory of `istio-ingressgateway` by HPA

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-hpa.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-hpa.yaml
@@ -20,14 +20,6 @@ spec:
       target:
         averageUtilization: 80
         type: Utilization
-{{- if eq .Values.terminateAPIServerTLS false }}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        averageUtilization: 80
-        type: Utilization
-{{- end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler.yaml
@@ -21,12 +21,6 @@ spec:
       target:
         averageUtilization: 80
         type: Utilization
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        averageUtilization: 80
-        type: Utilization
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
In PR #14197 we activated scaling the memory `istio-ingressgateway` via VPA. However, when `IstioTLSTermination` is not active it is still scaled by HPA. This won't work properly, so this PR removes memory from HPA in this case too.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @domdom82 @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
