### PR TITLE
Use `.spec.trafficDistribution=PreferSameZone` for Kubernetes 1.34+ for the etcd-client Service

### DIFF
--- a/pkg/component/etcd/etcd/etcd.go
+++ b/pkg/component/etcd/etcd/etcd.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // Class is a string type alias for etcd classes.
@@ -295,11 +294,6 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	clientService := &corev1.Service{}
 	gardenerutils.ReconcileTopologyAwareRoutingSettings(clientService, e.values.TopologyAwareRoutingEnabled, e.values.RuntimeKubernetesVersion)
-
-	// TODO(tobschli): Remove this once once etcd druid allows PreferSameZone.
-	if e.values.TopologyAwareRoutingEnabled && versionutils.ConstraintK8sGreaterEqual134.Check(e.values.RuntimeKubernetesVersion) {
-		clientService.Spec.TrafficDistribution = ptr.To(corev1.ServiceTrafficDistributionPreferClose)
-	}
 
 	ports := []networkingv1.NetworkPolicyPort{
 		{Port: ptr.To(intstr.FromInt32(etcdconstants.PortEtcdClient)), Protocol: ptr.To(corev1.ProtocolTCP)},

--- a/pkg/component/etcd/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd/etcd_test.go
@@ -1837,7 +1837,8 @@ var _ = Describe("Etcd", func() {
 					Expect(etcd.Deploy(ctx)).To(Succeed())
 				},
 
-				Entry("when runtime Kubernetes version is >= 1.32", semver.MustParse("1.32.1")),
+				Entry("when runtime Kubernetes version is >= 1.34", semver.MustParse("1.34.0")),
+				Entry("when runtime Kubernetes version is >= 1.32, < 1.34", semver.MustParse("1.32.1")),
 				Entry("when runtime Kubernetes version is 1.31", semver.MustParse("1.31.2")),
 				Entry("when runtime Kubernetes version is < 1.31", semver.MustParse("1.30.3")),
 			)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/14273 brings https://github.com/gardener/etcd-druid/pull/1280. With https://github.com/gardener/etcd-druid/pull/1280 we can clean up the TODO in https://github.com/gardener/gardener/blob/157649b98fa1c5a1a7c9c5f8cb68d2e62ffc2898/pkg/component/etcd/etcd/etcd.go#L299-L302 as `PreferSameZone` is a supported Service `trafficDistribution` value with [etcd-druid@v0.36.0](https://github.com/gardener/etcd-druid/releases/tag/v0.36.0).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13942

**Special notes for your reviewer**:
This PR is based on https://github.com/gardener/gardener/pull/14341. Hence, it is in draft state until https://github.com/gardener/gardener/pull/14341 is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `.spec.trafficDistribution` field of the topology-aware `etcd-{events,main}-client` Services will be automatically switched from the deprecated `PreferClose` to the new `PreferSameZone` option for Kubernetes 1.34+.
```
