### PR TITLE
[GEP-28] Support `.spec.files[].content.secretRef` file content in `gardener-node-agent`

### DIFF
--- a/docs/concepts/node-agent.md
+++ b/docs/concepts/node-agent.md
@@ -62,7 +62,9 @@ Amongst others, a prominent example is the configuration file for `kubelet` and 
 It also watches `Node`s and requeues the corresponding `Secret` when the reason of the node condition `InPlaceUpdate` changes to `ReadyForUpdate`.
 
 The controller decodes the configuration and computes the files and units that have changed since its last reconciliation.
-It writes or update the files and units to the file system, removes no longer needed files and units, reloads the systemd daemon, and starts or stops the units accordingly.
+File content can be provided inline, via an image reference, or via a `secretRef` pointing to a `Secret` in the `kube-system` namespace.
+For `secretRef` files, the controller reads the referenced `Secret` and extracts the data from the specified key.
+It writes or updates the files and units to the file system, removes no longer needed files and units, reloads the systemd daemon, and starts or stops the units accordingly.
 
 After successful reconciliation, it persists the just applied `OperatingSystemConfig` into a file on the host.
 This file will be used for future reconciliations to compute file/unit changes.

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
@@ -27,6 +27,7 @@ func OperatingSystemConfigSecret(
 	osc *extensionsv1alpha1.OperatingSystemConfig,
 	secretName string,
 	workerPoolName string,
+	resolveSecretRefs bool,
 ) (
 	*corev1.Secret,
 	error,
@@ -47,23 +48,26 @@ func OperatingSystemConfigSecret(
 		},
 	}
 
-	// The OperatingSystemConfig will be deployed to the shoot to get processed by gardener-node-agent. It doesn't
-	// have access to the referenced secrets (stored in the shoot namespace in the seed), hence we have to translate
-	// all references into inline content.
-	for i, file := range operatingSystemConfig.Spec.Files {
-		if file.Content.SecretRef == nil {
-			continue
-		}
+	// The OperatingSystemConfig will be deployed to the shoot to get processed by gardener-node-agent. In the regular
+	// shoot case, it doesn't have access to the referenced secrets (stored in the shoot namespace in the seed), hence
+	// we have to translate all references into inline content. In the self-hosted shoot case (gardenadm), the secrets
+	// already exist in kube-system and gardener-node-agent can resolve them itself.
+	if resolveSecretRefs {
+		for i, file := range operatingSystemConfig.Spec.Files {
+			if file.Content.SecretRef == nil {
+				continue
+			}
 
-		secret := &corev1.Secret{}
-		if err := seedClient.Get(ctx, client.ObjectKey{Name: file.Content.SecretRef.Name, Namespace: osc.Namespace}, secret); err != nil {
-			return nil, fmt.Errorf("cannot resolve secret ref from osc: %w", err)
-		}
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: file.Content.SecretRef.Name, Namespace: osc.Namespace}}
+			if err := seedClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+				return nil, fmt.Errorf("cannot resolve secret ref from osc: %w", err)
+			}
 
-		operatingSystemConfig.Spec.Files[i].Content.SecretRef = nil
-		operatingSystemConfig.Spec.Files[i].Content.Inline = &extensionsv1alpha1.FileContentInline{
-			Encoding: "b64",
-			Data:     utils.EncodeBase64(secret.Data[file.Content.SecretRef.DataKey]),
+			operatingSystemConfig.Spec.Files[i].Content.SecretRef = nil
+			operatingSystemConfig.Spec.Files[i].Content.Inline = &extensionsv1alpha1.FileContentInline{
+				Encoding: "b64",
+				Data:     utils.EncodeBase64(secret.Data[file.Content.SecretRef.DataKey]),
+			}
 		}
 	}
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Secrets", func() {
 		})
 
 		It("should generate the expected secret", func() {
-			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName)
+			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(secret).To(Equal(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -146,6 +146,16 @@ status:
 			}))
 		})
 
+		It("should preserve secretRef when resolveSecretRefs is false", func() {
+			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			oscYAML := string(secret.Data["osc.yaml"])
+			Expect(oscYAML).To(ContainSubstring("secretRef:"))
+			Expect(oscYAML).NotTo(ContainSubstring("inline:"))
+			Expect(secret.Annotations).To(HaveKeyWithValue("checksum/data-script", utils.ComputeSHA256Hex(secret.Data["osc.yaml"])))
+		})
+
 		It("should return an error because a referenced secret cannot be found", func() {
 			osc.Spec.Files = append(osc.Spec.Files, extensionsv1alpha1.File{
 				Path: "/non/existing/path",
@@ -157,7 +167,7 @@ status:
 				},
 			})
 
-			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName)
+			secret, err := OperatingSystemConfigSecret(ctx, fakeClient, osc, secretName, workerPoolName, true)
 			Expect(err).To(MatchError(ContainSubstring(`cannot resolve secret ref from osc: secrets "non-existing" not found`)))
 			Expect(secret).To(BeNil())
 		})

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -55,7 +55,7 @@ func (b *GardenadmBotanist) DeployOperatingSystemConfigSecretForBootstrap(ctx co
 func (b *GardenadmBotanist) createOperatingSystemConfigSecretForNodeAgent(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, secretName, poolName string) error {
 	var err error
 
-	b.operatingSystemConfigSecret, err = nodeagentcomponent.OperatingSystemConfigSecret(ctx, b.SeedClientSet.Client(), osc, secretName, poolName)
+	b.operatingSystemConfigSecret, err = nodeagentcomponent.OperatingSystemConfigSecret(ctx, b.SeedClientSet.Client(), osc, secretName, poolName, false)
 	if err != nil {
 		return fmt.Errorf("failed computing the OperatingSystemConfig secret for gardener-node-agent for pool %q: %w", poolName, err)
 	}
@@ -143,7 +143,8 @@ func (b *GardenadmBotanist) ApplyOperatingSystemConfig(ctx context.Context) erro
 	reconcilerCtx = log.IntoContext(reconcilerCtx, b.Logger.WithName("operatingsystemconfig-reconciler").WithValues("secret", client.ObjectKeyFromObject(b.operatingSystemConfigSecret)))
 
 	_, err = (&operatingsystemconfigcontroller.Reconciler{
-		Client: b.SeedClientSet.Client(),
+		APIReader: b.SeedClientSet.APIReader(),
+		Client:    b.SeedClientSet.Client(),
 		Config: nodeagentconfigv1alpha1.OperatingSystemConfigControllerConfig{
 			SyncPeriod:        &metav1.Duration{Duration: time.Minute},
 			SecretName:        b.operatingSystemConfigSecret.Name,

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -290,7 +290,7 @@ func (b *Botanist) generateOperatingSystemConfigSecretForWorker(
 	map[string][]byte,
 	error,
 ) {
-	oscSecret, err := NodeAgentOSCSecretFn(ctx, b.SeedClientSet.Client(), oscDataOriginal.Object, oscDataOriginal.GardenerNodeAgentSecretName, worker.Name)
+	oscSecret, err := NodeAgentOSCSecretFn(ctx, b.SeedClientSet.Client(), oscDataOriginal.Object, oscDataOriginal.GardenerNodeAgentSecretName, worker.Name, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing the OperatingSystemConfig secret for gardener-node-agent for pool %q: %w", worker.Name, err)
 	}

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig_test.go
@@ -310,7 +310,7 @@ var _ = Describe("operatingsystemconfig", func() {
 				})
 
 				It("should fail because the secret data generation function fails", func() {
-					DeferCleanup(test.WithVar(&NodeAgentOSCSecretFn, func(context.Context, client.Client, *extensionsv1alpha1.OperatingSystemConfig, string, string) (*corev1.Secret, error) {
+					DeferCleanup(test.WithVar(&NodeAgentOSCSecretFn, func(context.Context, client.Client, *extensionsv1alpha1.OperatingSystemConfig, string, string, bool) (*corev1.Secret, error) {
 						return nil, fakeErr
 					}))
 
@@ -341,7 +341,7 @@ var _ = Describe("operatingsystemconfig", func() {
 					By("Execute DeployManagedResourceForGardenerNodeAgent function")
 					Expect(botanist.DeployManagedResourceForGardenerNodeAgent(ctx)).To(Succeed())
 
-					expectedOSCSecretWorker1, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker1Name].Original.Object, worker1Key, worker1Name)
+					expectedOSCSecretWorker1, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker1Name].Original.Object, worker1Key, worker1Name, true)
 					Expect(err).NotTo(HaveOccurred())
 					expectedOSCSecretWorker1Raw, err := runtime.Encode(codec, expectedOSCSecretWorker1)
 					Expect(err).NotTo(HaveOccurred())
@@ -360,7 +360,7 @@ var _ = Describe("operatingsystemconfig", func() {
 					}
 					utilruntime.Must(kubernetesutils.MakeUnique(expectedMRSecretWorker1))
 
-					expectedOSCSecretWorker2, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker2Name].Original.Object, worker2Key, worker2Name)
+					expectedOSCSecretWorker2, err := NodeAgentOSCSecretFn(ctx, fakeClient, workerNameToOperatingSystemConfigMaps[worker2Name].Original.Object, worker2Key, worker2Name, true)
 					Expect(err).NotTo(HaveOccurred())
 					expectedOSCSecretWorker2Raw, err := runtime.Encode(codec, expectedOSCSecretWorker2)
 					Expect(err).NotTo(HaveOccurred())

--- a/pkg/nodeagent/controller/operatingsystemconfig/add.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/add.go
@@ -47,6 +47,9 @@ const ControllerName = "operatingsystemconfig"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -108,7 +108,8 @@ func init() {
 // Reconciler decodes the OperatingSystemConfig resources from secrets and applies the systemd units and files to the
 // node.
 type Reconciler struct {
-	Client client.Client
+	APIReader client.Reader
+	Client    client.Client
 	// LeaseClient is a cached client just for the leader election Lease in case the OperatingSystemConfig
 	// reconciliation is serialised.
 	LeaseClient      client.Client
@@ -272,8 +273,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		)
 	}
 
-	log.Info("Applying new or changed inline files")
-	if err := r.applyChangedInlineFiles(log, oscChanges); err != nil {
+	log.Info("Applying new or changed inline and secretRef files")
+	if err := r.applyChangedInlineFiles(ctx, log, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed applying changed inline files: %w", err)
 	}
 
@@ -464,7 +465,41 @@ func (r *Reconciler) applyChangedImageRefFiles(ctx context.Context, log logr.Log
 	return nil
 }
 
-func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, changes *operatingSystemConfigChanges) error {
+// getFileContentData resolves the data for a file from its inline content or secretRef.
+// It returns ok=false if the file has neither (e.g., imageRef files handled separately).
+func (r *Reconciler) getFileContentData(ctx context.Context, file extensionsv1alpha1.File) ([]byte, bool, error) {
+	switch {
+	case file.Content.Inline != nil:
+		data, err := extensionsv1alpha1helper.Decode(file.Content.Inline.Encoding, []byte(file.Content.Inline.Data))
+		if err != nil {
+			return nil, false, fmt.Errorf("unable to decode inline data: %w", err)
+		}
+		return data, true, nil
+
+	case file.Content.SecretRef != nil:
+		// APIReader is a direct client (not cached) for reading Secrets referenced via secretRef in the
+		// OperatingSystemConfig. gardener-node-agent only has permissions to watch the OSC secret by name (via the
+		// node-agent-authorizer) and the manager cache for Secrets is accordingly restricted. Hence, secretRef targets are
+		// invisible to the cached client.
+		// Since we plan to use files with secretRef only for the control plane worker pool of self-hosted shoots, the
+		// network I/O impact should be negligible.
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: file.Content.SecretRef.Name, Namespace: metav1.NamespaceSystem}}
+		if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
+			return nil, false, fmt.Errorf("unable to read referenced secret %q: %w", file.Content.SecretRef.Name, err)
+		}
+
+		data, ok := secret.Data[file.Content.SecretRef.DataKey]
+		if !ok {
+			return nil, false, fmt.Errorf("secret %q does not contain key %q", file.Content.SecretRef.Name, file.Content.SecretRef.DataKey)
+		}
+		return data, true, nil
+
+	default:
+		return nil, false, nil
+	}
+}
+
+func (r *Reconciler) applyChangedInlineFiles(ctx context.Context, log logr.Logger, changes *operatingSystemConfigChanges) error {
 	tmpDir, err := r.FS.TempDir(nodeagentconfigv1alpha1.TempDir, "osc-reconciliation-file-")
 	if err != nil {
 		return fmt.Errorf("unable to create temporary directory: %w", err)
@@ -473,17 +508,16 @@ func (r *Reconciler) applyChangedInlineFiles(log logr.Logger, changes *operating
 	defer func() { utilruntime.HandleError(r.FS.RemoveAll(tmpDir)) }()
 
 	for _, file := range slices.Clone(changes.Files.Changed) {
-		if file.Content.Inline == nil {
+		data, ok, err := r.getFileContentData(ctx, file)
+		if err != nil {
+			return fmt.Errorf("unable to get data of file %q: %w", file.Path, err)
+		}
+		if !ok {
 			continue
 		}
 
 		if err := r.FS.MkdirAll(filepath.Dir(file.Path), defaultDirPermissions); err != nil {
 			return fmt.Errorf("unable to create directory %q: %w", file.Path, err)
-		}
-
-		data, err := extensionsv1alpha1helper.Decode(file.Content.Inline.Encoding, []byte(file.Content.Inline.Data))
-		if err != nil {
-			return fmt.Errorf("unable to decode data of file %q: %w", file.Path, err)
 		}
 
 		tmpFilePath := filepath.Join(tmpDir, filepath.Base(file.Path))
@@ -1168,7 +1202,7 @@ func (r *Reconciler) restartNodeAgent(oscChanges *operatingSystemConfigChanges, 
 }
 
 func (r *Reconciler) ensureStaticPodsReconciledAndReady(ctx context.Context, log logr.Logger, node *corev1.Node, osc *extensionsv1alpha1.OperatingSystemConfig) (done bool, err error) {
-	staticPodNameToDesiredHash, err := r.getDesiredStaticPodHashes(log, osc)
+	staticPodNameToDesiredHash, err := r.getDesiredStaticPodHashes(ctx, log, osc)
 	if err != nil {
 		return false, fmt.Errorf("failed to retrieve desired static pod hashes from OperatingSystemConfig: %w", err)
 	}
@@ -1205,7 +1239,7 @@ func (r *Reconciler) ensureStaticPodsReconciledAndReady(ctx context.Context, log
 	return true, nil
 }
 
-func (r *Reconciler) getDesiredStaticPodHashes(log logr.Logger, osc *extensionsv1alpha1.OperatingSystemConfig) (map[string]string, error) {
+func (r *Reconciler) getDesiredStaticPodHashes(ctx context.Context, log logr.Logger, osc *extensionsv1alpha1.OperatingSystemConfig) (map[string]string, error) {
 	staticPodFiles := slices.DeleteFunc(append(osc.Spec.Files, osc.Status.ExtensionFiles...), func(file extensionsv1alpha1.File) bool {
 		return !strings.HasPrefix(file.Path, kubeletcomponent.FilePathKubernetesManifests) ||
 			(file.HostName != nil && *file.HostName != r.HostName)
@@ -1213,13 +1247,12 @@ func (r *Reconciler) getDesiredStaticPodHashes(log logr.Logger, osc *extensionsv
 
 	staticPodNameToHash := make(map[string]string)
 	for _, file := range staticPodFiles {
-		if file.Content.Inline == nil {
-			continue
-		}
-
-		data, err := extensionsv1alpha1helper.Decode(file.Content.Inline.Encoding, []byte(file.Content.Inline.Data))
+		data, ok, err := r.getFileContentData(ctx, file)
 		if err != nil {
-			return nil, fmt.Errorf("unable to decode data of file %q: %w", file.Path, err)
+			return nil, fmt.Errorf("unable to get data of file %q: %w", file.Path, err)
+		}
+		if !ok {
+			continue
 		}
 
 		pod := &corev1.Pod{}

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer.go
@@ -18,13 +18,19 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	nodeagentconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/nodeagent/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -52,7 +58,17 @@ var (
 	nodeResource                      = corev1.Resource("nodes")
 	podResource                       = corev1.Resource("pods")
 	secretsResource                   = corev1.Resource("secrets")
+
+	oscDecoder runtime.Decoder
 )
+
+func init() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
+	ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, scheme, scheme, jsonserializer.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+	oscDecoder = serializer.NewCodecFactory(scheme).CodecForVersions(nil, ser, nil, versions)
+}
 
 type authorizer struct {
 	sourceClient client.Client
@@ -283,7 +299,33 @@ func (a *authorizer) authorizeSecret(ctx context.Context, log logr.Logger, machi
 		if err := a.sourceClient.Get(ctx, client.ObjectKey{Name: machineName, Namespace: *a.machineNamespace}, machine); err != nil {
 			return auth.DecisionDeny, "", fmt.Errorf("error getting machine %q: %w", machineName, err)
 		}
-		validSecrets = append(validSecrets, machine.Spec.NodeTemplateSpec.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName])
+
+		oscSecretName := machine.Spec.NodeTemplateSpec.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName]
+		validSecrets = append(validSecrets, oscSecretName)
+
+		oscSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: oscSecretName, Namespace: metav1.NamespaceSystem}}
+		if err := a.targetClient.Get(ctx, client.ObjectKeyFromObject(oscSecret), oscSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return auth.DecisionDeny, "", fmt.Errorf("error getting OSC secret %q: %w", oscSecretName, err)
+			}
+		} else {
+			var hostname string
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: machine.Labels[machinev1alpha1.NodeLabelKey]}}
+			if err := a.targetClient.Get(ctx, client.ObjectKeyFromObject(node), node); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return auth.DecisionDeny, "", fmt.Errorf("error getting node %q: %w", node.Name, err)
+				}
+			} else {
+				hostname = node.Labels[corev1.LabelHostname]
+			}
+
+			secretRefNames, err := secretRefNamesFromOSCSecret(oscSecret, hostname)
+			if err != nil {
+				return auth.DecisionDeny, "", fmt.Errorf("error reading secretRef names from OSC secret %q: %w", oscSecretName, err)
+			}
+			validSecrets = append(validSecrets, secretRefNames...)
+		}
 	} else {
 		var nodeNotFound bool
 
@@ -307,12 +349,25 @@ func (a *authorizer) authorizeSecret(ctx context.Context, log logr.Logger, machi
 			// gardener-node-agent uses, it needs access to all operating system config secrets.
 			for _, oscSecret := range oscSecretList.Items {
 				validSecrets = append(validSecrets, oscSecret.Name)
+
+				secretRefNames, err := secretRefNamesFromOSCSecret(&oscSecret, "")
+				if err != nil {
+					return auth.DecisionDeny, "", fmt.Errorf("error reading secretRef names from OSC secret %q: %w", oscSecret.Name, err)
+				}
+				validSecrets = append(validSecrets, secretRefNames...)
 			}
 		} else {
 			// Verify that the secret from node label is an operating system config secret.
+			hostname := node.Labels[corev1.LabelHostname]
 			for _, oscSecret := range oscSecretList.Items {
 				if oscSecret.Name == node.Labels[v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName] {
 					validSecrets = append(validSecrets, oscSecret.Name)
+
+					secretRefNames, err := secretRefNamesFromOSCSecret(&oscSecret, hostname)
+					if err != nil {
+						return auth.DecisionDeny, "", fmt.Errorf("error reading secretRef names from OSC secret %q: %w", oscSecret.Name, err)
+					}
+					validSecrets = append(validSecrets, secretRefNames...)
 					break
 				}
 			}
@@ -325,6 +380,27 @@ func (a *authorizer) authorizeSecret(ctx context.Context, log logr.Logger, machi
 	}
 
 	return auth.DecisionAllow, "", nil
+}
+
+func secretRefNamesFromOSCSecret(secret *corev1.Secret, hostname string) ([]string, error) {
+	oscRaw, ok := secret.Data[nodeagentconfigv1alpha1.DataKeyOperatingSystemConfig]
+	if !ok {
+		return nil, nil
+	}
+
+	osc := &extensionsv1alpha1.OperatingSystemConfig{}
+	if err := runtime.DecodeInto(oscDecoder, oscRaw, osc); err != nil {
+		return nil, fmt.Errorf("unable to decode OSC from secret %q: %w", secret.Name, err)
+	}
+
+	var names []string
+	for _, file := range append(osc.Spec.Files, osc.Status.ExtensionFiles...) {
+		if file.Content.SecretRef != nil && (hostname == "" || file.HostName == nil || *file.HostName == hostname) {
+			names = append(names, file.Content.SecretRef.Name)
+		}
+	}
+
+	return names, nil
 }
 
 func (a *authorizer) checkVerb(log logr.Logger, attrs auth.Attributes, allowedVerbs ...string) (bool, string) {

--- a/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
+++ b/pkg/resourcemanager/webhook/nodeagentauthorizer/authorizer_test.go
@@ -16,16 +16,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/authentication/user"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/resourcemanager/webhook/nodeagentauthorizer"
@@ -727,6 +733,306 @@ var _ = Describe("Authorizer", func() {
 				Entry("delete", "delete"),
 				Entry("deletecollection", "deletecollection"),
 			)
+
+			It("should allow accessing secrets referenced via secretRef in the OSC", func() {
+				oscScheme := runtime.NewScheme()
+				Expect(extensionsv1alpha1.AddToScheme(oscScheme)).To(Succeed())
+				ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, oscScheme, oscScheme, jsonserializer.SerializerOptions{Yaml: true})
+				versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+				codec := serializer.NewCodecFactory(oscScheme).CodecForVersions(ser, ser, versions, versions)
+
+				osc := &extensionsv1alpha1.OperatingSystemConfig{
+					Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+						Files: []extensionsv1alpha1.File{{
+							Path:    "/some/file",
+							Content: extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "my-referenced-secret", DataKey: "data"}},
+						}},
+					},
+				}
+				oscRaw, err := runtime.Encode(codec, osc)
+				Expect(err).NotTo(HaveOccurred())
+
+				oscSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineSecretName,
+						Namespace: metav1.NamespaceSystem,
+					},
+					Data: map[string][]byte{"osc.yaml": oscRaw},
+				}
+				Expect(targetClient.Create(ctx, oscSecret)).To(Succeed())
+				DeferCleanup(func() { Expect(targetClient.Delete(ctx, oscSecret)).To(Succeed()) })
+
+				attrs := &auth.AttributesRecord{
+					User:            nodeAgentUser,
+					Name:            "my-referenced-secret",
+					Namespace:       "kube-system",
+					APIGroup:        "",
+					Resource:        "secrets",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should deny accessing host-specific secretRef files for a different hostname", func() {
+				patch := client.MergeFrom(node.DeepCopy())
+				metav1.SetMetaDataLabel(&node.ObjectMeta, corev1.LabelHostname, "my-hostname")
+				Expect(targetClient.Patch(ctx, node, patch)).To(Succeed())
+				DeferCleanup(func() {
+					patch := client.MergeFrom(node.DeepCopy())
+					delete(node.Labels, corev1.LabelHostname)
+					Expect(targetClient.Patch(ctx, node, patch)).To(Succeed())
+				})
+
+				oscScheme := runtime.NewScheme()
+				Expect(extensionsv1alpha1.AddToScheme(oscScheme)).To(Succeed())
+				ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, oscScheme, oscScheme, jsonserializer.SerializerOptions{Yaml: true})
+				versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+				codec := serializer.NewCodecFactory(oscScheme).CodecForVersions(ser, ser, versions, versions)
+
+				osc := &extensionsv1alpha1.OperatingSystemConfig{
+					Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+						Files: []extensionsv1alpha1.File{
+							{
+								Path:     "/host-specific/file",
+								HostName: ptr.To("other-hostname"),
+								Content:  extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "other-host-secret", DataKey: "data"}},
+							},
+							{
+								Path:     "/host-specific/file",
+								HostName: ptr.To("my-hostname"),
+								Content:  extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "my-host-secret", DataKey: "data"}},
+							},
+						},
+					},
+				}
+				oscRaw, err := runtime.Encode(codec, osc)
+				Expect(err).NotTo(HaveOccurred())
+
+				oscSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machineSecretName,
+						Namespace: metav1.NamespaceSystem,
+					},
+					Data: map[string][]byte{"osc.yaml": oscRaw},
+				}
+				Expect(targetClient.Create(ctx, oscSecret)).To(Succeed())
+				DeferCleanup(func() { Expect(targetClient.Delete(ctx, oscSecret)).To(Succeed()) })
+
+				By("Allowing the secret for the matching hostname")
+				decision, reason, err := authorizer.Authorize(ctx, &auth.AttributesRecord{
+					User: nodeAgentUser, Name: "my-host-secret", Namespace: "kube-system",
+					APIGroup: "", Resource: "secrets", ResourceRequest: true, Verb: "get",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+
+				By("Denying the secret for a different hostname")
+				decision, _, err = authorizer.Authorize(ctx, &auth.AttributesRecord{
+					User: nodeAgentUser, Name: "other-host-secret", Namespace: "kube-system",
+					APIGroup: "", Resource: "secrets", ResourceRequest: true, Verb: "get",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionDeny))
+			})
+
+			When("machineNamespace is nil (gardenadm mode)", func() {
+				var gardenadmAuthorizer auth.Authorizer
+
+				BeforeEach(func() {
+					gardenadmAuthorizer = NewAuthorizer(log, sourceClient, targetClient, nil, false)
+				})
+
+				It("should allow accessing secrets referenced via secretRef in the OSC when node exists", func() {
+					oscScheme := runtime.NewScheme()
+					Expect(extensionsv1alpha1.AddToScheme(oscScheme)).To(Succeed())
+					ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, oscScheme, oscScheme, jsonserializer.SerializerOptions{Yaml: true})
+					versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+					codec := serializer.NewCodecFactory(oscScheme).CodecForVersions(ser, ser, versions, versions)
+
+					osc := &extensionsv1alpha1.OperatingSystemConfig{
+						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+							Files: []extensionsv1alpha1.File{{
+								Path:    "/some/file",
+								Content: extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "gardenadm-referenced-secret", DataKey: "data"}},
+							}},
+						},
+					}
+					oscRaw, err := runtime.Encode(codec, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					oscSecretName := "gardenadm-osc-secret"
+					oscSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      oscSecretName,
+							Namespace: metav1.NamespaceSystem,
+							Labels:    map[string]string{v1beta1constants.LabelWorkerPool: "pool"},
+						},
+						Data: map[string][]byte{"osc.yaml": oscRaw},
+					}
+					Expect(targetClient.Create(ctx, oscSecret)).To(Succeed())
+					DeferCleanup(func() { Expect(targetClient.Delete(ctx, oscSecret)).To(Succeed()) })
+
+					gardenadmNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardenadm-node",
+							Labels: map[string]string{
+								v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName: oscSecretName,
+							},
+						},
+					}
+					Expect(targetClient.Create(ctx, gardenadmNode)).To(Succeed())
+					DeferCleanup(func() { Expect(targetClient.Delete(ctx, gardenadmNode)).To(Succeed()) })
+
+					gardenadmUser := &user.DefaultInfo{
+						Name:   fmt.Sprintf("%s%s", v1beta1constants.NodeAgentUserNamePrefix, "gardenadm-node"),
+						Groups: []string{v1beta1constants.NodeAgentsGroup},
+					}
+
+					attrs := &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            "gardenadm-referenced-secret",
+						Namespace:       "kube-system",
+						APIGroup:        "",
+						Resource:        "secrets",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+
+					decision, reason, err := gardenadmAuthorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should deny accessing host-specific secretRef files for a different hostname", func() {
+					oscScheme := runtime.NewScheme()
+					Expect(extensionsv1alpha1.AddToScheme(oscScheme)).To(Succeed())
+					ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, oscScheme, oscScheme, jsonserializer.SerializerOptions{Yaml: true})
+					versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+					codec := serializer.NewCodecFactory(oscScheme).CodecForVersions(ser, ser, versions, versions)
+
+					osc := &extensionsv1alpha1.OperatingSystemConfig{
+						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+							Files: []extensionsv1alpha1.File{
+								{
+									Path:     "/host-specific/file",
+									HostName: ptr.To("other-hostname"),
+									Content:  extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "other-host-secret", DataKey: "data"}},
+								},
+								{
+									Path:     "/host-specific/file",
+									HostName: ptr.To("gardenadm-hostname"),
+									Content:  extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "my-host-secret", DataKey: "data"}},
+								},
+							},
+						},
+					}
+					oscRaw, err := runtime.Encode(codec, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					oscSecretName := "gardenadm-hostname-osc-secret"
+					oscSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      oscSecretName,
+							Namespace: metav1.NamespaceSystem,
+							Labels:    map[string]string{v1beta1constants.LabelWorkerPool: "pool"},
+						},
+						Data: map[string][]byte{"osc.yaml": oscRaw},
+					}
+					Expect(targetClient.Create(ctx, oscSecret)).To(Succeed())
+					DeferCleanup(func() { Expect(targetClient.Delete(ctx, oscSecret)).To(Succeed()) })
+
+					gardenadmNode := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gardenadm-hostname-node",
+							Labels: map[string]string{
+								v1beta1constants.LabelWorkerPoolGardenerNodeAgentSecretName: oscSecretName,
+								corev1.LabelHostname: "gardenadm-hostname",
+							},
+						},
+					}
+					Expect(targetClient.Create(ctx, gardenadmNode)).To(Succeed())
+					DeferCleanup(func() { Expect(targetClient.Delete(ctx, gardenadmNode)).To(Succeed()) })
+
+					gardenadmUser := &user.DefaultInfo{
+						Name:   fmt.Sprintf("%s%s", v1beta1constants.NodeAgentUserNamePrefix, "gardenadm-hostname-node"),
+						Groups: []string{v1beta1constants.NodeAgentsGroup},
+					}
+
+					By("Allowing the secret for the matching hostname")
+					decision, reason, err := gardenadmAuthorizer.Authorize(ctx, &auth.AttributesRecord{
+						User: gardenadmUser, Name: "my-host-secret", Namespace: "kube-system",
+						APIGroup: "", Resource: "secrets", ResourceRequest: true, Verb: "get",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+
+					By("Denying the secret for a different hostname")
+					decision, _, err = gardenadmAuthorizer.Authorize(ctx, &auth.AttributesRecord{
+						User: gardenadmUser, Name: "other-host-secret", Namespace: "kube-system",
+						APIGroup: "", Resource: "secrets", ResourceRequest: true, Verb: "get",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionDeny))
+				})
+
+				It("should allow accessing secrets referenced via secretRef in the OSC during bootstrap", func() {
+					oscScheme := runtime.NewScheme()
+					Expect(extensionsv1alpha1.AddToScheme(oscScheme)).To(Succeed())
+					ser := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, oscScheme, oscScheme, jsonserializer.SerializerOptions{Yaml: true})
+					versions := schema.GroupVersions([]schema.GroupVersion{extensionsv1alpha1.SchemeGroupVersion})
+					codec := serializer.NewCodecFactory(oscScheme).CodecForVersions(ser, ser, versions, versions)
+
+					osc := &extensionsv1alpha1.OperatingSystemConfig{
+						Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+							Files: []extensionsv1alpha1.File{{
+								Path:    "/some/file",
+								Content: extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "bootstrap-referenced-secret", DataKey: "data"}},
+							}},
+						},
+					}
+					oscRaw, err := runtime.Encode(codec, osc)
+					Expect(err).NotTo(HaveOccurred())
+
+					oscSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bootstrap-osc-secret",
+							Namespace: metav1.NamespaceSystem,
+							Labels:    map[string]string{v1beta1constants.LabelWorkerPool: "pool"},
+						},
+						Data: map[string][]byte{"osc.yaml": oscRaw},
+					}
+					Expect(targetClient.Create(ctx, oscSecret)).To(Succeed())
+					DeferCleanup(func() { Expect(targetClient.Delete(ctx, oscSecret)).To(Succeed()) })
+
+					gardenadmUser := &user.DefaultInfo{
+						Name:   fmt.Sprintf("%s%s", v1beta1constants.NodeAgentUserNamePrefix, "non-existing-node"),
+						Groups: []string{v1beta1constants.NodeAgentsGroup},
+					}
+
+					attrs := &auth.AttributesRecord{
+						User:            gardenadmUser,
+						Name:            "bootstrap-referenced-secret",
+						Namespace:       "kube-system",
+						APIGroup:        "",
+						Resource:        "secrets",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+
+					decision, reason, err := gardenadmAuthorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+			})
 		})
 
 		Context("#Pods", func() {

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -428,6 +428,7 @@ build:
             - pkg/apis/authentication/v1alpha1
             - pkg/apis/config
             - pkg/apis/config/gardenlet/v1alpha1
+            - pkg/apis/config/nodeagent/v1alpha1
             - pkg/apis/config/resourcemanager/v1alpha1
             - pkg/apis/core
             - pkg/apis/core/install

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -277,6 +277,7 @@ build:
             - pkg/apis/authentication/v1alpha1
             - pkg/apis/config
             - pkg/apis/config/gardenlet/v1alpha1
+            - pkg/apis/config/nodeagent/v1alpha1
             - pkg/apis/config/resourcemanager/v1alpha1
             - pkg/apis/core
             - pkg/apis/core/install
@@ -986,8 +987,8 @@ deploy:
 profiles:
   - name: ipv6
     activation:
-    - env: IPFAMILY=ipv6
-    - env: IPFAMILY=dual
+      - env: IPFAMILY=ipv6
+      - env: IPFAMILY=dual
     patches:
       - op: add
         path: /deploy/helm/releases/0/setValueTemplates/env[1].name

--- a/skaffold-seed.yaml
+++ b/skaffold-seed.yaml
@@ -360,6 +360,7 @@ build:
             - pkg/apis/authentication/v1alpha1
             - pkg/apis/config
             - pkg/apis/config/gardenlet/v1alpha1
+            - pkg/apis/config/nodeagent/v1alpha1
             - pkg/apis/config/resourcemanager/v1alpha1
             - pkg/apis/core
             - pkg/apis/core/install

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1279,6 +1279,7 @@ build:
             - pkg/apis/authentication/v1alpha1
             - pkg/apis/config
             - pkg/apis/config/gardenlet/v1alpha1
+            - pkg/apis/config/nodeagent/v1alpha1
             - pkg/apis/config/resourcemanager/v1alpha1
             - pkg/apis/core
             - pkg/apis/core/install

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -67,7 +67,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		containerdConfigFileContent string
 
-		file1, file2, file3, file4, file5, file6, file7, file8                                                                         extensionsv1alpha1.File
+		file1, file2, file3, file4, file5, file6, file7, file8, file9                                                                  extensionsv1alpha1.File
 		gnaUnit, unit1, unit2, unit3, unit4, unit5, unit5DropInsOnly, unit6, unit7, unit8, unit9, existingUnitDropIn, containerdDropIn extensionsv1alpha1.Unit
 		cgroupDriver                                                                                                                   extensionsv1alpha1.CgroupDriverName
 		registryConfig1, registryConfig2                                                                                               extensionsv1alpha1.RegistryConfig
@@ -244,6 +244,25 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 			Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "", Data: "file8"}},
 			Permissions: ptr.To[uint32](0644),
 		}
+		file9 = extensionsv1alpha1.File{
+			Path:        "/secretref/file",
+			Content:     extensionsv1alpha1.FileContent{SecretRef: &extensionsv1alpha1.FileContentSecretRef{Name: "file9-secret", DataKey: "content"}},
+			Permissions: ptr.To[uint32](0750),
+		}
+
+		By("Create Secret referenced by file9")
+		file9Secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      file9.Content.SecretRef.Name,
+				Namespace: metav1.NamespaceSystem,
+				Labels:    map[string]string{testID: testRunID},
+			},
+			Data: map[string][]byte{"content": []byte("file9")},
+		}
+		Expect(testClient.Create(ctx, file9Secret)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, file9Secret)).To(Succeed())
+		})
 
 		gnaUnit = extensionsv1alpha1.Unit{
 			Name:    "gardener-node-agent.service",
@@ -387,7 +406,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 
 		operatingSystemConfig = &extensionsv1alpha1.OperatingSystemConfig{
 			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
-				Files: []extensionsv1alpha1.File{file1, file3, file5, file8},
+				Files: []extensionsv1alpha1.File{file1, file3, file5, file8, file9},
 				Units: []extensionsv1alpha1.Unit{unit1, unit2, unit5, unit5DropInsOnly, unit6, unit7},
 				CRIConfig: &extensionsv1alpha1.CRIConfig{
 					Name:         "containerd",
@@ -461,6 +480,7 @@ var _ = Describe("OperatingSystemConfig controller tests", func() {
 		test.AssertFileOnDisk(fakeFS, file5.Path, "file5", 0750)
 		test.AssertFileOnDisk(fakeFS, file6.Path, "file6", 0750)
 		test.AssertFileOnDisk(fakeFS, file7.Path, "file7", 0750)
+		test.AssertFileOnDisk(fakeFS, file9.Path, "file9", 0750)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+unit1.Name, "#unit1", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+unit1.Name+".d/"+unit1.DropIns[0].Name, "#unit1drop", 0600)
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+unit2.Name, "#unit2", 0600)
@@ -502,7 +522,7 @@ inPlaceUpdates:
   operatingSystem: false
   serviceAccountKeyRotation: false
 mustRestartNodeAgent: false
-operatingSystemConfigChecksum: ddafef1ed407f75f5fc6a8a075ff430fb03b348a4c00474978e2650a22edd9ff
+operatingSystemConfigChecksum: `+utils.ComputeSHA256Hex(oscRaw)+`
 units: {}
 `, 0600)
 
@@ -640,6 +660,7 @@ units: {}
 		test.AssertFileOnDisk(fakeFS, file5.Path, "changeme", 0750)
 		test.AssertFileOnDisk(fakeFS, file6.Path, "changed", 0750)
 		test.AssertFileOnDisk(fakeFS, file7.Path, "changed-as-well", 0750)
+		test.AssertFileOnDisk(fakeFS, file9.Path, "file9", 0750)
 		test.AssertNoFileOnDisk(fakeFS, "/etc/systemd/system/"+unit1.Name)
 		test.AssertNoDirectoryOnDisk(fakeFS, "/etc/systemd/system/"+unit1.Name+".d")
 		test.AssertFileOnDisk(fakeFS, "/etc/systemd/system/"+unit2.Name, "#unit2", 0600)


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds support for `secretRef` file content in `gardener-node-agent`. Instead of requiring all file content to be inlined in the `OperatingSystemConfig`, files can now reference secrets in `kube-system` via `.content.secretRef`. This will be useful for self-hosted shoot control plane worker pools where node-specific etcd certificates will be carried as secrets and referenced from the `OperatingSystemConfig` rather than inlined. There is currently no plan to use this for regular (hosted) shoots, but there is no restriction that would prevent it if ever needed.

The node agent authorizer is extended to allow `gardener-node-agent` to read `secretRef`-referenced secrets, with hostname-based filtering via `.hostName`.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
Tested on a self-hosted shoot with a `secretRef` in `.status.extensionFiles`:

```yaml
status:
  extensionFiles:
  - path: /var/lib/rfranzke
    content:
      secretRef:
        name: observability-ingress-users-f27eb0bf
        dataKey: password
```

```
root@machine-0:/# cat /var/lib/rfranzke
sNou...
```

Node agent authorizer correctly scopes access:

```
root@machine-0:/# k auth can-i get secret/some-secret --as-group gardener.cloud:node-agents --as gardener.cloud:node-agent:machine:machine-0
no - gardener-node-agent can only access secrets [gardener-valitail gardener-opentelemetry-collector gardener-node-agent-control-plane-2a6d099390c03bfe observability-ingress-users-f27eb0bf] in "kube-system" namespace
root@machine-0:/# k auth can-i get secret/observability-ingress-users-f27eb0bf --as-group gardener.cloud:node-agents --as gardener.cloud:node-agent:machine:machine-0
yes
```

**Release note**:
```feature developer
`gardener-node-agent` can now resolve `.spec.files[].content.secretRef` from `Secret`s in `kube-system`, enabling `OperatingSystemConfig` files to reference secrets instead of requiring inlined content.
```