### PR TITLE
[release-v1.136] Avoid unintended MCD replicas modification by worker-controller

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -188,52 +189,7 @@ func deployMachineDeployments(
 		var (
 			labels                    = map[string]string{extensionsworkercontroller.LabelKeyMachineDeploymentName: deployment.Name}
 			existingMachineDeployment = getExistingMachineDeployment(existingMachineDeployments, deployment.Name)
-			replicas                  int32
 		)
-
-		switch {
-		// If the Shoot is hibernated then the machine deployment's replicas should be zero.
-		// Also mark all machines for forceful deletion to avoid respecting of PDBs/SLAs in case of cluster hibernation.
-		case extensionscontroller.IsHibernationEnabled(cluster):
-			replicas = 0
-			if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
-				return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)
-			}
-		// If the cluster autoscaler is not enabled then min=max (as per API validation), hence
-		// we can use either min or max.
-		case !clusterAutoscalerUsed:
-			replicas = deployment.Minimum
-		// If the machine deployment does not yet exist we set replicas to min so that the cluster
-		// autoscaler can scale them as required.
-		case existingMachineDeployment == nil:
-			if deployment.State != nil {
-				// During restoration the actual replica count is in the State.Replicas
-				// If wanted deployment has no corresponding existing deployment, but has State, then we are in restoration process
-				replicas = deployment.State.Replicas
-			} else {
-				replicas = deployment.Minimum
-			}
-		// If the Shoot was hibernated and is now woken up we set replicas to min so that the cluster
-		// autoscaler can scale them as required.
-		case shootIsAwake(extensionscontroller.IsHibernationEnabled(cluster), existingMachineDeployments):
-			replicas = deployment.Minimum
-		// If the shoot worker pool minimum was updated and if the current machine deployment replica
-		// count is less than minimum, we update the machine deployment replica count to updated minimum.
-		case existingMachineDeployment.Spec.Replicas < deployment.Minimum:
-			replicas = deployment.Minimum
-		// If the shoot worker pool maximum was updated and if the current machine deployment replica
-		// count is greater than maximum, we update the machine deployment replica count to updated maximum.
-		case existingMachineDeployment.Spec.Replicas > deployment.Maximum:
-			replicas = deployment.Maximum
-		// In this case the machine deployment must exist (otherwise the above case was already true),
-		// and the cluster autoscaler must be enabled. We do not want to override the machine deployment's
-		// replicas as the cluster autoscaler is responsible for setting appropriate values.
-		default:
-			replicas = getDeploymentSpecReplicas(existingMachineDeployments, deployment.Name)
-			if replicas == -1 {
-				replicas = deployment.Minimum
-			}
-		}
 
 		machineDeployment := &machinev1alpha1.MachineDeployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -251,34 +207,73 @@ func deployMachineDeployments(
 					metav1.SetMetaDataAnnotation(&machineDeployment.ObjectMeta, k, v)
 				}
 			}
-			machineDeployment.Spec = machinev1alpha1.MachineDeploymentSpec{
-				Replicas:             replicas,
-				RevisionHistoryLimit: ptr.To[int32](0),
-				MinReadySeconds:      500,
-				Strategy:             deployment.Strategy,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: labels,
+
+			switch {
+			// If the Shoot is hibernated then the machine deployment's replicas should be zero.
+			// Also mark all machines for forceful deletion to avoid respecting of PDBs/SLAs in case of cluster hibernation.
+			case extensionscontroller.IsHibernationEnabled(cluster):
+				machineDeployment.Spec.Replicas = 0
+				if err := markAllMachinesForcefulDeletion(ctx, log, cl, worker.Namespace); err != nil {
+					return fmt.Errorf("marking all machines for forceful deletion failed: %w", err)
+				}
+			// If the cluster autoscaler is not enabled then min=max (as per API validation), hence
+			// we can use either min or max.
+			case !clusterAutoscalerUsed:
+				machineDeployment.Spec.Replicas = deployment.Minimum
+			// If the machine deployment does not yet exist we set replicas to min so that the cluster
+			// autoscaler can scale them as required.
+			case existingMachineDeployment == nil:
+				if deployment.State != nil {
+					// During restoration the actual replica count is in the State.Replicas
+					// If wanted deployment has no corresponding existing deployment, but has State, then we are in restoration process
+					machineDeployment.Spec.Replicas = deployment.State.Replicas
+				} else {
+					machineDeployment.Spec.Replicas = deployment.Minimum
+				}
+			// If the Shoot was hibernated and is now woken up we set replicas to min so that the cluster
+			// autoscaler can scale them as required.
+			case shootIsAwake(extensionscontroller.IsHibernationEnabled(cluster), existingMachineDeployments):
+				machineDeployment.Spec.Replicas = deployment.Minimum
+			// If the shoot worker pool minimum was updated and if the current machine deployment replica
+			// count is less than minimum, we update the machine deployment replica count to updated minimum.
+			case machineDeployment.Spec.Replicas < deployment.Minimum:
+				machineDeployment.Spec.Replicas = deployment.Minimum
+			// If the shoot worker pool maximum was updated and if the current machine deployment replica
+			// count is greater than maximum, we update the machine deployment replica count to updated maximum.
+			case machineDeployment.Spec.Replicas > deployment.Maximum:
+				machineDeployment.Spec.Replicas = deployment.Maximum
+			}
+
+			// machineDeployment.Spec.Replicas is not explicitly set for default switch case,
+			// as it would have been already set by the client.Get() call in getAndCreateOrMergePatch().
+			// This is done to avoid overwriting the machineDeployment.Spec.Replicas value
+			// which is fetched from the client.Get() call in getAndCreateOrMergePatch()
+			// and hence causing unnecessary updates to the machineDeployment.Spec.Replicas
+			machineDeployment.Spec.RevisionHistoryLimit = ptr.To[int32](0)
+			machineDeployment.Spec.MinReadySeconds = 500
+			machineDeployment.Spec.Strategy = deployment.Strategy
+			machineDeployment.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: labels,
+			}
+			machineDeployment.Spec.Template = machinev1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: getMachineLabels(deployment.Strategy, labels, worker.Name),
 				},
-				Template: machinev1alpha1.MachineTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: getMachineLabels(deployment.Strategy, labels, worker.Name),
+				Spec: machinev1alpha1.MachineSpec{
+					Class: machinev1alpha1.ClassSpec{
+						Kind: "MachineClass",
+						Name: deployment.ClassName,
 					},
-					Spec: machinev1alpha1.MachineSpec{
-						Class: machinev1alpha1.ClassSpec{
-							Kind: "MachineClass",
-							Name: deployment.ClassName,
+					NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: deployment.Annotations,
+							Labels:      deployment.Labels,
 						},
-						NodeTemplateSpec: machinev1alpha1.NodeTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: deployment.Annotations,
-								Labels:      deployment.Labels,
-							},
-							Spec: corev1.NodeSpec{
-								Taints: deployment.Taints,
-							},
+						Spec: corev1.NodeSpec{
+							Taints: deployment.Taints,
 						},
-						MachineConfiguration: deployment.MachineConfiguration,
 					},
+					MachineConfiguration: deployment.MachineConfiguration,
 				},
 			}
 			if existingMachineDeployment != nil && existingMachineDeployment.Spec.Template.Annotations != nil {
@@ -606,20 +601,11 @@ func shootIsAwake(isHibernated bool, existingMachineDeployments *machinev1alpha1
 	return true
 }
 
-func getDeploymentSpecReplicas(existingMachineDeployments *machinev1alpha1.MachineDeploymentList, name string) int32 {
-	for _, existingMachineDeployment := range existingMachineDeployments.Items {
-		if existingMachineDeployment.Name == name {
-			return existingMachineDeployment.Spec.Replicas
-		}
-	}
-	return -1
-}
-
 func getExistingMachineDeployment(existingMachineDeployments *machinev1alpha1.MachineDeploymentList, name string) *machinev1alpha1.MachineDeployment {
-	for _, machineDeployment := range existingMachineDeployments.Items {
-		if machineDeployment.Name == name {
-			return &machineDeployment
-		}
+	if idx := slices.IndexFunc(existingMachineDeployments.Items, func(machineDeployment machinev1alpha1.MachineDeployment) bool {
+		return machineDeployment.Name == name
+	}); idx != -1 {
+		return &existingMachineDeployments.Items[idx]
 	}
 	return nil
 }

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile_test.go
@@ -109,6 +109,7 @@ var _ = Describe("ActuatorReconcile", func() {
 				},
 			}
 		})
+
 		It("should remove cluster autoscaler annotations with no values", func() {
 			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, caUsed)
 			Expect(err).NotTo(HaveOccurred())
@@ -160,6 +161,59 @@ var _ = Describe("ActuatorReconcile", func() {
 				"non-ca-annotation": "",
 				"autoscaler.gardener.cloud/scale-down-unneeded-time": "20m",
 			}))
+		})
+
+		It("should not modify replicas of the existing machine deployment if they're within acceptable range", func() {
+			wantedMachineDeployments[0].Minimum = 2
+			wantedMachineDeployments[0].Maximum = 5
+			testDeployment.Spec.Replicas = 4
+			Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
+			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
+				Items: []machinev1alpha1.MachineDeployment{
+					*testDeployment,
+				},
+			}
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(4)))
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(4)))
+		})
+
+		It("should modify replicas of the existing machine deployment to the Minimum", func() {
+			wantedMachineDeployments[0].Minimum = 2
+			wantedMachineDeployments[0].Maximum = 5
+			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
+				Items: []machinev1alpha1.MachineDeployment{
+					*testDeployment,
+				},
+			}
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(0)))
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(wantedMachineDeployments[0].Minimum))
+		})
+
+		It("should set deployment replicas to 0 when marked for hibernation", func() {
+			wantedMachineDeployments[0].Minimum = 0
+			wantedMachineDeployments[0].Maximum = 3
+			testDeployment.Spec.Replicas = 2
+			Expect(seedClient.Update(ctx, testDeployment)).To(Succeed())
+			existingMachineDeployments = machinev1alpha1.MachineDeploymentList{
+				Items: []machinev1alpha1.MachineDeployment{
+					*testDeployment,
+				},
+			}
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(2)))
+			cluster.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: ptr.To(true)}
+			err := deployMachineDeployments(ctx, log, seedClient, cluster, worker, &existingMachineDeployments, wantedMachineDeployments, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seedClient.Get(ctx, client.ObjectKeyFromObject(testDeployment), &returnedDeployment)).To(Succeed())
+			Expect(returnedDeployment.Spec.Replicas).To(Equal(int32(0)))
 		})
 	})
 	Describe("#updateWorkerStatusInPlaceUpdateWorkerPoolHash", func() {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -47,12 +47,6 @@ func RestoreWithoutReconcile(
 		return fmt.Errorf("failed to generate the machine deployments: %w", err)
 	}
 
-	// Get the list of all existing machine deployments.
-	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
-	if err := seedClient.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
-		return err
-	}
-
 	// Parse the worker state to a separate machineDeployment states and attach them to
 	// the corresponding machineDeployments which are to be deployed later
 	log.Info("Extracting machine state")
@@ -70,6 +64,12 @@ func RestoreWithoutReconcile(
 	// Do the actual restoration
 	if err := restoreMachineSetsAndMachines(ctx, log, seedClient, wantedMachineDeployments); err != nil {
 		return fmt.Errorf("failed restoration of the machineSet and the machines: %w", err)
+	}
+
+	// Get the list of all existing machine deployments.
+	existingMachineDeployments := &machinev1alpha1.MachineDeploymentList{}
+	if err := seedClient.List(ctx, existingMachineDeployments, client.InNamespace(worker.Namespace)); err != nil {
+		return err
 	}
 
 	// Generate machine deployment configuration based on previously computed list of deployments and deploy them.


### PR DESCRIPTION
This is a cherry-pick of #14189

/kind bug
/assign @ScheererJ

```bugfix dependency github.com/gardener/gardener #14291 @r4mek
Fixing an issue where CA scale-downs were getting stuck when MCD replicas was updated with stale cache value of worker-controller
```