### PR TITLE
Add managedseeds permissions for gardener/dashboard

### DIFF
--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -33,6 +33,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/dashboard"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -757,6 +758,11 @@ frontend:
 				{
 					APIGroups: []string{"core.gardener.cloud"},
 					Resources: []string{"quotas", "projects", "shoots", "controllerregistrations", "namespacedcloudprofiles"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{seedmanagementv1alpha1.GroupName},
+					Resources: []string{"managedseeds"},
 					Verbs:     []string{"list", "watch"},
 				},
 				{

--- a/pkg/component/gardener/dashboard/rbac.go
+++ b/pkg/component/gardener/dashboard/rbac.go
@@ -14,6 +14,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -43,6 +44,11 @@ func (g *gardenerDashboard) clusterRole() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{gardencorev1beta1.GroupName},
 				Resources: []string{"quotas", "projects", "shoots", "controllerregistrations", "namespacedcloudprofiles"},
+				Verbs:     []string{"list", "watch"},
+			},
+			{
+				APIGroups: []string{seedmanagementv1alpha1.GroupName},
+				Resources: []string{"managedseeds"},
 				Verbs:     []string{"list", "watch"},
 			},
 			{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds `list` and `watch` permissions for `managedseeds.seedmanagement.gardener.cloud` to the Gardener Dashboard RBAC.

The additional permissions are required for newer dashboard functionality that displays ManagedSeed-related Shoot information and keeps it synchronized in real time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related dashboard change: gardener/dashboard gardener/dashboard#2834

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The Gardener Dashboard RBAC now allows listing and watching ManagedSeeds to support newer dashboard functionality around ManagedSeed-related Shoot information.
```