### PR TITLE
Add gardenerDiscoveryServer section to garden.yaml.tmpl

### DIFF
--- a/dev-setup/garden/overlays/remote/garden.yaml.tmpl
+++ b/dev-setup/garden/overlays/remote/garden.yaml.tmpl
@@ -37,3 +37,9 @@ spec:
     networking:
       # Enter service CIDRs of your virtual garden
       services: []
+    gardener:
+      gardenerDiscoveryServer:
+        domain:
+          # Enter subdomain of your primary domain e.g. "discovery.my-garden.my-domain.com"
+          name: ""
+          provider: primary


### PR DESCRIPTION
Add gardenerDiscoveryServer configuration to garden.yaml template

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

- With the new defaults in discovery server we need to explicitly set the discovery domain for the remote setup


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Remote setup garden template has been updated with gardenerDiscoveryServer configuration
```
