### PR TITLE
Add observability labels to victoria-logs

### DIFF
--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -128,6 +128,11 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *vmv1.VLSingle {
 			Labels:    getLabels(),
 		},
 		Spec: vmv1.VLSingleSpec{
+			PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{
+				Labels: map[string]string{
+					v1beta1constants.LabelObservabilityApplication: constants.VLSingleResourceName,
+				},
+			},
 			CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 				DisableSelfServiceScrape: ptr.To(true),
 				UseStrictSecurity:        ptr.To(true),
@@ -196,7 +201,7 @@ func getLabels() map[string]string {
 		gardenerutils.NetworkPolicyLabel(constants.ServiceName, constants.VictoriaLogsPort): v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                               v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                      "victoria-logs",
+		v1beta1constants.LabelObservabilityApplication:                                      constants.VLSingleResourceName,
 	}
 }
 

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -102,6 +102,11 @@ var _ = Describe("VictoriaLogs", func() {
 				Labels:    getLabels(),
 			},
 			Spec: vmv1.VLSingleSpec{
+				PodMetadata: &vmv1beta1.EmbeddedObjectMetadata{
+					Labels: map[string]string{
+						v1beta1constants.LabelObservabilityApplication: victorialogsconstants.VLSingleResourceName,
+					},
+				},
 				CommonDefaultableParams: vmv1beta1.CommonDefaultableParams{
 					DisableSelfServiceScrape: ptr.To(true),
 					UseStrictSecurity:        ptr.To(true),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR add observability labels to `victoria-logs` pods allowing `oidc-apps-controller` to pick up correspinding targets adding authentication and authorization side cars.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`victoria-logs` pods are now labeled according oidc-apps semantic.
```
