### PR TITLE
fix(hack/tools): ensure `golangci-lint` is compiled with same go version as `logcheck` plugin

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -161,7 +161,8 @@ $(GOIMPORTSREVISER): $(call tool_version_file,$(GOIMPORTSREVISER),$(GOIMPORTSREV
 $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION))
 	@# CGO_ENABLED has to be set to 1 in order for golangci-lint to be able to load plugins
 	@# see https://github.com/golangci/golangci-lint/issues/1276
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@# cd'ing to logcheck to ensure golangci-lint is compiled with the same go version as logcheck (required for loading golangci-lint plugins)
+	cd $(TOOLS_PKG_PATH)/logcheck; GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
 	@GOSEC_VERSION=$(GOSEC_VERSION) bash $(TOOLS_PKG_PATH)/install-gosec.sh


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind bug

**What this PR does / why we need it**:

This is needed because loading golangci-lint plugins requires the plugins to be compiled with the same exact go version (not just equal minor version).
This issue originally surfaced for setups where the go version was lower than the version in the main `go.mod`. Go defaults to the latest locally available toolchain version when the go version in the `go.mod` is lower or equal to the locally available version. This caused `golangci-lint` to be compiled with e.g., `1.25.6` and `logcheck` with `1.25.5` (the local go version, as the `go.mod` had `1.25.0`).

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14133

**Release note**:
```other operator
NONE
```
