### PR TITLE
Change gardenlet's workload identity `TokenExpirationDuration` config type to `metav1.Duration`

### DIFF
--- a/charts/gardener/gardenlet/test/test.go
+++ b/charts/gardener/gardenlet/test/test.go
@@ -771,7 +771,7 @@ func ComputeExpectedGardenletConfiguration(
 			},
 			TokenRequestorWorkloadIdentity: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
 				ConcurrentSyncs:         &five,
-				TokenExpirationDuration: ptr.To(6 * time.Hour),
+				TokenExpirationDuration: &metav1.Duration{Duration: 6 * time.Hour},
 			},
 			VPAEvictionRequirements: &gardenletconfigv1alpha1.VPAEvictionRequirementsControllerConfiguration{
 				ConcurrentSyncs: &five,

--- a/pkg/api/config/gardenlet/v1alpha1/validation/validation.go
+++ b/pkg/api/config/gardenlet/v1alpha1/validation/validation.go
@@ -327,7 +327,7 @@ func validateTokenRequestorWorkloadIdentityControllerConfiguration(cfg *gardenle
 	allErrs := field.ErrorList{}
 
 	if cfg.TokenExpirationDuration != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*cfg.TokenExpirationDuration), fldPath.Child("tokenExpirationDuration"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.TokenExpirationDuration.Duration), fldPath.Child("tokenExpirationDuration"))...)
 	}
 
 	return allErrs

--- a/pkg/api/config/gardenlet/v1alpha1/validation/validation_test.go
+++ b/pkg/api/config/gardenlet/v1alpha1/validation/validation_test.go
@@ -527,7 +527,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should allow valid configuration", func() {
-				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = ptr.To(6 * time.Hour)
+				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = &metav1.Duration{Duration: 6 * time.Hour}
 
 				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
 			})
@@ -539,7 +539,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			It("should forbid negative tokenExpirationDuration", func() {
-				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = ptr.To(-1 * time.Hour)
+				cfg.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration = &metav1.Duration{Duration: -1 * time.Hour}
 
 				errorList := ValidateGardenletConfiguration(cfg, nil)
 

--- a/pkg/apis/config/gardenlet/v1alpha1/defaults.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/defaults.go
@@ -433,7 +433,7 @@ func SetDefaults_TokenRequestorWorkloadIdentityControllerConfiguration(obj *Toke
 	}
 
 	if obj.TokenExpirationDuration == nil {
-		obj.TokenExpirationDuration = ptr.To(DefaultWorkloadIdentityTokenExpirationDuration)
+		obj.TokenExpirationDuration = &metav1.Duration{Duration: DefaultWorkloadIdentityTokenExpirationDuration}
 	}
 }
 

--- a/pkg/apis/config/gardenlet/v1alpha1/defaults_test.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/defaults_test.go
@@ -534,20 +534,20 @@ var _ = Describe("Defaults", func() {
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(PointTo(Equal(5)))
-			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(6 * time.Hour)))
+			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(metav1.Duration{Duration: 6 * time.Hour})))
 		})
 
 		It("should not overwrite already set values for the token requestor controller configuration", func() {
 			obj.Controllers = &GardenletControllerConfiguration{
 				TokenRequestorWorkloadIdentity: &TokenRequestorWorkloadIdentityControllerConfiguration{
 					ConcurrentSyncs:         ptr.To(10),
-					TokenExpirationDuration: ptr.To(12 * time.Hour),
+					TokenExpirationDuration: &metav1.Duration{Duration: 12 * time.Hour},
 				},
 			}
 			SetObjectDefaults_GardenletConfiguration(obj)
 
 			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(PointTo(Equal(10)))
-			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(12 * time.Hour)))
+			Expect(obj.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
 		})
 	})
 

--- a/pkg/apis/config/gardenlet/v1alpha1/types.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/types.go
@@ -468,7 +468,7 @@ type TokenRequestorWorkloadIdentityControllerConfiguration struct {
 	// The Gardener API Server may still issue tokens with a shorter or longer duration based on its configuration.
 	// Defaults to 6h.
 	// +optional
-	TokenExpirationDuration *time.Duration `json:"tokenExpirationDuration,omitempty"`
+	TokenExpirationDuration *metav1.Duration `json:"tokenExpirationDuration,omitempty"`
 }
 
 // VPAEvictionRequirementsControllerConfiguration defines the configuration of the VPAEvictionRequirements controller.

--- a/pkg/apis/config/gardenlet/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/zz_generated.deepcopy.go
@@ -10,8 +10,6 @@
 package v1alpha1
 
 import (
-	time "time"
-
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1419,7 +1417,7 @@ func (in *TokenRequestorWorkloadIdentityControllerConfiguration) DeepCopyInto(ou
 	}
 	if in.TokenExpirationDuration != nil {
 		in, out := &in.TokenExpirationDuration, &out.TokenExpirationDuration
-		*out = new(time.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	return

--- a/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
+++ b/pkg/gardenlet/controller/tokenrequestor/workloadidentity/reconciler_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Reconciler", func() {
 				Clock:                fakeClock,
 				JitterFunc:           fakeJitter,
 				Config: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
-					TokenExpirationDuration: ptr.To(6 * time.Hour),
+					TokenExpirationDuration: &metav1.Duration{Duration: 6 * time.Hour},
 				},
 			}
 

--- a/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_suite_test.go
+++ b/test/integration/gardenlet/tokenrequestor/workloadidentity/workloadidentity_suite_test.go
@@ -163,7 +163,7 @@ var _ = BeforeSuite(func() {
 		JitterFunc: func(_ time.Duration, _ float64) time.Duration { return time.Second },
 		Config: &gardenletconfigv1alpha1.TokenRequestorWorkloadIdentityControllerConfiguration{
 			ConcurrentSyncs:         ptr.To(5),
-			TokenExpirationDuration: ptr.To(6 * time.Hour),
+			TokenExpirationDuration: &metav1.Duration{Duration: 6 * time.Hour},
 		},
 	}).AddToManager(mgr, mgr, mgr)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Change gardenlet's workload identity `TokenExpirationDuration` config type to `metav1.Duration`.
The change is being introduced for two reasons:
- for consistency: there is no other API using `time.Duration`
- for readability reasons: it is much easier for human operator to read `tokenExpirationDuration: 6h` instead of `tokenExpirationDuration: 2.16e+13`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @dimityrmirchev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The type of the Gardenlet's configuration field `.controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration` has been changed from `time.Duration` to `k8s.io/apimachinery/pkg/apis/meta/v1.Duration`.
```
