### PR TITLE
[GEP-28] Fix ShootState resource deployment for a self-hosted Shoot

### DIFF
--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -261,7 +261,7 @@ func run(ctx context.Context, opts *Options) error {
 		compileShootState = g.Add(flow.Task{
 			Name: "Compiling ShootState",
 			Fn: func(ctx context.Context) error {
-				return shootstate.Deploy(ctx, b.Clock, b.GardenClient, b.SeedClientSet.Client(), b.Shoot.GetInfo(), false)
+				return shootstate.Deploy(ctx, b.Clock, b.GardenClient, b.SeedClientSet.Client(), b.Shoot.GetInfo(), b.Shoot.ControlPlaneNamespace, false)
 			},
 			Dependencies: flow.NewTaskIDs(migrateExtensionResources),
 		})

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go
@@ -243,7 +243,7 @@ func (r *Reconciler) runMigrateShootFlow(ctx context.Context, o *operation.Opera
 		persistShootState = g.Add(flow.Task{
 			Name: "Persisting ShootState in garden cluster",
 			Fn: func(ctx context.Context) error {
-				return shootstate.Deploy(ctx, r.Clock, botanist.GardenClient, botanist.SeedClientSet.Client(), botanist.Shoot.GetInfo(), false)
+				return shootstate.Deploy(ctx, r.Clock, botanist.GardenClient, botanist.SeedClientSet.Client(), botanist.Shoot.GetInfo(), botanist.Shoot.ControlPlaneNamespace, false)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilExtensionResourcesMigrated),
 		})

--- a/pkg/gardenlet/controller/shoot/state/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/state/reconciler.go
@@ -16,6 +16,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -86,7 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if nextBackupDue := lastBackup.Add(r.Config.SyncPeriod.Duration); nextBackupDue.Before(r.Clock.Now().UTC()) {
 		log.Info("Performing periodic ShootState backup", "lastBackup", lastBackup.Round(time.Minute), "nextBackupDue", nextBackupDue.Round(time.Minute))
-		if err := shootstate.Deploy(ctx, r.Clock, r.GardenClient, r.SeedClient, shoot, true); err != nil {
+		if err := shootstate.Deploy(ctx, r.Clock, r.GardenClient, r.SeedClient, shoot, v1beta1helper.ControlPlaneNamespaceForShoot(shoot), true); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed performing periodic ShootState backup: %w", err)
 		}
 		lastBackup = r.Clock.Now()

--- a/pkg/utils/gardener/shootstate/shootstate.go
+++ b/pkg/utils/gardener/shootstate/shootstate.go
@@ -32,7 +32,7 @@ import (
 
 // Deploy deploys the ShootState resource with the effective state for the given shoot into the garden
 // cluster.
-func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient client.Client, shoot *gardencorev1beta1.Shoot, overwriteSpec bool) error {
+func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient client.Client, shoot *gardencorev1beta1.Shoot, controlPlaneNamespace string, overwriteSpec bool) error {
 	shootState := &gardencorev1beta1.ShootState{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      shoot.Name,
@@ -40,7 +40,7 @@ func Deploy(ctx context.Context, clock clock.Clock, gardenClient, seedClient cli
 		},
 	}
 
-	spec, err := computeSpec(ctx, seedClient, shoot.Status.TechnicalID)
+	spec, err := computeSpec(ctx, seedClient, controlPlaneNamespace)
 	if err != nil {
 		return fmt.Errorf("failed computing spec of ShootState for shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
@@ -95,13 +95,13 @@ func Delete(ctx context.Context, gardenClient client.Client, shoot *gardencorev1
 	return client.IgnoreNotFound(gardenClient.Delete(ctx, shootState))
 }
 
-func computeSpec(ctx context.Context, seedClient client.Client, seedNamespace string) (*gardencorev1beta1.ShootStateSpec, error) {
-	gardener, err := computeGardenerData(ctx, seedClient, seedNamespace)
+func computeSpec(ctx context.Context, seedClient client.Client, controlPlaneNamespace string) (*gardencorev1beta1.ShootStateSpec, error) {
+	gardener, err := computeGardenerData(ctx, seedClient, controlPlaneNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing Gardener data: %w", err)
 	}
 
-	extensions, resources, err := computeExtensionsDataAndResources(ctx, seedClient, seedNamespace)
+	extensions, resources, err := computeExtensionsDataAndResources(ctx, seedClient, controlPlaneNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing extensions data and resources: %w", err)
 	}
@@ -116,17 +116,17 @@ func computeSpec(ctx context.Context, seedClient client.Client, seedNamespace st
 func computeGardenerData(
 	ctx context.Context,
 	seedClient client.Client,
-	seedNamespace string,
+	controlPlaneNamespace string,
 ) (
 	[]gardencorev1beta1.GardenerResourceData,
 	error,
 ) {
-	secretsToPersist, err := computeSecretsToPersist(ctx, seedClient, seedNamespace)
+	secretsToPersist, err := computeSecretsToPersist(ctx, seedClient, controlPlaneNamespace)
 	if err != nil {
 		return nil, err
 	}
 
-	machineState, err := computeMachineState(ctx, seedClient, seedNamespace)
+	machineState, err := computeMachineState(ctx, seedClient, controlPlaneNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -152,13 +152,13 @@ func computeGardenerData(
 func computeSecretsToPersist(
 	ctx context.Context,
 	seedClient client.Client,
-	seedNamespace string,
+	controlPlaneNamespace string,
 ) (
 	[]gardencorev1beta1.GardenerResourceData,
 	error,
 ) {
 	secretList := &corev1.SecretList{}
-	if err := seedClient.List(ctx, secretList, client.InNamespace(seedNamespace), client.MatchingLabels{
+	if err := seedClient.List(ctx, secretList, client.InNamespace(controlPlaneNamespace), client.MatchingLabels{
 		secretsmanager.LabelKeyPersist: secretsmanager.LabelValueTrue,
 	}); err != nil {
 		return nil, fmt.Errorf("failed listing all secrets that must be persisted: %w", err)
@@ -186,7 +186,7 @@ func computeSecretsToPersist(
 func computeExtensionsDataAndResources(
 	ctx context.Context,
 	seedClient client.Client,
-	seedNamespace string,
+	controlPlaneNamespace string,
 ) (
 	[]gardencorev1beta1.ExtensionResourceState,
 	[]gardencorev1beta1.ResourceData,
@@ -213,7 +213,7 @@ func computeExtensionsDataAndResources(
 		{extensionsv1alpha1.WorkerResource, func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} }},
 	} {
 		objList := extension.newObjectListFunc()
-		if err := seedClient.List(ctx, objList, client.InNamespace(seedNamespace)); err != nil {
+		if err := seedClient.List(ctx, objList, client.InNamespace(controlPlaneNamespace)); err != nil {
 			return nil, nil, fmt.Errorf("failed to list extension resources of kind %s: %w", extension.objKind, err)
 		}
 
@@ -237,9 +237,9 @@ func computeExtensionsDataAndResources(
 			})
 
 			for _, newResource := range extensionObj.GetExtensionStatus().GetResources() {
-				referencedObj, err := unstructuredutils.GetObjectByRef(ctx, seedClient, &newResource.ResourceRef, seedNamespace)
+				referencedObj, err := unstructuredutils.GetObjectByRef(ctx, seedClient, &newResource.ResourceRef, controlPlaneNamespace)
 				if err != nil {
-					return fmt.Errorf("failed reading referenced object %s: %w", client.ObjectKey{Name: newResource.ResourceRef.Name, Namespace: seedNamespace}, err)
+					return fmt.Errorf("failed reading referenced object %s: %w", client.ObjectKey{Name: newResource.ResourceRef.Name, Namespace: controlPlaneNamespace}, err)
 				}
 				if obj == nil {
 					return fmt.Errorf("object %v not found", newResource.ResourceRef)
@@ -247,7 +247,7 @@ func computeExtensionsDataAndResources(
 
 				raw := &runtime.RawExtension{}
 				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(referencedObj, raw); err != nil {
-					return fmt.Errorf("failed converting referenced object %s to raw extension: %w", client.ObjectKey{Name: newResource.ResourceRef.Name, Namespace: seedNamespace}, err)
+					return fmt.Errorf("failed converting referenced object %s to raw extension: %w", client.ObjectKey{Name: newResource.ResourceRef.Name, Namespace: controlPlaneNamespace}, err)
 				}
 
 				resources = append(resources, gardencorev1beta1.ResourceData{

--- a/pkg/utils/gardener/shootstate/shootstate_test.go
+++ b/pkg/utils/gardener/shootstate/shootstate_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 var _ = Describe("ShootState", func() {
+
 	var (
-		ctx           = context.TODO()
-		seedNamespace = "shoot--my-project--my-shoot"
+		ctx                   = context.TODO()
+		controlPlaneNamespace = "shoot--my-project--my-shoot"
 
 		fakeGardenClient client.Client
 		fakeSeedClient   client.Client
@@ -58,9 +59,6 @@ var _ = Describe("ShootState", func() {
 				Name:      "my-shoot",
 				Namespace: "garden-my-project",
 			},
-			Status: gardencorev1beta1.ShootStatus{
-				TechnicalID: seedNamespace,
-			},
 		}
 		shootState = &gardencorev1beta1.ShootState{
 			ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +70,7 @@ var _ = Describe("ShootState", func() {
 
 	Describe("#Deploy", func() {
 		It("should deploy an empty ShootState when there is nothing to persist", func() {
-			Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, true)).To(Succeed())
+			Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, true)).To(Succeed())
 			Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 			Expect(shootState.Spec).To(Equal(gardencorev1beta1.ShootStateSpec{}))
 			Expect(shootState.Annotations).To(HaveKeyWithValue("gardener.cloud/timestamp", fakeClock.Now().UTC().Format(time.RFC3339)))
@@ -95,27 +93,27 @@ var _ = Describe("ShootState", func() {
 				Expect(fakeGardenClient.Create(ctx, shootState)).To(Succeed())
 
 				By("Creating Gardener data")
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret1", seedNamespace, true, true))).To(Succeed())
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret2", seedNamespace, false, true))).To(Succeed())
-				Expect(fakeSeedClient.Create(ctx, newSecret("secret3", seedNamespace, true, false))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret1", controlPlaneNamespace, true, true))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret2", controlPlaneNamespace, false, true))).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, newSecret("secret3", controlPlaneNamespace, true, false))).To(Succeed())
 
 				By("Creating extensions data")
-				createExtensionObject(ctx, fakeSeedClient, "backupentry", seedNamespace, &extensionsv1alpha1.BackupEntry{}, &runtime.RawExtension{Raw: []byte(`{"name":"backupentry"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "containerruntime", seedNamespace, &extensionsv1alpha1.ContainerRuntime{}, &runtime.RawExtension{Raw: []byte(`{"name":"containerruntime"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "controlplane", seedNamespace, &extensionsv1alpha1.ControlPlane{Spec: extensionsv1alpha1.ControlPlaneSpec{}}, &runtime.RawExtension{Raw: []byte(`{"name":"controlplane"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "dnsrecord", seedNamespace, &extensionsv1alpha1.DNSRecord{}, &runtime.RawExtension{Raw: []byte(`{"name":"dnsrecord"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "extension", seedNamespace, &extensionsv1alpha1.Extension{}, &runtime.RawExtension{Raw: []byte(`{"name":"extension"}`)}, gardencorev1beta1.NamedResourceReference{Name: "resource-ref1", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "ConfigMap", APIVersion: "v1", Name: "extension-configmap"}})
-				Expect(fakeSeedClient.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "extension-configmap", Namespace: seedNamespace}, Data: map[string]string{"some-data": "for-extension"}})).To(Succeed())
-				createExtensionObject(ctx, fakeSeedClient, "infrastructure", seedNamespace, &extensionsv1alpha1.Infrastructure{}, &runtime.RawExtension{Raw: []byte(`{"name":"infrastructure"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "network", seedNamespace, &extensionsv1alpha1.Network{}, &runtime.RawExtension{Raw: []byte(`{"name":"network"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "osc", seedNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, &runtime.RawExtension{Raw: []byte(`{"name":"osc"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "selfhostedshootexposure", seedNamespace, &extensionsv1alpha1.SelfHostedShootExposure{}, &runtime.RawExtension{Raw: []byte(`{"name":"selfhostedshootexposure"}`)})
-				createExtensionObject(ctx, fakeSeedClient, "worker", seedNamespace, &extensionsv1alpha1.Worker{}, &runtime.RawExtension{Raw: []byte(`{"name":"worker"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "backupentry", controlPlaneNamespace, &extensionsv1alpha1.BackupEntry{}, &runtime.RawExtension{Raw: []byte(`{"name":"backupentry"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "containerruntime", controlPlaneNamespace, &extensionsv1alpha1.ContainerRuntime{}, &runtime.RawExtension{Raw: []byte(`{"name":"containerruntime"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "controlplane", controlPlaneNamespace, &extensionsv1alpha1.ControlPlane{Spec: extensionsv1alpha1.ControlPlaneSpec{}}, &runtime.RawExtension{Raw: []byte(`{"name":"controlplane"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "dnsrecord", controlPlaneNamespace, &extensionsv1alpha1.DNSRecord{}, &runtime.RawExtension{Raw: []byte(`{"name":"dnsrecord"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "extension", controlPlaneNamespace, &extensionsv1alpha1.Extension{}, &runtime.RawExtension{Raw: []byte(`{"name":"extension"}`)}, gardencorev1beta1.NamedResourceReference{Name: "resource-ref1", ResourceRef: autoscalingv1.CrossVersionObjectReference{Kind: "ConfigMap", APIVersion: "v1", Name: "extension-configmap"}})
+				Expect(fakeSeedClient.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "extension-configmap", Namespace: controlPlaneNamespace}, Data: map[string]string{"some-data": "for-extension"}})).To(Succeed())
+				createExtensionObject(ctx, fakeSeedClient, "infrastructure", controlPlaneNamespace, &extensionsv1alpha1.Infrastructure{}, &runtime.RawExtension{Raw: []byte(`{"name":"infrastructure"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "network", controlPlaneNamespace, &extensionsv1alpha1.Network{}, &runtime.RawExtension{Raw: []byte(`{"name":"network"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "osc", controlPlaneNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, &runtime.RawExtension{Raw: []byte(`{"name":"osc"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "selfhostedshootexposure", controlPlaneNamespace, &extensionsv1alpha1.SelfHostedShootExposure{}, &runtime.RawExtension{Raw: []byte(`{"name":"selfhostedshootexposure"}`)})
+				createExtensionObject(ctx, fakeSeedClient, "worker", controlPlaneNamespace, &extensionsv1alpha1.Worker{}, &runtime.RawExtension{Raw: []byte(`{"name":"worker"}`)})
 				// this extension object has no state, hence it should not be persisted in the ShootState
-				createExtensionObject(ctx, fakeSeedClient, "osc2", seedNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, nil)
+				createExtensionObject(ctx, fakeSeedClient, "osc2", controlPlaneNamespace, &extensionsv1alpha1.OperatingSystemConfig{}, nil)
 
 				By("Creating machine data")
-				cleanupMachineObjectsFunc = createMachineObjects(ctx, fakeSeedClient, seedNamespace)
+				cleanupMachineObjectsFunc = createMachineObjects(ctx, fakeSeedClient, controlPlaneNamespace)
 
 				expectedSpec = gardencorev1beta1.ShootStateSpec{
 					Gardener: []gardencorev1beta1.GardenerResourceData{
@@ -210,16 +208,16 @@ var _ = Describe("ShootState", func() {
 			})
 
 			It("should compute the expected spec for both gardener and extensions data and overwrite the spec", func() {
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, true)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, true)).To(Succeed())
 				Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 				Expect(shootState.Spec).To(Equal(expectedSpec))
 			})
 
 			It("should compute expected spec for both gardener and extension data and overwrite the spec with no longer existing machine resources", func() {
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, true)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, true)).To(Succeed())
 
 				cleanupMachineObjectsFunc(ctx)
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, true)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, true)).To(Succeed())
 				Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 
 				gardenerResourceData := v1beta1helper.GardenerResourceDataList(shootState.Spec.Gardener)
@@ -230,7 +228,7 @@ var _ = Describe("ShootState", func() {
 			})
 
 			It("should compute the expected spec for both gardener and extensions data and keep existing data in the spec", func() {
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, false)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, false)).To(Succeed())
 				Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 
 				expectedSpec.Gardener = append(existingGardenerData, expectedSpec.Gardener...)
@@ -240,10 +238,10 @@ var _ = Describe("ShootState", func() {
 			})
 
 			It("should compute the expected spec for both gardener and extension data and keep existing data in the spec if machine resources were deleted", func() {
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, false)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, false)).To(Succeed())
 
 				cleanupMachineObjectsFunc(ctx)
-				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, false)).To(Succeed())
+				Expect(Deploy(ctx, fakeClock, fakeGardenClient, fakeSeedClient, shoot, controlPlaneNamespace, false)).To(Succeed())
 				Expect(fakeGardenClient.Get(ctx, client.ObjectKeyFromObject(shootState), shootState)).To(Succeed())
 
 				expectedSpec.Gardener = append(existingGardenerData, expectedSpec.Gardener...)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/13432, the `shoot-state` controller of gardenlet creates a ShootState for a self-hosted Shoot. However, the created ShootState is empty:
```
% k -n garden get shootstate
NAME   GARDENER DATA   EXTENSION STATES   AGE
root   0               0                  3m46s
```

This is because the shootstate component uses the Shoot `.status.technicalID` as a control plane namespace for collecting the resources which need to be preserved in the ShootState.

However, for a self-hosted Shoot the control plane namespace is not Shoot `.status.technicalID` but `kube-system`.

Before the fix:
```
% k -n garden get shootstate
NAME   GARDENER DATA   EXTENSION STATES   AGE
root   0               0                  3m46s
```

After the fix:
```
% k -n garden get shootstate root
NAME   GARDENER DATA   EXTENSION STATES   AGE
root   14              0                  29s
```

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/13432
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
Steps to reproduce the issue and confirm the fix:
```shell
make kind-single-node-up
export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig
make gardenadm-up

# Create control plane Node
kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- gardenadm init -d /gardenadm/resources --use-bootstrap-etcd

# Join a worker Node
JOIN_COMMAND_1=$(kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- gardenadm token create --print-join-command | tr -d '"')
kubectl -n gardenadm-unmanaged-infra exec -it machine-1 -- $(echo $JOIN_COMMAND_1)

make gardenadm-up SCENARIO=connect

make gardenadm
CONNECT_COMMAND=$(KUBECONFIG="./dev-setup/kubeconfigs/virtual-garden/kubeconfig" ./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root | tr -d '"')
kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- $(echo $CONNECT_COMMAND)

# Patch the Shoot status to be Succeed. This is a prerequisite for the shoot-state controller.
KUBECONFIG="./dev-setup/kubeconfigs/virtual-garden/kubeconfig" kubectl -n garden patch shoot root --subresource status --type=merge --patch='{"status":{"lastOperation":{"state": "Succeeded"}}}'

# Restart gardenlet to trigger a new ShootState creation
kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- kubectl --kubeconfig=/etc/kubernetes/admin.conf delete po -l role=gardenlet
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing the `shootstate-controller` of gardenlet to populate all required states to the ShootState for a self-hosted Shoot is now fixed.
```
