### PR TITLE
docs: Add guidelines for `--webhook-config-owner-namespace`

### DIFF
--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -151,6 +151,10 @@ gardener:
     namespace: <Extension Namespace name in the virtual cluster (format "extension-<extension-name>")>
 ```
 
+> [!NOTE]
+> Extension admission components must set the `--webhook-config-owner-namespace` flag using the injected `gardener.virtualCluster.namespace` value (i.e. `--webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}`).
+> Without this flag, the `ValidatingWebhookConfiguration` owner reference defaults to the `garden` namespace in the runtime cluster instead of the extension's namespace in the virtual cluster. As a result, the webhook configuration is not cleaned up when the extension is uninstalled, which can block operations on resources.
+
 ##### Virtual
 
 The `virtual` part includes the webhook registration ([MutatingWebhookConfiguration`/`Validatingwebhookconfiguration](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)) and RBAC configuration.

--- a/docs/extensions/validation-guidelines-for-extensions.md
+++ b/docs/extensions/validation-guidelines-for-extensions.md
@@ -53,9 +53,6 @@ With https://github.com/gardener/gardener/issues/12582, we want to adapt Gardene
     - ensures no duplicate fields
     - ensures no unknown fields when decoding into typed structs
   - See [example](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/provider-local/controller/worker/actuator.go#L53).
-- Extension admission components deployed via `gardener-operator` should explicitly set the `--webhook-config-owner-namespace` flag using the value injected by the operator into the Helm chart (i.e. `--webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}`).
-  - The `gardener-operator` automatically injects `gardener.virtualCluster.namespace` into the Helm values during deployment of the admission runtime cluster resources.
-  - Without this flag, the `ValidatingWebhookConfiguration` owner reference defaults to the `garden` namespace in the runtime cluster instead of the extension's namespace in the virtual cluster. Therefore, the webhook configuration is not cleaned up when the extension is uninstalled, which can block operations on resources.
 - Webhooks of extension admission components should use `objectSelector` to filter only requests for resources that use the extension.
   - The extension admission components should use the extension-specific labels maintained on the API resources by the [`ExtensionLabels` admission plugin](../concepts/apiserver-admission-plugins.md#extensionlabels).
 - See the [General Guidelines for Gardener core components](../development/validation-guidelines.md#general-guidelines).

--- a/docs/extensions/validation-guidelines-for-extensions.md
+++ b/docs/extensions/validation-guidelines-for-extensions.md
@@ -53,6 +53,9 @@ With https://github.com/gardener/gardener/issues/12582, we want to adapt Gardene
     - ensures no duplicate fields
     - ensures no unknown fields when decoding into typed structs
   - See [example](https://github.com/gardener/gardener/blob/f6fb7e2ca019fdd2a09c0a5da6475bf5d6bd2430/pkg/provider-local/controller/worker/actuator.go#L53).
+- Extension admission components deployed via `gardener-operator` should explicitly set the `--webhook-config-owner-namespace` flag using the value injected by the operator into the Helm chart (i.e. `--webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}`).
+  - The `gardener-operator` automatically injects `gardener.virtualCluster.namespace` into the Helm values during deployment of the admission runtime cluster resources.
+  - Without this flag, the `ValidatingWebhookConfiguration` owner reference defaults to the `garden` namespace in the runtime cluster instead of the extension's namespace in the virtual cluster. Therefore, the webhook configuration is not cleaned up when the extension is uninstalled, which can block operations on resources.
 - Webhooks of extension admission components should use `objectSelector` to filter only requests for resources that use the extension.
   - The extension admission components should use the extension-specific labels maintained on the API resources by the [`ExtensionLabels` admission plugin](../concepts/apiserver-admission-plugins.md#extensionlabels).
 - See the [General Guidelines for Gardener core components](../development/validation-guidelines.md#general-guidelines).


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
When the `--webhook-config-owner-namespace` flag is not explicitly set in the extension admission deployment, the ValidatingWebhookConfiguration owner reference defaults to the garden namespace in the runtime cluster instead of the extension's namespace in the virtual cluster.

**Which issue(s) this PR fixes**:
Part of #14334

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc dependency
Extension admission components deployed via `gardener-operator` should set the `--webhook-config-owner-namespace` flag to prevent `ValidatingWebhookConfiguration` resources from leaking in the virtual garden cluster upon uninstall.
```
