### PR TITLE
Add worker name to `node-local-dns` label selector

### DIFF
--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -63,6 +63,7 @@ var _ = Describe("NodeLocalDNS", func() {
 		ipvsAddress           = "169.254.20.10"
 		labelKey              = "k8s-app"
 		labelValue            = "node-local-dns"
+		labelKeyPool          = "pool"
 		prometheusPort        = 9253
 		prometheusErrorPort   = 9353
 		prometheusScrape      = true
@@ -417,14 +418,16 @@ status:
 						RevisionHistoryLimit: ptr.To[int32](2),
 						Selector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								labelKey: labelValue,
+								labelKey:     labelValue,
+								labelKeyPool: "worker-aaaa",
 							},
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
-									labelKey:                                    labelValue,
-									v1beta1constants.LabelNetworkPolicyToDNS:    "allowed",
+									labelKey:                                 labelValue,
+									labelKeyPool:                             "worker-aaaa",
+									v1beta1constants.LabelNetworkPolicyToDNS: "allowed",
 									v1beta1constants.LabelNodeCriticalComponent: "true",
 								},
 								Annotations: map[string]string{

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -402,6 +402,9 @@ status:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-local-dns-worker-aaaa",
 						Namespace: metav1.NamespaceSystem,
+						Annotations: map[string]string{
+							resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+						},
 						Labels: map[string]string{
 							labelKey:                                    labelValue,
 							v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -161,6 +162,13 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-local-dns-" + worker.Name,
 				Namespace: metav1.NamespaceSystem,
+				Annotations: map[string]string{
+					// This annotation is required so that the new label selector that includes the worker's name,
+					// introduced with https://github.com/gardener/gardener/pull/14286, can be applied by GRM as
+					// the `spec.selector` field is immutable.
+					// TODO(plkokanov): Remove this annotation after v1.140 has been released.
+					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+				},
 				Labels: map[string]string{
 					labelKey:                                    nodelocaldnsconstants.LabelValue,
 					v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -184,11 +184,11 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 				},
 				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: getMatchLabels(worker.Name),
+					MatchLabels: getPoolLabels(worker.Name),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: utils.MergeStringMaps(getMatchLabels(worker.Name), map[string]string{
+						Labels: utils.MergeStringMaps(getPoolLabels(worker.Name), map[string]string{
 							v1beta1constants.LabelNetworkPolicyToDNS:    "allowed",
 							v1beta1constants.LabelNodeCriticalComponent: "true",
 						}),
@@ -444,7 +444,7 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 	return clientObjects
 }
 
-func getMatchLabels(workerName string) map[string]string {
+func getPoolLabels(workerName string) map[string]string {
 	return map[string]string{
 		labelKey:     nodelocaldnsconstants.LabelValue,
 		labelKeyPool: workerName,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
@@ -118,11 +119,13 @@ ip6.arpa:53 {
 				Name:      serviceName,
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					"k8s-app": "kube-dns-upstream",
+					labelKey: "kube-dns-upstream",
 				},
 			},
 			Spec: corev1.ServiceSpec{
-				Selector: map[string]string{"k8s-app": "kube-dns"},
+				Selector: map[string]string{
+					labelKey: "kube-dns",
+				},
 				Ports: []corev1.ServicePort{
 					{
 						Name:       "dns",
@@ -173,17 +176,14 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 				},
 				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						labelKey: nodelocaldnsconstants.LabelValue,
-					},
+					MatchLabels: getMatchLabels(worker.Name),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							labelKey:                                    nodelocaldnsconstants.LabelValue,
+						Labels: utils.MergeStringMaps(getMatchLabels(worker.Name), map[string]string{
 							v1beta1constants.LabelNetworkPolicyToDNS:    "allowed",
 							v1beta1constants.LabelNodeCriticalComponent: "true",
-						},
+						}),
 						Annotations: map[string]string{
 							"prometheus.io/port":   strconv.Itoa(prometheusPort),
 							"prometheus.io/scrape": strconv.FormatBool(prometheusScrape),
@@ -434,4 +434,11 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 		}
 	}
 	return clientObjects
+}
+
+func getMatchLabels(workerName string) map[string]string {
+	return map[string]string{
+		labelKey:     nodelocaldnsconstants.LabelValue,
+		labelKeyPool: workerName,
+	}
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
This PR adds the worker name as a label selector to the `node-local-dns` `Daemonsets` that are created for each worker pool.
Without this, the created VPAs for each `Daemonset` were using the same selector and matching all `node-loacal-dns` Pods for all worker pools. This resulted in incorrect recommendations as the resource usage was aggregated across all Pods instead of just across Pods of a particular `Daemonset`


Kudos to @vpnachev for reporting the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Note that `labelKeyPool` was already defined in `resources.go` but not used anywhere, so I decided to reuse that for the label key.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The per-worker-pool `node-local-dns` `Daemonset`s now also include the name of the worker in their label selector and in their Pods' labels. This resolves an issue where each of the corresponding `VPA`s targeted all `node-cache` containers from all of these `Daemonsets` resulting in incorrect resource recommendations.
```
