### PR TITLE
Fix duplicate ControllerInstallation creation due to stale cache

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Live lookup to prevent working on a stale cache and trying to create multiple installations for the same
 	// registration/seed/shoot combination.
 	controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-	if err := r.Client.List(ctx, controllerInstallationList); err != nil {
+	if err := r.APIReader.List(ctx, controllerInstallationList); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
/area control-plane
/kind bug

**What this PR does / why we need it**:
This is a fix for a small bug introduced in #14151. The `ControllerInstallation` reconciler listed `ControllerInstallation`s via `r.Client.List`, which reads from the informer cache. When two reconciliations happen in quick succession, the second can read a stale cache that doesn't yet reflect the first's creation, resulting in duplicate `ControllerInstallation`s for the same registration/seed combination.

This switches the list call back to `r.APIReader.List` so it hits the API server directly.

**Which issue(s) this PR fixes**:
Fixes flaky integration test.

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixed a race condition in the `ControllerInstallation` reconciler that could create duplicate installations due to reading from a stale informer cache instead of the API server.
```