### PR TITLE
Update the remote local setup to the latest changes in Gardener

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -369,7 +369,7 @@ spec:
           tmux select-pane -T top; rm -f ~/.config/procps/toprc
           for k in top Enter z C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
           new_pane "make kind-multi-zone-up" <<"EOF"
-            sync_kubeconfig example/gardener-local/kind/multi-zone & sleep 1
+            sync_kubeconfig dev-setup/kubeconfigs/runtime & sleep 1
             nice make kind-multi-zone-down kind-multi-zone-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
           EOF
           new_pane "make operator-up" <<"EOF"
@@ -427,7 +427,7 @@ spec:
           tmux select-pane -T top; rm -f ~/.config/procps/toprc
           for k in top Enter z C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
           new_pane "make kind-multi-zone-up" <<"EOF"
-            sync_kubeconfig example/gardener-local/kind/multi-zone & sleep 1
+            sync_kubeconfig dev-setup/kubeconfigs/runtime & sleep 1
             nice make kind-multi-zone-down kind-multi-zone-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
           EOF
           new_pane "make operator-up" <<"EOF"

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -348,7 +348,7 @@ spec:
             KUBECONFIG=<(generate-admin-kubeconf.sh) kubectl get pods -A
           EOF
           new_pane "Run simple e2e test (create and delete shoot)" <<"EOF"
-            make test-e2e-local-simple
+            GOFLAGS="-tags=musl" make test-e2e-local-simple
           EOF
           new_window "ad-hoc" "ad-hoc" Enter <<"EOF"
             # Use this pane for ad-hoc commands
@@ -406,7 +406,7 @@ spec:
             git log --oneline -1
           EOF
           new_window "make generate" "make generate" <<"EOF"
-            nice make generate check test test-integration
+            GOFLAGS-"-tags=musl" nice make generate check test test-integration
           EOF
           new_window "ad-hoc" "ad-hoc" Enter <<"EOF"
             # Use this pane for ad-hoc commands
@@ -537,7 +537,7 @@ spec:
             git log --oneline -1
           EOF
           new_window "make generate" "make generate" <<"EOF"
-            nice make generate check test test-integration
+            GOFLAGS="-tags=musl" nice make generate check test test-integration
           EOF
           new_window "ad-hoc" "ad-hoc" Enter <<"EOF"
             # Use this pane for ad-hoc commands

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -95,7 +95,7 @@ spec:
           echo '
           listen-address=127.0.0.1
           bind-interfaces
-          address=/.local.gardener.cloud/172.18.255.53
+          server=/.local.gardener.cloud/172.18.255.53
           ' > /etc/dnsmasq.d/gardener.conf
           sed '1inameserver 127.0.0.1' /etc/resolv.conf > /tmp/resolv.conf && cat /tmp/resolv.conf > /etc/resolv.conf
           nice dnsmasq --no-daemon --log-debug --log-queries 2>&1 | ts > ~/.dnsmasq.log &

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -446,6 +446,12 @@ if [[ "$CLUSTER_NAME" == "gardener-operator-local" ]] ; then
   sed "s/127\.0\.0\.1:[0-9]\+/$CLUSTER_NAME-control-plane:6443/g" "$PATH_KUBECONFIG" > "$(dirname "$0")/../dev-setup/gardenconfig/components/credentials/secret-project-garden-with-kind-kubeconfig/kubeconfig"
 fi
 
+if [[ "$IPFAMILY" == "ipv6" ]] || [[ "$IPFAMILY" == "dual" ]]; then
+  # All outgoing traffic from the cluster is masqueraded to the host's IPv6 address. This is to ensure outgoing traffic
+  # can also be routed back to the cluster.
+  ip6tables -t nat -A POSTROUTING -o $(ip route | grep '^default' | awk '{print $5}') -s $(docker network inspect kind -f='{{json .IPAM.Config}}' | jq -r '.[1].Subnet') -j MASQUERADE
+fi
+
 kubectl apply -k "$(dirname "$0")/../dev-setup/kind/calico/overlays/$IPFAMILY" --server-side
 kubectl apply -k "$(dirname "$0")/../dev-setup/kind/metrics-server"            --server-side
 kubectl apply -k "$(dirname "$0")/../dev-setup/kind/node-status-capacity"      --server-side


### PR DESCRIPTION
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

This PR applies the following changes to the remote local setup:

- Fixes the `dnsmasq` configuration to forward name resolution to the new upstream DNS server `172.18.255.53`.
- On IPv6 and dual setups, re-adds the `iptables` entry that allows outgoing traffic to be routed back to the KinD cluster.
- Adds `-tags musl` to the `make test` commands to force `musl` linking. Without this, the default behavior is to link using `glibc`, which is not available in Alpine. This is caused by the `gozstd` library, which is an indirect dependency.
- Makes sure the right `kubeconfig` files are used.

**Special notes for your reviewer**:

/cc @timebertt @istvanballok 

**Release note**:

```other developer
The remote local setup has been updated to the latest changes in Gardener.
```
