### PR TITLE
[GRM] Improve bootstrap secret cleanup

### DIFF
--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -402,7 +402,7 @@ func createOldCASecrets(c client.Client, name string, caConfigs []SecretConfigWi
 	for _, caConfig := range caConfigs {
 		secretData, err := caConfig.Config.Generate()
 		Expect(err).NotTo(HaveOccurred(), caConfig.Config.GetName())
-		secretMeta, err := secretsmanager.ObjectMeta(name, testIdentity, caConfig.Config, false, "", nil, nil, nil)
+		secretMeta, err := secretsmanager.ObjectMeta(name, nil, testIdentity, caConfig.Config, false, "", nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred(), caConfig.Config.GetName())
 
 		dataMap := secretData.SecretData()

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/networking/nginxingress"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
@@ -177,10 +178,6 @@ func DeployGardenerResourceManager(
 		if err := waitUntilGardenerResourceManagerBootstrapped(timeoutCtx, c, namespace); err != nil {
 			return err
 		}
-
-		if err := c.Delete(ctx, bootstrapKubeconfigSecret); client.IgnoreNotFound(err) != nil {
-			return err
-		}
 	}
 
 	secrets.BootstrapKubeconfig = nil
@@ -259,7 +256,10 @@ func reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx context.Conte
 			APIServerHost: getAPIServerAddress(),
 			CAData:        caBundleSecret.Data[secretsutils.DataKeyCertificateBundle],
 		}},
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient))
+	},
+		secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient),
+		secretsmanager.WithLabels(map[string]string{references.LabelKeyGarbageCollectable: references.LabelValueGarbageCollectable}),
+	)
 }
 
 func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.Client, namespace string) error {

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -227,13 +227,6 @@ var _ = Describe("ResourceManager", func() {
 							return nil
 						}),
 
-						// delete bootstrap kubeconfig
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, _ ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
-							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
-							return nil
-						}),
-
 						// set secrets and deploy with shoot access token
 						resourceManager.EXPECT().SetSecrets(secrets),
 						resourceManager.EXPECT().Deploy(ctx),
@@ -388,45 +381,6 @@ var _ = Describe("ResourceManager", func() {
 
 						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", namespace, managedResource.Name)))
 					})
-				})
-
-				It("fails because the bootstrap kubeconfig cannot be deleted", func() {
-					gomock.InOrder(
-						// create bootstrap kubeconfig
-						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
-							Expect(s.Data["kubeconfig"]).NotTo(BeNil())
-							return nil
-						}),
-
-						// set secrets and deploy with bootstrap kubeconfig
-						resourceManager.EXPECT().SetSecrets(&secretMatcher{
-							bootstrapKubeconfigName: &bootstrapKubeconfigSecret.Name,
-						}),
-						resourceManager.EXPECT().Deploy(ctx),
-
-						// wait for shoot access secret to be reconciled and managed resource to be healthy
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
-							return nil
-						}),
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource, _ ...client.GetOption) error {
-							obj.Status.ObservedGeneration = obj.Generation
-							obj.Status.Conditions = []gardencorev1beta1.Condition{
-								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionTrue},
-								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
-							}
-							return nil
-						}),
-
-						// delete bootstrap kubeconfig
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, _ ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
-							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
-							return fakeErr
-						}),
-					)
-
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
 				})
 			})
 		})

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -501,13 +501,6 @@ var _ = Describe("ResourceManager", func() {
 							return nil
 						}),
 
-						// delete bootstrap kubeconfig
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, _ ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
-							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
-							return nil
-						}),
-
 						// set secrets and deploy with shoot access token
 						resourceManager.EXPECT().SetSecrets(secrets),
 						resourceManager.EXPECT().Deploy(ctx),
@@ -693,45 +686,6 @@ var _ = Describe("ResourceManager", func() {
 
 						Expect(botanist.DeployGardenerResourceManager(ctx).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", controlPlaneNamespace, managedResource.Name)))
 					})
-				})
-
-				It("fails because the bootstrap kubeconfig cannot be deleted", func() {
-					gomock.InOrder(
-						// create bootstrap kubeconfig
-						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
-							Expect(s.Data["kubeconfig"]).NotTo(BeNil())
-							return nil
-						}),
-
-						// set secrets and deploy with bootstrap kubeconfig
-						resourceManager.EXPECT().SetSecrets(&secretMatcher{
-							bootstrapKubeconfigName: &bootstrapKubeconfigSecret.Name,
-						}),
-						resourceManager.EXPECT().Deploy(ctx),
-
-						// wait for shoot access secret to be reconciled and managed resource to be healthy
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
-							return nil
-						}),
-						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource, _ ...client.GetOption) error {
-							obj.Status.ObservedGeneration = obj.Generation
-							obj.Status.Conditions = []gardencorev1beta1.Condition{
-								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionTrue},
-								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
-							}
-							return nil
-						}),
-
-						// delete bootstrap kubeconfig
-						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, _ ...client.DeleteOption) error {
-							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
-							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
-							return fakeErr
-						}),
-					)
-
-					Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(fakeErr))
 				})
 			})
 		})

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -69,7 +69,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretsutils.ConfigIn
 		return nil, err
 	}
 
-	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, true, "", nil, &options.Persist, nil)
+	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, nil, ManagerIdentity, config, true, "", nil, &options.Persist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -44,6 +44,7 @@ func (m *manager) Generate(ctx context.Context, config secretsutils.ConfigInterf
 
 	objectMeta, err := ObjectMeta(
 		namespace,
+		options.Labels,
 		m.identity,
 		config,
 		options.IgnoreConfigChecksumForCASecretName,
@@ -391,6 +392,8 @@ type GenerateOptions struct {
 	IgnoreConfigChecksumForCASecretName bool
 	// Namespace overwrites the namespace in which the secret should be created.
 	Namespace string
+	// Labels are additional labels that should be added to the secret.
+	Labels map[string]string
 
 	signingCAChecksum *string
 	isBundleSecret    bool
@@ -622,6 +625,14 @@ func isBundleSecret() GenerateOption {
 func Namespace(namespace string) GenerateOption {
 	return func(_ Interface, _ secretsutils.ConfigInterface, options *GenerateOptions) error {
 		options.Namespace = namespace
+		return nil
+	}
+}
+
+// WithLabels returns a function which sets the 'Labels' field.
+func WithLabels(labels map[string]string) GenerateOption {
+	return func(_ Interface, _ secretsutils.ConfigInterface, options *GenerateOptions) error {
+		options.Labels = labels
 		return nil
 	}
 }

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -103,6 +103,29 @@ var _ = Describe("Generate", func() {
 				})
 			})
 
+			It("should add custom labels to the generated secret", func() {
+				customLabels := map[string]string{
+					"app":         "test-app",
+					"environment": "test",
+					"custom-key":  "custom-value",
+				}
+
+				By("Generate new secret with custom labels")
+				secret, err := m.Generate(ctx, config, WithLabels(customLabels))
+				Expect(err).NotTo(HaveOccurred())
+				expectSecretWasCreated(ctx, fakeClient, secret)
+
+				By("Verify custom labels are present")
+				for key, value := range customLabels {
+					Expect(secret.Labels).To(HaveKeyWithValue(key, value))
+				}
+
+				By("Verify standard labels are still present")
+				Expect(secret.Labels).To(HaveKeyWithValue(LabelKeyName, name))
+				Expect(secret.Labels).To(HaveKeyWithValue(LabelKeyManagedBy, LabelValueSecretsManager))
+				Expect(secret.Labels).To(HaveKeyWithValue(LabelKeyManagerIdentity, identity))
+			})
+
 			It("should maintain the lifetime labels (w/o validity)", func() {
 				By("Generate new secret")
 				secret, err := m.Generate(ctx, config)

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -347,6 +347,7 @@ func computeSecretInfo(obj *corev1.Secret) (secretInfo, error) {
 // ObjectMeta returns the object meta based on the given settings.
 func ObjectMeta(
 	namespace string,
+	labels map[string]string,
 	managerIdentity string,
 	config secretsutils.ConfigInterface,
 	ignoreConfigChecksumForCASecretName bool,
@@ -363,7 +364,7 @@ func ObjectMeta(
 		return metav1.ObjectMeta{}, err
 	}
 
-	labels := map[string]string{
+	secretLabels := map[string]string{
 		LabelKeyName:                       config.GetName(),
 		LabelKeyManagedBy:                  LabelValueSecretsManager,
 		LabelKeyManagerIdentity:            managerIdentity,
@@ -372,21 +373,29 @@ func ObjectMeta(
 	}
 
 	if signingCAChecksum != nil {
-		labels[LabelKeyChecksumSigningCA] = *signingCAChecksum
+		secretLabels[LabelKeyChecksumSigningCA] = *signingCAChecksum
 	}
 
 	if persist != nil && *persist {
-		labels[LabelKeyPersist] = LabelValueTrue
+		secretLabels[LabelKeyPersist] = LabelValueTrue
 	}
 
 	if bundleFor != nil {
-		labels[LabelKeyBundleFor] = *bundleFor
+		secretLabels[LabelKeyBundleFor] = *bundleFor
+	}
+
+	for k, v := range labels {
+		if _, exists := secretLabels[k]; exists {
+			// don't allow overriding of labels which are set by the secrets manager itself, as they are crucial for the correct functioning of the manager
+			continue
+		}
+		secretLabels[k] = v
 	}
 
 	return metav1.ObjectMeta{
-		Name:      computeSecretName(config, labels, ignoreConfigChecksumForCASecretName),
+		Name:      computeSecretName(config, secretLabels, ignoreConfigChecksumForCASecretName),
 		Namespace: namespace,
-		Labels:    labels,
+		Labels:    secretLabels,
 	}, nil
 }
 

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -342,7 +342,7 @@ var _ = Describe("Manager", func() {
 			func(ignoreChecksum bool, expectedName string, lastRotationInitiationTime string) {
 				config := &secretsutils.CertificateSecretConfig{Name: configName}
 
-				meta, err := ObjectMeta(namespace, "test", config, ignoreChecksum, lastRotationInitiationTime, nil, nil, nil)
+				meta, err := ObjectMeta(namespace, map[string]string{"custom-1": "true", "managed-by": "invalid-manager"}, "test", config, ignoreChecksum, lastRotationInitiationTime, nil, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -354,6 +354,7 @@ var _ = Describe("Manager", func() {
 						"manager-identity":              "test",
 						"checksum-of-config":            "1645436262831067767",
 						"last-rotation-initiation-time": lastRotationInitiationTime,
+						"custom-1":                      "true",
 					},
 				}))
 			},
@@ -371,7 +372,7 @@ var _ = Describe("Manager", func() {
 					SigningCA: &secretsutils.Certificate{},
 				}
 
-				meta, err := ObjectMeta(namespace, "test", config, false, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
+				meta, err := ObjectMeta(namespace, nil, "test", config, false, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
 				Expect(err).NotTo(HaveOccurred())
 
 				labels := map[string]string{

--- a/test/integration/operator/garden/garden/garden_test.go
+++ b/test/integration/operator/garden/garden/garden_test.go
@@ -747,15 +747,6 @@ spec:
 			"shoot-core-gardener-resource-manager",
 		))
 
-		// The secret with the bootstrap certificate should be gone when virtual-garden-gardener-resource-manager was bootstrapped.
-		Eventually(func(g Gomega) []string {
-			secretList := &corev1.SecretList{}
-			g.Expect(testClient.List(ctx, secretList, client.InNamespace(testNamespace.Name))).To(Succeed())
-			return test.ObjectNames(secretList)
-		}).ShouldNot(ContainElement(
-			ContainSubstring("shoot-access-gardener-resource-manager-bootstrap-"),
-		))
-
 		// The garden controller waits for the virtual-garden-gardener-resource-manager Deployment to be healthy, so let's fake this here.
 		By("Patch virtual-garden-gardener-resource-manager deployment to report healthiness")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
When the `gardener-resource-manager` is initiated with a bootstrap process, a dedicated bootstrap secret is created, which is deleted once the token-based kubeconfig is issued and the bootstrap completes. However, if the bootstrap process fails (e.g., due to a blocking webhook in the shoot cluster), each subsequent reconciliation creates a new bootstrap secret. This can result in thousands of unused bootstrap secrets until the process eventually succeeds.

This PR removes the manual cleanup logic for these secrets. Instead, it delegates the [garbage collection](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#garbage-collector-for-immutable-configmapssecrets) of unused bootstrap secrets to the GRM running in the seed or runtime garden, ensuring that obsolete secrets are automatically cleaned up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Unused bootstrap secrets from the `gardener-resource-manager` are cleaned up properly. Earlier, the shoot reconciliation left a considerable amount of unused secrets in the control-plane, if the GRM bootstrap procedure was stuck.
```
