### PR TITLE
Extend fluent-operator RBAC to cover opentelemetry collector extension

### DIFF
--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -103,7 +103,12 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
-					Verbs:     []string{"get"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
 					APIGroups: []string{"extensions.gardener.cloud"},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -119,7 +119,12 @@ var _ = Describe("Fluent Operator", func() {
 				{
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
-					Verbs:     []string{"get"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
 					APIGroups: []string{"extensions.gardener.cloud"},


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:

This PR extends current RBAC for `fluent-operator` allowing watching pods and namespaces resources. The read-only access is required to cover resources created by the `gardener-otelcol-extension`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The RBAC for fluent-operator is allowing watching pods and namespaces resources, required by `gardener-otelcol-extension` scenario.
```
