### PR TITLE
[GEP-28] `gardenadm connect`: Enable `ControllerInstallation` care controller in `gardenlet`

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -376,6 +376,12 @@ func (g *garden) Start(ctx context.Context) error {
 						Field:      fields.SelectorFromSet(fields.Set{operations.BastionShootName: g.selfHostedShootInfo.Meta.Name}),
 						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
 					},
+					&gardencorev1beta1.ControllerInstallation{}: {
+						Field: fields.SelectorFromSet(fields.Set{
+							gardencore.ShootRefName:      g.selfHostedShootInfo.Meta.Name,
+							gardencore.ShootRefNamespace: g.selfHostedShootInfo.Meta.Namespace,
+						}),
+					},
 					&gardencorev1beta1.Shoot{}: {
 						Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: g.selfHostedShootInfo.Meta.Name}),
 						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
@@ -803,6 +809,8 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 		fns = []func(context.Context, client.FieldIndexer) error{
 			// core API group
 			indexer.AddBackupEntryBucketName,
+			indexer.AddControllerInstallationShootRefName,
+			indexer.AddControllerInstallationShootRefNamespace,
 		}
 	}
 

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -809,6 +809,7 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 		fns = []func(context.Context, client.FieldIndexer) error{
 			// core API group
 			indexer.AddBackupEntryBucketName,
+			indexer.AddControllerInstallationRegistrationRefName,
 			indexer.AddControllerInstallationShootRefName,
 			indexer.AddControllerInstallationShootRefNamespace,
 		}

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -154,7 +154,7 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 
 		case controllerInstallationResource:
 			return requestAuthorizer.Check(graph.VertexTypeControllerInstallation, attrs,
-				authwebhook.WithAllowedVerbs("get", "list", "watch", "patch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
 				authwebhook.WithAllowedSubresources("status"),
 				authwebhook.WithFieldSelectors(map[string]string{
 					core.ShootRefName:      shootName,

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -65,6 +65,7 @@ var (
 	cloudProfileResource              = gardencorev1beta1.Resource("cloudprofiles")
 	configMapResource                 = corev1.Resource("configmaps")
 	controllerDeploymentResource      = gardencorev1beta1.Resource("controllerdeployments")
+	controllerInstallationResource    = gardencorev1beta1.Resource("controllerinstallations")
 	controllerRegistrationResource    = gardencorev1beta1.Resource("controllerregistrations")
 	credentialsBindingResource        = securityv1alpha1.Resource("credentialsbindings")
 	eventCoreResource                 = corev1.Resource("events")
@@ -150,6 +151,16 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 
 		case configMapResource:
 			return requestAuthorizer.CheckRead(graph.VertexTypeConfigMap, attrs)
+
+		case controllerInstallationResource:
+			return requestAuthorizer.Check(graph.VertexTypeControllerInstallation, attrs,
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "patch"),
+				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithFieldSelectors(map[string]string{
+					core.ShootRefName:      shootName,
+					core.ShootRefNamespace: shootNamespace,
+				}),
+			)
 
 		case eventCoreResource, eventResource:
 			return a.authorizeEvent(log, attrs)

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -649,6 +649,100 @@ var _ = Describe("Shoot", func() {
 				})
 			})
 
+			When("requested for ControllerInstallations", func() {
+				var (
+					name  string
+					attrs *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name = "foo"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "controllerinstallations",
+						ResourceRequest: true,
+						Verb:            "list",
+					}
+				})
+
+				DescribeTable("should have no opinion because no allowed verb",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because no allowed subresource", func() {
+					attrs.Subresource = "foo"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb, subresource string) {
+						attrs.Verb = verb
+						attrs.Subresource = subresource
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerInstallation, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerInstallation, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+						decision, reason, err = authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
+					},
+
+					Entry("get w/o subresource", "get", ""),
+					Entry("patch w/o subresource", "patch", ""),
+					Entry("patch w/ status subresource", "patch", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector("spec.shootRef.name=" + shootName + ",spec.shootRef.namespace=" + shootNamespace)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+				)
+			})
+
 			Context("when requested for corev1.Events", func() {
 				var (
 					name, namespace string

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -674,11 +674,10 @@ var _ = Describe("Shoot", func() {
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(decision).To(Equal(auth.DecisionNoOpinion))
-						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch watch]"))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
 					},
 
 					Entry("create", "create"),
-					Entry("update", "update"),
 					Entry("delete", "delete"),
 					Entry("deletecollection", "deletecollection"),
 				)
@@ -711,6 +710,8 @@ var _ = Describe("Shoot", func() {
 					},
 
 					Entry("get w/o subresource", "get", ""),
+					Entry("update w/o subresource", "update", ""),
+					Entry("update w/ status subresource", "update", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ status subresource", "patch", "status"),
 				)

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/backupentry"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/bastion"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation"
+	controllerinstallationcare "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/gardenlet"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy"
@@ -108,6 +109,14 @@ func AddToManager(
 			Config: *cfg.Controllers.Bastion,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding Bastion controller: %w", err)
+		}
+
+		// TODO(rfranzke): Remove this once all ControllerInstallation reconcilers are added via `shoot.AddToManager`.
+		if err := (&controllerinstallationcare.Reconciler{
+			Config:                   *cfg.Controllers.ControllerInstallationCare,
+			ManagedResourceNamespace: metav1.NamespaceSystem,
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding ControllerInstallation care controller: %w", err)
 		}
 
 		if err := (&gardenlet.Reconciler{

--- a/pkg/gardenlet/controller/controllerinstallation/care/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/add.go
@@ -42,8 +42,8 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
 	}
-	if r.GardenNamespace == "" {
-		r.GardenNamespace = v1beta1constants.GardenNamespace
+	if r.ManagedResourceNamespace == "" {
+		r.ManagedResourceNamespace = v1beta1constants.GardenNamespace
 	}
 
 	return builder.
@@ -75,7 +75,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 // the 'controllerinstallation-name' label is present.
 func (r *Reconciler) IsExtensionDeployment() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		return obj.GetNamespace() == v1beta1constants.GardenNamespace &&
+		return obj.GetNamespace() == r.ManagedResourceNamespace &&
 			obj.GetLabels()[utils.LabelKeyControllerInstallationName] != ""
 	})
 }

--- a/pkg/gardenlet/controller/controllerinstallation/care/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/add.go
@@ -7,6 +7,7 @@ package care
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
@@ -21,9 +22,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/utils"
 )
@@ -64,7 +67,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 		WatchesRawSource(source.Kind[client.Object](
 			seedCluster.GetCache(),
 			&resourcesv1alpha1.ManagedResource{},
-			handler.EnqueueRequestsFromMapFunc(r.MapManagedResourceToControllerInstallation),
+			handler.EnqueueRequestsFromMapFunc(r.MapManagedResourceToControllerInstallation(mgr.GetLogger().WithName(ControllerName))),
 			r.IsExtensionDeployment(),
 			predicateutils.ManagedResourceConditionsChanged(),
 		)).
@@ -82,16 +85,31 @@ func (r *Reconciler) IsExtensionDeployment() predicate.Predicate {
 
 // MapManagedResourceToControllerInstallation is a handler.MapFunc for mapping a ManagedResource to the owning
 // ControllerInstallation.
-func (r *Reconciler) MapManagedResourceToControllerInstallation(_ context.Context, obj client.Object) []reconcile.Request {
-	managedResource, ok := obj.(*resourcesv1alpha1.ManagedResource)
-	if !ok {
-		return nil
-	}
+func (r *Reconciler) MapManagedResourceToControllerInstallation(log logr.Logger) func(context.Context, client.Object) []reconcile.Request {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		managedResource, ok := obj.(*resourcesv1alpha1.ManagedResource)
+		if !ok {
+			return nil
+		}
 
-	controllerInstallationName, ok := managedResource.Labels[utils.LabelKeyControllerInstallationName]
-	if !ok || len(controllerInstallationName) == 0 {
-		return nil
-	}
+		controllerInstallationName := managedResource.Labels[utils.LabelKeyControllerInstallationName]
+		if controllerInstallationName == "" {
+			return nil
+		}
 
-	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: controllerInstallationName}}}
+		// If the controllerinstallation-name and controllerregistration-name labels are equal, the
+		// controllerinstallation-name label is stale (set during `gardenadm init` before the real ControllerInstallation
+		// was created with a generated name). Look up the correct ControllerInstallation by the registration name.
+		if controllerRegistrationName := managedResource.Labels[utils.LabelKeyControllerRegistrationName]; controllerRegistrationName != "" && controllerInstallationName == controllerRegistrationName {
+			controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+			if err := r.GardenClient.List(ctx, controllerInstallationList, client.MatchingFields{gardencore.RegistrationRefName: controllerRegistrationName}); err != nil {
+				log.Error(err, "Failed to list ControllerInstallations when trying to map ManagedResource")
+				return nil
+			}
+
+			return mapper.ObjectListToRequests(controllerInstallationList)
+		}
+
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: controllerInstallationName}}}
+	}
 }

--- a/pkg/gardenlet/controller/controllerinstallation/care/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/add_test.go
@@ -7,24 +7,30 @@ package care_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
 )
 
 var _ = Describe("Add", func() {
 	var (
-		reconciler                 *Reconciler
-		managedResource            *resourcesv1alpha1.ManagedResource
-		controllerInstallationName = "foo"
+		reconciler      *Reconciler
+		managedResource *resourcesv1alpha1.ManagedResource
 	)
 
 	BeforeEach(func() {
@@ -32,7 +38,7 @@ var _ = Describe("Add", func() {
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "garden",
-				Labels:    map[string]string{"controllerinstallation-name": controllerInstallationName},
+				Labels:    map[string]string{"controllerinstallation-name": "foo"},
 			},
 		}
 	})
@@ -80,26 +86,79 @@ var _ = Describe("Add", func() {
 	})
 
 	Describe("#MapManagedResourceToControllerInstallation", func() {
-		ctx := context.TODO()
+		var (
+			ctx   = context.TODO()
+			mapFn func(context.Context, client.Object) []reconcile.Request
+		)
+
+		BeforeEach(func() {
+			mapFn = reconciler.MapManagedResourceToControllerInstallation(logr.Discard())
+		})
 
 		It("should return nothing because object is no ManagedResource", func() {
-			Expect(reconciler.MapManagedResourceToControllerInstallation(ctx, &corev1.Secret{})).To(BeEmpty())
+			Expect(mapFn(ctx, &corev1.Secret{})).To(BeEmpty())
 		})
 
 		It("should return nothing because label is not present", func() {
 			delete(managedResource.Labels, "controllerinstallation-name")
-			Expect(reconciler.MapManagedResourceToControllerInstallation(ctx, managedResource)).To(BeEmpty())
+			Expect(mapFn(ctx, managedResource)).To(BeEmpty())
 		})
 
 		It("should return nothing because label value is empty", func() {
 			managedResource.Labels["controllerinstallation-name"] = ""
-			Expect(reconciler.MapManagedResourceToControllerInstallation(ctx, managedResource)).To(BeEmpty())
+			Expect(mapFn(ctx, managedResource)).To(BeEmpty())
 		})
 
 		It("should return a request with the controller installation name", func() {
-			Expect(reconciler.MapManagedResourceToControllerInstallation(ctx, managedResource)).To(ConsistOf(
-				reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallationName}},
+			Expect(mapFn(ctx, managedResource)).To(ConsistOf(
+				reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo"}},
 			))
+		})
+
+		When("controllerinstallation-name label is stale (equals controllerregistration-name)", func() {
+			BeforeEach(func() {
+				managedResource.Labels["controllerinstallation-name"] = "my-extension"
+				managedResource.Labels["controllerregistration-name"] = "my-extension"
+			})
+
+			It("should return nothing when no ControllerInstallation matches the registration name", func() {
+				reconciler.GardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).
+					WithIndex(&gardencorev1beta1.ControllerInstallation{}, gardencore.RegistrationRefName, indexer.ControllerInstallationRegistrationRefNameIndexerFunc).
+					Build()
+				mapFn = reconciler.MapManagedResourceToControllerInstallation(logr.Discard())
+
+				Expect(mapFn(ctx, managedResource)).To(BeEmpty())
+			})
+
+			It("should return the correct ControllerInstallation name looked up by registration name", func() {
+				reconciler.GardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).
+					WithIndex(&gardencorev1beta1.ControllerInstallation{}, gardencore.RegistrationRefName, indexer.ControllerInstallationRegistrationRefNameIndexerFunc).
+					WithObjects(
+						&gardencorev1beta1.ControllerInstallation{
+							ObjectMeta: metav1.ObjectMeta{Name: "my-extension-abc12"},
+							Spec: gardencorev1beta1.ControllerInstallationSpec{
+								RegistrationRef: corev1.ObjectReference{Name: "my-extension"},
+								ShootRef:        &corev1.ObjectReference{Name: "shoot1", Namespace: "garden"},
+							},
+						},
+					).Build()
+				mapFn = reconciler.MapManagedResourceToControllerInstallation(logr.Discard())
+
+				Expect(mapFn(ctx, managedResource)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: "my-extension-abc12"}},
+				))
+			})
+		})
+
+		When("controllerinstallation-name differs from controllerregistration-name", func() {
+			It("should use the controllerinstallation-name label directly", func() {
+				managedResource.Labels["controllerinstallation-name"] = "my-extension-abc12"
+				managedResource.Labels["controllerregistration-name"] = "my-extension"
+
+				Expect(mapFn(ctx, managedResource)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: "my-extension-abc12"}},
+				))
+			})
 		})
 	})
 })

--- a/pkg/gardenlet/controller/controllerinstallation/care/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/add_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Add", func() {
 	)
 
 	BeforeEach(func() {
-		reconciler = &Reconciler{}
+		reconciler = &Reconciler{ManagedResourceNamespace: "garden"}
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "garden",

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
@@ -21,6 +21,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
@@ -63,7 +64,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	managedResource := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerInstallation.Name,
+			Name:      gardenerutils.ManagedResourceNameForControllerInstallation(controllerInstallation),
 			Namespace: r.ManagedResourceNamespace,
 		},
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler.go
@@ -26,11 +26,11 @@ import (
 
 // Reconciler reconciles ControllerInstallations, checks their health status and reports it via conditions.
 type Reconciler struct {
-	GardenClient    client.Client
-	SeedClient      client.Client
-	Config          gardenletconfigv1alpha1.ControllerInstallationCareControllerConfiguration
-	Clock           clock.Clock
-	GardenNamespace string
+	GardenClient             client.Client
+	SeedClient               client.Client
+	Config                   gardenletconfigv1alpha1.ControllerInstallationCareControllerConfiguration
+	Clock                    clock.Clock
+	ManagedResourceNamespace string
 }
 
 // Reconcile reconciles ControllerInstallations, checks their health status and reports it via conditions.
@@ -64,7 +64,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	managedResource := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerInstallation.Name,
-			Namespace: r.GardenNamespace,
+			Namespace: r.ManagedResourceNamespace,
 		},
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
@@ -77,8 +77,8 @@ var _ = Describe("Reconciler", func() {
 			Config: gardenletconfigv1alpha1.ControllerInstallationCareControllerConfiguration{
 				SyncPeriod: &metav1.Duration{Duration: syncPeriodDuration},
 			},
-			Clock:           fakeClock,
-			GardenNamespace: gardenNamespace,
+			Clock:                    fakeClock,
+			ManagedResourceNamespace: gardenNamespace,
 		}
 	})
 

--- a/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/care/reconciler_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(controllerInstallation.Status.Conditions).To(matchExpectedConditions)
 		},
 			Entry("managed resource conditions are not set",
-				managedResource(nil),
+				managedResource(controllerInstallationName, nil),
 				ConsistOf(
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending"),
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
@@ -136,7 +136,7 @@ var _ = Describe("Reconciler", func() {
 				),
 			),
 			Entry("managed resource is not healthy",
-				notHealthyManagedResource(),
+				notHealthyManagedResource(controllerInstallationName),
 				ConsistOf(
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending"),
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
@@ -144,7 +144,7 @@ var _ = Describe("Reconciler", func() {
 				),
 			),
 			Entry("managed resource is healthy",
-				healthyManagedResource(),
+				healthyManagedResource(controllerInstallationName),
 				ConsistOf(
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionTrue, "InstallationSuccessful"),
 					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionTrue, "ControllerHealthy"),
@@ -152,6 +152,29 @@ var _ = Describe("Reconciler", func() {
 				),
 			),
 		)
+
+		When("ControllerInstallation has ShootRef", func() {
+			BeforeEach(func() {
+				controllerInstallation.Spec.SeedRef = nil
+				controllerInstallation.Spec.ShootRef = &corev1.ObjectReference{Name: "shoot1", Namespace: "garden"}
+				controllerInstallation.Spec.RegistrationRef = corev1.ObjectReference{Name: "my-extension"}
+			})
+
+			It("should look up the ManagedResource by RegistrationRef name", func() {
+				Expect(seedClient.Create(ctx, healthyManagedResource("my-extension"))).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: syncPeriodDuration}))
+
+				Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionTrue, "InstallationSuccessful"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionTrue, "ControllerHealthy"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationProgressing, gardencorev1beta1.ConditionFalse, "ControllerRolledOut"),
+				))
+			})
+		})
 	})
 })
 
@@ -171,52 +194,50 @@ func conditionWithTypeStatusReasonAndMessage(condType gardencorev1beta1.Conditio
 	return And(OfType(condType), WithStatus(status), WithReason(reason), WithMessage(message))
 }
 
-func healthyManagedResource() *resourcesv1alpha1.ManagedResource {
-	return managedResource(
-		[]gardencorev1beta1.Condition{
-			{
-				Type:   resourcesv1alpha1.ResourcesApplied,
-				Status: gardencorev1beta1.ConditionTrue,
-			},
-			{
-				Type:   resourcesv1alpha1.ResourcesHealthy,
-				Status: gardencorev1beta1.ConditionTrue,
-			},
-			{
-				Type:   resourcesv1alpha1.ResourcesProgressing,
-				Status: gardencorev1beta1.ConditionFalse,
-			},
-		})
+func healthyManagedResource(name string) *resourcesv1alpha1.ManagedResource {
+	return managedResource(name, []gardencorev1beta1.Condition{
+		{
+			Type:   resourcesv1alpha1.ResourcesApplied,
+			Status: gardencorev1beta1.ConditionTrue,
+		},
+		{
+			Type:   resourcesv1alpha1.ResourcesHealthy,
+			Status: gardencorev1beta1.ConditionTrue,
+		},
+		{
+			Type:   resourcesv1alpha1.ResourcesProgressing,
+			Status: gardencorev1beta1.ConditionFalse,
+		},
+	})
 }
 
-func notHealthyManagedResource() *resourcesv1alpha1.ManagedResource {
-	return managedResource(
-		[]gardencorev1beta1.Condition{
-			{
-				Type:    resourcesv1alpha1.ResourcesApplied,
-				Reason:  "NotApplied",
-				Message: "Resources are not applied",
-				Status:  gardencorev1beta1.ConditionFalse,
-			},
-			{
-				Type:    resourcesv1alpha1.ResourcesHealthy,
-				Reason:  "NotHealthy",
-				Message: "Resources are not healthy",
-				Status:  gardencorev1beta1.ConditionFalse,
-			},
-			{
-				Type:    resourcesv1alpha1.ResourcesProgressing,
-				Reason:  "ResourcesProgressing",
-				Message: "Resources are progressing",
-				Status:  gardencorev1beta1.ConditionTrue,
-			},
-		})
+func notHealthyManagedResource(name string) *resourcesv1alpha1.ManagedResource {
+	return managedResource(name, []gardencorev1beta1.Condition{
+		{
+			Type:    resourcesv1alpha1.ResourcesApplied,
+			Reason:  "NotApplied",
+			Message: "Resources are not applied",
+			Status:  gardencorev1beta1.ConditionFalse,
+		},
+		{
+			Type:    resourcesv1alpha1.ResourcesHealthy,
+			Reason:  "NotHealthy",
+			Message: "Resources are not healthy",
+			Status:  gardencorev1beta1.ConditionFalse,
+		},
+		{
+			Type:    resourcesv1alpha1.ResourcesProgressing,
+			Reason:  "ResourcesProgressing",
+			Message: "Resources are progressing",
+			Status:  gardencorev1beta1.ConditionTrue,
+		},
+	})
 }
 
-func managedResource(conditions []gardencorev1beta1.Condition) *resourcesv1alpha1.ManagedResource {
+func managedResource(name string, conditions []gardencorev1beta1.Condition) *resourcesv1alpha1.ManagedResource {
 	return &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerInstallationName,
+			Name:      name,
 			Namespace: gardenNamespace,
 		},
 		Status: resourcesv1alpha1.ManagedResourceStatus{

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -369,11 +369,13 @@ func (r *Reconciler) reconcile(
 		return reconcile.Result{}, fmt.Errorf("failed to inject garden access secrets: %w", err)
 	}
 
+	managedResourceName := gardenerutils.ManagedResourceNameForControllerInstallation(controllerInstallation)
+
 	if err := managedresources.Create(
 		seedCtx,
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
-		controllerInstallation.Name,
+		managedResourceName,
 		map[string]string{ctrlinstutils.LabelKeyControllerInstallationName: controllerInstallation.Name},
 		false,
 		v1beta1constants.SeedResourceManagerClass,
@@ -382,14 +384,14 @@ func (r *Reconciler) reconcile(
 		nil,
 		nil,
 	); err != nil {
-		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "InstallationFailed", fmt.Sprintf("Creation of ManagedResource %q failed: %+v", controllerInstallation.Name, err))
+		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "InstallationFailed", fmt.Sprintf("Creation of ManagedResource %q failed: %+v", managedResourceName, err))
 		return reconcile.Result{}, err
 	}
 
 	if conditionInstalled.Status == gardencorev1beta1.ConditionUnknown {
 		// initially set condition to Pending
 		// care controller will update condition based on 'ResourcesApplied' condition of ManagedResource
-		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending", fmt.Sprintf("Installation of ManagedResource %q is still pending.", controllerInstallation.Name))
+		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending", fmt.Sprintf("Installation of ManagedResource %q is still pending.", managedResourceName))
 	}
 
 	return reconcile.Result{}, nil
@@ -426,26 +428,28 @@ func (r *Reconciler) delete(
 		return reconcile.Result{}, err
 	}
 
+	managedResourceName := gardenerutils.ManagedResourceNameForControllerInstallation(controllerInstallation)
+
 	mr := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerInstallation.Name,
+			Name:      managedResourceName,
 			Namespace: r.GardenNamespace,
 		},
 	}
 
 	if err := client.IgnoreNotFound(managedresources.Delete(seedCtx, r.SeedClientSet.Client(), mr.Namespace, mr.Name, false)); err != nil {
 		log.Info("Deletion of ManagedResource and its secrets failed", "managedResource", client.ObjectKeyFromObject(mr))
-		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource %q and its secrets failed: %+v", controllerInstallation.Name, err))
+		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource %q and its secrets failed: %+v", managedResourceName, err))
 		return reconcile.Result{}, err
 	}
 
 	if err := r.SeedClientSet.Client().Get(seedCtx, client.ObjectKeyFromObject(mr), mr); err == nil {
 		log.Info("Deletion of ManagedResource is still pending", "managedResource", client.ObjectKeyFromObject(mr))
-		msg := fmt.Sprintf("Deletion of ManagedResource %q is still pending.", controllerInstallation.Name)
+		msg := fmt.Sprintf("Deletion of ManagedResource %q is still pending.", managedResourceName)
 		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionPending", msg)
 		return reconcile.Result{RequeueAfter: RequeueDurationWhenResourceDeletionStillPresent}, nil
 	} else if !apierrors.IsNotFound(err) {
-		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource %q failed: %+v", controllerInstallation.Name, err))
+		conditionInstalled = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource %q failed: %+v", managedResourceName, err))
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -376,7 +376,10 @@ func (r *Reconciler) reconcile(
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
 		managedResourceName,
-		map[string]string{ctrlinstutils.LabelKeyControllerInstallationName: controllerInstallation.Name},
+		map[string]string{
+			ctrlinstutils.LabelKeyControllerInstallationName: controllerInstallation.Name,
+			ctrlinstutils.LabelKeyControllerRegistrationName: controllerInstallation.Spec.RegistrationRef.Name,
+		},
 		false,
 		v1beta1constants.SeedResourceManagerClass,
 		secretData,

--- a/pkg/gardenlet/controller/controllerinstallation/utils/constants.go
+++ b/pkg/gardenlet/controller/controllerinstallation/utils/constants.go
@@ -7,3 +7,7 @@ package utils
 // LabelKeyControllerInstallationName is a constant for a label key on ManagedResource objects whose value contains the
 // name of the ControllerInstallation the ManagedResource was created for.
 const LabelKeyControllerInstallationName = "controllerinstallation-name"
+
+// LabelKeyControllerRegistrationName is a constant for a label key on ManagedResource objects whose value contains the
+// name of the ControllerRegistration the ManagedResource was created for.
+const LabelKeyControllerRegistrationName = "controllerregistration-name"

--- a/pkg/utils/gardener/controllerinstallation.go
+++ b/pkg/utils/gardener/controllerinstallation.go
@@ -8,7 +8,19 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
-// NamespaceNameForControllerInstallation returns the name of the namespace that will be used for the extension controller in the seed.
+// ManagedResourceNameForControllerInstallation returns the name of the ManagedResource for the given
+// ControllerInstallation. For self-hosted shoot ControllerInstallations, this is the registration name (matching the
+// ManagedResource created during bootstrapping). For seed ControllerInstallations, it is the ControllerInstallation
+// name.
+func ManagedResourceNameForControllerInstallation(controllerInstallation *gardencorev1beta1.ControllerInstallation) string {
+	if controllerInstallation.Spec.ShootRef != nil {
+		return controllerInstallation.Spec.RegistrationRef.Name
+	}
+	return controllerInstallation.Name
+}
+
+// NamespaceNameForControllerInstallation returns the name of the namespace that will be used for the extension
+// controller in the seed or self-hosted shoot cluster.
 func NamespaceNameForControllerInstallation(controllerInstallation *gardencorev1beta1.ControllerInstallation) string {
-	return "extension-" + controllerInstallation.Name
+	return "extension-" + ManagedResourceNameForControllerInstallation(controllerInstallation)
 }

--- a/pkg/utils/gardener/controllerinstallation_test.go
+++ b/pkg/utils/gardener/controllerinstallation_test.go
@@ -7,6 +7,7 @@ package gardener_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -14,11 +15,44 @@ import (
 )
 
 var _ = Describe("ControllerInstallation", func() {
-	Describe("#NamespaceNameForControllerInstallation", func() {
-		It("should return the correct namespace name for the ControllerInstallation", func() {
+	Describe("#ManagedResourceNameForControllerInstallation", func() {
+		It("should return the ControllerInstallation name for seed ControllerInstallations", func() {
 			controllerInstallation := &gardencorev1beta1.ControllerInstallation{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc12"},
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					RegistrationRef: corev1.ObjectReference{Name: "foo"},
+					SeedRef:         &corev1.ObjectReference{Name: "seed1"},
+				},
+			}
+			Expect(ManagedResourceNameForControllerInstallation(controllerInstallation)).To(Equal("foo-abc12"))
+		})
+
+		It("should return the RegistrationRef name for self-hosted shoot ControllerInstallations", func() {
+			controllerInstallation := &gardencorev1beta1.ControllerInstallation{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc12"},
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					RegistrationRef: corev1.ObjectReference{Name: "foo"},
+					ShootRef:        &corev1.ObjectReference{Name: "shoot1", Namespace: "garden"},
+				},
+			}
+			Expect(ManagedResourceNameForControllerInstallation(controllerInstallation)).To(Equal("foo"))
+		})
+	})
+
+	Describe("#NamespaceNameForControllerInstallation", func() {
+		It("should return the correct namespace name for a seed ControllerInstallation", func() {
+			controllerInstallation := &gardencorev1beta1.ControllerInstallation{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			}
+			Expect(NamespaceNameForControllerInstallation(controllerInstallation)).To(Equal("extension-foo"))
+		})
+
+		It("should return the correct namespace name for a self-hosted shoot ControllerInstallation", func() {
+			controllerInstallation := &gardencorev1beta1.ControllerInstallation{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo-abc12"},
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					RegistrationRef: corev1.ObjectReference{Name: "foo"},
+					ShootRef:        &corev1.ObjectReference{Name: "shoot1", Namespace: "garden"},
 				},
 			}
 			Expect(NamespaceNameForControllerInstallation(controllerInstallation)).To(Equal("extension-foo"))

--- a/pkg/utils/graph/eventhandler_controllerinstallation.go
+++ b/pkg/utils/graph/eventhandler_controllerinstallation.go
@@ -87,6 +87,11 @@ func (g *graph) handleControllerInstallationCreateOrUpdate(controllerInstallatio
 		g.addEdge(controllerInstallationVertex, seedVertex)
 	}
 
+	if controllerInstallation.Spec.ShootRef != nil {
+		shootVertex := g.getOrCreateVertex(VertexTypeShoot, controllerInstallation.Spec.ShootRef.Namespace, controllerInstallation.Spec.ShootRef.Name)
+		g.addEdge(controllerInstallationVertex, shootVertex)
+	}
+
 	if controllerInstallation.Spec.DeploymentRef != nil {
 		controllerDeploymentVertex := g.getOrCreateVertex(VertexTypeControllerDeployment, "", controllerInstallation.Spec.DeploymentRef.Name)
 		g.addEdge(controllerDeploymentVertex, controllerInstallationVertex)

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -75,6 +75,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 			resourceSetup{&gardencorev1beta1.BackupEntry{}, g.setupBackupEntryWatch},
 			resourceSetup{&operationsv1alpha1.Bastion{}, g.setupBastionWatch},
 			resourceSetup{&certificatesv1.CertificateSigningRequest{}, g.setupCertificateSigningRequestWatch},
+			resourceSetup{&gardencorev1beta1.ControllerInstallation{}, g.setupControllerInstallationWatch},
 			resourceSetup{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
 			resourceSetup{&corev1.ServiceAccount{}, g.setupServiceAccountWatch},
 			resourceSetup{&gardencorev1beta1.Shoot{}, g.setupShootWatch},

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -320,6 +320,7 @@ var _ = Describe("graph for seeds", func() {
 				DeploymentRef:   &corev1.ObjectReference{Name: "controllerdeployment1"},
 				RegistrationRef: corev1.ObjectReference{Name: "controllerregistration1"},
 				SeedRef:         &corev1.ObjectReference{Name: seed1.Name},
+				ShootRef:        &corev1.ObjectReference{Name: shoot1.Name, Namespace: shoot1.Namespace},
 			},
 		}
 
@@ -1593,54 +1594,59 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 	It("should behave as expected for gardencorev1beta1.ControllerInstallation", func() {
 		By("Add")
 		fakeInformerControllerInstallation.Add(controllerInstallation1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeTrue())
 
 		By("Update (irrelevant change)")
 		controllerInstallation1Copy := controllerInstallation1.DeepCopy()
 		controllerInstallation1.Spec.RegistrationRef.ResourceVersion = "123"
 		fakeInformerControllerInstallation.Update(controllerInstallation1Copy, controllerInstallation1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeTrue())
 
 		By("Update (controller registration name)")
 		controllerInstallation1Copy = controllerInstallation1.DeepCopy()
 		controllerInstallation1.Spec.RegistrationRef.Name = "newreg"
 		fakeInformerControllerInstallation.Update(controllerInstallation1Copy, controllerInstallation1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1Copy.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeTrue())
 
 		By("Update (controller deployment name)")
 		controllerInstallation1Copy = controllerInstallation1.DeepCopy()
 		controllerInstallation1.Spec.DeploymentRef.Name = "newdeploy"
 		fakeInformerControllerInstallation.Update(controllerInstallation1Copy, controllerInstallation1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1Copy.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeTrue())
 
 		By("Update (seed name)")
 		controllerInstallation1Copy = controllerInstallation1.DeepCopy()
 		controllerInstallation1.Spec.SeedRef.Name = "newseed"
 		fakeInformerControllerInstallation.Update(controllerInstallation1Copy, controllerInstallation1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1Copy.Spec.SeedRef.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeTrue())
 
 		By("Delete")
 		fakeInformerControllerInstallation.Delete(controllerInstallation1)
@@ -1649,6 +1655,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		Expect(graph.HasPathFrom(VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name)).To(BeFalse())
+		Expect(graph.HasPathFrom(VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name)).To(BeFalse())
 	})
 
 	It("should behave as expected for seedmanagementv1alpha1.ManagedSeed", func() {
@@ -2028,10 +2035,11 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			fakeInformerControllerInstallation.Add(controllerInstallation1)
 			lock.Lock()
 			defer lock.Unlock()
-			nodes, edges = nodes+3, edges+3
+			nodes, edges = nodes+3, edges+4
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name, BeTrue()})
+			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			fakeInformerManagedSeed.Add(managedSeed1)
@@ -2180,6 +2188,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name, BeTrue()})
+			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			managedSeed1Copy := managedSeed1.DeepCopy()
@@ -2344,6 +2353,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerDeployment, "", controllerInstallation1.Spec.DeploymentRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeTrue()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name, BeTrue()})
+			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			managedSeed1Copy := managedSeed1.DeepCopy()
@@ -2471,6 +2481,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			defer lock.Unlock()
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerRegistration, "", controllerInstallation1.Spec.RegistrationRef.Name, VertexTypeControllerInstallation, "", controllerInstallation1.Name, BeFalse()})
 			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeSeed, "", controllerInstallation1.Spec.SeedRef.Name, BeFalse()})
+			paths[VertexTypeControllerInstallation] = append(paths[VertexTypeControllerInstallation], pathExpectation{VertexTypeControllerInstallation, "", controllerInstallation1.Name, VertexTypeShoot, controllerInstallation1.Spec.ShootRef.Namespace, controllerInstallation1.Spec.ShootRef.Name, BeFalse()})
 		})
 		wg.Go(func() {
 			fakeInformerManagedSeed.Delete(managedSeed1)

--- a/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 			ConcurrentSyncs: ptr.To(5),
 			SyncPeriod:      &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
-		GardenNamespace: gardenNamespace.Name,
+		ManagedResourceNamespace: gardenNamespace.Name,
 	}).AddToManager(mgr, mgr, mgr)).To(Succeed())
 
 	By("Start manager")

--- a/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -129,6 +130,8 @@ var _ = BeforeSuite(func() {
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	Expect(indexer.AddControllerInstallationRegistrationRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
 	By("Register controller")
 	Expect((&care.Reconciler{

--- a/test/integration/gardenlet/controllerinstallation/care/care_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_test.go
@@ -152,6 +152,74 @@ var _ = Describe("ControllerInstallation Care controller tests", func() {
 	})
 })
 
+var _ = Describe("ControllerInstallation Care controller tests (self-hosted shoot)", func() {
+	var controllerInstallation *gardencorev1beta1.ControllerInstallation
+
+	BeforeEach(func() {
+		By("Create ControllerInstallation with ShootRef")
+		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "foo-",
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				ShootRef: &corev1.ObjectReference{
+					Name:      "shoot1",
+					Namespace: "garden",
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: "my-extension",
+				},
+				DeploymentRef: &corev1.ObjectReference{
+					Name: "foo-deployment",
+				},
+			},
+		}
+		Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())
+		log.Info("Created ControllerInstallation for test", "controllerInstallation", client.ObjectKeyFromObject(controllerInstallation))
+
+		DeferCleanup(func() {
+			By("Delete ControllerInstallation")
+			Expect(testClient.Delete(ctx, controllerInstallation)).To(Succeed())
+		})
+	})
+
+	It("should look up ManagedResource by RegistrationRef name", func() {
+		By("Create ManagedResource with RegistrationRef name")
+		managedResource := &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-extension",
+				Namespace: gardenNamespace.Name,
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},
+			},
+		}
+		Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
+		})
+
+		By("Update ManagedResource status to healthy")
+		managedResource.Status.ObservedGeneration = managedResource.Generation
+		managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+			{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+			{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+		}
+		Expect(testClient.Status().Update(ctx, managedResource)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			g.Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+				And(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("InstallationSuccessful")),
+				And(OfType(gardencorev1beta1.ControllerInstallationHealthy), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ControllerHealthy")),
+				And(OfType(gardencorev1beta1.ControllerInstallationProgressing), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("ControllerRolledOut")),
+			))
+		}).Should(Succeed())
+	})
+})
+
 func withMessageSubstrings(messages ...string) gomegatypes.GomegaMatcher {
 	var substringMatchers = make([]gomegatypes.GomegaMatcher, 0, len(messages))
 	for _, message := range messages {

--- a/test/integration/gardenlet/controllerinstallation/care/care_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_test.go
@@ -185,11 +185,15 @@ var _ = Describe("ControllerInstallation Care controller tests (self-hosted shoo
 	})
 
 	It("should look up ManagedResource by RegistrationRef name", func() {
-		By("Create ManagedResource with RegistrationRef name")
+		By("Create ManagedResource with RegistrationRef name and stale labels")
 		managedResource := &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-extension",
 				Namespace: gardenNamespace.Name,
+				Labels: map[string]string{
+					"controllerinstallation-name": "my-extension",
+					"controllerregistration-name": "my-extension",
+				},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{{Name: "foo-secret"}},


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

After `gardenadm connect`, the self-hosted gardenlet needs to report `ControllerInstallation` conditions (`Installed`, `Healthy`, `Progressing`) by watching the `ManagedResource`s that were created during `gardenadm init`. This PR enables the `ControllerInstallation` care controller in the self-hosted gardenlet, including authorization, resource dependency graph edges, and handling the naming mismatch between bootstrapping and normal operation.

During `gardenadm init`, `ManagedResource`s are created with the `ControllerRegistration` name (no random suffix). After `gardenadm connect`, `gardener-controller-manager` creates real `ControllerInstallation` objects with `.metadata.generateName` (random suffix). A new `controllerregistration-name` label on `ManagedResource`s enables detection of this staleness: when both labels are equal, the map function falls back to looking up the correct `ControllerInstallation` by `.spec.registrationRef.name`.

```
$ k get ctrlinst -w
NAME                      REGISTRATION        CLUSTER             VALID       INSTALLED   HEALTHY   PROGRESSING   AGE
networking-calico-gq46n   networking-calico   Shoot/garden/root   <unknown>   Unknown     Unknown   Unknown       17h
provider-local-vsrxp      provider-local      Shoot/garden/root   <unknown>   Unknown     Unknown   Unknown       17h

provider-local-vsrxp      provider-local      Shoot/garden/root   <unknown>   True        True      False         18h
networking-calico-gq46n   networking-calico   Shoot/garden/root   <unknown>   True        True      False         18h
```

**Which issue(s) this PR fixes**:

Part of #2906

**Release note**:
```other operator
NONE
```