### PR TITLE
Restore the type and immutable fields of secrets not managed by secrets-manager during CPM

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -496,7 +496,7 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := g.runMigrations(ctx, log); err != nil {
+	if err := g.runMigrations(ctx, log, gardenCluster.GetClient()); err != nil {
 		return err
 	}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -6,24 +6,117 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/cmd/internal/migration"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
+	corev1 "k8s.io/api/core/v1"
 )
 
-func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
+func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClient client.Client) error {
+	seedClient := g.mgr.GetClient()
+
 	if features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates) {
-		if err := migration.MigrateVPAEmptyPatch(ctx, g.mgr.GetClient(), log); err != nil {
+		if err := migration.MigrateVPAEmptyPatch(ctx, seedClient, log); err != nil {
 			return fmt.Errorf("failed to migrate VerticalPodAutoscaler with 'MigrateVPAEmptyPatch' migration: %w", err)
 		}
 	} else {
-		if err := migration.MigrateVPAUpdateModeToRecreate(ctx, g.mgr.GetClient(), log); err != nil {
+		if err := migration.MigrateVPAUpdateModeToRecreate(ctx, seedClient, log); err != nil {
 			return fmt.Errorf("failed to migrate VerticalPodAutoscaler with 'MigrateVPAUpdateModeToRecreate' migration: %w", err)
 		}
 	}
 
+	if err := migrateShootStateSecretFormat(ctx, gardenClient, seedClient, log); err != nil {
+		return fmt.Errorf("failed to migrate ShootState secret format: %w", err)
+	}
+
 	return nil
+}
+
+// TODO(tobschli): Remove this migration in the following release after the one that introduces it.
+func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Client, seedClient client.Client, log logr.Logger) error {
+	shootList := &gardencorev1beta1.ShootList{}
+	if err := gardenClient.List(ctx, shootList); err != nil {
+		return fmt.Errorf("failed listing Shoots: %w", err)
+	}
+
+	var tasks []flow.TaskFn
+
+	for _, shoot := range shootList.Items {
+		tasks = append(tasks, func(ctx context.Context) error {
+			ss := &gardencorev1beta1.ShootState{}
+			if err := gardenClient.Get(ctx, client.ObjectKey{Name: shoot.Name, Namespace: shoot.Namespace}, ss); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("failed getting ShootState for shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
+			}
+
+			patch := client.MergeFrom(ss.DeepCopy())
+			changed := false
+
+			for i, entry := range ss.Spec.Gardener {
+				if entry.Type != v1beta1constants.DataTypeSecret {
+					continue
+				}
+
+				var newFormat shootstate.SecretState
+				if err := json.Unmarshal(entry.Data.Raw, &newFormat); err == nil && newFormat.Data != nil {
+					continue
+				}
+
+				var oldFormat map[string][]byte
+				if err := json.Unmarshal(entry.Data.Raw, &oldFormat); err != nil {
+					log.Error(err, "Failed to unmarshal secret data, skipping", "shootState", client.ObjectKeyFromObject(ss), "secret", entry.Name)
+					continue
+				}
+
+				newFormat = shootstate.SecretState{
+					Data: oldFormat,
+					Type: corev1.SecretTypeOpaque,
+				}
+
+				secret := &corev1.Secret{}
+				err := seedClient.Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: entry.Name}, secret)
+				if err != nil {
+					return fmt.Errorf("failed getting secret %s for ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(ss), err)
+				}
+
+				if err == nil {
+					newFormat.Type = secret.Type
+					newFormat.Immutable = secret.Immutable
+				}
+
+				newRaw, err := json.Marshal(newFormat)
+				if err != nil {
+					return fmt.Errorf("failed marshalling secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(ss), err)
+				}
+
+				ss.Spec.Gardener[i].Data.Raw = newRaw
+				changed = true
+			}
+
+			if !changed {
+				return nil
+			}
+
+			if err := gardenClient.Patch(ctx, ss, patch); err != nil {
+				return fmt.Errorf("failed patching ShootState %s: %w", client.ObjectKeyFromObject(ss), err)
+			}
+
+			log.Info("Successfully migrated ShootState secret format", "shootState", client.ObjectKeyFromObject(ss))
+			return nil
+		})
+	}
+
+	return flow.Parallel(tasks...)(ctx)
 }

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -42,7 +42,7 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClien
 	return nil
 }
 
-// TODO(tobschli): Remove this migration in the following release after the one that introduces it.
+// TODO(tobschli): Remove this migration after v1.143 has been released.
 func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Client, seedClient client.Client, log logr.Logger) error {
 	shootList := &gardencorev1beta1.ShootList{}
 	if err := gardenClient.List(ctx, shootList); err != nil {
@@ -53,18 +53,20 @@ func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Clie
 
 	for _, shoot := range shootList.Items {
 		tasks = append(tasks, func(ctx context.Context) error {
-			ss := &gardencorev1beta1.ShootState{}
-			if err := gardenClient.Get(ctx, client.ObjectKey{Name: shoot.Name, Namespace: shoot.Namespace}, ss); err != nil {
+			shootState := &gardencorev1beta1.ShootState{}
+			if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(&shoot), shootState); err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil
 				}
-				return fmt.Errorf("failed getting ShootState for shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
+				return fmt.Errorf("failed getting ShootState for Shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
 			}
 
-			patch := client.MergeFrom(ss.DeepCopy())
-			changed := false
+			var (
+				patch   = client.MergeFrom(shootState.DeepCopy())
+				changed bool
+			)
 
-			for i, entry := range ss.Spec.Gardener {
+			for i, entry := range shootState.Spec.Gardener {
 				if entry.Type != v1beta1constants.DataTypeSecret {
 					continue
 				}
@@ -73,11 +75,11 @@ func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Clie
 				if err := json.Unmarshal(entry.Data.Raw, &newFormat); err == nil && newFormat.Data != nil {
 					continue
 				}
+				newFormat = shootstate.SecretState{}
 
 				var oldFormat map[string][]byte
 				if err := json.Unmarshal(entry.Data.Raw, &oldFormat); err != nil {
-					log.Error(err, "Failed to unmarshal secret data, skipping", "shootState", client.ObjectKeyFromObject(ss), "secret", entry.Name)
-					continue
+					return fmt.Errorf("failed to unmarshal secret data for secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
 				}
 
 				newFormat = shootstate.SecretState{
@@ -86,34 +88,30 @@ func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Clie
 				}
 
 				secret := &corev1.Secret{}
-				err := seedClient.Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: entry.Name}, secret)
-				if err != nil {
-					return fmt.Errorf("failed getting secret %s for ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(ss), err)
+				if err := seedClient.Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: entry.Name}, secret); err != nil {
+					return fmt.Errorf("failed getting secret %s for ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
 				}
 
-				if err == nil {
-					newFormat.Type = secret.Type
-					newFormat.Immutable = secret.Immutable
-				}
+				newFormat.Type = secret.Type
+				newFormat.Immutable = secret.Immutable
 
 				newRaw, err := json.Marshal(newFormat)
 				if err != nil {
-					return fmt.Errorf("failed marshalling secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(ss), err)
+					return fmt.Errorf("failed marshalling secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
 				}
 
-				ss.Spec.Gardener[i].Data.Raw = newRaw
-				changed = true
+				shootState.Spec.Gardener[i].Data.Raw, changed = newRaw, true
 			}
 
 			if !changed {
 				return nil
 			}
 
-			if err := gardenClient.Patch(ctx, ss, patch); err != nil {
-				return fmt.Errorf("failed patching ShootState %s: %w", client.ObjectKeyFromObject(ss), err)
+			if err := gardenClient.Patch(ctx, shootState, patch); err != nil {
+				return fmt.Errorf("failed patching ShootState %s: %w", client.ObjectKeyFromObject(shootState), err)
 			}
 
-			log.Info("Successfully migrated ShootState secret format", "shootState", client.ObjectKeyFromObject(ss))
+			log.Info("Successfully migrated ShootState secret format", "shootState", client.ObjectKeyFromObject(shootState))
 			return nil
 		})
 	}

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClient client.Client) error {

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -132,11 +132,11 @@ func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Clien
 	var (
 		secretData map[string][]byte
 		immutable  *bool
-		secretType corev1.SecretType
+		secretType = corev1.SecretTypeOpaque
 	)
 
 	if err := json.Unmarshal(rawData, &newSecretInfo); err != nil || newSecretInfo.Data == nil {
-		// TODO(tobschli): Remove this fallback after v1.140 has been released, as ShootStates will be reconciled and use the new format.
+		// TODO(tobschli): Remove this fallback after v1.143 has been released, as ShootStates will be reconciled and use the new format.
 		// plain map[string][]byte
 		if err := json.Unmarshal(rawData, &secretData); err != nil {
 			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)
@@ -146,16 +146,11 @@ func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Clien
 			secret := secretsmanager.Secret(objectMeta, secretData)
 			return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
 		}
-
-		immutable = nil
-		secretType = corev1.SecretTypeOpaque
 	} else {
 		secretData = newSecretInfo.Data
 		immutable = newSecretInfo.Immutable
 		if newSecretInfo.Type != "" {
 			secretType = newSecretInfo.Type
-		} else {
-			secretType = corev1.SecretTypeOpaque
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -116,33 +116,54 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 				Labels:    entry.Labels,
 			}
 
-			data := make(map[string][]byte)
-			if err := json.Unmarshal(entry.Data.Raw, &data); err != nil {
-				return err
-			}
-
-			var secret *corev1.Secret
-			if objectMeta.Labels[secretsmanager.LabelKeyManagedBy] == secretsmanager.LabelValueSecretsManager {
-				secret = secretsmanager.Secret(objectMeta, data)
-			} else {
-				// TODO(plkokanov): Add ability to also restore the secret's immutability and type from the `ShootState`.
-				// For secrets that have the `managed-by: secrets-manager` label this information is inferred from the
-				// secret data and handled by the `secretsmanager.Secret(objectMeta, data)` function above.
-				// Currently only opaque secrets that do not have the `managed-by: secrets-manager` are expected to be persisted and restored.
-				// For more details, see https://github.com/gardener/gardener/issues/13262.
-				// Note that the e2e and testmachinery tests, check that the restored type and immutability matches the original.
-				secret = &corev1.Secret{
-					ObjectMeta: objectMeta,
-					Data:       data,
-					Type:       corev1.SecretTypeOpaque,
-				}
-			}
-
-			return client.IgnoreAlreadyExists(b.SeedClientSet.Client().Create(ctx, secret))
+			return restoreSecretFromPersistedData(ctx, b.SeedClientSet.Client(), objectMeta, entry.Data.Raw)
 		})
 	}
 
 	return flow.Parallel(fns...)(ctx)
+}
+
+// restoreSecretFromPersistedData restores a Kubernetes Secret from persisted GardenerResourceData.
+// It handles both formats (with Immutable and Type fields) and (plain map[string][]byte)
+func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Client, objectMeta metav1.ObjectMeta, rawData []byte) error {
+	newSecretInfo := struct {
+		Data      map[string][]byte `json:"data"`
+		Immutable *bool             `json:"immutable"`
+		Type      string            `json:"type"`
+	}{}
+
+	var secretData map[string][]byte
+	var Immutable *bool
+	var Type corev1.SecretType
+
+	if err := json.Unmarshal(rawData, &newSecretInfo); err == nil && newSecretInfo.Data != nil {
+		secretData = newSecretInfo.Data
+		Immutable = newSecretInfo.Immutable
+		if newSecretInfo.Type != "" {
+			Type = corev1.SecretType(newSecretInfo.Type)
+		} else {
+			Type = corev1.SecretTypeOpaque
+		}
+	} else {
+		// plain map[string][]byte
+		oldSecretData := make(map[string][]byte)
+		if err := json.Unmarshal(rawData, &oldSecretData); err != nil {
+			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)
+		}
+
+		secretData = oldSecretData
+		Immutable = nil
+		Type = corev1.SecretTypeOpaque
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: objectMeta,
+		Type:       Type,
+		Data:       secretData,
+		Immutable:  Immutable,
+	}
+
+	return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
 }
 
 func caCertConfigurations(isWorkerless, isSelfHosted bool) []secretsutils.ConfigInterface {

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -150,14 +150,13 @@ func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Clien
 			return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
 		}
 
-		secretData = secretData
 		immutable = nil
 		secretType = corev1.SecretTypeOpaque
 	} else {
 		secretData = newSecretInfo.Data
 		immutable = newSecretInfo.Immutable
 		if newSecretInfo.Type != "" {
-			secretType = corev1.SecretType(newSecretInfo.Type)
+			secretType = newSecretInfo.Type
 		} else {
 			secretType = corev1.SecretTypeOpaque
 		}

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -126,11 +127,7 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 // restoreSecretFromPersistedData restores a Kubernetes Secret from persisted GardenerResourceData.
 // It handles both formats (with Immutable and Type fields) and (plain map[string][]byte)
 func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Client, objectMeta metav1.ObjectMeta, rawData []byte) error {
-	newSecretInfo := struct {
-		Data      map[string][]byte `json:"data"`
-		Immutable *bool             `json:"immutable,omitempty"`
-		Type      corev1.SecretType `json:"type,omitempty"`
-	}{}
+	var newSecretInfo shootstate.SecretState
 
 	var (
 		secretData map[string][]byte
@@ -139,7 +136,7 @@ func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Clien
 	)
 
 	if err := json.Unmarshal(rawData, &newSecretInfo); err != nil || newSecretInfo.Data == nil {
-		// TODO: Remove this fallback in a future release after all ShootStates have been reconciled and use the new format.
+		// TODO(tobschli): Remove this fallback after v1.140 has been released, as ShootStates will be reconciled and use the new format.
 		// plain map[string][]byte
 		if err := json.Unmarshal(rawData, &secretData); err != nil {
 			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -128,44 +128,46 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Client, objectMeta metav1.ObjectMeta, rawData []byte) error {
 	newSecretInfo := struct {
 		Data      map[string][]byte `json:"data"`
-		Immutable *bool             `json:"immutable"`
-		Type      string            `json:"type"`
+		Immutable *bool             `json:"immutable,omitempty"`
+		Type      corev1.SecretType `json:"type,omitempty"`
 	}{}
 
-	var secretData map[string][]byte
-	var Immutable *bool
-	var Type corev1.SecretType
+	var (
+		secretData map[string][]byte
+		immutable  *bool
+		secretType corev1.SecretType
+	)
 
-	if err := json.Unmarshal(rawData, &newSecretInfo); err == nil && newSecretInfo.Data != nil {
-		secretData = newSecretInfo.Data
-		Immutable = newSecretInfo.Immutable
-		if newSecretInfo.Type != "" {
-			Type = corev1.SecretType(newSecretInfo.Type)
-		} else {
-			Type = corev1.SecretTypeOpaque
-		}
-	} else {
+	if err := json.Unmarshal(rawData, &newSecretInfo); err != nil || newSecretInfo.Data == nil {
+		// TODO: Remove this fallback in a future release after all ShootStates have been reconciled and use the new format.
 		// plain map[string][]byte
-		oldSecretData := make(map[string][]byte)
-		if err := json.Unmarshal(rawData, &oldSecretData); err != nil {
+		if err := json.Unmarshal(rawData, &secretData); err != nil {
 			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)
 		}
 
 		if objectMeta.Labels[secretsmanager.LabelKeyManagedBy] == secretsmanager.LabelValueSecretsManager {
-			secret := secretsmanager.Secret(objectMeta, oldSecretData)
+			secret := secretsmanager.Secret(objectMeta, secretData)
 			return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
 		}
 
-		secretData = oldSecretData
-		Immutable = nil
-		Type = corev1.SecretTypeOpaque
+		secretData = secretData
+		immutable = nil
+		secretType = corev1.SecretTypeOpaque
+	} else {
+		secretData = newSecretInfo.Data
+		immutable = newSecretInfo.Immutable
+		if newSecretInfo.Type != "" {
+			secretType = corev1.SecretType(newSecretInfo.Type)
+		} else {
+			secretType = corev1.SecretTypeOpaque
+		}
 	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: objectMeta,
-		Type:       Type,
+		Type:       secretType,
 		Data:       secretData,
-		Immutable:  Immutable,
+		Immutable:  immutable,
 	}
 
 	return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -151,6 +151,11 @@ func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Clien
 			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)
 		}
 
+		if objectMeta.Labels[secretsmanager.LabelKeyManagedBy] == secretsmanager.LabelValueSecretsManager {
+			secret := secretsmanager.Secret(objectMeta, oldSecretData)
+			return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
+		}
+
 		secretData = oldSecretData
 		Immutable = nil
 		Type = corev1.SecretTypeOpaque

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -6,6 +6,7 @@ package botanist_test
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -483,6 +485,43 @@ var _ = Describe("Secrets", func() {
 								Data: runtime.RawExtension{Raw: rawData("secret-without-labels")},
 							},
 							{
+								Name:   "new-format-secret",
+								Type:   "secret",
+								Labels: map[string]string{"managed-by": "test"},
+								Data: runtime.RawExtension{
+									Raw: rawData("new-format-secret", struct {
+										Immutable *bool
+										Type      corev1.SecretType
+									}{
+										Immutable: ptr.To(true),
+										Type:      corev1.SecretTypeOpaque,
+									})},
+							},
+							{
+								Name: "new-format-mutable-secret",
+								Type: "secret",
+								Data: runtime.RawExtension{
+									Raw: rawData("new-format-mutable-secret", struct {
+										Immutable *bool
+										Type      corev1.SecretType
+									}{
+										Immutable: ptr.To(false),
+										Type:      corev1.SecretTypeOpaque,
+									})},
+							},
+							{
+								Name: "new-format-tls-secret",
+								Type: "secret",
+								Data: runtime.RawExtension{
+									Raw: rawData("new-format-tls-secret", struct {
+										Immutable *bool
+										Type      corev1.SecretType
+									}{
+										Immutable: ptr.To(true),
+										Type:      corev1.SecretTypeTLS,
+									})},
+							},
+							{
 								Name: "some-other-data",
 								Type: "not-a-secret",
 							},
@@ -528,6 +567,25 @@ var _ = Describe("Secrets", func() {
 				Expect(secret.Labels).To(BeEmpty())
 				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
 
+				By("Verify new format secret got restored")
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "new-format-secret"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(PointTo(BeTrue()))
+				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "test"}))
+				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
+
+				By("Verify new format mutable secret got restored")
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "new-format-mutable-secret"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(PointTo(BeFalse()))
+				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
+
+				By("Verify new format TLS secret got restored")
+				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "new-format-tls-secret"}, secret)).To(Succeed())
+				Expect(secret.Immutable).To(PointTo(BeTrue()))
+				Expect(secret.Type).To(Equal(corev1.SecretType("kubernetes.io/tls")))
+				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
+
 				By("Verify unrelated data not to be restored")
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "some-other-data"}, &corev1.Secret{})).To(BeNotFoundError())
 			})
@@ -553,6 +611,27 @@ func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.
 	}
 }
 
-func rawData(value string) []byte {
-	return []byte(`{"data-for":"` + utils.EncodeBase64([]byte(value)) + `"}`)
+func rawData(value string, opts ...struct {
+	Immutable *bool
+	Type      corev1.SecretType
+}) []byte {
+	if len(opts) == 0 {
+		return []byte(`{"data-for":"` + utils.EncodeBase64([]byte(value)) + `"}`)
+	}
+
+	o := opts[0]
+
+	type newFormat struct {
+		Data      map[string][]byte `json:"data"`
+		Immutable *bool             `json:"immutable,omitempty"`
+		Type      corev1.SecretType `json:"type,omitempty"`
+	}
+
+	b, _ := json.Marshal(newFormat{
+		Data:      map[string][]byte{"data-for": []byte(value)},
+		Immutable: o.Immutable,
+		Type:      o.Type,
+	})
+
+	return b
 }

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -30,6 +30,13 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
+// SecretState stores the data, immutability and type of a secret to be persisted in the ShootState.
+type SecretState struct {
+	Data      map[string][]byte `json:"data"`
+	Immutable *bool             `json:"immutable,omitempty"`
+	Type      corev1.SecretType `json:"type,omitempty"`
+}
+
 // Deploy deploys the ShootState resource with the effective state for the given shoot into the garden
 // cluster.
 func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient client.Client, shoot *gardencorev1beta1.Shoot, controlPlaneNamespace string, overwriteSpec bool) error {
@@ -167,11 +174,7 @@ func computeSecretsToPersist(
 	dataList := make([]gardencorev1beta1.GardenerResourceData, 0, len(secretList.Items))
 
 	for _, secret := range secretList.Items {
-		secretInfo := struct {
-			Data      map[string][]byte `json:"data"`
-			Immutable *bool             `json:"immutable,omitempty"`
-			Type      corev1.SecretType `json:"type,omitempty"`
-		}{
+		secretInfo := SecretState{
 			Data:      secret.Data,
 			Immutable: secret.Immutable,
 			Type:      secret.Type,

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -169,12 +169,12 @@ func computeSecretsToPersist(
 	for _, secret := range secretList.Items {
 		secretInfo := struct {
 			Data      map[string][]byte `json:"data"`
-			Immutable *bool             `json:"immutable"`
-			Type      string            `json:"type"`
+			Immutable *bool             `json:"immutable,omitempty"`
+			Type      corev1.SecretType `json:"type,omitempty"`
 		}{
 			Data:      secret.Data,
 			Immutable: secret.Immutable,
-			Type:      string(secret.Type),
+			Type:      secret.Type,
 		}
 
 		dataJSON, err := json.Marshal(secretInfo)

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -167,7 +167,17 @@ func computeSecretsToPersist(
 	dataList := make([]gardencorev1beta1.GardenerResourceData, 0, len(secretList.Items))
 
 	for _, secret := range secretList.Items {
-		dataJSON, err := json.Marshal(secret.Data)
+		secretInfo := struct {
+			Data      map[string][]byte `json:"data"`
+			Immutable *bool             `json:"immutable"`
+			Type      string            `json:"type"`
+		}{
+			Data:      secret.Data,
+			Immutable: secret.Immutable,
+			Type:      string(secret.Type),
+		}
+
+		dataJSON, err := json.Marshal(secretInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed marshalling secret data to JSON for secret %s: %w", client.ObjectKeyFromObject(&secret), err)
 		}

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -96,13 +96,13 @@ var _ = Describe("ShootState", func() {
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret1", controlPlaneNamespace, true, true))).To(Succeed())
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret2", controlPlaneNamespace, false, true))).To(Succeed())
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret3", controlPlaneNamespace, true, false))).To(Succeed())
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret4", seedNamespace, true, false, func(s *corev1.Secret) {
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret4", controlPlaneNamespace, true, false, func(s *corev1.Secret) {
 					s.Immutable = ptr.To(true)
 				}))).To(Succeed())
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret5", seedNamespace, true, false, func(s *corev1.Secret) {
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret5", controlPlaneNamespace, true, false, func(s *corev1.Secret) {
 					s.Type = corev1.SecretTypeTLS
 				}))).To(Succeed())
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret6", seedNamespace, true, false, func(s *corev1.Secret) {
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret6", controlPlaneNamespace, true, false, func(s *corev1.Secret) {
 					s.Immutable = ptr.To(true)
 					s.Type = corev1.SecretTypeTLS
 				}))).To(Succeed())

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -96,6 +96,16 @@ var _ = Describe("ShootState", func() {
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret1", controlPlaneNamespace, true, true))).To(Succeed())
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret2", controlPlaneNamespace, false, true))).To(Succeed())
 				Expect(fakeSeedClient.Create(ctx, newSecret("secret3", controlPlaneNamespace, true, false))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret4", seedNamespace, true, false, func(s *corev1.Secret) {
+					s.Immutable = ptr.To(true)
+				}))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret5", seedNamespace, true, false, func(s *corev1.Secret) {
+					s.Type = corev1.SecretTypeTLS
+				}))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret6", seedNamespace, true, false, func(s *corev1.Secret) {
+					s.Immutable = ptr.To(true)
+					s.Type = corev1.SecretTypeTLS
+				}))).To(Succeed())
 
 				By("Creating extensions data")
 				createExtensionObject(ctx, fakeSeedClient, "backupentry", controlPlaneNamespace, &extensionsv1alpha1.BackupEntry{}, &runtime.RawExtension{Raw: []byte(`{"name":"backupentry"}`)})
@@ -120,13 +130,31 @@ var _ = Describe("ShootState", func() {
 						{
 							Name:   "secret1",
 							Type:   "secret",
-							Data:   runtime.RawExtension{Raw: []byte(`{"secret1":"c29tZS1kYXRh"}`)},
+							Data:   runtime.RawExtension{Raw: []byte(`{"data":{"secret1":"c29tZS1kYXRh"},"type":"Opaque"}`)},
 							Labels: map[string]string{"managed-by": "secrets-manager", "persist": "true"},
 						},
 						{
 							Name:   "secret3",
 							Type:   "secret",
-							Data:   runtime.RawExtension{Raw: []byte(`{"secret3":"c29tZS1kYXRh"}`)},
+							Data:   runtime.RawExtension{Raw: []byte(`{"data":{"secret3":"c29tZS1kYXRh"},"type":"Opaque"}`)},
+							Labels: map[string]string{"persist": "true"},
+						},
+						{
+							Name:   "secret4",
+							Type:   "secret",
+							Data:   runtime.RawExtension{Raw: []byte(`{"data":{"secret4":"c29tZS1kYXRh"},"immutable":true,"type":"Opaque"}`)},
+							Labels: map[string]string{"persist": "true"},
+						},
+						{
+							Name:   "secret5",
+							Type:   "secret",
+							Data:   runtime.RawExtension{Raw: []byte(`{"data":{"secret5":"c29tZS1kYXRh"},"type":"kubernetes.io/tls"}`)},
+							Labels: map[string]string{"persist": "true"},
+						},
+						{
+							Name:   "secret6",
+							Type:   "secret",
+							Data:   runtime.RawExtension{Raw: []byte(`{"data":{"secret6":"c29tZS1kYXRh"},"immutable":true,"type":"kubernetes.io/tls"}`)},
 							Labels: map[string]string{"persist": "true"},
 						},
 						{
@@ -265,7 +293,7 @@ var _ = Describe("ShootState", func() {
 	})
 })
 
-func newSecret(name, namespace string, withPersistLabel bool, withManagedByLabel bool) *corev1.Secret {
+func newSecret(name, namespace string, withPersistLabel bool, withManagedByLabel bool, opts ...func(*corev1.Secret)) *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -281,6 +309,10 @@ func newSecret(name, namespace string, withPersistLabel bool, withManagedByLabel
 	}
 	if withPersistLabel {
 		metav1.SetMetaDataLabel(&secret.ObjectMeta, "persist", "true")
+	}
+
+	for _, opt := range opts {
+		opt(secret)
 	}
 
 	return secret


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR updates how secrets that need to be persisted are stored in the shootstate, so that information about immutability and type is also persisted.

**Which issue(s) this PR fixes**:
Fixes #13262 

**Special notes for your reviewer**:

**Release note**:

<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```