### PR TITLE
Add "events.k8s.io" API group in RBAC for events

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -57,8 +57,8 @@ rules:
   - patch
   - update
 - apiGroups:
-  - events.k8s.io
   - ""
+  - events.k8s.io
   resources:
   - events
   - namespaces

--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -57,6 +57,7 @@ rules:
   - patch
   - update
 - apiGroups:
+  - events.k8s.io
   - ""
   resources:
   - events

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -94,6 +94,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -174,7 +175,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				Verbs:         []string{"delete"},
 			},
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{"", eventsv1.GroupName},
 				Resources: []string{"events"},
 				Verbs:     []string{"get", "list", "create", "patch", "update"},
 			},

--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -51,8 +51,8 @@ rules:
   - update
   - patch
 - apiGroups:
-  - events.k8s.io
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -51,6 +51,7 @@ rules:
   - update
   - patch
 - apiGroups:
+  - events.k8s.io
   - ""
   resources:
   - events


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind regression

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/13982, components using `mgr.GetEventRecorder` needs permission for `events.k8s.io` Events as well.
Without this, `gardener-operator` records errors such as
```
{"level":"error","ts":"2026-03-16T07:57:34.011Z","msg":"Server rejected event (will not retry!)","event":{"namespace":"default","name":"networking-calico.189d435376f0c606"},"error":"events.events.k8s.io is forbidden: User \"system:serviceaccount:garden:gardener-operator\" cannot create resource \"events\" in API group \"events.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/client-go/tools/events.recordEvent\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:270\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).attemptRecording\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:211\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:200"}
{"level":"error","ts":"2026-03-16T07:57:34.011Z","msg":"Server rejected event (will not retry!)","event":{"namespace":"default","name":"networking-cilium.189d435376f652ec"},"error":"events.events.k8s.io is forbidden: User \"system:serviceaccount:garden:gardener-operator\" cannot create resource \"events\" in API group \"events.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/client-go/tools/events.recordEvent\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:270\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).attemptRecording\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:211\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:200"}
{"level":"info","ts":"2026-03-16T07:57:34.011Z","msg":"Succeeded","controller":"extension","controllerGroup":"operator.gardener.cloud","controllerKind":"Extension","Extension":{"name":"networking-calico"},"namespace":"","name":"networking-calico","reconcileID":"8c034f8b-69af-48e8-95b8-717790987f64","flow":"Extension reconciliation","task":"Deploying ControllerRegistration and ControllerDeployment"}
{"level":"error","ts":"2026-03-16T07:57:34.012Z","msg":"Server rejected event (will not retry!)","event":{"namespace":"default","name":"networking-calico.189d43537701ad7f"},"error":"events.events.k8s.io is forbidden: User \"system:serviceaccount:garden:gardener-operator\" cannot create resource \"events\" in API group \"events.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/client-go/tools/events.recordEvent\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:270\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).attemptRecording\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:211\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:200"}
{"level":"info","ts":"2026-03-16T07:57:34.012Z","msg":"Succeeded","controller":"extension","controllerGroup":"operator.gardener.cloud","controllerKind":"Extension","Extension":{"name":"networking-cilium"},"namespace":"","name":"networking-cilium","reconcileID":"4e68bd1d-60b3-401d-9345-66334afd83d8","flow":"Extension reconciliation","task":"Deploying ControllerRegistration and ControllerDeployment"}
{"level":"error","ts":"2026-03-16T07:57:34.012Z","msg":"Server rejected event (will not retry!)","event":{"namespace":"default","name":"networking-cilium.189d4353770a583f"},"error":"events.events.k8s.io is forbidden: User \"system:serviceaccount:garden:gardener-operator\" cannot create resource \"events\" in API group \"events.k8s.io\" in the namespace \"default\"","stacktrace":"k8s.io/client-go/tools/events.recordEvent\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:270\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).attemptRecording\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:211\nk8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1\n\tk8s.io/client-go@v0.35.2/tools/events/event_broadcaster.go:200"}
```

I adapted the `gardenlet` and `gardener-admin` RBAC as well along the way.
Similar to changes done in: https://github.com/gardener/gardener/pull/13982/changes/1af137c934493e396d15aa3678a101db9b5aaa70

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing `gardener-operator` to fail to create resource `events` in API group `events.k8s.io` is now fixed.
```
