### PR TITLE
Evict stale Istio Gateway metrics and reenable scraping

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/service.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/service.yaml
@@ -13,6 +13,7 @@ metadata:
 {{- end }}
   labels:
     app.kubernetes.io/version: {{ .Values.ingressVersion }}
+    metrics-scrape-target: "true"
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
   type: {{ .Values.serviceType }}

--- a/pkg/component/networking/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 5
           env:
+          - name: METRIC_ROTATION_INTERVAL
+            value: 6m
+          - name: METRIC_GRACEFUL_DELETION_INTERVAL
+            value: 3m
           - name: REVISION
             value: "default"
           - name: PILOT_CERT_PROVIDER

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -436,14 +436,8 @@ var _ = Describe("istiod", func() {
 				istioIngressMetricsGateway(),
 				istioIngressMetricsServiceEntry(),
 				istioIngressMetricsVirtualService(),
-			}
-
-			// TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved
-			if false {
-				expectedIstioManifests = append(expectedIstioManifests,
-					istioIngressServiceMonitor(),
-					istioIngressTelemetry(),
-				)
+				istioIngressServiceMonitor(),
+				istioIngressTelemetry(),
 			}
 
 			expectedIstioSystemManifests := []string{

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -269,7 +269,10 @@ func (i *istiod) Deploy(ctx context.Context) error {
 		if err := registry.Add(&monitoringv1.ServiceMonitor{
 			ObjectMeta: monitoringutils.ConfigObjectMeta("istio-ingressgateway", istioIngressGateway.Namespace, prometheusName),
 			Spec: monitoringv1.ServiceMonitorSpec{
-				Selector: metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelApp: "istio-ingressgateway"}},
+				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
+					v1beta1constants.LabelApp: "istio-ingressgateway",
+					"metrics-scrape-target":   "true",
+				}},
 				Endpoints: []monitoringv1.Endpoint{{
 					Path: "/stats/prometheus",
 					Port: "tcp",

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -266,10 +266,6 @@ func (i *istiod) Deploy(ctx context.Context) error {
 	}
 
 	for _, istioIngressGateway := range i.values.IngressGateway {
-		// TODO(istvanballok): remove this block once the issue: 'Istio metrics leak for deleted shoots' #12699 is resolved
-		if true {
-			continue
-		}
 		if err := registry.Add(&monitoringv1.ServiceMonitor{
 			ObjectMeta: monitoringutils.ConfigObjectMeta("istio-ingressgateway", istioIngressGateway.Namespace, prometheusName),
 			Spec: monitoringv1.ServiceMonitorSpec{

--- a/pkg/component/networking/istio/test_charts/ingress_service.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_service_class.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service_class.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_service_dualstack.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service_dualstack.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_service_dualstack_etp.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service_dualstack_etp.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_service_etp_cluster.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service_etp_cluster.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_service_etp_local.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_service_etp_local.yaml
@@ -11,6 +11,7 @@ metadata:
     foo: bar
   labels:
     app.kubernetes.io/version: 1.27.1
+    metrics-scrape-target: "true"
     app: istio-ingressgateway
     foo: bar
 spec:

--- a/pkg/component/networking/istio/test_charts/ingress_servicemonitor.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_servicemonitor.yaml
@@ -25,4 +25,3 @@ spec:
   selector:
     matchLabels:
       app: istio-ingressgateway
-status: {}

--- a/pkg/component/networking/istio/test_charts/ingress_servicemonitor.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_servicemonitor.yaml
@@ -25,3 +25,4 @@ spec:
   selector:
     matchLabels:
       app: istio-ingressgateway
+      metrics-scrape-target: "true"

--- a/pkg/component/networking/istio/test_charts/istiod_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/istiod_deployment.yaml
@@ -72,6 +72,10 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 5
           env:
+          - name: METRIC_ROTATION_INTERVAL
+            value: 6m
+          - name: METRIC_GRACEFUL_DELETION_INTERVAL
+            value: 3m
           - name: REVISION
             value: "default"
           - name: PILOT_CERT_PROVIDER


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area monitoring
/area ipcei

/kind enhancement

**What this PR does / why we need it**:
Why Istio metrics were previously disabled:
#12699 
#12896 
In summary, metrics for older components (for example kube-apiserver) were kept by the metrics exporter., which caused major network traffic when scraping. This change configures Istio to evict them after some time of inactivity and reenables scraping.

**Which issue(s) this PR fixes**:
Fixes #12699 

Reverts #12896 

**Special notes for your reviewer**:
Istio v1.28 has similar (the same?) functionality exposed through the `
sidecar.istio.io/statsEvictionInterval` annotation.

Environment variables usage mentioned here:
https://istio.io/v1.27/docs/reference/commands/pilot-agent/#metric-rotation-interval

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix Istio Gateway metric retention and reenable metric scraping.
```
