### PR TITLE
[GEP-28] `gardenadm connect`: Enable `shoot/status` controller in `gardenlet`

### DIFF
--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -123,8 +123,7 @@ func AddToManager(
 		}
 		// TODO(tobschli): Remove this once all shoot reconcilers are added via `shoot.AddToManager`.
 		if err := (&status.Reconciler{
-			Config:   *cfg.Controllers.ShootStatus,
-			SeedName: "",
+			Config: *cfg.Controllers.ShootStatus,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding status reconciler: %w", err)
 		}

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/lease"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/state"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/status"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/tokenrequestor/workloadidentity"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/vpaevictionrequirements"
 	"github.com/gardener/gardener/pkg/healthz"
@@ -119,6 +120,13 @@ func AddToManager(
 			Config: *cfg.Controllers.ShootState,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding ShootState controller: %w", err)
+		}
+		// TODO(tobschli): Remove this once all shoot reconcilers are added via `shoot.AddToManager`.
+		if err := (&status.Reconciler{
+			Config:   *cfg.Controllers.ShootStatus,
+			SeedName: "",
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding status reconciler: %w", err)
 		}
 
 		if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, seedNetworks, nil); err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind quality

**What this PR does / why we need it**:

This PR enables the `shoot/status` controller in the `gardenlet` for SHSC's

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

Because the connect scenario is currently not supported in the managed-infra case, I tested the workings of the controller in the unmanaged case using the local setup.
To reproduce, you can follow these steps:
1. Create a dummy `kube-system/root` `Worker` resource in the SHSC
2. Patch its status to something like:
```yaml
status:
  inPlaceUpdates:
    workerPoolToHashMap:
      local-worker: abcdefg
```
3. Patch the `Shoot`s status to something like:
```yaml
inPlaceUpdates:
    pendingWorkerUpdates:
      manualInPlaceUpdate:
        - local-worker
```
4. Observe that the reconciler updates the status by removing the `inPlaceUpdates` field in the `Shoot`s status

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
