### PR TITLE
Update etcd-druid version to v0.36.1

### DIFF
--- a/dev-setup/gardenlet/base/gardenlet.yaml
+++ b/dev-setup/gardenlet/base/gardenlet.yaml
@@ -22,6 +22,9 @@ spec:
         respectSyncPeriodOverwrite: true
       shootState:
         concurrentSyncs: 0 # we don't need the shootstate controller locally, and enabling it would even distort the results of CPM e2e tests
+    etcdConfig:
+      featureGates:
+        UpgradeEtcdVersion: false
     logging:
       enabled: true
       vali:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -179,7 +179,7 @@ etcdConfig:
     metricsScrapeWaitDuration: "60s"
   deltaSnapshotRetentionPeriod: 48h
 # featureGates:
-#   UseEtcdWrapper: true
+#   UpgradeEtcdVersion: false
 # backupLeaderElection:
 #   reelectionPeriod: 5s
 #   etcdConnectionTimeout: 5s

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -43,6 +43,9 @@ config:
     VictoriaLogsBackend: true
     VPNBondingModeRoundRobin: true
     PrometheusHealthChecks: true
+  etcdConfig:
+    featureGates:
+      UpgradeEtcdVersion: false
   logging:
     enabled: true
     vali:

--- a/example/operator/10-componentconfig.yaml
+++ b/example/operator/10-componentconfig.yaml
@@ -47,7 +47,7 @@ controllers:
         metricsScrapeWaitDuration: "60s"
     # deltaSnapshotRetentionPeriod: 48h
     # featureGates:
-    #   UseEtcdWrapper: true
+    #   UpgradeEtcdVersion: false
     # backupLeaderElection:
     #   reelectionPeriod: 5s
     #   etcdConnectionTimeout: 5s

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fluent/fluent-operator/v3 v3.7.0
 	github.com/gardener/cert-management v0.19.0
 	github.com/gardener/dependency-watchdog v1.7.0
-	github.com/gardener/etcd-druid/api v0.35.1
+	github.com/gardener/etcd-druid/api v0.36.1
 	github.com/gardener/gardener/pkg/apis v0.0.0
 	github.com/gardener/machine-controller-manager v0.61.2
 	github.com/gardener/terminal-controller-manager v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/gardener/cert-management v0.19.0 h1:BNumdw748Pg9798NzxHmmpKuXFRLHSPuv
 github.com/gardener/cert-management v0.19.0/go.mod h1:u5OKwiDyUdCuW9vhDV92ozCVkynXUBrYCMHr4rVNiCY=
 github.com/gardener/dependency-watchdog v1.7.0 h1:oTAmbmXbPOT/LnxDZ0A0DO0W8GDYe9oykF+I6lCLKpI=
 github.com/gardener/dependency-watchdog v1.7.0/go.mod h1:3nQlFmW17dWL+90KK3PPa52XSnpjnk5mOaC2Pev+VNo=
-github.com/gardener/etcd-druid/api v0.35.1 h1:hkd+5iV4xb7glnlo8rCqeXFIy9KmXF958x4une4cs6E=
-github.com/gardener/etcd-druid/api v0.35.1/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
+github.com/gardener/etcd-druid/api v0.36.1 h1:vO4WISqEW7T/s9vgrbVkfdyEfvQ9fiZgQOJQBmiM8hk=
+github.com/gardener/etcd-druid/api v0.36.1/go.mod h1:RwZzKp8K415AS0zg8VoODjBxYepCAUYyLgXnZc1bmbo=
 github.com/gardener/machine-controller-manager v0.61.2 h1:kG8DgmOqqlljWqxa4x0ER4+L5zg1lxNd1dQXT9gKbvA=
 github.com/gardener/machine-controller-manager v0.61.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/gardener/terminal-controller-manager v0.35.0 h1:LccE3ZT8KCZtdfMtyVtHuFIXwFnnBpIKE68aoDpgJss=

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -74,7 +74,7 @@ images:
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
-    tag: "v0.35.1"
+    tag: "v0.36.1"
   - name: etcd
     sourceRepository: github.com/etcd-io/etcd
     repository: quay.io/coreos/etcd


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR bumps the etcd-druid version to v0.36.1.
Since the new version of etcd-druid brings with it the upgrade of the etcd version from 3.4.34 to 3.5.27 via a feature gate, this PR adds the default value of the feature-gate to False in the examples..


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/etcd-druid/issues/445

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependencies have been updated:
- `gardener/etcd-druid` from `v0.35.1` to `v0.36.1`. [Release Notes](https://github.com/gardener/etcd-druid/releases/tag/v0.36.1)
- `github.com/gardener/etcd-druid/api` from `v0.35.1` to `v0.36.1`. 
```
