### PR TITLE
[GEP-28] `gardenadm connect`: Enable `Bastion` controller in `gardenlet`

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -372,6 +372,10 @@ func (g *garden) Start(ctx context.Context) error {
 						}),
 						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
 					},
+					&operationsv1alpha1.Bastion{}: {
+						Field:      fields.SelectorFromSet(fields.Set{operations.BastionShootName: g.selfHostedShootInfo.Meta.Name}),
+						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
+					},
 					&gardencorev1beta1.Shoot{}: {
 						Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: g.selfHostedShootInfo.Meta.Name}),
 						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/operations"
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
@@ -58,6 +60,7 @@ var (
 	// group and the resource (but it ignores the version).
 	backupBucketResource              = gardencorev1beta1.Resource("backupbuckets")
 	backupEntryResource               = gardencorev1beta1.Resource("backupentries")
+	bastionResource                   = operationsv1alpha1.Resource("bastions")
 	certificateSigningRequestResource = certificatesv1.Resource("certificatesigningrequests")
 	cloudProfileResource              = gardencorev1beta1.Resource("cloudprofiles")
 	configMapResource                 = corev1.Resource("configmaps")
@@ -121,6 +124,16 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 				authwebhook.WithFieldSelectors(map[string]string{
 					core.BackupEntryShootRefName:      shootName,
 					core.BackupEntryShootRefNamespace: shootNamespace,
+				}),
+			)
+
+		case bastionResource:
+			return requestAuthorizer.Check(graph.VertexTypeBastion, attrs,
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
+				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithAllowedNamespaces(requestAuthorizer.ToNamespace),
+				authwebhook.WithFieldSelectors(map[string]string{
+					operations.BastionShootName: shootName,
 				}),
 			)
 

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth/shoot"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -374,6 +375,113 @@ var _ = Describe("Shoot", func() {
 
 					Entry("list w/ needed selector", "list", true),
 					Entry("list w/o needed selector", "list", false),
+				)
+			})
+
+			When("requested for Bastions", func() {
+				var (
+					name, namespace string
+					attrs           *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name, namespace = "foo", shootNamespace
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						Namespace:       namespace,
+						APIGroup:        operationsv1alpha1.SchemeGroupVersion.Group,
+						Resource:        "bastions",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should have no opinion because no allowed verb",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because no allowed subresource", func() {
+					attrs.Subresource = "foo"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+				})
+
+				It("should have no opinion because request is for a namespace the gardenlet is not responsible for", func() {
+					attrs.Namespace = "other-namespace"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following namespaces are allowed for this resource type"))
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb, subresource string) {
+						attrs.Verb = verb
+						attrs.Subresource = subresource
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeBastion, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeBastion, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+						decision, reason, err = authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
+					},
+
+					Entry("get", "get", ""),
+					Entry("patch w/o subresource", "patch", ""),
+					Entry("patch w/ status subresource", "patch", "status"),
+					Entry("update w/o subresource", "update", ""),
+					Entry("update w/ status subresource", "update", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector("spec.shootRef.name=" + shootName)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -104,6 +104,12 @@ func AddToManager(
 			return fmt.Errorf("failed adding BackupEntry controller: %w", err)
 		}
 
+		if err := (&bastion.Reconciler{
+			Config: *cfg.Controllers.Bastion,
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding Bastion controller: %w", err)
+		}
+
 		if err := (&gardenlet.Reconciler{
 			Config: *cfg,
 		}).AddToManager(mgr, gardenCluster, seedClientSet); err != nil {

--- a/pkg/utils/graph/eventhandler_bastion.go
+++ b/pkg/utils/graph/eventhandler_bastion.go
@@ -63,10 +63,18 @@ func (g *graph) handleBastionCreateOrUpdate(bastion *operationsv1alpha1.Bastion)
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	g.deleteVertex(VertexTypeBastion, bastion.Namespace, bastion.Name)
+	if g.forSelfHostedShoots {
+		g.deleteAllOutgoingEdges(VertexTypeBastion, bastion.Namespace, bastion.Name, VertexTypeShoot)
+	} else {
+		g.deleteAllOutgoingEdges(VertexTypeBastion, bastion.Namespace, bastion.Name, VertexTypeSeed)
+	}
 
-	if bastion.Spec.SeedName != nil {
-		bastionVertex := g.getOrCreateVertex(VertexTypeBastion, bastion.Namespace, bastion.Name)
+	bastionVertex := g.getOrCreateVertex(VertexTypeBastion, bastion.Namespace, bastion.Name)
+
+	if g.forSelfHostedShoots {
+		shootVertex := g.getOrCreateVertex(VertexTypeShoot, bastion.Namespace, bastion.Spec.ShootRef.Name)
+		g.addEdge(bastionVertex, shootVertex)
+	} else if bastion.Spec.SeedName != nil {
 		seedVertex := g.getOrCreateVertex(VertexTypeSeed, "", *bastion.Spec.SeedName)
 		g.addEdge(bastionVertex, seedVertex)
 	}

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -73,6 +73,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 		setups = append(setups,
 			resourceSetup{&gardencorev1beta1.BackupBucket{}, g.setupBackupBucketWatch},
 			resourceSetup{&gardencorev1beta1.BackupEntry{}, g.setupBackupEntryWatch},
+			resourceSetup{&operationsv1alpha1.Bastion{}, g.setupBastionWatch},
 			resourceSetup{&certificatesv1.CertificateSigningRequest{}, g.setupCertificateSigningRequestWatch},
 			resourceSetup{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
 			resourceSetup{&corev1.ServiceAccount{}, g.setupServiceAccountWatch},

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -2517,6 +2517,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeClient                            client.Client
 		fakeInformerBackupBucket              *controllertest.FakeInformer
 		fakeInformerBackupEntry               *controllertest.FakeInformer
+		fakeInformerBastion                   *controllertest.FakeInformer
 		fakeInformerCertificateSigningRequest *controllertest.FakeInformer
 		fakeInformerGardenlet                 *controllertest.FakeInformer
 		fakeInformerServiceAccount            *controllertest.FakeInformer
@@ -2537,6 +2538,8 @@ var _ = Describe("graph for shoots", func() {
 		backupBucket1GeneratedSecretRef             = corev1.SecretReference{Namespace: "generated", Name: "secret"}
 
 		backupEntry1 *gardencorev1beta1.BackupEntry
+
+		bastion1 *operationsv1alpha1.Bastion
 
 		csr1 *certificatesv1.CertificateSigningRequest
 
@@ -2575,6 +2578,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		fakeInformerBackupBucket = &controllertest.FakeInformer{}
 		fakeInformerBackupEntry = &controllertest.FakeInformer{}
+		fakeInformerBastion = &controllertest.FakeInformer{}
 		fakeInformerCertificateSigningRequest = &controllertest.FakeInformer{}
 		fakeInformerGardenlet = &controllertest.FakeInformer{}
 		fakeInformerServiceAccount = &controllertest.FakeInformer{}
@@ -2585,6 +2589,7 @@ var _ = Describe("graph for shoots", func() {
 			InformersByGVK: map[schema.GroupVersionKind]toolscache.SharedIndexInformer{
 				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupBucket"):           fakeInformerBackupBucket,
 				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupEntry"):            fakeInformerBackupEntry,
+				operationsv1alpha1.SchemeGroupVersion.WithKind("Bastion"):               fakeInformerBastion,
 				certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
 				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("Gardenlet"):         fakeInformerGardenlet,
 				corev1.SchemeGroupVersion.WithKind("ServiceAccount"):                    fakeInformerServiceAccount,
@@ -2727,6 +2732,13 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 				ShootRef:   &corev1.ObjectReference{Name: shoot1.Name, Namespace: "backupentry1namespace"},
 			},
 		}
+
+		bastion1 = &operationsv1alpha1.Bastion{
+			ObjectMeta: metav1.ObjectMeta{Name: "bastion1", Namespace: namespace1.Name},
+			Spec: operationsv1alpha1.BastionSpec{
+				ShootRef: corev1.LocalObjectReference{Name: shoot1.Name},
+			},
+		}
 	})
 
 	It("should behave as expected for gardencorev1beta1.BackupBucket", func() {
@@ -2840,6 +2852,36 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 		Expect(graph.HasPathFrom(VertexTypeBackupBucket, "", backupEntry1.Spec.BucketName, VertexTypeBackupEntry, backupEntry1.Namespace, backupEntry1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeBackupEntry, backupEntry1.Namespace, backupEntry1.Name, VertexTypeShoot, backupEntry1.Namespace, shoot1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeBackupEntry, backupEntry1.Namespace, backupEntry1.Name, VertexTypeShoot, backupEntry1.Namespace, shoot1.Name)).To(BeFalse())
+	})
+
+	It("should behave as expected for operationsv1alpha1.Bastion", func() {
+		By("Add")
+		fakeInformerBastion.Add(bastion1)
+		Expect(graph.graph.Nodes().Len()).To(Equal(2))
+		Expect(graph.graph.Edges().Len()).To(Equal(1))
+		Expect(graph.HasPathFrom(VertexTypeBastion, bastion1.Namespace, bastion1.Name, VertexTypeShoot, bastion1.Namespace, bastion1.Spec.ShootRef.Name)).To(BeTrue())
+
+		By("Update (irrelevant change)")
+		bastion1Copy := bastion1.DeepCopy()
+		bastion1.Spec.SSHPublicKey = "foobar"
+		fakeInformerBastion.Update(bastion1Copy, bastion1)
+		Expect(graph.graph.Nodes().Len()).To(Equal(2))
+		Expect(graph.graph.Edges().Len()).To(Equal(1))
+		Expect(graph.HasPathFrom(VertexTypeBastion, bastion1.Namespace, bastion1.Name, VertexTypeShoot, bastion1.Namespace, bastion1.Spec.ShootRef.Name)).To(BeTrue())
+
+		By("Update (seed name)")
+		bastion1Copy = bastion1.DeepCopy()
+		bastion1.Spec.SeedName = ptr.To("newseed")
+		fakeInformerBastion.Update(bastion1Copy, bastion1)
+		Expect(graph.graph.Nodes().Len()).To(Equal(2))
+		Expect(graph.graph.Edges().Len()).To(Equal(1))
+		Expect(graph.HasPathFrom(VertexTypeBastion, bastion1.Namespace, bastion1.Name, VertexTypeShoot, bastion1.Namespace, bastion1.Spec.ShootRef.Name)).To(BeTrue())
+
+		By("Delete")
+		fakeInformerBastion.Delete(bastion1)
+		Expect(graph.graph.Nodes().Len()).To(BeZero())
+		Expect(graph.graph.Edges().Len()).To(BeZero())
+		Expect(graph.HasPathFrom(VertexTypeBastion, bastion1.Namespace, bastion1.Name, VertexTypeShoot, bastion1.Namespace, bastion1.Spec.ShootRef.Name)).To(BeFalse())
 	})
 
 	It("should behave as expected for certificatesv1.CertificateSigningRequest", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Enables the `Bastion` controller in the `gardenlet` running inside self-hosted shoot clusters, following the same pattern established for `BackupBucket`/`BackupEntry` in #13519. The resource dependency graph maps `Bastion → Shoot` (via `.spec.shootRef.name`) instead of `Bastion → Seed`, the shoot authorizer allows scoped access, and the garden cluster cache is filtered to only watch `Bastion`s belonging to the self-hosted shoot.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```other operator
NONE
```