### PR TITLE
feat: add support for configuring GRM deployment via the extension webhook ensurer

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -51,7 +51,9 @@ const Name = "gardener-resource-manager"
 
 // NewCommand creates a new cobra.Command for running gardener-resource-manager.
 func NewCommand() *cobra.Command {
-	opts := &options{}
+	opts := &options{
+		extraTargetNamespaces: make([]string, 0),
+	}
 
 	cmd := &cobra.Command{
 		Use:   Name,

--- a/cmd/gardener-resource-manager/app/options.go
+++ b/cmd/gardener-resource-manager/app/options.go
@@ -29,12 +29,17 @@ func init() {
 type options struct {
 	configFile string
 	config     *resourcemanagerconfigv1alpha1.ResourceManagerConfiguration
+
+	// extraTargetNamespaces specifies a list of additional target
+	// namespaces to be configured.
+	extraTargetNamespaces []string
 }
 
 var _ initrun.Options = &options{}
 
 func (o *options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.configFile, "config", o.configFile, "Path to configuration file.")
+	fs.StringArrayVar(&o.extraTargetNamespaces, "extra-target-namespace", nil, "Extra target namespace.")
 }
 
 func (o *options) Complete() error {
@@ -50,6 +55,18 @@ func (o *options) Complete() error {
 	o.config = &resourcemanagerconfigv1alpha1.ResourceManagerConfiguration{}
 	if err = runtime.DecodeInto(configDecoder, data, o.config); err != nil {
 		return fmt.Errorf("error decoding config: %w", err)
+	}
+
+	// Configure additional target namespaces
+	if o.extraTargetNamespaces != nil {
+		if o.config.TargetClientConnection != nil {
+			o.config.TargetClientConnection.Namespaces = append(
+				o.config.TargetClientConnection.Namespaces,
+				o.extraTargetNamespaces...,
+			)
+		} else {
+			o.config.TargetClientConnection.Namespaces = o.extraTargetNamespaces
+		}
 	}
 
 	return nil

--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -146,6 +146,20 @@ func (mr *MockEnsurerMockRecorder) EnsureETCD(ctx, gctx, new, old any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureETCD", reflect.TypeOf((*MockEnsurer)(nil).EnsureETCD), ctx, gctx, new, old)
 }
 
+// EnsureGardenerResourceManagerDeployment mocks base method.
+func (m *MockEnsurer) EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureGardenerResourceManagerDeployment", ctx, gctx, new, old)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureGardenerResourceManagerDeployment indicates an expected call of EnsureGardenerResourceManagerDeployment.
+func (mr *MockEnsurerMockRecorder) EnsureGardenerResourceManagerDeployment(ctx, gctx, new, old any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureGardenerResourceManagerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureGardenerResourceManagerDeployment), ctx, gctx, new, old)
+}
+
 // EnsureKubeAPIServerDeployment mocks base method.
 func (m *MockEnsurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx context0.GardenContext, new, old *v1.Deployment) error {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -32,8 +32,9 @@ import (
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 )
 
-// Ensurer ensures that various standard Kubernetes control plane objects conform to the provider requirements.
-// If they don't initially, they are mutated accordingly.
+// Ensurer ensures that various standard Kubernetes and Gardener control-plane
+// objects conform to the provider requirements.  If they don't initially, they
+// are mutated accordingly.
 type Ensurer interface {
 	// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
@@ -89,6 +90,9 @@ type Ensurer interface {
 	// EnsureCRIConfig ensures the CRI config.
 	// "old" might be "nil" and must always be checked.
 	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *extensionsv1alpha1.CRIConfig) error
+	// EnsureGardenerResourceManagerDeployment ensures that the Resource Manager deployment conforms to the provider requirements.
+	// "old" might be "nil" and must always be checked.
+	EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
 }
 
 // NewMutator creates a new controlplane mutator.
@@ -157,6 +161,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		case v1beta1constants.DeploymentNameVPNSeedServer:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureVPNSeedServerDeployment(ctx, gctx, x, oldDep)
+		case v1beta1constants.DeploymentNameGardenerResourceManager, operatorv1alpha1.DeploymentNameVirtualGardenGardenerResourceManager:
+			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
+			return m.ensurer.EnsureGardenerResourceManagerDeployment(ctx, gctx, x, oldDep)
 		}
 	case *appsv1.StatefulSet:
 		var oldSet *appsv1.StatefulSet

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -31,8 +31,9 @@ import (
 	"github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
 )
 
-// Ensurer ensures that various standard Kubernetes control plane objects conform to the provider requirements.
-// If they don't initially, they are mutated accordingly.
+// Ensurer ensures that various standard Kubernetes and Gardener control-plane
+// objects conform to the provider requirements.  If they don't initially, they
+// are mutated accordingly.
 type Ensurer interface {
 	// EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
@@ -88,6 +89,9 @@ type Ensurer interface {
 	// EnsureCRIConfig ensures the CRI config.
 	// "old" might be "nil" and must always be checked.
 	EnsureCRIConfig(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *extensionsv1alpha1.CRIConfig) error
+	// EnsureGardenerResourceManagerDeployment ensures that the Resource Manager deployment conforms to the provider requirements.
+	// "old" might be "nil" and must always be checked.
+	EnsureGardenerResourceManagerDeployment(ctx context.Context, gctx extensionscontextwebhook.GardenContext, new, old *appsv1.Deployment) error
 }
 
 // NewMutator creates a new controlplane mutator.
@@ -156,6 +160,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		case v1beta1constants.DeploymentNameVPNSeedServer:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureVPNSeedServerDeployment(ctx, gctx, x, oldDep)
+		case v1beta1constants.DeploymentNameGardenerResourceManager, operatorv1alpha1.DeploymentNameVirtualGardenGardenerResourceManager:
+			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
+			return m.ensurer.EnsureGardenerResourceManagerDeployment(ctx, gctx, x, oldDep)
 		}
 	case *appsv1.StatefulSet:
 		var oldSet *appsv1.StatefulSet

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -288,6 +288,28 @@ var _ = Describe("Mutator", func() {
 					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a gardener-resource-manager deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager"}}
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a virtual-garden-gardener-resource-manager deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-gardener-resource-manager"}}
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a gardener-resource-manager deployment and existing deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager"}}
+					oldObj = newObj.DeepCopyObject().(client.Object)
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
 		)
 
 		DescribeTable("EnsureETCD", func(newObj, oldObj *druidcorev1alpha1.Etcd) {

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -286,6 +286,28 @@ var _ = Describe("Mutator", func() {
 					ensurer.EXPECT().EnsureVPNSeedServerStatefulSet(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
 				},
 			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a gardener-resource-manager deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager"}}
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a virtual-garden-gardener-resource-manager deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "virtual-garden-gardener-resource-manager"}}
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureGardenerResourceManagerDeployment with a gardener-resource-manager deployment and existing deployment",
+				func() {
+					newObj = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager"}}
+					oldObj = newObj.DeepCopyObject().(client.Object)
+					ensurer.EXPECT().EnsureGardenerResourceManagerDeployment(context.Background(), gomock.Any(), newObj, oldObj).Return(nil)
+				},
+			),
 		)
 
 		DescribeTable("EnsureETCD", func(newObj, oldObj *druidcorev1alpha1.Etcd) {

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -117,3 +117,8 @@ func (e *NoopEnsurer) EnsureAdditionalProvisionFiles(_ context.Context, _ extens
 func (e *NoopEnsurer) EnsureCRIConfig(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *extensionsv1alpha1.CRIConfig) error {
 	return nil
 }
+
+// EnsureGardenerResourceManager ensures the Gardener Resource Manager deployment.
+func (e *NoopEnsurer) EnsureGardenerResourceManagerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
+	return nil
+}

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -118,7 +118,7 @@ func (e *NoopEnsurer) EnsureCRIConfig(_ context.Context, _ extensionscontextwebh
 	return nil
 }
 
-// EnsureGardenerResourceManager ensures the Gardener Resource Manager deployment.
+// EnsureGardenerResourceManagerDeployment ensures the Gardener Resource Manager deployment.
 func (e *NoopEnsurer) EnsureGardenerResourceManagerDeployment(_ context.Context, _ extensionscontextwebhook.GardenContext, _, _ *appsv1.Deployment) error {
 	return nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `EnsureGardenerResourceManagerDeployment` method to the `genericmutator.Ensurer` interface.

This method allows extensions to mutate the GRM deployment and apply various configurations, which they might need.

Also, this PR adds a new CLI flag to GRM for configuring extra target namespace with the `--extra-target-namespace` option.

Various extensions already depend on being able to configure the list of target namespaces for GRM and currently they rely on mutating the GRM configmap, which is not the best approach.

- https://github.com/gardener/gardener-extension-provider-equinix-metal/blob/5cac13eb9316cb8f03bd5fa38b020d55f0f97296/pkg/webhook/controlplane/mutator.go#L83-L103
- https://github.com/gardener/gardener-extension-shoot-agent-sandbox/blob/424da5bd83767fbdbc48e5b1a20ff3af9c54e665/pkg/webhook/mutator.go#L121-L151

With the `--extra-target-namespace` CLI flag of GRM and the `EnsureGardenerResourceManagerDeployment` extensions will be able to mutate the deployment and simply append any additional namespace via the option mentioned previously.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add --extra-target-namespace option to Gardener Resource Manager
Add EnsureGardenerResourceManagerDeployment to genericmutator.Ensurer interface
```
