### PR TITLE
Increase e2e test timeout to 125 minutes

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -43,4 +43,4 @@ if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
   local_address_operator="::3"
 fi
 
-GO111MODULE=on ginkgo run --timeout=105m $ginkgo_flags --v --show-node-events "$@"
+GO111MODULE=on ginkgo run --timeout=125m $ginkgo_flags --v --show-node-events "$@"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR increases the timeout for e2e tests from 105 to 125 minutes.
Currently a lot of the `gardener-e2e-kind`, `pull-gardener-e2e-kind-ha-multi-node` and `pull-gardener-e2e-kind-ha-multi-zone` tests run close to the timeout of 105 minutes and from time to time they fail due to not fitting in this timeout. Checking the logs they would need 15~20 more minutes so that the runtime of the failing step can fit in its particular `SpecTimeout`

Here are some examples:
- In https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/batch/pull-gardener-e2e-kind/2031754275805204480 the 
`ManagedSeed Tests [It] Wait for Shoot to be deleted [ManagedSeed, default]` step failed as it could only run for `93.811` seconds instead of the full 20 minutes that are specified in the corresponding [`SpecTimeout` for waiting until Shoot is deleted](https://github.com/gardener/gardener/blob/611d0305a488f1f71a5feb8f683147cf34c6f978/test/e2e/gardener/shoot/shoot.go#L176-L193)
- The same happened in https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14289/pull-gardener-e2e-kind/2031751505484189696, however here the step could only run for 37 seconds instead of the full 20 minutes.

One reason for the increased test duration might be the introduction of prometheus health checks when determining the healthiness of `Shoot`s and `Seed`s when they are created, which was introduced in https://github.com/gardener/gardener/pull/13341.

Additionally, I will open a PR on https://github.com/gardener/ci-infra to increase the number of parallel workers for the `*-gardener-e2e-kind`, `*-gardener-e2e-kind-ha-multi-node` and `*-gardener-e2e-kind-ha-multi-zone` tests to see if that will also help speed them up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
