### PR TITLE
[GEP-28] gardenadm: persist machine state across pod restarts

### DIFF
--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -18,13 +18,17 @@ spec:
         cni.projectcalico.org/ipv4pools: '["gardenadm-unmanaged-infra"]'
     spec:
       initContainers:
+      # The main container mounts /etc/systemd/system from the persistent volume so that systemd
+      # unit files written by gardenadm survive pod restarts. On the very first boot the volume
+      # subPath is empty, so this init container seeds it from the image's default unit files.
+      # On subsequent boots the directory is already populated and the copy is skipped, preserving
+      # any changes made at runtime.
       - name: init-systemd-system
         image: local-skaffold/gardener-extension-provider-local-node
         command:
         - sh
         - -c
         - |
-          # Only seed on first boot (empty subPath); subsequent boots preserve runtime state.
           if [ -z "$(ls -A /mnt/systemd-system)" ]; then
             cp -a /etc/systemd/system/. /mnt/systemd-system/
           fi
@@ -62,20 +66,8 @@ spec:
           mountPath: /etc/systemd/system
           subPath: systemd-system
         - name: machine-state
-          mountPath: /var/lib/etcd-main
-          subPath: etcd-main
-        - name: machine-state
-          mountPath: /var/lib/etcd-events
-          subPath: etcd-events
-        - name: machine-state
-          mountPath: /var/lib/kube-apiserver
-          subPath: kube-apiserver
-        - name: machine-state
-          mountPath: /var/lib/kube-controller-manager
-          subPath: kube-controller-manager
-        - name: machine-state
-          mountPath: /var/lib/kube-scheduler
-          subPath: kube-scheduler
+          mountPath: /var/lib/static-pods
+          subPath: static-pods
         - name: machine-state
           mountPath: /var/lib/kubelet
           subPath: kubelet

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -17,6 +17,21 @@ spec:
       annotations:
         cni.projectcalico.org/ipv4pools: '["gardenadm-unmanaged-infra"]'
     spec:
+      initContainers:
+      - name: init-systemd-system
+        image: local-skaffold/gardener-extension-provider-local-node
+        command:
+        - sh
+        - -c
+        - |
+          # Only seed on first boot (empty subPath); subsequent boots preserve runtime state.
+          if [ -z "$(ls -A /mnt/systemd-system)" ]; then
+            cp -a /etc/systemd/system/. /mnt/systemd-system/
+          fi
+        volumeMounts:
+        - name: machine-state
+          mountPath: /mnt/systemd-system
+          subPath: systemd-system
       containers:
       - name: node
         image: local-skaffold/gardener-extension-provider-local-node
@@ -37,8 +52,45 @@ spec:
           readOnly: true
         - name: etcd-backup
           mountPath: /etc/gardener/local-backupbuckets
-        - name: gardenadm
+        - name: machine-state
           mountPath: /gardenadm
+          subPath: gardenadm
+        - name: machine-state
+          mountPath: /etc/kubernetes
+          subPath: kubernetes
+        - name: machine-state
+          mountPath: /etc/systemd/system
+          subPath: systemd-system
+        - name: machine-state
+          mountPath: /var/lib/etcd-main
+          subPath: etcd-main
+        - name: machine-state
+          mountPath: /var/lib/etcd-events
+          subPath: etcd-events
+        - name: machine-state
+          mountPath: /var/lib/kube-apiserver
+          subPath: kube-apiserver
+        - name: machine-state
+          mountPath: /var/lib/kube-controller-manager
+          subPath: kube-controller-manager
+        - name: machine-state
+          mountPath: /var/lib/kube-scheduler
+          subPath: kube-scheduler
+        - name: machine-state
+          mountPath: /var/lib/kubelet
+          subPath: kubelet
+        - name: machine-state
+          mountPath: /var/lib/gardenadm
+          subPath: gardenadm-state
+        - name: machine-state
+          mountPath: /var/lib/gardener-node-agent
+          subPath: gardener-node-agent
+        - name: machine-state
+          mountPath: /opt/bin
+          subPath: opt-bin
+        - name: machine-state
+          mountPath: /root
+          subPath: root-home
         - name: bashrc
           mountPath: /root/.bashrc
           subPath: bashrc
@@ -65,12 +117,12 @@ spec:
           name: machine-bashrc
   volumeClaimTemplates:
   - metadata:
-      name: gardenadm
+      name: machine-state
     spec:
       accessModes: ["ReadWriteOnce"]
       resources:
         requests:
-          storage: 1Gi
+          storage: 2Gi
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -81,5 +133,6 @@ metadata:
 data:
   bashrc: |
     export KUBECONFIG=/etc/kubernetes/admin.conf
+    export HISTFILE=/root/.bash_history
     alias k=kubectl
     alias kg='kubectl -n garden'

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -32,10 +32,16 @@ spec:
           if [ -z "$(ls -A /mnt/systemd-system)" ]; then
             cp -a /etc/systemd/system/. /mnt/systemd-system/
           fi
+          if [ -z "$(ls -A /mnt/containerd)" ]; then
+            cp -a /etc/containerd/. /mnt/containerd/
+          fi
         volumeMounts:
         - name: machine-state
           mountPath: /mnt/systemd-system
           subPath: systemd-system
+        - name: machine-state
+          mountPath: /mnt/containerd
+          subPath: containerd
       containers:
       - name: node
         image: local-skaffold/gardener-extension-provider-local-node
@@ -59,6 +65,12 @@ spec:
         - name: machine-state
           mountPath: /gardenadm
           subPath: gardenadm
+        - name: machine-state
+          mountPath: /etc/containerd
+          subPath: containerd
+        - name: machine-state
+          mountPath: /etc/cni/net.d
+          subPath: cni-net-d
         - name: machine-state
           mountPath: /etc/kubernetes
           subPath: kubernetes

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -18,11 +18,11 @@ spec:
         cni.projectcalico.org/ipv4pools: '["gardenadm-unmanaged-infra"]'
     spec:
       initContainers:
-      # The main container mounts /etc/systemd/system and /etc/containerd from the persistent volume so that state written by gardenadm survives pod restarts.
+      # The main container mounts several directories from the persistent volume so that state written by gardenadm survives pod restarts.
       # On the very first boot the volume subPaths are empty, so this init container seeds them from the image's default files.
-      # For /etc/containerd, it also patches config_path so containerd finds the registry mirror configuration in /etc/containerd/certs.d from the start.
       # On subsequent boots the directories are already populated and the copy is skipped, preserving any changes made at runtime.
-      - name: init-systemd-system
+      # For /etc/containerd, it also patches config_path so containerd finds the registry mirror configuration in /etc/containerd/certs.d from the very first start.
+      - name: init-machine-state
         image: local-skaffold/gardener-extension-provider-local-node
         command:
         - sh
@@ -66,9 +66,8 @@ spec:
           readOnly: true
         - name: etcd-backup
           mountPath: /etc/gardener/local-backupbuckets
-        - name: machine-state
+        - name: gardenadm
           mountPath: /gardenadm
-          subPath: gardenadm
         - name: machine-state
           mountPath: /etc/containerd
           subPath: containerd
@@ -124,6 +123,13 @@ spec:
         configMap:
           name: machine-bashrc
   volumeClaimTemplates:
+  - metadata:
+      name: gardenadm
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
   - metadata:
       name: machine-state
     spec:

--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -18,11 +18,10 @@ spec:
         cni.projectcalico.org/ipv4pools: '["gardenadm-unmanaged-infra"]'
     spec:
       initContainers:
-      # The main container mounts /etc/systemd/system from the persistent volume so that systemd
-      # unit files written by gardenadm survive pod restarts. On the very first boot the volume
-      # subPath is empty, so this init container seeds it from the image's default unit files.
-      # On subsequent boots the directory is already populated and the copy is skipped, preserving
-      # any changes made at runtime.
+      # The main container mounts /etc/systemd/system and /etc/containerd from the persistent volume so that state written by gardenadm survives pod restarts.
+      # On the very first boot the volume subPaths are empty, so this init container seeds them from the image's default files.
+      # For /etc/containerd, it also patches config_path so containerd finds the registry mirror configuration in /etc/containerd/certs.d from the start.
+      # On subsequent boots the directories are already populated and the copy is skipped, preserving any changes made at runtime.
       - name: init-systemd-system
         image: local-skaffold/gardener-extension-provider-local-node
         command:
@@ -34,6 +33,11 @@ spec:
           fi
           if [ -z "$(ls -A /mnt/containerd)" ]; then
             cp -a /etc/containerd/. /mnt/containerd/
+            # Ensure containerd finds registry mirror configs in /etc/containerd/certs.d.
+            # The base image ships without config_path, so we inject it here.
+            if ! grep -q 'config_path' /mnt/containerd/config.toml; then
+              sed -i '/^\[plugins\."io\.containerd\.grpc\.v1\.cri"\.containerd\]$/a\  config_path = "/etc/containerd/certs.d"' /mnt/containerd/config.toml
+            fi
           fi
         volumeMounts:
         - name: machine-state

--- a/pkg/gardenadm/staticpod/translator.go
+++ b/pkg/gardenadm/staticpod/translator.go
@@ -195,5 +195,5 @@ func StatefulSetVolumeClaimTemplateHostPath(volumeClaimTemplateName string) stri
 
 // HostPath returns the host path for the given pod name and volume name.
 func HostPath(podName, volumeName string) string {
-	return filepath.Join(string(filepath.Separator), "var", "lib", podName, volumeName)
+	return filepath.Join(string(filepath.Separator), "var", "lib", "static-pods", podName, volumeName)
 }

--- a/pkg/gardenadm/staticpod/translator_test.go
+++ b/pkg/gardenadm/staticpod/translator_test.go
@@ -261,44 +261,44 @@ spec:
     fsGroup: 0
   volumes:
   - hostPath:
-      path: /var/lib/foo/v1
+      path: /var/lib/static-pods/foo/v1
     name: v1
   - hostPath:
-      path: /var/lib/foo/v2
+      path: /var/lib/static-pods/foo/v2
     name: v2
   - hostPath:
-      path: /var/lib/foo/v3
+      path: /var/lib/static-pods/foo/v3
     name: v3
 status: {}
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[0].Name + "/cm1file1.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[0].Name + "/cm1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[0].Name + "/cm1file2.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[0].Name + "/cm1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file2.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[1].Name + "/secret1file1.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[1].Name + "/secret1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file1.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[1].Name + "/secret1file2.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[1].Name + "/secret1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file2.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/cm2file1.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/cm2file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap2.Data["cm2file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/cm2file2.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/cm2file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
 clusters:
@@ -309,7 +309,7 @@ kind: Config
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/mystery.txt",
+						Path:        "/var/lib/static-pods/" + deployment.Name + "/" + deployment.Spec.Template.Spec.Volumes[2].Name + "/mystery.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret2.Data["secret2file2.txt"])}},
 					},
@@ -564,13 +564,13 @@ spec:
     fsGroup: 0
   volumes:
   - hostPath:
-      path: /var/lib/foo/v1
+      path: /var/lib/static-pods/foo/v1
     name: v1
   - hostPath:
-      path: /var/lib/foo/v2
+      path: /var/lib/static-pods/foo/v2
     name: v2
   - hostPath:
-      path: /var/lib/foo/v3
+      path: /var/lib/static-pods/foo/v3
     name: v3
   - hostPath:
       path: /var/lib/pvc1/data
@@ -582,32 +582,32 @@ status: {}
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file1.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file2.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[0].Name + "/cm1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file2.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file1.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file1.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file2.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[1].Name + "/secret1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file2.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file1.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap2.Data["cm2file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file2.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/cm2file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
 clusters:
@@ -618,7 +618,7 @@ kind: Config
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/mystery.txt",
+						Path:        "/var/lib/static-pods/" + statefulSet.Name + "/" + statefulSet.Spec.Template.Spec.Volumes[2].Name + "/mystery.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret2.Data["secret2file2.txt"])}},
 					},
@@ -842,44 +842,44 @@ spec:
   priorityClassName: system-node-critical
   volumes:
   - hostPath:
-      path: /var/lib/foo/v1
+      path: /var/lib/static-pods/foo/v1
     name: v1
   - hostPath:
-      path: /var/lib/foo/v2
+      path: /var/lib/static-pods/foo/v2
     name: v2
   - hostPath:
-      path: /var/lib/foo/v3
+      path: /var/lib/static-pods/foo/v3
     name: v3
 status: {}
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[0].Name + "/cm1file1.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[0].Name + "/cm1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[0].Name + "/cm1file2.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[0].Name + "/cm1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap1.Data["cm1file2.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[1].Name + "/secret1file1.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[1].Name + "/secret1file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file1.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[1].Name + "/secret1file2.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[1].Name + "/secret1file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret1.Data["secret1file2.txt"])}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/cm2file1.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/cm2file1.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(configMap2.Data["cm2file1.txt"]))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/cm2file2.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/cm2file2.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content: extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64([]byte(`apiVersion: v1
 clusters:
@@ -890,7 +890,7 @@ kind: Config
 `))}},
 					},
 					extensionsv1alpha1.File{
-						Path:        "/var/lib/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/mystery.txt",
+						Path:        "/var/lib/static-pods/" + pod.Name + "/" + pod.Spec.Volumes[2].Name + "/mystery.txt",
 						Permissions: ptr.To[uint32](0640),
 						Content:     extensionsv1alpha1.FileContent{Inline: &extensionsv1alpha1.FileContentInline{Encoding: "b64", Data: utils.EncodeBase64(secret2.Data["secret2file2.txt"])}},
 					},
@@ -907,7 +907,7 @@ kind: Config
 
 	Describe("#HostPath", func() {
 		It("should return the expected path", func() {
-			Expect(HostPath("my-pod", "my-volume")).To(Equal("/var/lib/my-pod/my-volume"))
+			Expect(HostPath("my-pod", "my-volume")).To(Equal("/var/lib/static-pods/my-pod/my-volume"))
 		})
 	})
 

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -53,10 +53,15 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 		statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: namespace}}
 		Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
 
-		By("Deleting machine PVCs to ensure clean state")
+		By("Deleting machine state PVCs to ensure clean state")
 		pvcList := &corev1.PersistentVolumeClaimList{}
 		Expect(RuntimeClient.Client().List(ctx, pvcList, client.InNamespace(namespace), client.MatchingLabels{"app": statefulSetName})).To(Succeed())
 		for _, pvc := range pvcList.Items {
+			// Only delete machine-state PVCs (shoot cluster state). The gardenadm PVCs hold the
+			// gardenadm binary and imagevectors populated by skaffold and must not be wiped.
+			if !strings.HasPrefix(pvc.Name, "machine-state-") {
+				continue
+			}
 			Expect(client.IgnoreNotFound(RuntimeClient.Client().Delete(ctx, &pvc))).To(Succeed())
 		}
 

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -53,6 +53,13 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 		statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: namespace}}
 		Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
 
+		By("Deleting machine PVCs to ensure clean state")
+		pvcList := &corev1.PersistentVolumeClaimList{}
+		Expect(RuntimeClient.Client().List(ctx, pvcList, client.InNamespace(namespace), client.MatchingLabels{"app": statefulSetName})).To(Succeed())
+		for _, pvc := range pvcList.Items {
+			Expect(client.IgnoreNotFound(RuntimeClient.Client().Delete(ctx, &pvc))).To(Succeed())
+		}
+
 		patch := client.MergeFrom(statefulSet.DeepCopy())
 		metav1.SetMetaDataAnnotation(&statefulSet.Spec.Template.ObjectMeta, "test-run-id", testRunID)
 		Expect(RuntimeClient.Client().Patch(ctx, statefulSet, patch)).To(Succeed())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity ipcei
/kind enhancement

**What this PR does / why we need it**:
Replace the single `/gardenadm` PVC with a unified `machine-state` PVC (2Gi) per machine pod, using subPath mounts to persist all state that must survive a pod restart:

```
- /gardenadm                       - binary and imagevector overrides
- /etc/containerd                  - config.toml (with config_path set) and certs.d registry configs
- /etc/cni/net.d                   - CNI network config (avoids CNI bootstrap deadlock on worker nodes after restart)
- /etc/kubernetes                  - admin.conf and static pod manifests
- /etc/systemd/system              - unit files
- /var/lib/static-pods             - static pod manifests written at runtime
- /var/lib/kubelet                 - PKI, state, checkpoints
- /var/lib/gardenadm               - shoot-uid, config dir
- /var/lib/gardener-node-agent     - credentials, last-applied OSC
- /opt/bin                         - kubelet and gardener-node-agent binaries (extracted from images by GNA, not in base image)
- /root                            - bash history and home dir
```

An init container seeds /etc/systemd/system and /etc/containerd from the image defaults on first boot only (when the subPath is empty).

Bash history is configured via `HISTFILE=/root/.bash_history` pointing into the persisted `/root` subPath.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @rfranzke 

When a machine is to be reset, its pvc and pod need to be deleted. Afterwards, a `make gardenadm-up` is required to build and copy the `/gardenadm` directory contents again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `gardenadm` machine pods have their state persisted in a unified PVC. Existing local `gardenadm` setups need to be recreated. To reset a local machine pod, delete both the pod and its corresponding PVC.
```
