### PR TITLE
Fix nil pointer panic in gardenlet config validation when `staleExtensionHealthChecks.threshold` is nil

### DIFF
--- a/pkg/api/config/gardenlet/v1alpha1/validation/validation.go
+++ b/pkg/api/config/gardenlet/v1alpha1/validation/validation.go
@@ -240,7 +240,7 @@ func validateShootCareControllerConfiguration(cfg *gardenletconfigv1alpha1.Shoot
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.SyncPeriod.Duration), fldPath.Child("syncPeriod"))...)
 	}
 
-	if cfg.StaleExtensionHealthChecks != nil {
+	if cfg.StaleExtensionHealthChecks != nil && cfg.StaleExtensionHealthChecks.Threshold != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.StaleExtensionHealthChecks.Threshold.Duration), fldPath.Child("staleExtensionHealthChecks", "threshold"))...)
 	}
 

--- a/pkg/api/config/gardenlet/v1alpha1/validation/validation_test.go
+++ b/pkg/api/config/gardenlet/v1alpha1/validation/validation_test.go
@@ -396,6 +396,14 @@ var _ = Describe("GardenletConfiguration", func() {
 					})),
 				))
 			})
+
+			It("should not panic when staleExtensionHealthChecks is set but threshold is nil", func() {
+				cfg.Controllers.ShootCare.StaleExtensionHealthChecks = &gardenletconfigv1alpha1.StaleExtensionHealthChecks{Enabled: true}
+
+				errorList := ValidateGardenletConfiguration(cfg, nil)
+
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 
 		Context("managed seed controller", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fix nil pointer panic in gardenlet config validation when `staleExtensionHealthChecks.threshold` is nil. Check https://github.com/gardener/gardener/issues/13145 for more details.

**Which issue(s) this PR fixes**:
Fixes #13145

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the nil pointer panic in gardenlet config validation when `staleExtensionHealthChecks.threshold` is nil is fixed.
```
