### PR TITLE
[GEP-26] Forbid Shoot `.spec.dns.providers[].secretName` field for Kubernetes 1.35+

### DIFF
--- a/docs/usage/shoot/shoot_kubernetes_versions.md
+++ b/docs/usage/shoot/shoot_kubernetes_versions.md
@@ -15,6 +15,7 @@ For Kubernetes specific upgrade notes the upstream Kubernetes release notes, [ch
 - The `Shoot`'s `.spec.addons` field is forbidden. The retirement of the previously contained components [Kubernetes Dashboard](https://github.com/kubernetes-retired/dashboard) and [Ingress NGINX Controller](https://github.com/kubernetes/ingress-nginx), requires owners to remove any existing addon configurations from the `Shoot`.
 - The `Shoot`'s `.spec.kubernetes.kubeAPIServer.watchCacheSizes.default` field is forbidden. Watch cache sizes are automatically sized by Kubernetes.
 - The `Shoot`'s `.spec.kubernetes.kubeScheduler.kubeMaxPDVols` field is forbidden. The maximum number of attachable volumes is maintained by the respective CSI plugin.
+- The `Shoot`'s `.spec.dns.providers[].secretName` field is forbidden, use `.spec.dns.providers[].credentialsRef` instead.
 
 ## Upgrading to Kubernetes `v1.34`
 

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -381,7 +381,11 @@ spec:
     # Provider configuration required if custom shoot domain is configured.
   # providers:
   # - type: aws-route53
-  #   secretName: my-custom-domain-secret
+  #   secretName: my-custom-domain-secret # Deprecated, will be removed in a future version of gardener. Use `credentialsRef` instead.
+  #   credentialsRef:
+  #     apiVersion: v1
+  #     kind: Secret
+  #     name: my-custom-domain-secret
   extensions:
   - type: foobar
   # providerConfig:

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -381,7 +381,7 @@ spec:
     # Provider configuration required if custom shoot domain is configured.
   # providers:
   # - type: aws-route53
-  #   secretName: my-custom-domain-secret # Deprecated, will be removed in a future version of gardener. Use `credentialsRef` instead.
+  #   secretName: my-custom-domain-secret # Deprecated. Forbidden for Kubernetes >= 1.35. Use `credentialsRef` instead.
   #   credentialsRef:
   #     apiVersion: v1
   #     kind: Secret

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -81,6 +81,28 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 		warnings = append(warnings, GetKubeAPIServerWarnings(kubeAPIServer, path)...)
 	}
 
+	if shoot.Spec.DNS != nil {
+		warnings = append(warnings, GetDNSProviderWarnings(shoot.Spec.DNS, field.NewPath("spec", "dns"))...)
+	}
+
+	return warnings
+}
+
+// GetDNSProviderWarnings returns warnings for the given DNS configuration.
+func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path) []string {
+	var warnings []string
+
+	for i, provider := range dns.Providers {
+		if provider.SecretName != nil {
+			providerPath := fldPath.Child("providers").Index(i)
+			warnings = append(warnings, fmt.Sprintf(
+				"you are setting the %s field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use %s instead.",
+				providerPath.Child("secretName").String(),
+				providerPath.Child("credentialsRef").String(),
+			))
+		}
+	}
+
 	return warnings
 }
 

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -512,4 +512,60 @@ var _ = Describe("Warnings", func() {
 			),
 		)
 	})
+
+	Describe("#GetDNSProviderWarnings", func() {
+		DescribeTable("providers[].secretName",
+			func(dns *core.DNS, fldPath *field.Path, matcher gomegatypes.GomegaMatcher) {
+				Expect(GetDNSProviderWarnings(dns, fldPath)).To(matcher)
+			},
+
+			Entry("should not return a warning when dns.providers is nil",
+				&core.DNS{Providers: nil},
+				field.NewPath("spec", "dns"),
+				BeEmpty(),
+			),
+			Entry("should not return a warning when dns.providers is empty",
+				&core.DNS{Providers: []core.DNSProvider{}},
+				field.NewPath("spec", "dns"),
+				BeEmpty(),
+			),
+			Entry("should not return a warning when secretName is not set",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: nil}}},
+				field.NewPath("spec", "dns"),
+				BeEmpty(),
+			),
+			Entry("should return a warning when secretName is set for a single provider",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: ptr.To("secret")}}},
+				field.NewPath("spec", "dns"),
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
+			Entry("should return warnings when secretName is set for multiple providers",
+				&core.DNS{Providers: []core.DNSProvider{
+					{SecretName: ptr.To("secret1")},
+					{SecretName: ptr.To("secret2")},
+				}},
+				field.NewPath("spec", "dns"),
+				And(
+					ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+					ContainElement(Equal("you are setting the spec.dns.providers[1].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[1].credentialsRef instead.")),
+				),
+			),
+			Entry("should return warning only for provider with secretName set",
+				&core.DNS{Providers: []core.DNSProvider{
+					{SecretName: nil},
+					{SecretName: ptr.To("secret")},
+				}},
+				field.NewPath("spec", "dns"),
+				And(
+					ContainElement(Equal("you are setting the spec.dns.providers[1].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[1].credentialsRef instead.")),
+					Not(ContainElement(ContainSubstring("spec.dns.providers[0].secretName"))),
+				),
+			),
+			Entry("should use custom field path in warning message",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: ptr.To("secret")}}},
+				field.NewPath("custom", "path"),
+				ContainElement(Equal("you are setting the custom.path.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use custom.path.providers[0].credentialsRef instead.")),
+			),
+		)
+	})
 })

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -421,6 +421,29 @@ var _ = Describe("Warnings", func() {
 				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
+
+		DescribeTable("spec.dns.providers[].secretName",
+			func(dns *core.DNS, matcher gomegatypes.GomegaMatcher) {
+				shoot.Spec.DNS = dns
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+			},
+			Entry("should not return a warning when dns is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when dns.providers is nil",
+				&core.DNS{Providers: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when secretName is not set",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: nil}}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when secretName is set",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: ptr.To("secret")}}},
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
+		)
 	})
 
 	Describe("#GetKubeAPIServerWarnings", func() {

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -316,7 +316,7 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 	allErrs = append(allErrs, ValidateCloudProfileReference(spec.CloudProfile, spec.CloudProfileName, spec.Kubernetes.Version, fldPath)...)
 	allErrs = append(allErrs, validateProvider(meta.Namespace, spec.Provider, spec.Kubernetes, spec.Networking, workerless, fldPath.Child("provider"), inTemplate)...)
 	allErrs = append(allErrs, validateAddons(spec.Addons, spec.Purpose, workerless, spec.Kubernetes.Version, fldPath.Child("addons"))...)
-	allErrs = append(allErrs, validateDNS(spec.DNS, fldPath.Child("dns"))...)
+	allErrs = append(allErrs, validateDNS(spec.DNS, spec.Kubernetes.Version, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateExtensions(spec.Extensions, fldPath.Child("extensions"))...)
 	allErrs = append(allErrs, ValidateResources(spec.Resources, fldPath.Child("resources"), true)...)
 	allErrs = append(allErrs, validateKubernetes(spec.Kubernetes, spec.Networking, opts, workerless, fldPath.Child("kubernetes"))...)
@@ -1037,7 +1037,7 @@ func validateDNSCredentialsRef(provider core.DNSProvider, fldPath *field.Path) f
 	return allErrs
 }
 
-func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
+func validateDNS(dns *core.DNS, kubernetesVersion string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if dns == nil {
@@ -1067,6 +1067,10 @@ func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
 	)
 	for i, provider := range dns.Providers {
 		idxPath := fldPath.Child("providers").Index(i)
+
+		if provider.SecretName != nil && versionutils.ConstraintK8sGreaterEqual135.CheckVersion(kubernetesVersion) {
+			allErrs = append(allErrs, field.Forbidden(idxPath.Child("secretName"), "for Kubernetes versions >= 1.35, secretName field is no longer supported"))
+		}
 
 		allErrs = append(allErrs, validateDNSCredentialsRef(provider, idxPath)...)
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1004,10 +1004,11 @@ func validateWorkerGroupAndControlPlaneKubernetesVersion(controlPlaneVersion, wo
 }
 
 // validateDNSCredentialsRef validates the DNS provider credentials reference and secret name for backward compatibility.
-func validateDNSCredentialsRef(provider core.DNSProvider, fldPath *field.Path) field.ErrorList {
+func validateDNSCredentialsRef(provider core.DNSProvider, kubernetesVersion string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// How to achieve backward compatibility between secretName and credentialsRef?
+	// For kubernetes version >= 1.35, secretName must not be set.
 	// - if secretName is set, credentialsRef must be set and refer the same secret
 	// - if secretName is not set, then credentialsRef could be either unset or set but refer to a non-secret resource
 	//
@@ -1017,14 +1018,15 @@ func validateDNSCredentialsRef(provider core.DNSProvider, fldPath *field.Path) f
 	// - secretName can be unset only when workloadIdentity is used, which we respect here
 
 	if provider.CredentialsRef == nil {
-		if provider.SecretName != nil {
+		if provider.SecretName != nil && versionutils.ConstraintK8sLess135.CheckVersion(kubernetesVersion) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretName"), "must not be set when `credentialsRef` is not set"))
 		}
 	} else {
 		allErrs = append(allErrs, ValidateLocalCredentialsRef(*provider.CredentialsRef, fldPath.Child("credentialsRef"))...)
 
 		if provider.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && provider.CredentialsRef.Kind == "Secret" {
-			if provider.SecretName == nil || *provider.SecretName != provider.CredentialsRef.Name {
+			if versionutils.ConstraintK8sLess135.CheckVersion(kubernetesVersion) &&
+				(provider.SecretName == nil || *provider.SecretName != provider.CredentialsRef.Name) {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("secretName"), "must refer to the same secret as `credentialsRef`"))
 			}
 		} else {
@@ -1072,7 +1074,7 @@ func validateDNS(dns *core.DNS, kubernetesVersion string, fldPath *field.Path) f
 			allErrs = append(allErrs, field.Forbidden(idxPath.Child("secretName"), "for Kubernetes versions >= 1.35, secretName field is no longer supported"))
 		}
 
-		allErrs = append(allErrs, validateDNSCredentialsRef(provider, idxPath)...)
+		allErrs = append(allErrs, validateDNSCredentialsRef(provider, kubernetesVersion, idxPath)...)
 
 		if provider.CredentialsRef != nil && provider.Type != nil {
 			credential := credentialConfig{

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -2400,6 +2400,29 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 			})
+
+			DescribeTable("secretName validation for Kubernetes >= 1.35",
+				func(kubernetesVersion string, expectForbidden bool) {
+					shoot.Spec.Kubernetes.Version = kubernetesVersion
+					shoot.Spec.DNS.Providers[0].SecretName = &dnsSecretName
+					shoot.Spec.DNS.Providers[0].CredentialsRef = &dnsSecretRef
+
+					matcher := ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.dns.providers[0].secretName"),
+						"Detail": Equal("for Kubernetes versions >= 1.35, secretName field is no longer supported"),
+					})))
+
+					if !expectForbidden {
+						matcher = Not(matcher)
+					}
+
+					Expect(ValidateShoot(shoot)).To(matcher)
+				},
+				Entry("should allow secretName for Kubernetes < 1.35", "1.34.0", false),
+				Entry("should forbid secretName for Kubernetes = 1.35", "1.35.0", true),
+				Entry("should forbid secretName for Kubernetes > 1.35", "1.36.0", true),
+			)
 		})
 
 		Context("ETCD validation", func() {

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -2298,7 +2298,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			Context("#validateDNSCredentialsRef", func() {
-				It("should forbid to unset credentialsRef when secretName is set (kubernetes version <1.35)", func() {
+				It("should forbid to unset credentialsRef when secretName is set for Kubernetes version < 1.35", func() {
 					shoot.Spec.Kubernetes.Version = "1.34.0"
 					shoot.Spec.DNS.Providers[0].CredentialsRef = nil
 					shoot.Spec.DNS.Providers[0].SecretName = &dnsSecretName

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -2283,9 +2283,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				}
 
-				errorList := ValidateShoot(shoot)
-
-				Expect(errorList).To(ConsistOf(
+				Expect(ValidateShoot(shoot)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeRequired),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -2300,26 +2298,23 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 
 			Context("#validateDNSCredentialsRef", func() {
-				It("should forbid unset credentialsRef when secretName is set", func() {
+				It("should forbid to unset credentialsRef when secretName is set (kubernetes version <1.35)", func() {
+					shoot.Spec.Kubernetes.Version = "1.34.0"
 					shoot.Spec.DNS.Providers[0].CredentialsRef = nil
 					shoot.Spec.DNS.Providers[0].SecretName = &dnsSecretName
 
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					Expect(ValidateShoot(shoot)).To(ContainElements(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("spec.dns.providers[0].secretName"),
 						"Detail": ContainSubstring("must not be set when `credentialsRef` is not set"),
 					}))))
 				})
 
-				It("should allow both credentialsRef when secretName to be unset", func() {
+				It("should allow both credentialsRef and secretName to be unset", func() {
 					shoot.Spec.DNS.Providers[0].CredentialsRef = nil
 					shoot.Spec.DNS.Providers[0].SecretName = nil
 
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(BeEmpty())
+					Expect(ValidateShoot(shoot)).To(BeEmpty())
 				})
 
 				DescribeTable("forbid invalid credentialsRef fields", func(ref autoscalingv1.CrossVersionObjectReference, matcher gomegatypes.GomegaMatcher) {
@@ -2328,9 +2323,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						shoot.Spec.DNS.Providers[0].SecretName = &ref.Name
 					}
 
-					errorList := ValidateShoot(shoot)
-					Expect(errorList).To(matcher)
-
+					Expect(ValidateShoot(shoot)).To(matcher)
 				},
 					Entry("empty APIVersion",
 						autoscalingv1.CrossVersionObjectReference{APIVersion: "", Kind: "Secret", Name: dnsSecretName},
@@ -2378,9 +2371,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.DNS.Providers[0].CredentialsRef = &dnsSecretRef
 					shoot.Spec.DNS.Providers[0].SecretName = ptr.To("other")
 
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					Expect(ValidateShoot(shoot)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("spec.dns.providers[0].secretName"),
 						"Detail": ContainSubstring("must refer to the same secret as `credentialsRef`"),
@@ -2391,12 +2382,22 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.DNS.Providers[0].CredentialsRef = &dnsWorkloadIdentityRef
 					shoot.Spec.DNS.Providers[0].SecretName = &dnsSecretName
 
-					errorList := ValidateShoot(shoot)
-
-					Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("spec.dns.providers[0].secretName"),
 						"Detail": ContainSubstring("must not be set when `credentialsRef` does not refer to secret resource"),
+					}))))
+				})
+
+				It("should allow secretName to be unset for Kubernetes >= 1.35", func() {
+					shoot.Spec.Kubernetes.Version = "1.35.0"
+					shoot.Spec.DNS.Providers[0].SecretName = nil
+					shoot.Spec.DNS.Providers[0].CredentialsRef = &dnsSecretRef
+
+					Expect(ValidateShoot(shoot)).ToNot(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.dns.providers[0].secretName"),
+						"Detail": Equal("for Kubernetes versions >= 1.35, secretName field is no longer supported"),
 					}))))
 				})
 			})

--- a/pkg/api/seedmanagement/managedseedset/warnings.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings.go
@@ -24,5 +24,10 @@ func GetWarnings(managedseedset *seedmanagement.ManagedSeedSet) []string {
 		warnings = append(warnings, shoot.GetKubeAPIServerWarnings(kubeAPIServer, path)...)
 	}
 
+	if dns := managedseedset.Spec.ShootTemplate.Spec.DNS; dns != nil {
+		path := field.NewPath("spec", "shootTemplate", "spec", "dns")
+		warnings = append(warnings, shoot.GetDNSProviderWarnings(dns, path)...)
+	}
+
 	return warnings
 }

--- a/pkg/api/seedmanagement/managedseedset/warnings_test.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings_test.go
@@ -93,5 +93,28 @@ var _ = Describe("Warnings", func() {
 				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
+
+		DescribeTable("spec.dns.providers[].secretName",
+			func(dns *core.DNS, matcher gomegatypes.GomegaMatcher) {
+				managedSeedSet.Spec.ShootTemplate.Spec.DNS = dns
+				Expect(GetWarnings(managedSeedSet)).To(matcher)
+			},
+			Entry("should not return a warning when dns is nil",
+				nil,
+				BeEmpty(),
+			),
+			Entry("should not return a warning when dns.providers is nil",
+				&core.DNS{Providers: nil},
+				BeEmpty(),
+			),
+			Entry("should not return a warning when secretName is not set",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: nil}}},
+				BeEmpty(),
+			),
+			Entry("should return a warning when secretName is set",
+				&core.DNS{Providers: []core.DNSProvider{{SecretName: ptr.To("secret")}}},
+				ContainElement(Equal("you are setting the spec.shootTemplate.spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.shootTemplate.spec.dns.providers[0].credentialsRef instead.")),
+			),
+		)
 	})
 })

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -33,6 +33,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 type shootStrategy struct {
@@ -467,6 +468,10 @@ func cleanUpOperation(operation string) string {
 // TODO(vpnachev): Remove this function once support for Kubernetes 1.34 is dropped.
 func SyncDNSProviderCredentials(shoot *core.Shoot) {
 	if shoot.Spec.DNS == nil {
+		return
+	}
+
+	if versionutils.ConstraintK8sGreaterEqual135.CheckVersion(shoot.Spec.Kubernetes.Version) {
 		return
 	}
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -270,6 +270,22 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 		}
 	}
 
+	// Set the .spec.dns.providers[].secretName field to nil, when Shoot cluster is being forcefully updated to K8s >= 1.35.
+	// Gardener forbids setting the field for Shoots with K8s 1.35+.
+	{
+		oldK8sLess135, _ := versionutils.CheckVersionMeetsConstraint(oldShootKubernetesVersion.String(), "< 1.35")
+		newK8sGreaterEqual135, _ := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.35")
+		if oldK8sLess135 && newK8sGreaterEqual135 {
+			for i := range maintainedShoot.Spec.DNS.Providers {
+				if maintainedShoot.Spec.DNS.Providers[i].SecretName != nil {
+					maintainedShoot.Spec.DNS.Providers[i].SecretName = nil
+					reason := fmt.Sprintf(".spec.dns.providers[%d].secretName was removed. Reason: The field is no longer supported for Shoot clusters using Kubernetes version 1.35+", i)
+					operations = append(operations, reason)
+				}
+			}
+		}
+	}
+
 	// Now it's time to update worker pool kubernetes version if specified
 	for i, pool := range maintainedShoot.Spec.Provider.Workers {
 		if pool.Kubernetes == nil || pool.Kubernetes.Version == nil {

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -275,7 +275,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	{
 		oldK8sLess135 := versionutils.ConstraintK8sLess135.Check(oldShootKubernetesVersion)
 		newK8sGreaterEqual135 := versionutils.ConstraintK8sGreaterEqual135.Check(shootKubernetesVersion)
-		if oldK8sLess135 && newK8sGreaterEqual135 {
+		if oldK8sLess135 && newK8sGreaterEqual135 && maintainedShoot.Spec.DNS != nil {
 			for i := range maintainedShoot.Spec.DNS.Providers {
 				if maintainedShoot.Spec.DNS.Providers[i].SecretName != nil {
 					maintainedShoot.Spec.DNS.Providers[i].SecretName = nil

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -273,8 +273,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log logr.Logger, shoot *gard
 	// Set the .spec.dns.providers[].secretName field to nil, when Shoot cluster is being forcefully updated to K8s >= 1.35.
 	// Gardener forbids setting the field for Shoots with K8s 1.35+.
 	{
-		oldK8sLess135, _ := versionutils.CheckVersionMeetsConstraint(oldShootKubernetesVersion.String(), "< 1.35")
-		newK8sGreaterEqual135, _ := versionutils.CheckVersionMeetsConstraint(shootKubernetesVersion.String(), ">= 1.35")
+		oldK8sLess135 := versionutils.ConstraintK8sLess135.Check(oldShootKubernetesVersion)
+		newK8sGreaterEqual135 := versionutils.ConstraintK8sGreaterEqual135.Check(shootKubernetesVersion)
 		if oldK8sLess135 && newK8sGreaterEqual135 {
 			for i := range maintainedShoot.Spec.DNS.Providers {
 				if maintainedShoot.Spec.DNS.Providers[i].SecretName != nil {

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1957,6 +1958,20 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 						Default: ptr.To[int32](50),
 					},
 				}
+				dnsCredentialsSecretName := "dns-credentials-secret"
+				shoot134.Spec.DNS = &gardencorev1beta1.DNS{
+					Providers: []gardencorev1beta1.DNSProvider{
+						{
+							Type:       ptr.To("test-dns"),
+							SecretName: &dnsCredentialsSecretName,
+							CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+								APIVersion: "v1",
+								Kind:       "Secret",
+								Name:       dnsCredentialsSecretName,
+							},
+						},
+					},
+				}
 
 				By("Create Shoot with k8s v1.34")
 				Expect(testClient.Create(ctx, shoot134)).To(Succeed())
@@ -1968,6 +1983,7 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 				})
 
 				Expect(shoot134.Spec.Addons.KubernetesDashboard).NotTo(BeNil())
+				Expect(shoot134.Spec.DNS.Providers[0].SecretName).NotTo(BeNil())
 
 				By("Expire Shoot's kubernetes version in the CloudProfile to force update to 1.35")
 				Expect(patchCloudProfileForKubernetesVersionMaintenance(ctx, testClient, shoot134.Spec.CloudProfile.Name, "1.34.0", &expirationDateInThePast, &deprecatedClassification)).To(Succeed())
@@ -1989,6 +2005,7 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 					g.Expect(shoot134.Spec.Kubernetes.KubeScheduler.KubeMaxPDVols).To(BeNil(), "KubeMaxPDVols should be unset after migration")
 					g.Expect(shoot134.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(BeNil(), "Default watch cache size should be unset after migration")
 					g.Expect(shoot134.Spec.Kubernetes.KubeAPIServer.WatchCacheSizes.Default).To(BeNil(), "Default watch cache size should be unset after migration")
+					g.Expect(shoot134.Spec.DNS.Providers[0].SecretName).To(BeNil(), "DNS Provider secretName should be unset after migration")
 
 					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.addons was removed"))
 					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.kubernetes.kubeAPIServer.watchCacheSizes.default was removed"))

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -2011,6 +2011,7 @@ var _ = DescribeTableSubtree("Shoot Maintenance controller tests", func(isCapabi
 					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.kubernetes.kubeAPIServer.watchCacheSizes.default was removed"))
 					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.kubernetes.kubeScheduler.kubeMaxPDVols was removed"))
 					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication was removed"))
+					g.Expect(shoot134.Status.LastMaintenance.Description).To(ContainSubstring(".spec.dns.providers[0].secretName was removed"))
 					g.Expect(shoot134.Status.LastMaintenance.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
 					g.Expect(shoot134.Status.LastMaintenance.TriggeredTime).To(Equal(metav1.Time{Time: fakeClock.Now()}))
 				}).Should(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei documentation
/kind enhancement
/label ipcei/workload-identity


**What this PR does / why we need it**:
Document `.spec.dns.providers[].secretName` deprecation in shoot upgrade guide

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
⚠️ The Shoot field `.spec.dns.providers[].secretName` has been forbidden for clusters running on Kubernetes version v1.35.0 or higher. Please, use `.spec.dns.providers[].credentialsRef` instead. 
```
