### PR TITLE
[GEP-28] Enable etcd `v3.5.27` (upgrade from `v3.4.34`) in `gardenadm` setup and streamline version resolution in scripts

### DIFF
--- a/hack/resolve-etcd-version-from-etcd-druid.sh
+++ b/hack/resolve-etcd-version-from-etcd-druid.sh
@@ -10,14 +10,13 @@ set -o errexit
 
 # Temp dirs
 WORKDIR=$(mktemp -d)
-ETCD_DRUID_IMAGES_URL="https://raw.githubusercontent.com/gardener/etcd-druid/master/internal/images/images.yaml"
-ETCD_REPO="https://github.com/etcd-io/etcd.git"
-
+ETCD_DRUID_VERSION=$(yq '.images[] | select(.name == "etcd-druid") | .tag' "$1")
+ETCD_DRUID_IMAGES_URL="https://raw.githubusercontent.com/gardener/etcd-druid/${ETCD_DRUID_VERSION}/internal/images/images.yaml"
 echo "Fetching etcd-druid images.yaml..."
 curl -fsSL "$ETCD_DRUID_IMAGES_URL" -o "$WORKDIR/images.yaml"
 
 # Extract etcd-wrapper tag from images.yaml
-WRAPPER_TAG=$(yq '.images[] | select(.name == "etcd-wrapper") | .tag' "$WORKDIR/images.yaml")
+WRAPPER_TAG=$(yq '.images[] | select(.name == "etcd-wrapper-next") | .tag' "$WORKDIR/images.yaml")
 echo "Found etcd-wrapper tag: $WRAPPER_TAG"
 
 echo "Fetching go.mod from etcd-wrapper at tag $WRAPPER_TAG..."
@@ -29,43 +28,6 @@ ETCD_LINE=$(grep 'go.etcd.io/etcd' "$WORKDIR/go.mod" | head -n1)
 ETCD_VERSION=$(echo "$ETCD_LINE" | awk '{print $2}')
 echo "Found etcd version string: $ETCD_VERSION"
 
-# Check if it's a real tag (vX.Y.Z) or a pseudo-version
-# TODO: This if-else handling can be removed after https://github.com/gardener/etcd-druid/issues/445 is resolved (with
-#  v3.5, the etcd-io/etcd repo supports proper usage of the direct tag, i.e., no commit hash is needed anymore).
-if [[ "$ETCD_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Resolved etcd tag directly: $ETCD_VERSION"
-else
-  # Extract commit hash from pseudo-version
-  COMMIT_HASH=$(echo "$ETCD_VERSION" | sed -E 's/.*-([a-f0-9]{12})$/\1/')
-
-  if [ -z "$COMMIT_HASH" ]; then
-    echo "Could not parse commit hash from version string: $ETCD_VERSION"
-    exit 1
-  fi
-
-  echo "Extracted commit hash: $COMMIT_HASH"
-
-  echo "Fetching etcd tags and commit info..."
-  git clone -q --filter=blob:none --no-checkout "$ETCD_REPO" "$WORKDIR/etcd"
-  pushd "$WORKDIR/etcd" > /dev/null
-
-  # Find tag that contains the commit
-  FULL_COMMIT=$(git rev-parse "$COMMIT_HASH") || {
-    echo "Commit $COMMIT_HASH not found in etcd repo"
-    exit 1
-  }
-
-  ETCD_TAG=$(git tag --contains "$FULL_COMMIT" | grep '^v' | sort -V | head -n 1)
-  popd > /dev/null
-fi
-
-if [ -n "$ETCD_TAG" ]; then
-  echo "Resolved etcd tag: $ETCD_TAG"
-else
-  echo "No tag found containing commit $FULL_COMMIT"
-  exit 1
-fi
-
 # Update images.yaml with the resolved etcd tag
-echo "Updating $1 with etcd $ETCD_TAG tag"
-yq -i "(.images[] | select(.name == \"etcd\") ).tag = \"$ETCD_TAG\"" "$1"
+echo "Updating $1 with etcd $ETCD_VERSION tag"
+yq -i "(.images[] | select(.name == \"etcd\") ).tag = \"$ETCD_VERSION\"" "$1"

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -77,8 +77,8 @@ images:
     tag: "v0.35.1"
   - name: etcd
     sourceRepository: github.com/etcd-io/etcd
-    repository: quay.io/coreos/etcd
-    tag: "v3.4.34"
+    repository: gcr.io/etcd-development/etcd
+    tag: "v3.5.27"
   - name: dependency-watchdog
     sourceRepository: github.com/gardener/dependency-watchdog
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog

--- a/pkg/gardenadm/botanist/etcd.go
+++ b/pkg/gardenadm/botanist/etcd.go
@@ -47,6 +47,7 @@ func (b *GardenadmBotanist) DeployEtcdDruid(ctx context.Context) error {
 
 	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
 	gardenletconfigv1alpha1.SetObjectDefaults_GardenletConfiguration(gardenletConfig)
+	gardenletConfig.ETCDConfig.FeatureGates = map[string]bool{"UpgradeEtcdVersion": true}
 
 	deployer, err := sharedcomponent.NewEtcdDruid(
 		b.SeedClientSet.Client(),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind technical-debt bug cleanup

**What this PR does / why we need it**:
As the etcd image used before is not multi-arch, on Apple Silicon (`arm64`) the `gardenadm` setup would not work without Rosetta emulation enabled.
After https://github.com/gardener/gardener/pull/14341 is merged, we are able to update the version of the bootstrap etcd, which comes with multi-arch images. Also, the script used for updating the image tag was cleaned up.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @rfranzke @ialidzhikov 

Switched the etcd image registry because the upstream etcd releases mention it as their primary image registry, e.g., [etcd-io/etcd@v3.6.8 (release)](https://github.com/etcd-io/etcd/releases/tag/v3.6.8).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
`gardenadm` bootstrap etcd version is updated from `v3.4.34` to `v3.5.27`.
```
