### PR TITLE
Introduce `kube-apiserver` like autoscaling with `HPA` + `VPA` for `istio-ingressgateway` 

### DIFF
--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -109,11 +109,11 @@ However, in the case of newly spun-up clusters requiring immediate heavy usage, 
 
 The Istio ingress gateway is scaled simultaneously by VPA and HPA.
 
-The pod-trashing cycle between VPA and HPA scaling on the same metric is avoided by configuring the HPA to scale on average value (not on average utilization).
+Scaling with VPA and HPA on the same metric can lead to a pod-trashing cycle. This is avoided here by configuring the HPA to scale on average value (not on average utilization).
 This makes it possible for VPA to first scale vertically on CPU/memory usage.
-Once all Pods' average CPU usage exceeds the HPA's target average value, HPA scales horizontally (by adding a new replica).
+Once all pods' average CPU usage exceeds the HPA's target average value, HPA scales horizontally (by adding a new replica).
 
-The HPA's target average CPU value depends on whether the `IstioTLSTermination` feature gate is enabled:
+The HPA's target average CPU value depends on whether the `IstioTLSTermination` feature gate is enabled because with the feature gate enabled more CPU-intensive TLS encryption/decryption takes place:
 - When `IstioTLSTermination` is disabled: HPA's target average value is `2` CPU, initial CPU request is `300m`.
 - When `IstioTLSTermination` is enabled: HPA's target average value is `4` CPU, initial CPU request is `1` CPU.
 
@@ -123,6 +123,6 @@ The HPA replica count is calculated based on the number of availability zones:
 - Min replicas: `2 * number of zones`
 - Max replicas: `16 * number of zones`
 
-For zonal istio-ingressgateways, the HPA replica count is fixed:
+For zonal istio-ingressgateways, i.e. istio-ingressgateways covering a single availability zone, the HPA replica count is fixed:
 - Min replicas: `2`
 - Max replicas: `16`

--- a/docs/development/autoscaling-specifics-for-components.md
+++ b/docs/development/autoscaling-specifics-for-components.md
@@ -104,3 +104,25 @@ However, in the case of newly spun-up clusters requiring immediate heavy usage, 
 
 > [!NOTE]
 > To use this feature effectively, users should thoroughly analyze their cluster usage patterns in advance to identify appropriate resource values.
+
+## Istio Ingress Gateway
+
+The Istio ingress gateway is scaled simultaneously by VPA and HPA.
+
+The pod-trashing cycle between VPA and HPA scaling on the same metric is avoided by configuring the HPA to scale on average value (not on average utilization).
+This makes it possible for VPA to first scale vertically on CPU/memory usage.
+Once all Pods' average CPU usage exceeds the HPA's target average value, HPA scales horizontally (by adding a new replica).
+
+The HPA's target average CPU value depends on whether the `IstioTLSTermination` feature gate is enabled:
+- When `IstioTLSTermination` is disabled: HPA's target average value is `2` CPU, initial CPU request is `300m`.
+- When `IstioTLSTermination` is enabled: HPA's target average value is `4` CPU, initial CPU request is `1` CPU.
+
+The VPA is configured with `updateMode: InPlaceOrRecreate` and controls both CPU and memory requests for the `istio-proxy` container.
+
+The HPA replica count is calculated based on the number of availability zones:
+- Min replicas: `2 * number of zones`
+- Max replicas: `16 * number of zones`
+
+For zonal istio-ingressgateways, the HPA replica count is fixed:
+- Min replicas: `2`
+- Max replicas: `16`

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-hpa.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-hpa.yaml
@@ -18,8 +18,8 @@ spec:
     resource:
       name: cpu
       target:
-        averageUtilization: 80
-        type: Utilization
+        type: AverageValue
+        averageValue: "{{ .Values.hpaCPUAverageValue }}"
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-vpa.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/autoscale-vpa.yaml
@@ -12,12 +12,13 @@ spec:
     kind: Deployment
     name: istio-ingressgateway
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: istio-proxy
       controlledValues: RequestsOnly
       controlledResources:
+      - cpu
       - memory
     - containerName: '*'
       mode: "Off"

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         proxy.istio.io/config: |-
-          concurrency: 4
           protocolDetectionTimeout: 100ms
           runtimeValues:
             "overload.global_downstream_max_connections": "750000"

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -43,3 +43,4 @@ httpProxy:
     enabled: false
     header: Reversed-VPN
     port: 8132
+vpaUpdateMode: InPlaceOrRecreate

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -78,6 +78,11 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			}
 		}
 
+		vpaUpdateMode := "InPlaceOrRecreate"
+		if !features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates) {
+			vpaUpdateMode = "Recreate"
+		}
+
 		cpuRequests := "300m"
 		hpaCPUAverageValue := "2"
 		if enableAPIServerTLSTermination {
@@ -119,6 +124,7 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			"apiServerAuthenticationDynamicMetadataKey": apiserverexposure.AuthenticationDynamicMetadataKey,
 			"cpuRequests":        cpuRequests,
 			"hpaCPUAverageValue": hpaCPUAverageValue,
+			"vpaUpdateMode":      vpaUpdateMode,
 			"kubernetesVersion":  istioIngressGateway.KubernetesVersion,
 		}
 

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -79,8 +79,10 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 		}
 
 		cpuRequests := "300m"
+		hpaCPUAverageValue := "2"
 		if enableAPIServerTLSTermination {
-			cpuRequests = "450m"
+			cpuRequests = "1"
+			hpaCPUAverageValue = "4"
 		}
 
 		httpProxy := map[string]any{
@@ -115,8 +117,9 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			"apiServerRequestHeaderUserName":     kubeapiserverconstants.RequestHeaderUserName,
 			"apiServerRequestHeaderGroup":        kubeapiserverconstants.RequestHeaderGroup,
 			"apiServerAuthenticationDynamicMetadataKey": apiserverexposure.AuthenticationDynamicMetadataKey,
-			"cpuRequests":       cpuRequests,
-			"kubernetesVersion": istioIngressGateway.KubernetesVersion,
+			"cpuRequests":        cpuRequests,
+			"hpaCPUAverageValue": hpaCPUAverageValue,
+			"kubernetesVersion":  istioIngressGateway.KubernetesVersion,
 		}
 
 		if istioIngressGateway.MinReplicas != nil {

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -52,6 +52,7 @@ var _ = Describe("istiod", func() {
 		labels                        map[string]string
 		networkLabels                 map[string]string
 		expectAPIServerTLSTermination bool
+		expectVPARecreateMode         bool
 
 		managedResourceIstioName   string
 		managedResourceIstio       *resourcesv1alpha1.ManagedResource
@@ -150,6 +151,11 @@ var _ = Describe("istiod", func() {
 
 		istioIngressAutoscalerVPA = func() string {
 			data, _ := os.ReadFile("./test_charts/ingress_autoscaler_vpa.yaml")
+			return string(data)
+		}
+
+		istioIngressAutoscalerVPARecreate = func() string {
+			data, _ := os.ReadFile("./test_charts/ingress_autoscaler_vpa_recreate.yaml")
 			return string(data)
 		}
 
@@ -311,6 +317,7 @@ var _ = Describe("istiod", func() {
 		labels = map[string]string{"foo": "bar"}
 		networkLabels = map[string]string{"to-target": "allowed"}
 		expectAPIServerTLSTermination = false
+		expectVPARecreateMode = false
 		expectedCPURequests = "300m"
 		expectedMinReplicas = 2
 		expectedMaxReplicas = 9
@@ -467,7 +474,12 @@ var _ = Describe("istiod", func() {
 
 			expectedIstioManifests = append(expectedIstioManifests, istioIngressPodDisruptionBudget())
 			expectedIstioSystemManifests = append(expectedIstioSystemManifests, istiodPodDisruptionBudget())
-			expectedIstioManifests = append(expectedIstioManifests, istioIngressAutoscalerVPA())
+
+			if expectVPARecreateMode {
+				expectedIstioManifests = append(expectedIstioManifests, istioIngressAutoscalerVPARecreate())
+			} else {
+				expectedIstioManifests = append(expectedIstioManifests, istioIngressAutoscalerVPA())
+			}
 
 			if expectAPIServerTLSTermination {
 				expectedIstioManifests = append(expectedIstioManifests,
@@ -837,6 +849,17 @@ var _ = Describe("istiod", func() {
 			})
 
 			It("should successfully deploy all resources", func() {
+				checkSuccessfulDeployment(nil, nil)
+			})
+		})
+
+		Context("With VPAInPlaceUpdates feature gate disabled", func() {
+			BeforeEach(func() {
+				expectVPARecreateMode = true
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VPAInPlaceUpdates, false))
+			})
+
+			It("should successfully deploy all resources with VPA Recreate mode", func() {
 				checkSuccessfulDeployment(nil, nil)
 			})
 		})

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -812,7 +812,7 @@ var _ = Describe("istiod", func() {
 		Context("With IstioTLSTermination feature gate enabled", func() {
 			BeforeEach(func() {
 				expectAPIServerTLSTermination = true
-				expectedCPURequests = "450m"
+				expectedCPURequests = "1"
 				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.IstioTLSTermination, true))
 			})
 
@@ -824,7 +824,7 @@ var _ = Describe("istiod", func() {
 		Context("With IstioTLSTermination feature gate disabled but with shoots still using the feature", func() {
 			BeforeEach(func() {
 				expectAPIServerTLSTermination = true
-				expectedCPURequests = "450m"
+				expectedCPURequests = "1"
 
 				envoyFilter := istionetworkingv1alpha3.EnvoyFilter{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler.yaml
@@ -19,8 +19,8 @@ spec:
     resource:
       name: cpu
       target:
-        averageUtilization: 80
-        type: Utilization
+        type: AverageValue
+        averageValue: "2"
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler_tls_termination_hpa.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler_tls_termination_hpa.yaml
@@ -19,8 +19,8 @@ spec:
     resource:
       name: cpu
       target:
-        averageUtilization: 80
-        type: Utilization
+        type: AverageValue
+        averageValue: "4"
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler_vpa.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler_vpa.yaml
@@ -13,12 +13,13 @@ spec:
     kind: Deployment
     name: istio-ingressgateway
   updatePolicy:
-    updateMode: Initial
+    updateMode: InPlaceOrRecreate
   resourcePolicy:
     containerPolicies:
     - containerName: istio-proxy
       controlledValues: RequestsOnly
       controlledResources:
+      - cpu
       - memory
     - containerName: '*'
       mode: "Off"

--- a/pkg/component/networking/istio/test_charts/ingress_autoscaler_vpa_recreate.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_autoscaler_vpa_recreate.yaml
@@ -2,17 +2,18 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: istio-ingressgateway
-  namespace: {{ .Release.Namespace }}
+  namespace: test-ingress
   labels:
-    app.kubernetes.io/version: {{ .Values.ingressVersion }}
-{{ .Values.labels | toYaml | indent 4 }}
+    app.kubernetes.io/version: 1.27.1
+    app: istio-ingressgateway
+    foo: bar
 spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istio-ingressgateway
   updatePolicy:
-    updateMode: {{ .Values.vpaUpdateMode }}
+    updateMode: Recreate
   resourcePolicy:
     containerPolicies:
     - containerName: istio-proxy

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -29,7 +29,6 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         proxy.istio.io/config: |-
-          concurrency: 4
           protocolDetectionTimeout: 100ms
           runtimeValues:
             "overload.global_downstream_max_connections": "750000"

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -168,7 +168,7 @@ func AddIstioIngressGateway(
 	enforceSpreadAcrossHosts := templateValues.EnforceSpreadAcrossHosts
 
 	if zone != nil {
-		zones = append(zones, *zone)
+		zones = []string{*zone}
 
 		minReplicas = ptr.To(minReplicasPerZone)
 		maxReplicas = ptr.To(maxReplicasPerZone)

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -25,13 +25,22 @@ import (
 	"github.com/gardener/gardener/pkg/component/networking/istio"
 	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
 	vpnseedserver "github.com/gardener/gardener/pkg/component/networking/vpn/seedserver"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // ImageVector is an alias for imagevector.Containers(). Exposed for testing.
 var ImageVector = imagevector.Containers()
+
+const (
+	// Each availability zone should have at least 2 replicas as on some infrastructures each
+	// zonal load balancer is exposed individually via its own IP address. Therefore, having
+	// just one replica may negatively affect availability.
+	minReplicasPerZone = 2
+	// The maximum is chosen high enough to allow for sufficient scaling headroom during peak
+	// load while still providing a reasonable upper bound to prevent runaway scaling.
+	maxReplicasPerZone = 16
+)
 
 // NewIstio returns a deployer for Istio.
 func NewIstio(
@@ -58,11 +67,6 @@ func NewIstio(
 	istio.Interface,
 	error,
 ) {
-	var (
-		minReplicas *int
-		maxReplicas *int
-	)
-
 	istiodImage, err := ImageVector.FindImage(imagevector.ContainerImageNameIstioIstiod)
 	if err != nil {
 		return nil, err
@@ -73,20 +77,8 @@ func NewIstio(
 		return nil, err
 	}
 
-	if len(zones) > 1 {
-		// Each availability zone should have at least 2 replicas as on some infrastructures each
-		// zonal load balancer is exposed individually via its own IP address. Therefore, having
-		// just one replica may negatively affect availability.
-		minReplicas = ptr.To(len(zones) * 2)
-		// The default configuration without availability zones has 9 as the maximum amount of
-		// replicas, which apparently works in all known Gardener scenarios. Reducing it to less
-		// per zone gives some room for autoscaling while it is assumed to never reach the maximum.
-		maxReplicas = ptr.To(len(zones) * 6)
-		if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
-			// When IstioTLSTermination server is enabled, more resources might be required on seeds.
-			maxReplicas = ptr.To(len(zones) * 8)
-		}
-	}
+	minReplicas := ptr.To(max(1, len(zones)) * minReplicasPerZone)
+	maxReplicas := ptr.To(max(1, len(zones)) * maxReplicasPerZone)
 
 	policyLabels := commonIstioIngressNetworkPolicyLabels(vpnEnabled)
 	policyLabels[toKubeAPIServerPolicyLabel] = v1beta1constants.LabelNetworkPolicyAllowed
@@ -168,27 +160,21 @@ func AddIstioIngressGateway(
 	// Take the first ingress gateway values to create additional gateways
 	templateValues := gatewayValues[0]
 
-	var (
-		zones                    []string
-		minReplicas              *int
-		maxReplicas              *int
-		enforceSpreadAcrossHosts bool
-		err                      error
-	)
+	var zones []string
 
-	if zone == nil {
-		minReplicas = templateValues.MinReplicas
-		maxReplicas = templateValues.MaxReplicas
-		enforceSpreadAcrossHosts = templateValues.EnforceSpreadAcrossHosts
-	} else {
-		zones = []string{*zone}
+	minReplicas := templateValues.MinReplicas
+	maxReplicas := templateValues.MaxReplicas
 
-		if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
-			// When IstioTLSTermination server is enabled, more resources might be required on seeds.
-			maxReplicas = ptr.To(len(zones) * 12)
-		}
+	enforceSpreadAcrossHosts := templateValues.EnforceSpreadAcrossHosts
 
-		enforceSpreadAcrossHosts, err = ShouldEnforceSpreadAcrossHosts(ctx, cl, []string{*zone})
+	if zone != nil {
+		zones = append(zones, *zone)
+
+		minReplicas = ptr.To(minReplicasPerZone)
+		maxReplicas = ptr.To(maxReplicasPerZone)
+
+		var err error
+		enforceSpreadAcrossHosts, err = ShouldEnforceSpreadAcrossHosts(ctx, cl, zones)
 		if err != nil {
 			return err
 		}

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -89,15 +89,9 @@ func createIstio(testValues istioTestValues) istio.Interface {
 }
 
 func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
-	var minReplicas, maxReplicas *int
-
-	if zoneSize := len(testValues.zones); zoneSize > 1 {
-		minReplicas = ptr.To(zoneSize * 2)
-		maxReplicas = ptr.To(zoneSize * 6)
-		if features.DefaultFeatureGate.Enabled(features.IstioTLSTermination) {
-			maxReplicas = ptr.To(zoneSize * 8)
-		}
-	}
+	zoneSize := len(testValues.zones)
+	minReplicas := ptr.To(max(1, zoneSize) * 2)
+	maxReplicas := ptr.To(max(1, zoneSize) * 16)
 
 	networkPolicyLabels := map[string]string{
 		"networking.gardener.cloud/to-dns":                                     "allowed",
@@ -160,21 +154,24 @@ func checkAdditionalIstioGateway(cl client.Client,
 	dualstack bool) {
 	var (
 		zones                    []string
-		minReplicas              *int
-		maxReplicas              *int
 		enforceSpreadAcrossHosts bool
 		err                      error
 
 		ingressValues = istioDeploy.GetValues().IngressGateway
 	)
 
-	if zone == nil {
-		minReplicas = ingressValues[0].MinReplicas
-		maxReplicas = ingressValues[0].MaxReplicas
-	} else {
-		zones = []string{*zone}
+	minReplicas := ingressValues[0].MinReplicas
+	maxReplicas := ingressValues[0].MaxReplicas
 
-		enforceSpreadAcrossHosts, err = ShouldEnforceSpreadAcrossHosts(context.Background(), cl, []string{*zone})
+	enforceSpreadAcrossHosts = ingressValues[0].EnforceSpreadAcrossHosts
+
+	if zone != nil {
+		zones = append(zones, *zone)
+
+		minReplicas = ptr.To(2)
+		maxReplicas = ptr.To(16)
+
+		enforceSpreadAcrossHosts, err = ShouldEnforceSpreadAcrossHosts(context.Background(), cl, zones)
 		Expect(err).ToNot(HaveOccurred())
 	}
 

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -166,7 +166,7 @@ func checkAdditionalIstioGateway(cl client.Client,
 	enforceSpreadAcrossHosts = ingressValues[0].EnforceSpreadAcrossHosts
 
 	if zone != nil {
-		zones = append(zones, *zone)
+		zones = []string{*zone}
 
 		minReplicas = ptr.To(2)
 		maxReplicas = ptr.To(16)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling networking
/kind enhancement

**What this PR does / why we need it**:
We still struggle with autoscaling of `istio-ingressgateway` especially when L7 load-balancing is active. 
On seeds with many heavily utilized shoot control-planes, we hit the CPU limit of istio-ingressgateway even when it is scaled to the maximum via HPA. Still, we don't want to just raise the CPU requests because this would have negative impacts on the cost on seeds with low utilization.

Since we had similar issues in the past with `kube-apiservers` and solved with an autoscaling approach wich is using HPA and VPA, we could use it for `istio-ingressgateways` too. The tests I made look promising.

The new configuration looks as following

**HPA Configuration**
The HPA scales based on CPU usage using an **averageValue** metric (not averageUtilization). This allows VPA to scale vertically first, and only when all pods' average CPU usage exceeds the HPA target does horizontal scaling occur.

**Target CPU Values**
- **IstioTLSTermination disabled**: `2` CPU average value, initial request `300m`
- **IstioTLSTermination enabled**: `4` CPU average value, initial request `1` CPU

**VPA Configuration**
The VPA uses `updateMode: InPlaceOrRecreate` and controls both CPU and memory requests for the `istio-proxy` container with `controlledValues: RequestsOnly`.

**Replica Counts**
- **Default gateways**:
  - Min replicas: `2 × number of zones`
  - Max replicas: `16 × number of zones`
- **Zonal gateways**:
  - Min replicas: `2`
  - Max replicas: `16`

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `istio-ingressgateway` now uses a dual autoscaling approach with both `VPA` (VerticalPodAutoscaler) and `HPA` (HorizontalPodAutoscaler) working together without causing pod-thrashing.
```
