### PR TITLE
[GEP-28] Don't create duplicate `ControllerInstallation`s when self-hosted `Shoot` is also a `Seed`

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -466,7 +466,7 @@ func (g *garden) Start(ctx context.Context) error {
 		}
 
 		log.Info("Registering Seed object in garden cluster")
-		if err := g.registerSeed(ctx, gardenCluster.GetClient()); err != nil {
+		if err := g.registerSeed(ctx, gardenCluster.GetClient(), isSelfHostedShoot); err != nil {
 			return err
 		}
 	}
@@ -553,7 +553,7 @@ func (g *garden) Start(ctx context.Context) error {
 	return nil
 }
 
-func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) error {
+func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client, isSelfHostedShoot bool) error {
 	seed := &gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: g.config.SeedConfig.Name,
@@ -565,6 +565,10 @@ func (g *garden) registerSeed(ctx context.Context, gardenClient client.Client) e
 		seed.Labels = utils.MergeStringMaps(map[string]string{
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 		}, g.config.SeedConfig.Labels)
+
+		if isSelfHostedShoot {
+			metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster, "true")
+		}
 
 		var (
 			internalDNS = seed.Spec.DNS.Internal

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -446,6 +446,25 @@ func (g *garden) Start(ctx context.Context) error {
 	}
 
 	if !gardenlet.IsResponsibleForSelfHostedShoot() {
+		isSelfHostedShoot, err := gardenlet.SeedIsSelfHostedShoot(ctx, g.mgr.GetClient())
+		if err != nil {
+			return fmt.Errorf("failed checking if seed cluster is a self-hosted shoot: %w", err)
+		}
+
+		if isSelfHostedShoot {
+			// Abort startup if the corresponding Shoot does not yet exist in the garden cluster. This prevents
+			// GCM from creating `ControllerInstallation`s with `.spec.seedRef`. However, if the seed is a self-hosted
+			// shoot, we want all `ControllerInstallation`s to use `.spec.shootRef`. Self-hosted shoots must be in the
+			// garden namespace (for now), so the name is sufficient to identify the Shoot.
+			shoot := &gardencorev1beta1.Shoot{}
+			if err := gardenCluster.GetClient().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: g.config.SeedConfig.Name}, shoot); err != nil {
+				if apierrors.IsNotFound(err) {
+					return fmt.Errorf("seed cluster is a self-hosted shoot but the corresponding Shoot %q does not yet exist in namespace %q; run `gardenadm connect` first", g.config.SeedConfig.Name, v1beta1constants.GardenNamespace)
+				}
+				return fmt.Errorf("failed getting Shoot for self-hosted seed: %w", err)
+			}
+		}
+
 		log.Info("Registering Seed object in garden cluster")
 		if err := g.registerSeed(ctx, gardenCluster.GetClient()); err != nil {
 			return err

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -110,6 +110,8 @@ For example, if the shoots in the seed are no longer using the DNS provider `aws
 When the `Seed` carries the label `seed.gardener.cloud/self-hosted-shoot-cluster=true`, the seed cluster is also a self-hosted shoot cluster managed by the ["Self-Hosted Shoot" Reconciler](#self-hosted-shoot-reconciler).
 In this case, the seed reconciler subtracts all kind/type combinations already covered by the self-hosted shoot (its own extensions, `BackupBucket`s, and `BackupEntry`s referencing the shoot) from the set of required kind/types, so that only extensions exclusively needed by the seed role remain.
 `ControllerInstallations` created for these seed-exclusive extensions reference the shoot via `.spec.shootRef` (not `.spec.seedRef`), so that extensions are not uninstalled if the seed is later deregistered while the shoot still exists.
+These `ControllerInstallation`s are marked with a `seed-ref-name` label so that the shoot reconciler does not accidentally manage or delete them.
+If an extension previously exclusive to the seed becomes also required by the shoot (e.g., because of a shoot spec change), the seed reconciler removes the `seed-ref-name` label instead of deleting the `ControllerInstallation`, handing ownership to the shoot reconciler.
 `Always` and `AlwaysExceptNoShoots` deployment policies are also suppressed for the seed reconciler in this case — they are handled by the self-hosted shoot reconciler.
 
 #### ["Self-Hosted Shoot" Reconciler](../../pkg/controllermanager/controller/controllerregistration/controllerinstallation/shoot)

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -107,6 +107,11 @@ The controller then creates or updates the required `ControllerInstallation` obj
 It also deletes every existing `ControllerInstallation` whose referenced `ControllerRegistration` is not part of the required list.
 For example, if the shoots in the seed are no longer using the DNS provider `aws-route53`, then the controller proceeds to delete the respective `ControllerInstallation` object.
 
+When the `Seed` carries the label `seed.gardener.cloud/self-hosted-shoot-cluster=true`, the seed cluster is also a self-hosted shoot cluster managed by the ["Self-Hosted Shoot" Reconciler](#self-hosted-shoot-reconciler).
+In this case, the seed reconciler subtracts all kind/type combinations already covered by the self-hosted shoot (its own extensions, `BackupBucket`s, and `BackupEntry`s referencing the shoot) from the set of required kind/types, so that only extensions exclusively needed by the seed role remain.
+`ControllerInstallations` created for these seed-exclusive extensions reference the shoot via `.spec.shootRef` (not `.spec.seedRef`), so that extensions are not uninstalled if the seed is later deregistered while the shoot still exists.
+`Always` and `AlwaysExceptNoShoots` deployment policies are also suppressed for the seed reconciler in this case — they are handled by the self-hosted shoot reconciler.
+
 #### ["Self-Hosted Shoot" Reconciler](../../pkg/controllermanager/controller/controllerregistration/controllerinstallation/shoot)
 
 This reconciliation loop uses the same shared reconciler logic but watches self-hosted `Shoot` objects (i.e., `Shoot`s whose worker pools are configured for self-hosting the control plane) instead of `Seed` objects.

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -381,6 +381,12 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("seedName"), *spec.SeedName, "cannot set seedName for self-hosted shoots"))
 		}
 
+		// Self-hosted shoots must reside in the garden namespace so that the corresponding Seed object (if the cluster
+		// is also registered as a seed) can be unambiguously identified by name alone.
+		if meta.Namespace != v1beta1constants.GardenNamespace {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), meta.Namespace, fmt.Sprintf("self-hosted shoots must be in the %q namespace", v1beta1constants.GardenNamespace)))
+		}
+
 		for i, worker := range spec.Provider.Workers {
 			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "workers").Index(i).Child("systemComponents"), *worker.SystemComponents, "systemComponents is only allowed for the control plane worker pool for self-hosted shoots"))

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1538,10 +1538,26 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			Context("self-hosted shoots", func() {
+				BeforeEach(func() {
+					// Self-hosted shoots are required to reside in the garden namespace.
+					shoot.Namespace = "garden"
+				})
+
 				It("should allow 'ControlPlane' field for worker pool", func() {
 					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
 
 					Expect(ValidateShoot(shoot)).To(BeEmpty())
+				})
+
+				It("should prevent creating a self-hosted shoot outside the garden namespace", func() {
+					shoot.Namespace = "other-namespace"
+					shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
+
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("metadata.namespace"),
+						"Detail": ContainSubstring(`self-hosted shoots must be in the "garden" namespace`),
+					}))))
 				})
 
 				It("should prevent having more then one 'ControlPlane' worker pool", func() {
@@ -1624,7 +1640,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 								APIVersion: "v1",
 								Kind:       "Secret",
 								Name:       "backup-foo",
-								Namespace:  shootNamespace,
+								Namespace:  "garden",
 							},
 						}}
 					})
@@ -1661,7 +1677,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						})
 
 						It("should forbid credentialsRef to refer a WorkloadIdentity", func() {
-							shoot.Spec.Provider.Workers[0].ControlPlane.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Namespace: shootNamespace, Name: "backup"}
+							shoot.Spec.Provider.Workers[0].ControlPlane.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Namespace: "garden", Name: "backup"}
 
 							Expect(ValidateShoot(shoot)).To(ConsistOf(
 								PointTo(MatchFields(IgnoreExtras, Fields{
@@ -1673,7 +1689,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						})
 
 						It("should allow credentialsRef to refer a Secret", func() {
-							shoot.Spec.Provider.Workers[0].ControlPlane.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: shootNamespace, Name: "backup"}
+							shoot.Spec.Provider.Workers[0].ControlPlane.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "garden", Name: "backup"}
 
 							Expect(ValidateShoot(shoot)).To(BeEmpty())
 						})

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
@@ -144,11 +144,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 		if metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) {
 			shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: seed.Name, Namespace: v1beta1constants.GardenNamespace}}
-			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil && !apierrors.IsNotFound(err) {
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed getting Shoot for self-hosted seed: %w", err)
-			} else if err == nil {
-				selfHostedShoot = shoot
 			}
+			selfHostedShoot = shoot
 		}
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
@@ -191,7 +191,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if err := deleteUnneededInstallations(ctx, log, r.Client, wantedControllerRegistrationNames, registrationNameToInstallation); err != nil {
+	if err := deleteUnneededInstallations(ctx, log, r.Client, r.Kind, wantedControllerRegistrationNames, registrationNameToInstallation); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -599,6 +599,10 @@ func deployNeededInstallation(
 			}
 
 		case ShootKind:
+			// If this ControllerInstallation was previously created by the seed reconciler for a self-hosted-shoot
+			// seed, strip the ownership label to adopt it.
+			delete(controllerInstallation.Labels, SeedRefName)
+
 			shoot, ok := obj.(*gardencorev1beta1.Shoot)
 			if !ok {
 				return fmt.Errorf("cannot convert object of type %T to *gardencorev1beta1.Shoot", obj)
@@ -664,20 +668,44 @@ func deployNeededInstallation(
 // deleteUnneededInstallations takes the list of required names of ControllerRegistrations, and another mapping of
 // ControllerRegistration names to existing ControllerInstallations. It deletes every existing ControllerInstallation
 // whose referenced ControllerRegistration is not part of the given list of required list.
+// For the seed reconciler: ControllerInstallations with the SeedRefName label are not deleted but instead the label is
+// stripped — this hands ownership to the shoot reconciler.
+// For the shoot reconciler: ControllerInstallations with the SeedRefName label are skipped entirely (the seed
+// reconciler owns them).
 func deleteUnneededInstallations(
 	ctx context.Context,
 	log logr.Logger,
 	c client.Client,
+	kind Kind,
 	wantedControllerRegistrationNames sets.Set[string],
 	registrationNameToInstallation map[string]*gardencorev1beta1.ControllerInstallation,
 ) error {
 	for registrationName, installation := range registrationNameToInstallation {
-		if !wantedControllerRegistrationNames.Has(registrationName) {
-			log.Info("Deleting unneeded ControllerInstallation for ControllerRegistration", "controllerRegistrationName", registrationName, "controllerInstallationName", installation.Name)
+		if wantedControllerRegistrationNames.Has(registrationName) {
+			continue
+		}
 
-			if err := c.Delete(ctx, installation); client.IgnoreNotFound(err) != nil {
-				return err
+		// ControllerInstallations with the SeedRefName label are owned by the seed reconciler.
+		if metav1.HasLabel(installation.ObjectMeta, SeedRefName) {
+			if kind == ShootKind {
+				// The shoot reconciler must not delete or modify seed-owned ControllerInstallations.
+				continue
 			}
+
+			log.Info("Removing seed ownership label from ControllerInstallation to hand over to shoot reconciler", "controllerRegistrationName", registrationName, "controllerInstallationName", installation.Name)
+
+			patch := client.MergeFrom(installation.DeepCopy())
+			delete(installation.Labels, SeedRefName)
+			if err := c.Patch(ctx, installation, patch); err != nil {
+				return fmt.Errorf("failed removing %s label from ControllerInstallation %s: %w", SeedRefName, installation.Name, err)
+			}
+			continue
+		}
+
+		log.Info("Deleting unneeded ControllerInstallation for ControllerRegistration", "controllerRegistrationName", registrationName, "controllerInstallationName", installation.Name)
+
+		if err := c.Delete(ctx, installation); client.IgnoreNotFound(err) != nil {
+			return err
 		}
 	}
 
@@ -767,11 +795,12 @@ func controllerInstallationReferencesObject(controllerInstallation gardencorev1b
 	switch kind {
 	case SeedKind:
 		if selfHostedShoot != nil {
-			// For self-hosted-shoot seeds the seed reconciler creates ControllerInstallations with .spec.shootRef,
-			// so match by shootRef rather than seedRef.
+			// For self-hosted-shoot seeds the seed reconciler creates ControllerInstallations with .spec.shootRef
+			// and marks them with the SeedRefName label. Only match those — the shoot reconciler manages the rest.
 			if controllerInstallation.Spec.ShootRef == nil ||
 				controllerInstallation.Spec.ShootRef.Name != selfHostedShoot.Name ||
-				controllerInstallation.Spec.ShootRef.Namespace != selfHostedShoot.Namespace {
+				controllerInstallation.Spec.ShootRef.Namespace != selfHostedShoot.Namespace ||
+				!metav1.HasLabel(controllerInstallation.ObjectMeta, SeedRefName) {
 				return false
 			}
 		} else {
@@ -783,12 +812,6 @@ func controllerInstallationReferencesObject(controllerInstallation gardencorev1b
 		if controllerInstallation.Spec.ShootRef == nil ||
 			controllerInstallation.Spec.ShootRef.Name != obj.GetName() ||
 			controllerInstallation.Spec.ShootRef.Namespace != obj.GetNamespace() {
-			return false
-		}
-		// ControllerInstallations created by the seed reconciler for self-hosted-shoot seeds use .spec.shootRef
-		// as well (so the shoot gardenlet can manage them), but are marked with SeedRefName to prevent the shoot
-		// reconciler from managing or deleting them.
-		if metav1.HasLabel(controllerInstallation.ObjectMeta, SeedRefName) {
 			return false
 		}
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler.go
@@ -43,6 +43,10 @@ const (
 	// RegistrationSpecHash is a constant for a label on `ControllerInstallation`s (similar to `pod-template-hash` on
 	// Pod`s).
 	RegistrationSpecHash = "registration-spec-hash"
+	// SeedRefName is a constant for a label on `ControllerInstallation`s created by the seed reconciler for
+	// self-hosted-shoot seeds. Its value is the seed name. It allows the shoot reconciler to distinguish these
+	// ControllerInstallations (which use .spec.shootRef) from those it owns.
+	SeedRefName = "seed-ref-name"
 )
 
 // Kind is a string alias.
@@ -126,25 +130,64 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	wantedKindTypeCombinations = wantedKindTypeCombinations.Union(wantedKindTypeCombinationForShoots)
 
+	// selfHostedShoot is non-nil when the seed being reconciled is a self-hosted shoot cluster. In that case the
+	// shoot reconciler already manages ControllerInstallations with .spec.shootRef for this shoot. The seed reconciler
+	// must only handle extensions exclusively needed by the seed role (i.e., not already covered by the shoot
+	// reconciler), and creates those ControllerInstallations with .spec.shootRef as well (not .spec.seedRef).
+	var selfHostedShoot *gardencorev1beta1.Shoot
 	if r.Kind == SeedKind {
 		seed, ok := obj.(*gardencorev1beta1.Seed)
 		if !ok {
 			return reconcile.Result{}, fmt.Errorf("cannot convert object of type %T to *gardencorev1beta1.Seed", obj)
 		}
 		wantedKindTypeCombinations = wantedKindTypeCombinations.Union(computeKindTypesForSeed(seed, controllerRegistrationList))
+
+		if metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) {
+			shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: seed.Name, Namespace: v1beta1constants.GardenNamespace}}
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(shoot), shoot); err != nil && !apierrors.IsNotFound(err) {
+				return reconcile.Result{}, fmt.Errorf("failed getting Shoot for self-hosted seed: %w", err)
+			} else if err == nil {
+				selfHostedShoot = shoot
+			}
+		}
 	}
 
-	wantedControllerRegistrationNames, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), obj, r.Kind)
+	if selfHostedShoot != nil {
+		// Subtract all kind/type combinations already managed by the shoot reconciler for this shoot so that the
+		// seed reconciler only creates ControllerInstallations for extensions exclusively needed by the seed role.
+		// This covers the shoot's own spec, plus BackupBuckets and BackupEntries referencing the shoot.
+		shootBackupBucketList := &gardencorev1beta1.BackupBucketList{}
+		if err := r.Client.List(ctx, shootBackupBucketList, backupBucketFieldSelector(selfHostedShoot, ShootKind)...); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed listing BackupBuckets for self-hosted shoot: %w", err)
+		}
+		shootBackupBucketNameToObject := make(map[string]*gardencorev1beta1.BackupBucket, len(shootBackupBucketList.Items))
+		for _, backupBucket := range shootBackupBucketList.Items {
+			shootBackupBucketNameToObject[backupBucket.Name] = &backupBucket
+		}
+
+		shootBackupEntryList := &gardencorev1beta1.BackupEntryList{}
+		if err := r.Client.List(ctx, shootBackupEntryList, backupEntryFieldSelector(selfHostedShoot, ShootKind)...); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed listing BackupEntries for self-hosted shoot: %w", err)
+		}
+
+		shootKindTypeCombinations := sets.New[string]().
+			Union(computeKindTypesForBackupBuckets(shootBackupBucketNameToObject, selfHostedShoot, ShootKind)).
+			Union(computeKindTypesForBackupEntries(log, shootBackupEntryList, shootBackupBucketNameToObject)).
+			Union(gardenerutils.ComputeRequiredExtensionsForShoot(selfHostedShoot, nil, controllerRegistrationList, nil, nil))
+		wantedKindTypeCombinations = wantedKindTypeCombinations.Difference(shootKindTypeCombinations)
+	}
+
+	wantedControllerRegistrationNames, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), obj, r.Kind, selfHostedShoot)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	registrationNameToInstallation, err := computeRegistrationNameToInstallationMap(controllerInstallationList, controllerRegistrations, obj, r.Kind)
+	registrationNameToInstallation, err := computeRegistrationNameToInstallationMap(controllerInstallationList, controllerRegistrations, obj, r.Kind, selfHostedShoot)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if err := deployNeededInstallations(ctx, log, r.Client, obj, r.Kind, wantedControllerRegistrationNames, controllerRegistrations, registrationNameToInstallation); err != nil {
+	if err := deployNeededInstallations(ctx, log, r.Client, obj, r.Kind, selfHostedShoot, wantedControllerRegistrationNames, controllerRegistrations, registrationNameToInstallation); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -328,6 +371,7 @@ func computeWantedControllerRegistrationNames(
 	numberOfShoots int,
 	obj client.Object,
 	kind Kind,
+	selfHostedShoot *gardencorev1beta1.Shoot,
 ) (
 	sets.Set[string],
 	error,
@@ -338,7 +382,9 @@ func computeWantedControllerRegistrationNames(
 	)
 
 	for name, controllerRegistration := range controllerRegistrations {
-		if controllerRegistration.obj.DeletionTimestamp == nil {
+		// When the seed is a self-hosted shoot, the shoot reconciler handles Always/AlwaysExceptNoShoots
+		// registrations — skip them here to avoid duplicate ControllerInstallations.
+		if controllerRegistration.obj.DeletionTimestamp == nil && selfHostedShoot == nil {
 			if controllerRegistration.deployAlways && obj.GetDeletionTimestamp() == nil {
 				wantedControllerRegistrationNames.Insert(name)
 			}
@@ -362,7 +408,11 @@ func computeWantedControllerRegistrationNames(
 		wantedControllerRegistrationNames.Insert(names...)
 	}
 
-	wantedControllerRegistrationNames.Insert(sets.List(installedAndRequiredRegistrationNames(controllerInstallationList, obj, kind))...)
+	// When the seed is a self-hosted shoot, the shoot reconciler owns all ControllerInstallations for this shoot —
+	// the seed reconciler must not keep any of them alive via the "installed and required" mechanism.
+	if selfHostedShoot == nil {
+		wantedControllerRegistrationNames.Insert(sets.List(installedAndRequiredRegistrationNames(controllerInstallationList, obj, kind))...)
+	}
 
 	if kind == ShootKind {
 		return wantedControllerRegistrationNames, nil
@@ -374,7 +424,7 @@ func computeWantedControllerRegistrationNames(
 func installedAndRequiredRegistrationNames(controllerInstallationList *gardencorev1beta1.ControllerInstallationList, obj client.Object, kind Kind) sets.Set[string] {
 	requiredControllerRegistrationNames := sets.New[string]()
 	for _, controllerInstallation := range controllerInstallationList.Items {
-		if !controllerInstallationReferencesObject(controllerInstallation, obj, kind) {
+		if !controllerInstallationReferencesObject(controllerInstallation, obj, kind, nil) {
 			continue
 		}
 		if !v1beta1helper.IsControllerInstallationRequired(controllerInstallation) {
@@ -392,6 +442,7 @@ func computeRegistrationNameToInstallationMap(
 	controllerRegistrations map[string]controllerRegistration,
 	obj client.Object,
 	kind Kind,
+	selfHostedShoot *gardencorev1beta1.Shoot,
 ) (
 	map[string]*gardencorev1beta1.ControllerInstallation,
 	error,
@@ -399,7 +450,7 @@ func computeRegistrationNameToInstallationMap(
 	registrationNameToInstallationName := make(map[string]*gardencorev1beta1.ControllerInstallation)
 
 	for _, controllerInstallation := range controllerInstallationList.Items {
-		if !controllerInstallationReferencesObject(controllerInstallation, obj, kind) {
+		if !controllerInstallationReferencesObject(controllerInstallation, obj, kind, selfHostedShoot) {
 			continue
 		}
 
@@ -416,13 +467,15 @@ func computeRegistrationNameToInstallationMap(
 
 // deployNeededInstallations takes the list of required names of ControllerRegistrations, a mapping of ControllerRegistration
 // names to their actual objects, and another mapping of ControllerRegistration names to existing ControllerInstallations. It
-// creates or update ControllerInstallation objects for that reference the given seed and the various desired ControllerRegistrations.
+// creates or updates ControllerInstallation objects that reference the given seed or shoot and the various desired
+// ControllerRegistrations.
 func deployNeededInstallations(
 	ctx context.Context,
 	log logr.Logger,
 	c client.Client,
 	obj client.Object,
 	kind Kind,
+	selfHostedShoot *gardencorev1beta1.Shoot,
 	wantedControllerRegistrations sets.Set[string],
 	controllerRegistrations map[string]controllerRegistration,
 	registrationNameToInstallation map[string]*gardencorev1beta1.ControllerInstallation,
@@ -460,7 +513,7 @@ func deployNeededInstallations(
 			return fmt.Errorf("cannot deploy new ControllerInstallation for %q because the deletion of the old ControllerInstallation is still pending", registrationName)
 		}
 
-		if err := deployNeededInstallation(ctx, c, obj, kind, controllerDeployment, controllerRegistration, existingControllerInstallation); err != nil {
+		if err := deployNeededInstallation(ctx, c, obj, kind, selfHostedShoot, controllerDeployment, controllerRegistration, existingControllerInstallation); err != nil {
 			return err
 		}
 	}
@@ -473,6 +526,7 @@ func deployNeededInstallation(
 	c client.Client,
 	obj client.Object,
 	kind Kind,
+	selfHostedShoot *gardencorev1beta1.Shoot,
 	controllerDeployment *gardencorev1.ControllerDeployment,
 	controllerRegistration *gardencorev1beta1.ControllerRegistration,
 	existingControllerInstallation *gardencorev1beta1.ControllerInstallation,
@@ -486,9 +540,20 @@ func deployNeededInstallation(
 
 	switch kind {
 	case SeedKind:
-		installationSpec.SeedRef = &corev1.ObjectReference{
-			Name:            obj.GetName(),
-			ResourceVersion: obj.GetResourceVersion(),
+		if selfHostedShoot != nil {
+			// For self-hosted-shoot seeds the seed reconciler creates ControllerInstallations with .spec.shootRef
+			// (not .spec.seedRef) so that the shoot gardenlet can manage them alongside those owned by the shoot
+			// reconciler.
+			installationSpec.ShootRef = &corev1.ObjectReference{
+				Name:            selfHostedShoot.Name,
+				Namespace:       selfHostedShoot.Namespace,
+				ResourceVersion: selfHostedShoot.ResourceVersion,
+			}
+		} else {
+			installationSpec.SeedRef = &corev1.ObjectReference{
+				Name:            obj.GetName(),
+				ResourceVersion: obj.GetResourceVersion(),
+			}
 		}
 	case ShootKind:
 		installationSpec.ShootRef = &corev1.ObjectReference{
@@ -509,16 +574,29 @@ func deployNeededInstallation(
 	mutate := func() error {
 		switch kind {
 		case SeedKind:
-			seed, ok := obj.(*gardencorev1beta1.Seed)
-			if !ok {
-				return fmt.Errorf("cannot convert object of type %T to *gardencorev1beta1.Seed", obj)
+			if selfHostedShoot != nil {
+				// Mark this ControllerInstallation as owned by the seed reconciler so that the shoot reconciler
+				// does not accidentally manage or delete it (both use .spec.shootRef for the same shoot).
+				metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, SeedRefName, obj.GetName())
+
+				shootSpecMap, err := convertObjToMap(selfHostedShoot.Spec)
+				if err != nil {
+					return err
+				}
+				shootSpecHash := utils.HashForMap(shootSpecMap)[:16]
+				metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, ShootSpecHash, shootSpecHash)
+			} else {
+				seed, ok := obj.(*gardencorev1beta1.Seed)
+				if !ok {
+					return fmt.Errorf("cannot convert object of type %T to *gardencorev1beta1.Seed", obj)
+				}
+				seedSpecMap, err := convertObjToMap(seed.Spec)
+				if err != nil {
+					return err
+				}
+				seedSpecHash := utils.HashForMap(seedSpecMap)[:16]
+				metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, SeedSpecHash, seedSpecHash)
 			}
-			seedSpecMap, err := convertObjToMap(seed.Spec)
-			if err != nil {
-				return err
-			}
-			seedSpecHash := utils.HashForMap(seedSpecMap)[:16]
-			metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, SeedSpecHash, seedSpecHash)
 
 		case ShootKind:
 			shoot, ok := obj.(*gardencorev1beta1.Shoot)
@@ -685,15 +763,34 @@ func getShoots(ctx context.Context, c client.Reader, obj client.Object, kind Kin
 	return shootListAsItems.Union(&shootListAsItems2), nil
 }
 
-func controllerInstallationReferencesObject(controllerInstallation gardencorev1beta1.ControllerInstallation, obj client.Object, kind Kind) bool {
-	if kind == SeedKind &&
-		(controllerInstallation.Spec.SeedRef == nil || controllerInstallation.Spec.SeedRef.Name != obj.GetName()) {
-		return false
-	}
-
-	if kind == ShootKind &&
-		(controllerInstallation.Spec.ShootRef == nil || controllerInstallation.Spec.ShootRef.Name != obj.GetName() || controllerInstallation.Spec.ShootRef.Namespace != obj.GetNamespace()) {
-		return false
+func controllerInstallationReferencesObject(controllerInstallation gardencorev1beta1.ControllerInstallation, obj client.Object, kind Kind, selfHostedShoot *gardencorev1beta1.Shoot) bool {
+	switch kind {
+	case SeedKind:
+		if selfHostedShoot != nil {
+			// For self-hosted-shoot seeds the seed reconciler creates ControllerInstallations with .spec.shootRef,
+			// so match by shootRef rather than seedRef.
+			if controllerInstallation.Spec.ShootRef == nil ||
+				controllerInstallation.Spec.ShootRef.Name != selfHostedShoot.Name ||
+				controllerInstallation.Spec.ShootRef.Namespace != selfHostedShoot.Namespace {
+				return false
+			}
+		} else {
+			if controllerInstallation.Spec.SeedRef == nil || controllerInstallation.Spec.SeedRef.Name != obj.GetName() {
+				return false
+			}
+		}
+	case ShootKind:
+		if controllerInstallation.Spec.ShootRef == nil ||
+			controllerInstallation.Spec.ShootRef.Name != obj.GetName() ||
+			controllerInstallation.Spec.ShootRef.Namespace != obj.GetNamespace() {
+			return false
+		}
+		// ControllerInstallations created by the seed reconciler for self-hosted-shoot seeds use .spec.shootRef
+		// as well (so the shoot gardenlet can manage them), but are marked with SeedRefName to prevent the shoot
+		// reconciler from managing or deleting them.
+		if metav1.HasLabel(controllerInstallation.ObjectMeta, SeedRefName) {
+			return false
+		}
 	}
 
 	return true

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
@@ -709,7 +709,7 @@ var _ = Describe("Reconciler", func() {
 				extensionsv1alpha1.ControlPlaneResource+"/"+type3,
 			)
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), seed, SeedKind)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), seed, SeedKind, nil)
 
 			Expect(names).To(Equal(sets.New(controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name, controllerRegistration8.Name)))
 			Expect(err).NotTo(HaveOccurred())
@@ -718,7 +718,7 @@ var _ = Describe("Reconciler", func() {
 		It("should not consider 'always-deploy-if-shoots' registrations when seed has no shoots", func() {
 			wantedKindTypeCombinations := sets.New[string]()
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seed, SeedKind)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seed, SeedKind, nil)
 
 			Expect(names).To(Equal(sets.New(controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
@@ -727,7 +727,7 @@ var _ = Describe("Reconciler", func() {
 		It("should consider 'always-deploy' registrations when seed has no shoots but no deletion timestamp", func() {
 			wantedKindTypeCombinations := sets.New[string]()
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seed, SeedKind)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seed, SeedKind, nil)
 
 			Expect(names).To(Equal(sets.New(controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
@@ -739,16 +739,36 @@ var _ = Describe("Reconciler", func() {
 			seedCopy.DeletionTimestamp = &time
 			wantedKindTypeCombinations := sets.New[string]()
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedCopy, SeedKind)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seedCopy, SeedKind, nil)
 
 			Expect(names).To(Equal(sets.New(controllerRegistration7.Name)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not include Always/AlwaysExceptNoShoots registrations or installedAndRequired when seed is a self-hosted shoot", func() {
+			// When selfHostedShoot is non-nil, the shoot reconciler handles Always/AlwaysExceptNoShoots registrations
+			// and owns all ControllerInstallations — the seed reconciler must not add any of them.
+			// controllerRegistration4 has deployAlways=true, controllerRegistration7 would normally be kept alive via
+			// installedAndRequired (controllerInstallation7 is Required=true with seedRef=seedName) — both must be
+			// excluded so the shoot reconciler remains the sole owner.
+			selfHostedShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seedName,
+					Namespace: "garden",
+				},
+			}
+			wantedKindTypeCombinations := sets.New[string]()
+
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, 0, seed, SeedKind, selfHostedShoot)
+
+			Expect(names).To(BeEmpty())
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Describe("#computeRegistrationNameToInstallationNameMap", func() {
 		It("should correctly compute the result w/o error", func() {
-			regNameToInstallationName, err := computeRegistrationNameToInstallationMap(controllerInstallationList, controllerRegistrations, seed, SeedKind)
+			regNameToInstallationName, err := computeRegistrationNameToInstallationMap(controllerInstallationList, controllerRegistrations, seed, SeedKind, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(regNameToInstallationName).To(Equal(map[string]*gardencorev1beta1.ControllerInstallation{
@@ -760,7 +780,7 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should fail to compute the result and return error", func() {
-			regNameToInstallationName, err := computeRegistrationNameToInstallationMap(controllerInstallationList, map[string]controllerRegistration{}, seed, SeedKind)
+			regNameToInstallationName, err := computeRegistrationNameToInstallationMap(controllerInstallationList, map[string]controllerRegistration{}, seed, SeedKind, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(regNameToInstallationName).To(BeNil())
@@ -804,7 +824,7 @@ var _ = Describe("Reconciler", func() {
 
 				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{})).Return(fakeErr)
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
 				Expect(err).To(Equal(fakeErr))
 			})
@@ -820,7 +840,7 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
 				Expect(err).To(HaveOccurred())
 			})
@@ -857,7 +877,7 @@ var _ = Describe("Reconciler", func() {
 
 				k8sClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -901,7 +921,7 @@ var _ = Describe("Reconciler", func() {
 
 				k8sClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 
-				Expect(deployNeededInstallations(ctx, log, k8sClient, shoot3, ShootKind, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)).To(Succeed())
+				Expect(deployNeededInstallations(ctx, log, k8sClient, shoot3, ShootKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)).To(Succeed())
 			})
 
 			It("should not skip the controller registration that is after one in deletion", func() {
@@ -929,7 +949,7 @@ var _ = Describe("Reconciler", func() {
 				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, registrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -951,7 +971,7 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, registrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -986,7 +1006,7 @@ var _ = Describe("Reconciler", func() {
 				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, registrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -1021,7 +1041,7 @@ var _ = Describe("Reconciler", func() {
 				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
-				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, registrations, registrationNameToInstallation)
+				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1037,7 +1057,7 @@ var _ = Describe("Reconciler", func() {
 				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
 				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
-				err = deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, wantedControllerRegistrations, registrations, registrationNameToInstallation)
+				err = deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
@@ -1075,7 +1075,7 @@ var _ = Describe("Reconciler", func() {
 
 				k8sClient.EXPECT().Delete(ctx, controllerInstallation1).Return(fakeErr)
 
-				err := deleteUnneededInstallations(ctx, log, k8sClient, wantedControllerRegistrationNames, registrationNameToInstallation)
+				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
 				Expect(err).To(Equal(fakeErr))
 			})
@@ -1093,7 +1093,43 @@ var _ = Describe("Reconciler", func() {
 				k8sClient.EXPECT().Delete(ctx, controllerInstallation1)
 				k8sClient.EXPECT().Delete(ctx, controllerInstallation3)
 
-				err := deleteUnneededInstallations(ctx, log, k8sClient, wantedControllerRegistrationNames, registrationNameToInstallation)
+				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should remove the seed ownership label instead of deleting when the ControllerInstallation has the seed-ref-name label", func() {
+				installation := controllerInstallation2.DeepCopy()
+				metav1.SetMetaDataLabel(&installation.ObjectMeta, SeedRefName, seedName)
+
+				var (
+					wantedControllerRegistrationNames = sets.New[string]()
+					registrationNameToInstallation    = map[string]*gardencorev1beta1.ControllerInstallation{
+						controllerRegistration2.Name: installation,
+					}
+				)
+
+				expectedInstallation := installation.DeepCopy()
+				delete(expectedInstallation.Labels, SeedRefName)
+				k8sClient.EXPECT().Patch(ctx, expectedInstallation, gomock.Any())
+
+				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should skip seed-owned ControllerInstallations when the shoot reconciler calls", func() {
+				installation := controllerInstallation2.DeepCopy()
+				metav1.SetMetaDataLabel(&installation.ObjectMeta, SeedRefName, seedName)
+
+				var (
+					wantedControllerRegistrationNames = sets.New[string]()
+					registrationNameToInstallation    = map[string]*gardencorev1beta1.ControllerInstallation{
+						controllerRegistration2.Name: installation,
+					}
+				)
+
+				err := deleteUnneededInstallations(ctx, log, k8sClient, ShootKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -24,6 +25,7 @@ import (
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerinstallation"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
@@ -80,7 +82,7 @@ func AddToManager(mgr manager.Manager, config controllermanagerconfigv1alpha1.Co
 		).
 		Watches(
 			&gardencorev1beta1.Shoot{},
-			handler.EnqueueRequestsFromMapFunc(MapShootToSeed),
+			handler.EnqueueRequestsFromMapFunc(MapShootToSeed(log, r)),
 			builder.WithPredicates(controllerinstallation.ShootPredicate(controllerinstallation.SeedKind)),
 		).
 		Complete(r)
@@ -152,17 +154,37 @@ func MapBackupEntryToSeed(_ context.Context, obj client.Object) []reconcile.Requ
 }
 
 // MapShootToSeed returns a reconcile.Request object for the seed specified in the .spec.seedName field.
-func MapShootToSeed(_ context.Context, obj client.Object) []reconcile.Request {
-	shoot, ok := obj.(*gardencorev1beta1.Shoot)
-	if !ok {
-		return nil
-	}
+// For self-hosted shoot clusters in the garden namespace, it additionally enqueues the corresponding Seed
+// (which has the same name as the Shoot) so that the seed reconciler can re-evaluate its ControllerInstallations.
+func MapShootToSeed(log logr.Logger, r *controllerinstallation.Reconciler) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		shoot, ok := obj.(*gardencorev1beta1.Shoot)
+		if !ok {
+			return nil
+		}
 
-	if shoot.Spec.SeedName == nil {
-		return nil
-	}
+		var requests []reconcile.Request
 
-	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: *shoot.Spec.SeedName}}}
+		if shoot.Spec.SeedName != nil {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: *shoot.Spec.SeedName}})
+		}
+
+		if shoot.Namespace == v1beta1constants.GardenNamespace {
+			seed := &gardencorev1beta1.Seed{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Name: shoot.Name}, seed); err != nil {
+				if !apierrors.IsNotFound(err) {
+					log.Error(err, "Failed to get Seed for self-hosted shoot mapping", "shootName", shoot.Name)
+				}
+				return requests
+			}
+
+			if metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: shoot.Name}})
+			}
+		}
+
+		return requests
+	}
 }
 
 // MapControllerInstallationToSeed returns a reconcile.Request object for the seed specified in the .spec.seedRef.name field.

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add_test.go
@@ -19,6 +19,7 @@ import (
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerinstallation"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed"
@@ -114,16 +115,52 @@ var _ = Describe("Add", func() {
 			)
 
 			BeforeEach(func() {
-				shoot = &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName}}
+				shoot = &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-shoot",
+						Namespace: "some-namespace",
+					},
+					Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName},
+				}
 			})
 
-			It("should return nil when seed name is not set", func() {
+			It("should return nil when seed name is not set and shoot is not in garden namespace", func() {
 				shoot.Spec.SeedName = nil
-				Expect(MapShootToSeed(ctx, shoot)).To(BeEmpty())
+				Expect(MapShootToSeed(log, reconciler)(ctx, shoot)).To(BeEmpty())
 			})
 
 			It("should map to the seed", func() {
-				Expect(MapShootToSeed(ctx, shoot)).To(ConsistOf(
+				Expect(MapShootToSeed(log, reconciler)(ctx, shoot)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}},
+				))
+			})
+
+			It("should also map to the self-hosted seed when shoot is in garden namespace", func() {
+				selfHostedSeed := &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "self-hosted",
+						Labels: map[string]string{v1beta1constants.LabelSelfHostedShootCluster: "true"},
+					},
+				}
+				Expect(fakeClient.Create(ctx, selfHostedSeed)).To(Succeed())
+
+				shoot.Name = "self-hosted"
+				shoot.Namespace = v1beta1constants.GardenNamespace
+				Expect(MapShootToSeed(log, reconciler)(ctx, shoot)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}},
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: "self-hosted"}},
+				))
+			})
+
+			It("should not map to a seed without the self-hosted label when shoot is in garden namespace", func() {
+				regularSeed := &gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{Name: "regular-seed"},
+				}
+				Expect(fakeClient.Create(ctx, regularSeed)).To(Succeed())
+
+				shoot.Name = "regular-seed"
+				shoot.Namespace = v1beta1constants.GardenNamespace
+				Expect(MapShootToSeed(log, reconciler)(ctx, shoot)).To(ConsistOf(
 					reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}},
 				))
 			})

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -11,12 +11,14 @@ import (
 	"io"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 	kubeinformers "k8s.io/client-go/informers"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
@@ -149,6 +151,11 @@ func (v *ValidateSeed) validateSeedUpdate(a admission.Attributes) error {
 	oldSeed, newSeed, err := getOldAndNewSeeds(a)
 	if err != nil {
 		return err
+	}
+
+	if metav1.HasLabel(oldSeed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) &&
+		!metav1.HasLabel(newSeed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) {
+		return admission.NewForbidden(a, fmt.Errorf("label %q cannot be removed from a Seed", v1beta1constants.LabelSelfHostedShootCluster))
 	}
 
 	if err := admissionutils.ValidateZoneRemovalFromSeeds(&oldSeed.Spec, &newSeed.Spec, newSeed.Name, v.shootLister, "Seed"); err != nil {

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -262,6 +262,35 @@ var _ = Describe("validator", func() {
 					Expect(err).To(MatchError(ContainSubstring("seed using backup of type \"anotherProvider\" cannot use WorkloadIdentity of type \"provider\"")))
 				})
 			})
+
+			Context("LabelSelfHostedShootCluster label", func() {
+				BeforeEach(func() {
+					oldSeed = seedBase.DeepCopy()
+					newSeed = seedBase.DeepCopy()
+				})
+
+				It("should allow adding the label", func() {
+					metav1.SetMetaDataLabel(&newSeed.ObjectMeta, "seed.gardener.cloud/self-hosted-shoot-cluster", "true")
+					attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+				})
+
+				It("should forbid removing the label once set", func() {
+					metav1.SetMetaDataLabel(&oldSeed.ObjectMeta, "seed.gardener.cloud/self-hosted-shoot-cluster", "true")
+					attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(BeForbiddenError())
+				})
+
+				It("should allow keeping the label", func() {
+					metav1.SetMetaDataLabel(&oldSeed.ObjectMeta, "seed.gardener.cloud/self-hosted-shoot-cluster", "true")
+					metav1.SetMetaDataLabel(&newSeed.ObjectMeta, "seed.gardener.cloud/self-hosted-shoot-cluster", "true")
+					attrs := admission.NewAttributesRecord(newSeed, oldSeed, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+					Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+				})
+			})
 		})
 
 		// The verification of protection is independent of the Cloud Provider (being checked before).

--- a/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_suite_test.go
@@ -131,7 +131,11 @@ var _ = BeforeSuite(func() {
 
 	By("Setup field indexes")
 	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddBackupBucketShootRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddBackupBucketShootRefNamespace(ctx, mgr.GetFieldIndexer())).To(Succeed())
 	Expect(indexer.AddBackupEntrySeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddBackupEntryShootRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddBackupEntryShootRefNamespace(ctx, mgr.GetFieldIndexer())).To(Succeed())
 	Expect(indexer.AddShootSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 	Expect(indexer.AddShootStatusSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_test.go
@@ -11,6 +11,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -19,6 +20,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerinstallation"
+	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -457,9 +459,18 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 		// extensions exclusively needed by the seed role are created with .spec.shootRef (not .spec.seedRef) so
 		// that the shoot gardenlet can manage them. They are marked with the SeedRefName label so that the shoot
 		// reconciler does not accidentally manage or delete them.
-		It("should create ControllerInstallations with .spec.shootRef for seed-role extensions, not interfering with shoot-role ControllerInstallations", func() {
-			selfHostedSeedName := "self-hosted-" + seedName
-			selfHostedProviderType := "self-hosted-provider"
+
+		var (
+			selfHostedSeedName                    string
+			selfHostedProviderType                string
+			selfHostedShoot                       *gardencorev1beta1.Shoot
+			selfHostedSeed                        *gardencorev1beta1.Seed
+			selfHostedShootControllerRegistration *gardencorev1beta1.ControllerRegistration
+		)
+
+		BeforeEach(func() {
+			selfHostedSeedName = "sh-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+			selfHostedProviderType = "self-hosted-provider"
 
 			By("Create garden namespace")
 			gardenNamespace := &corev1.Namespace{
@@ -468,11 +479,6 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 				},
 			}
 			Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
-
-			DeferCleanup(func() {
-				By("Delete garden namespace")
-				Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
-			})
 
 			selfHostedSeedNamespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -503,17 +509,22 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 				Expect(testClient.Delete(ctx, selfHostedSeedInternalDomainSecret)).To(Or(Succeed(), BeNotFoundError()))
 			})
 
-			// selfHostedShootControllerRegistration covers the extension type used by the self-hosted Shoot itself.
+			// selfHostedShootControllerRegistration covers all extension types used by the self-hosted Shoot itself.
 			// The shoot reconciler will create ControllerInstallations for these (without SeedRefName label).
-			// Using Extension resources (with WorkerlessSupported) avoids the need for a full worker pool spec.
-			selfHostedShootControllerRegistration := &gardencorev1beta1.ControllerRegistration{
+			selfHostedShootControllerRegistration = &gardencorev1beta1.ControllerRegistration{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "ctrlreg-self-hosted-shoot-",
 					Labels:       map[string]string{testID: testRunID},
 				},
 				Spec: gardencorev1beta1.ControllerRegistrationSpec{
 					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: extensionsv1alpha1.ExtensionResource, Type: selfHostedProviderType, WorkerlessSupported: ptr.To(true)},
+						{Kind: extensionsv1alpha1.ControlPlaneResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.InfrastructureResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.WorkerResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.NetworkResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.ContainerRuntimeResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.OperatingSystemConfigResource, Type: selfHostedProviderType},
+						{Kind: extensionsv1alpha1.ExtensionResource, Type: selfHostedProviderType},
 					},
 				},
 			}
@@ -535,7 +546,7 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 			// Create the Shoot before the Seed so that the seed reconciler sees the self-hosted Shoot from its
 			// very first reconciliation.
 			By("Create self-hosted Shoot in garden namespace")
-			selfHostedShoot := &gardencorev1beta1.Shoot{
+			selfHostedShoot = &gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      selfHostedSeedName,
 					Namespace: v1beta1constants.GardenNamespace,
@@ -551,12 +562,32 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 						// Use a different provider type so that the shoot's required extensions do not overlap
 						// with the seed's providerType extensions, leaving those for the seed reconciler to handle.
 						Type: selfHostedProviderType,
+						Workers: []gardencorev1beta1.Worker{{
+							Name:         "control-plane",
+							ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+							Minimum:      1,
+							Maximum:      1,
+							Machine: gardencorev1beta1.Machine{
+								Type: "large",
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name:    selfHostedProviderType,
+									Version: ptr.To("0.0.0"),
+								},
+							},
+							CRI: &gardencorev1beta1.CRI{
+								Name: gardencorev1beta1.CRINameContainerD,
+								ContainerRuntimes: []gardencorev1beta1.ContainerRuntime{{
+									Type: selfHostedProviderType,
+								}},
+							},
+						}},
 					},
 					Kubernetes: gardencorev1beta1.Kubernetes{
 						Version: "1.31.1",
 					},
-					// Use an explicit Extension instead of workers to trigger the shoot reconciler without
-					// needing a full worker pool spec (which requires machine image, networking type, etc.).
+					Networking: &gardencorev1beta1.Networking{
+						Type: ptr.To(selfHostedProviderType),
+					},
 					Extensions: []gardencorev1beta1.Extension{
 						{Type: selfHostedProviderType},
 					},
@@ -568,10 +599,21 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 			DeferCleanup(func() {
 				By("Delete self-hosted Shoot")
 				Expect(testClient.Delete(ctx, selfHostedShoot)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Wait for shoot-role ControllerInstallations to be cleaned up")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: selfHostedShootControllerRegistration.Name,
+						core.ShootRefName:        selfHostedSeedName,
+						core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(BeEmpty())
+				}).Should(Succeed())
 			})
 
 			By("Create self-hosted Seed")
-			selfHostedSeed := seed.DeepCopy()
+			selfHostedSeed = seed.DeepCopy()
 			selfHostedSeed.Name = selfHostedSeedName
 			selfHostedSeed.ResourceVersion = ""
 			selfHostedSeed.Labels = map[string]string{
@@ -601,7 +643,9 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 					return mgrClient.Get(ctx, client.ObjectKeyFromObject(selfHostedSeed), selfHostedSeed)
 				}).Should(BeNotFoundError())
 			})
+		})
 
+		It("should create ControllerInstallations with .spec.shootRef for seed-role extensions, not interfering with shoot-role ControllerInstallations", func() {
 			By("Expect seed-role ControllerInstallations to be created with .spec.shootRef and SeedRefName label (seed reconciler)")
 			Eventually(func(g Gomega) {
 				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
@@ -640,6 +684,107 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 					g.Expect(item.Spec.SeedRef).To(BeNil(), "shoot-role ControllerInstallation %q must not have .spec.seedRef", item.Name)
 					g.Expect(item.Labels).NotTo(HaveKey(controllerinstallation.SeedRefName), "shoot-role ControllerInstallation %q must not carry SeedRefName label", item.Name)
 				}
+			}).Should(Succeed())
+		})
+
+		It("should hand over a seed-exclusive ControllerInstallation to the shoot reconciler by stripping the seed-ref-name label", func() {
+			handoffType := "handoff-ext"
+
+			By("Enable handoff extension on the self-hosted seed")
+			patch := client.MergeFrom(selfHostedSeed.DeepCopy())
+			selfHostedSeed.Spec.Extensions = []gardencorev1beta1.Extension{{Type: handoffType}}
+			Expect(testClient.Patch(ctx, selfHostedSeed, patch)).To(Succeed())
+
+			By("Create ControllerRegistration for the handoff extension")
+			handoffControllerRegistration := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ctrlreg-handoff-",
+					Labels:       map[string]string{testID: testRunID},
+				},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{
+							Kind:                extensionsv1alpha1.ExtensionResource,
+							Type:                handoffType,
+							WorkerlessSupported: ptr.To(true),
+						},
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, handoffControllerRegistration)).To(Succeed())
+			log.Info("Created handoff ControllerRegistration", "controllerRegistration", client.ObjectKeyFromObject(handoffControllerRegistration))
+
+			DeferCleanup(func() {
+				By("Revert self-hosted Seed extensions first to prevent the seed reconciler from re-creating the ControllerInstallation")
+				seedPatch := client.MergeFrom(selfHostedSeed.DeepCopy())
+				selfHostedSeed.Spec.Extensions = nil
+				Expect(testClient.Patch(ctx, selfHostedSeed, seedPatch)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Revert self-hosted Shoot extensions so the shoot reconciler deletes the handoff ControllerInstallation")
+				shootPatch := client.MergeFrom(selfHostedShoot.DeepCopy())
+				selfHostedShoot.Spec.Extensions = []gardencorev1beta1.Extension{{Type: selfHostedProviderType}}
+				Expect(testClient.Patch(ctx, selfHostedShoot, shootPatch)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Wait for shoot reconciler to delete the handoff ControllerInstallation")
+				Eventually(func(g Gomega) {
+					controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+					g.Expect(mgrClient.List(ctx, controllerInstallationList, client.MatchingFields{
+						core.RegistrationRefName: handoffControllerRegistration.Name,
+					})).To(Succeed())
+					g.Expect(controllerInstallationList.Items).To(BeEmpty())
+				}).Should(Succeed())
+
+				By("Delete handoff ControllerRegistration")
+				Expect(testClient.Delete(ctx, handoffControllerRegistration)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Wait until manager has observed handoff ControllerRegistration deletion")
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(handoffControllerRegistration), handoffControllerRegistration)
+				}).Should(BeNotFoundError())
+			})
+
+			By("Expect seed-exclusive ControllerInstallation with seed-ref-name label")
+			var handoffControllerInstallationName string
+			Eventually(func(g Gomega) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+					core.RegistrationRefName: handoffControllerRegistration.Name,
+					core.ShootRefName:        selfHostedSeedName,
+					core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+				})).To(Succeed())
+				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				g.Expect(controllerInstallationList.Items[0].Labels).To(HaveKeyWithValue(controllerinstallation.SeedRefName, selfHostedSeedName))
+				handoffControllerInstallationName = controllerInstallationList.Items[0].Name
+			}).Should(Succeed())
+
+			By("Update self-hosted Shoot to also require the handoff extension type")
+			shootPatch := client.MergeFrom(selfHostedShoot.DeepCopy())
+			selfHostedShoot.Spec.Extensions = append(selfHostedShoot.Spec.Extensions, gardencorev1beta1.Extension{Type: handoffType})
+			Expect(testClient.Patch(ctx, selfHostedShoot, shootPatch)).To(Succeed())
+
+			By("Ensure no additional ControllerInstallation is created for the handoff extension")
+			Consistently(func(g Gomega) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+					core.RegistrationRefName: handoffControllerRegistration.Name,
+					core.ShootRefName:        selfHostedSeedName,
+					core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+				})).To(Succeed())
+				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				g.Expect(controllerInstallationList.Items[0].Name).To(Equal(handoffControllerInstallationName))
+			}).Should(Succeed())
+
+			By("Expect seed-ref-name label to be removed from the same ControllerInstallation (ownership handed to shoot reconciler)")
+			Eventually(func(g Gomega) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+					core.RegistrationRefName: handoffControllerRegistration.Name,
+					core.ShootRefName:        selfHostedSeedName,
+					core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+				})).To(Succeed())
+				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				g.Expect(controllerInstallationList.Items[0].Name).To(Equal(handoffControllerInstallationName))
+				g.Expect(controllerInstallationList.Items[0].Labels).NotTo(HaveKey(controllerinstallation.SeedRefName))
 			}).Should(Succeed())
 		})
 	})

--- a/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerinstallation/seed/seed_test.go
@@ -7,6 +7,7 @@ package seed_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,10 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration/controllerinstallation"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -443,6 +447,199 @@ var _ = Describe("ControllerInstallation-Seed controller test", func() {
 					core.SeedRefName:         seed.Name,
 				})).To(Succeed())
 				g.Expect(controllerInstallationList.Items).To(BeEmpty())
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Self-hosted shoot seed", func() {
+		// When the seed is a self-hosted shoot cluster, the seed reconciler must subtract kind/type combinations
+		// already managed by the shoot reconciler for the corresponding Shoot. ControllerInstallations for
+		// extensions exclusively needed by the seed role are created with .spec.shootRef (not .spec.seedRef) so
+		// that the shoot gardenlet can manage them. They are marked with the SeedRefName label so that the shoot
+		// reconciler does not accidentally manage or delete them.
+		It("should create ControllerInstallations with .spec.shootRef for seed-role extensions, not interfering with shoot-role ControllerInstallations", func() {
+			selfHostedSeedName := "self-hosted-" + seedName
+			selfHostedProviderType := "self-hosted-provider"
+
+			By("Create garden namespace")
+			gardenNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1beta1constants.GardenNamespace,
+				},
+			}
+			Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+
+			DeferCleanup(func() {
+				By("Delete garden namespace")
+				Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			selfHostedSeedNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: gardenerutils.ComputeGardenNamespace(selfHostedSeedName),
+				},
+			}
+
+			By("Create self-hosted Seed Namespace")
+			Expect(testClient.Create(ctx, selfHostedSeedNamespace)).To(Succeed())
+
+			DeferCleanup(func() {
+				By("Delete self-hosted Seed Namespace")
+				Expect(testClient.Delete(ctx, selfHostedSeedNamespace)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			selfHostedSeedInternalDomainSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      internalDomainSecret.Name,
+					Namespace: selfHostedSeedNamespace.Name,
+				},
+			}
+
+			By("Create self-hosted Seed Internal Domain Secret")
+			Expect(testClient.Create(ctx, selfHostedSeedInternalDomainSecret)).To(Succeed())
+
+			DeferCleanup(func() {
+				By("Delete self-hosted Seed Internal Domain Secret")
+				Expect(testClient.Delete(ctx, selfHostedSeedInternalDomainSecret)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			// selfHostedShootControllerRegistration covers the extension type used by the self-hosted Shoot itself.
+			// The shoot reconciler will create ControllerInstallations for these (without SeedRefName label).
+			// Using Extension resources (with WorkerlessSupported) avoids the need for a full worker pool spec.
+			selfHostedShootControllerRegistration := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "ctrlreg-self-hosted-shoot-",
+					Labels:       map[string]string{testID: testRunID},
+				},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: extensionsv1alpha1.ExtensionResource, Type: selfHostedProviderType, WorkerlessSupported: ptr.To(true)},
+					},
+				},
+			}
+
+			By("Create self-hosted Shoot ControllerRegistration")
+			Expect(testClient.Create(ctx, selfHostedShootControllerRegistration)).To(Succeed())
+			log.Info("Created self-hosted Shoot ControllerRegistration for test", "controllerRegistration", client.ObjectKeyFromObject(selfHostedShootControllerRegistration))
+
+			DeferCleanup(func() {
+				By("Delete self-hosted Shoot ControllerRegistration")
+				Expect(testClient.Delete(ctx, selfHostedShootControllerRegistration)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Wait until manager has observed self-hosted Shoot ControllerRegistration deletion")
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(selfHostedShootControllerRegistration), selfHostedShootControllerRegistration)
+				}).Should(BeNotFoundError())
+			})
+
+			// Create the Shoot before the Seed so that the seed reconciler sees the self-hosted Shoot from its
+			// very first reconciliation.
+			By("Create self-hosted Shoot in garden namespace")
+			selfHostedShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      selfHostedSeedName,
+					Namespace: v1beta1constants.GardenNamespace,
+					Labels:    map[string]string{testID: testRunID},
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					CloudProfile: &gardencorev1beta1.CloudProfileReference{
+						Kind: "CloudProfile",
+						Name: "test-cloudprofile",
+					},
+					Region: "foo-region",
+					Provider: gardencorev1beta1.Provider{
+						// Use a different provider type so that the shoot's required extensions do not overlap
+						// with the seed's providerType extensions, leaving those for the seed reconciler to handle.
+						Type: selfHostedProviderType,
+					},
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.31.1",
+					},
+					// Use an explicit Extension instead of workers to trigger the shoot reconciler without
+					// needing a full worker pool spec (which requires machine image, networking type, etc.).
+					Extensions: []gardencorev1beta1.Extension{
+						{Type: selfHostedProviderType},
+					},
+				},
+			}
+			Expect(testClient.Create(ctx, selfHostedShoot)).To(Succeed())
+			log.Info("Created self-hosted Shoot for test", "shoot", client.ObjectKeyFromObject(selfHostedShoot))
+
+			DeferCleanup(func() {
+				By("Delete self-hosted Shoot")
+				Expect(testClient.Delete(ctx, selfHostedShoot)).To(Or(Succeed(), BeNotFoundError()))
+			})
+
+			By("Create self-hosted Seed")
+			selfHostedSeed := seed.DeepCopy()
+			selfHostedSeed.Name = selfHostedSeedName
+			selfHostedSeed.ResourceVersion = ""
+			selfHostedSeed.Labels = map[string]string{
+				testID: testRunID,
+				v1beta1constants.LabelSelfHostedShootCluster: "true",
+			}
+			selfHostedSeed.Spec.DNS.Internal = &gardencorev1beta1.SeedDNSProviderConfig{
+				Type:   providerType,
+				Domain: "internal.example.com",
+				CredentialsRef: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "Secret",
+					Name:       selfHostedSeedInternalDomainSecret.Name,
+					Namespace:  selfHostedSeedNamespace.Name,
+				},
+			}
+
+			Expect(testClient.Create(ctx, selfHostedSeed)).To(Succeed())
+			log.Info("Created self-hosted Seed for test", "seed", client.ObjectKeyFromObject(selfHostedSeed))
+
+			DeferCleanup(func() {
+				By("Delete self-hosted Seed")
+				Expect(testClient.Delete(ctx, selfHostedSeed)).To(Or(Succeed(), BeNotFoundError()))
+
+				By("Wait until manager has observed self-hosted Seed deletion")
+				Eventually(func() error {
+					return mgrClient.Get(ctx, client.ObjectKeyFromObject(selfHostedSeed), selfHostedSeed)
+				}).Should(BeNotFoundError())
+			})
+
+			By("Expect seed-role ControllerInstallations to be created with .spec.shootRef and SeedRefName label (seed reconciler)")
+			Eventually(func(g Gomega) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+					core.RegistrationRefName: seedControllerRegistration.Name,
+					core.ShootRefName:        selfHostedSeedName,
+					core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+				})).To(Succeed())
+				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				for _, item := range controllerInstallationList.Items {
+					g.Expect(item.Spec.RegistrationRef.Name).To(Equal(seedControllerRegistration.Name), "seed-role ControllerInstallation %q must reference seedControllerRegistration", item.Name)
+					g.Expect(item.Spec.ShootRef).To(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(selfHostedSeedName),
+						"Namespace": Equal(v1beta1constants.GardenNamespace),
+					})), "seed-role ControllerInstallation %q must reference the self-hosted shoot", item.Name)
+					g.Expect(item.Spec.SeedRef).To(BeNil(), "seed-role ControllerInstallation %q must not have .spec.seedRef", item.Name)
+					g.Expect(item.Labels).To(HaveKeyWithValue(controllerinstallation.SeedRefName, selfHostedSeedName), "seed-role ControllerInstallation %q must carry SeedRefName label", item.Name)
+				}
+			}).Should(Succeed())
+
+			By("Expect shoot-role ControllerInstallations to be created with .spec.shootRef and no SeedRefName label (shoot reconciler)")
+			Eventually(func(g Gomega) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				g.Expect(testClient.List(ctx, controllerInstallationList, client.MatchingFields{
+					core.RegistrationRefName: selfHostedShootControllerRegistration.Name,
+					core.ShootRefName:        selfHostedSeedName,
+					core.ShootRefNamespace:   v1beta1constants.GardenNamespace,
+				})).To(Succeed())
+				g.Expect(controllerInstallationList.Items).To(HaveLen(1))
+				for _, item := range controllerInstallationList.Items {
+					g.Expect(item.Spec.RegistrationRef.Name).To(Equal(selfHostedShootControllerRegistration.Name), "shoot-role ControllerInstallation %q must reference selfHostedShootControllerRegistration", item.Name)
+					g.Expect(item.Spec.ShootRef).To(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":      Equal(selfHostedSeedName),
+						"Namespace": Equal(v1beta1constants.GardenNamespace),
+					})), "shoot-role ControllerInstallation %q must reference the self-hosted shoot", item.Name)
+					g.Expect(item.Spec.SeedRef).To(BeNil(), "shoot-role ControllerInstallation %q must not have .spec.seedRef", item.Name)
+					g.Expect(item.Labels).NotTo(HaveKey(controllerinstallation.SeedRefName), "shoot-role ControllerInstallation %q must not carry SeedRefName label", item.Name)
+				}
 			}).Should(Succeed())
 		})
 	})

--- a/test/integration/controllermanager/controllerregistration/controllerinstallation/shoot/shoot_suite_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerinstallation/shoot/shoot_suite_test.go
@@ -29,6 +29,7 @@ import (
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/controllerregistration"
@@ -188,10 +189,19 @@ var _ = BeforeSuite(func() {
 		}).Should(BeNotFoundError())
 	})
 
+	By("Create garden Namespace")
+	gardenNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.GardenNamespace}}
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+
+	DeferCleanup(func() {
+		By("Delete garden Namespace")
+		Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
 	shoot = &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: testID + "-",
-			Namespace:    testNamespace.Name,
+			Namespace:    v1beta1constants.GardenNamespace,
 			Labels:       map[string]string{testID: testRunID},
 		},
 		Spec: gardencorev1beta1.ShootSpec{

--- a/test/integration/controllermanager/controllerregistration/controllerinstallation/shoot/shoot_test.go
+++ b/test/integration/controllermanager/controllerregistration/controllerinstallation/shoot/shoot_test.go
@@ -289,7 +289,7 @@ var _ = Describe("ControllerInstallation-Shoot controller test", func() {
 			backupEntry := &gardencorev1beta1.BackupEntry{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: testID + "-",
-					Namespace:    testNamespace.Name,
+					Namespace:    shoot.Namespace,
 					Labels:       map[string]string{testID: testRunID},
 				},
 				Spec: gardencorev1beta1.BackupEntrySpec{

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -30,7 +29,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -211,7 +209,6 @@ var _ = BeforeSuite(func() {
 			ByObject: map[client.Object]cache.ByObject{
 				&gardencorev1beta1.ControllerInstallation{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
-					Field: fields.SelectorFromSet(fields.Set{gardencore.SeedRefName: seed.Name}),
 				},
 				&gardencorev1beta1.ControllerRegistration{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -105,7 +105,9 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 		}).Should(Succeed())
 
 		By("Create ControllerInstallation")
-		controllerInstallation.Spec.SeedRef = &corev1.ObjectReference{Name: seed.Name}
+		if controllerInstallation.Spec.SeedRef == nil {
+			controllerInstallation.Spec.SeedRef = &corev1.ObjectReference{Name: seed.Name}
+		}
 		controllerInstallation.Spec.RegistrationRef = corev1.ObjectReference{Name: controllerRegistration.Name}
 		controllerInstallation.Spec.DeploymentRef = &corev1.ObjectReference{Name: controllerDeployment.Name}
 		Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())
@@ -626,16 +628,39 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 
 		When("seed is marked as self-hosted shoot clusters", func() {
 			BeforeEach(func() {
-				By("Mark Seed as self-hosted shoot cluster")
-				patch := client.MergeFrom(seed.DeepCopy())
-				metav1.SetMetaDataLabel(&seed.ObjectMeta, "seed.gardener.cloud/self-hosted-shoot-cluster", "true")
-				Expect(testClient.Patch(ctx, seed, patch)).To(Succeed())
+				// Use a dedicated seed with the label pre-set so the suite-global seed remains unaffected.
+				// The label cannot be removed once set (enforced by GAPI validation), so a throwaway seed
+				// is the only way to cleanly isolate this test.
+				selfHostedSeed := seed.DeepCopy()
+				selfHostedSeed.Name = ""
+				selfHostedSeed.ResourceVersion = ""
+				selfHostedSeed.Labels = map[string]string{
+					testID: testRunID,
+					"seed.gardener.cloud/self-hosted-shoot-cluster": "true",
+				}
+
+				By("Create self-hosted seed")
+				Expect(testClient.Create(ctx, selfHostedSeed)).To(Succeed())
+
+				By("Patch self-hosted seed status")
+				statusPatch := client.MergeFrom(selfHostedSeed.DeepCopy())
+				selfHostedSeed.Status.ClusterIdentity = ptr.To(seedClusterIdentity)
+				Expect(testClient.Status().Patch(ctx, selfHostedSeed, statusPatch)).To(Succeed())
+
+				By("Create self-hosted seed namespace")
+				selfHostedSeedNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "seed-" + selfHostedSeed.Name}}
+				Expect(testClient.Create(ctx, selfHostedSeedNamespace)).To(Succeed())
 
 				DeferCleanup(func() {
-					patch := client.MergeFrom(seed.DeepCopy())
-					delete(seed.Labels, "seed.gardener.cloud/self-hosted-shoot-cluster")
-					Expect(testClient.Patch(ctx, seed, patch)).To(Succeed())
+					By("Delete self-hosted seed")
+					Expect(testClient.Delete(ctx, selfHostedSeed)).To(Or(Succeed(), BeNotFoundError()))
+
+					By("Delete self-hosted seed namespace")
+					Expect(testClient.Delete(ctx, selfHostedSeedNamespace)).To(Or(Succeed(), BeNotFoundError()))
 				})
+
+				// Wire the ControllerInstallation (created in JustBeforeEach) to the self-hosted seed.
+				controllerInstallation.Spec.SeedRef = &corev1.ObjectReference{Name: selfHostedSeed.Name}
 			})
 
 			It("should set the selfHostedShootCluster value in the chart", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
When a self-hosted shoot cluster is also registered as a `Seed`, two gardenlets run on it: the *shoot gardenlet* managing the shoot lifecycle, and the *seed gardenlet* managing shoots hosted on this seed. Both cause GCM to create `ControllerInstallation`s — the shoot reconciler with `.spec.shootRef`, the seed reconciler with `.spec.seedRef` — resulting in duplicate extension controller installations.

This PR eliminates the duplication with the following changes:

- **`garden` namespace restriction for self-hosted shoots** (`pkg/api/core/validation`): A `Shoot` with a control-plane worker pool is now required to reside in the `garden` namespace. This allows the seed reconciler to unambiguously identify the corresponding `Shoot` as `{Namespace: "garden", Name: seed.Name}` without any additional lookup.
- **Seed gardenlet aborts startup if the shoot doesn't exist yet** (`cmd/gardenlet/app`): If the seed cluster is a self-hosted shoot but the corresponding `Shoot` object doesn't yet exist in the garden cluster (i.e., `gardenadm connect` hasn't been run), the gardenlet exits early. This prevents GCM from ever seeing a `Seed` without the `seed.gardener.cloud/self-hosted-shoot-cluster` label — which would cause it to create `.spec.seedRef` `ControllerInstallation`s.
- **Seed gardenlet sets `seed.gardener.cloud/self-hosted-shoot-cluster=true`** (`cmd/gardenlet/app`): During `registerSeed()`, the gardenlet detects whether the seed cluster is a self-hosted shoot and sets this label on the `Seed` object so GCM can distinguish the two cases.
- **GAPI forbids removing the label** (`plugin/pkg/seed/validator`): Once set, `seed.gardener.cloud/self-hosted-shoot-cluster=true` cannot be removed. The GCM seed reconciler's routing logic depends on this label being stable.
- **GCM seed reconciler uses `.spec.shootRef`** (`pkg/controllermanager/controller/controllerregistration/controllerinstallation`): When reconciling a `Seed` carrying the `self-hosted-shoot-cluster` label, the seed reconciler creates `ControllerInstallation`s with `.spec.shootRef` instead of `.spec.seedRef`, and subtracts extension kind/type combinations already covered by the shoot reconciler's existing `ControllerInstallation`s — those are left entirely untouched. Seed-reconciler-owned `ControllerInstallation`s are marked with a `seed-ref-name` label (value = seed name) so the shoot reconciler can recognise and skip them.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
This is intentionally intermediate state: the shoot gardenlet does not yet act on seed-role `ControllerInstallation`s (those carrying the `seed-ref-name` label). The full end-to-end wiring is deferred to a follow-up. The deduplication invariant is already fully enforced by this PR.

**Release note**:
```other developer
NONE
```