### PR TITLE
Support custom CA certificates and pull secrets for OCI Helm chart registries in `Gardenlet` 

### DIFF
--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -268,6 +268,50 @@ selfUpgrade:
 in your `gardenlet-values.yaml` file.
 Please replace the `ref` placeholder with the URL to the OCI repository containing the gardenlet Helm chart you are installing.
 
+If the OCI repository requires authentication or uses a custom certificate, you can specify a pull secret and/or a CA bundle.
+
+```yaml
+helm:
+  ociRepository:
+    repository: registry.example.com
+    tag: 1.0.0
+    pullSecretRef:
+      name: my-pull-secret
+    caBundleSecretRef:
+      name: my-ca-bundle
+```
+
+Both secrets must be located in the same cluster and namespace as the `Gardenlet` resource (typically the `garden` namespace).
+
+The pull secret must be of type `kubernetes.io/dockerconfigjson` and contain a `.dockerconfigjson` data key.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-pull-secret
+  namespace: <gardenlet-namespace>
+  labels:
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <base64-encoded-docker-config-json>
+```
+
+The CA bundle secret must contain a `bundle.crt` data key with a PEM-encoded certificate bundle.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-ca-bundle
+  namespace: <gardenlet-namespace>
+type: Opaque
+data:
+  bundle.crt: <base64-encoded-ca-bundle>
+```
+
 > [!NOTE]
 > If you don't configure this `selfUpgrade` section in the initial deployment, you can also do it later, or you directly create the corresponding `seedmanagement.gardener.cloud/v1alpha1.Gardenlet` resource in the garden cluster.
 
@@ -430,6 +474,10 @@ spec:
     helm:
       ociRepository:
         ref: <url-to-gardenlet-chart-repository>:v1.97.0
+        caBundleSecretRef:
+          name: <my-ca-bundle-secret>
+        pullSecretRef:
+          name: <my-pull-secret>
   config:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -292,7 +292,6 @@ kind: Secret
 metadata:
   name: my-pull-secret
   namespace: <gardenlet-namespace>
-  labels:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: <base64-encoded-docker-config-json>

--- a/pkg/gardenlet/controller/gardenlet/reconciler.go
+++ b/pkg/gardenlet/controller/gardenlet/reconciler.go
@@ -28,7 +28,6 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controller/gardenletdeployer"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	"github.com/gardener/gardener/pkg/utils/oci"
 )
@@ -121,7 +120,7 @@ func (r *Reconciler) deployGardenlet(
 
 	secretNamespace := metav1.NamespaceSystem
 	if seed != nil {
-		secretNamespace = gardenerutils.ComputeGardenNamespace(seed.Name)
+		secretNamespace = gardenlet.Namespace
 	}
 
 	subCtx := context.WithValue(ctx, oci.ContextKeySecretNamespace, secretNamespace)

--- a/pkg/operator/controller/gardenlet/add.go
+++ b/pkg/operator/controller/gardenlet/add.go
@@ -60,7 +60,7 @@ func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager, virt
 		r.Recorder = mgr.GetEventRecorder(ControllerName + "-controller")
 	}
 	if r.HelmRegistry == nil {
-		r.HelmRegistry = oci.NewHelmRegistry(r.RuntimeCluster.GetClient())
+		r.HelmRegistry = oci.NewHelmRegistry(virtualCluster.GetClient())
 	}
 
 	return builder.

--- a/pkg/utils/graph/eventhandler_gardenlet.go
+++ b/pkg/utils/graph/eventhandler_gardenlet.go
@@ -138,6 +138,16 @@ func (g *graph) handleGardenletCreateOrUpdateForSeeds(ctx context.Context, garde
 		secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraptoken.TokenID(gardenlet.ObjectMeta))
 		g.addEdge(secretVertex, gardenletVertex)
 	}
+
+	if gardenlet.Spec.Deployment.Helm.OCIRepository.CABundleSecretRef != nil {
+		caBundleSecretVertex := g.getOrCreateVertex(VertexTypeSecret, gardenlet.Namespace, gardenlet.Spec.Deployment.Helm.OCIRepository.CABundleSecretRef.Name)
+		g.addEdge(caBundleSecretVertex, gardenletVertex)
+	}
+
+	if gardenlet.Spec.Deployment.Helm.OCIRepository.PullSecretRef != nil {
+		pullSecretVertex := g.getOrCreateVertex(VertexTypeSecret, gardenlet.Namespace, gardenlet.Spec.Deployment.Helm.OCIRepository.PullSecretRef.Name)
+		g.addEdge(pullSecretVertex, gardenletVertex)
+	}
 }
 
 func (g *graph) handleGardenletCreateOrUpdateForShoots(gardenlet *seedmanagementv1alpha1.Gardenlet) {

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -30,6 +30,7 @@ import (
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
@@ -136,6 +137,9 @@ var _ = Describe("graph for seeds", func() {
 		serviceAccount1Secret1 = "sa1secret1"
 		serviceAccount1Secret2 = "sa1secret2"
 		serviceAccount1        *corev1.ServiceAccount
+
+		pullSecret1     = "pull-secret"
+		caBundleSecret1 = "ca-bundle-secret"
 	)
 
 	BeforeEach(func() {
@@ -372,6 +376,14 @@ var _ = Describe("graph for seeds", func() {
 				Config: runtime.RawExtension{
 					Object: &gardenletconfigv1alpha1.GardenletConfiguration{
 						SeedConfig: seedConfig2,
+					},
+				},
+				Deployment: seedmanagementv1alpha1.GardenletSelfDeployment{
+					Helm: seedmanagementv1alpha1.GardenletHelm{
+						OCIRepository: gardencorev1.OCIRepository{
+							PullSecretRef:     &corev1.LocalObjectReference{Name: pullSecret1},
+							CABundleSecretRef: &corev1.LocalObjectReference{Name: caBundleSecret1},
+						},
 					},
 				},
 			},
@@ -1790,17 +1802,19 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 	It("should behave as expected for seedmanagementv1alpha1.Gardenlet", func() {
 		By("Add")
 		fakeInformerGardenlet.Add(gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeSecret, gardenlet1.Namespace, caBundleSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeSecret, gardenlet1.Namespace, pullSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
 
 		By("Update (irrelevant change)")
 		gardenlet1Copy := gardenlet1.DeepCopy()
 		seedConfig2.Labels = map[string]string{"new": "labels"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
 
@@ -1808,8 +1822,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		gardenlet1Copy = gardenlet1.DeepCopy()
 		seedConfig2.Spec.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Namespace: "newcredentialsnamespaces", Name: "newcredentials"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeSecret, seedConfig2.Spec.Backup.CredentialsRef.Namespace, seedConfig2.Spec.Backup.CredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
@@ -1818,8 +1832,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		gardenlet1Copy = gardenlet1.DeepCopy()
 		seedConfig2.Spec.Backup.CredentialsRef = &corev1.ObjectReference{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentity", Namespace: "newcredentialsnamespaces", Name: "newcredentials"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeWorkloadIdentity, seedConfig2.Spec.Backup.CredentialsRef.Namespace, seedConfig2.Spec.Backup.CredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
@@ -1834,8 +1848,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		gardenlet1Copy = gardenlet1.DeepCopy()
 		gardenlet1.Annotations = map[string]string{"gardener.cloud/operation": "reconcile"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(6))
+		Expect(graph.graph.Edges().Len()).To(Equal(5))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeWorkloadIdentity, seedConfig2.Spec.Backup.CredentialsRef.Namespace, seedConfig2.Spec.Backup.CredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, bootstrapTokenNamespace, gardenletBootstrapTokenName, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
@@ -1850,8 +1864,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		gardenlet1Copy = gardenlet1.DeepCopy()
 		gardenlet1.Annotations = map[string]string{"gardener.cloud/operation": "reconcile-again"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(5))
+		Expect(graph.graph.Edges().Len()).To(Equal(4))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeWorkloadIdentity, seedConfig2.Spec.Backup.CredentialsRef.Namespace, seedConfig2.Spec.Backup.CredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, bootstrapTokenNamespace, gardenletBootstrapTokenName, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeFalse())
@@ -1860,8 +1874,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		gardenlet1Copy = gardenlet1.DeepCopy()
 		gardenlet1.Annotations = map[string]string{"gardener.cloud/operation": "renew-kubeconfig"}
 		fakeInformerGardenlet.Update(gardenlet1Copy, gardenlet1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(4))
-		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.graph.Nodes().Len()).To(Equal(6))
+		Expect(graph.graph.Edges().Len()).To(Equal(5))
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeWorkloadIdentity, seedConfig2.Spec.Backup.CredentialsRef.Namespace, seedConfig2.Spec.Backup.CredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, bootstrapTokenNamespace, gardenletBootstrapTokenName, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name)).To(BeTrue())
@@ -2048,9 +2062,11 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			fakeInformerGardenlet.Add(gardenlet1)
 			lock.Lock()
 			defer lock.Unlock()
-			nodes, edges = nodes+1, edges+2
+			nodes, edges = nodes+3, edges+4
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name, BeTrue()})
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, caBundleSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, pullSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			fakeInformerCertificateSigningRequest.Add(csr1)
@@ -2204,6 +2220,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name, BeTrue()})
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, "newsecretnamespace", "newsecretname", VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeFalse()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, caBundleSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, pullSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			fakeInformerCertificateSigningRequest.Delete(csr1)
@@ -2365,6 +2383,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			defer lock.Unlock()
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name, BeTrue()})
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, "newsecretnamespace", "newsecretname", VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, caBundleSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, pullSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeTrue()})
 		})
 		wg.Go(func() {
 			fakeInformerCertificateSigningRequest.Add(csr1)
@@ -2487,6 +2507,8 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 			defer lock.Unlock()
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeSeed, "", seed1.Name, BeFalse()})
 			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, backupSecretCredentialsRef.Namespace, backupSecretCredentialsRef.Name, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeFalse()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, caBundleSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeFalse()})
+			paths[VertexTypeGardenlet] = append(paths[VertexTypeGardenlet], pathExpectation{VertexTypeSecret, gardenlet1.Namespace, pullSecret1, VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, BeFalse()})
 		})
 		wg.Go(func() {
 			fakeInformerCertificateSigningRequest.Delete(csr1)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
1. Use the virtual garden client in the helm registry used in the `gardenlet` controller of the `gardener-operator`. The secret should be created in the same cluster where `Gardenlet` is created, which should be the virtual garden. Currently runtime client is used and it looks for the secret in the runtime cluster. 
2. Enhance the GAC graph to allow gardenlet to access secrets referred in the `Gardenlet` resource.
3. Enhance gardenlet deployment documentation to mention CA bundle secret usage.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13751

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `gardenlet` reconciler in the `gardener-operator` now uses the virtual cluster client to fetch the pull secret and CA bundle secret. It was wrongly using the runtime cluster client earlier.
```
