### PR TITLE
[GEP-28] Ensure all system pods run on system component nodes

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -466,7 +466,7 @@ func (g *garden) Start(ctx context.Context) error {
 	}
 
 	if !gardenlet.IsResponsibleForSelfHostedShoot() {
-		isSelfHostedShoot, err := gardenlet.SeedIsSelfHostedShoot(ctx, g.mgr.GetClient())
+		isSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, g.mgr.GetClient())
 		if err != nil {
 			return fmt.Errorf("failed checking if seed cluster is a self-hosted shoot: %w", err)
 		}

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -1194,12 +1194,13 @@ The following tasks are performed by this webhook:
 2. Add `pod.spec.tolerations` as given in the webhook configuration.
 3. Add `pod.spec.tolerations` for any existing nodes matching the node selector given in the webhook configuration. Known taints and tolerations used for [taint based evictions](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#taint-based-evictions) are disregarded.
 
-Gardener enables this webhook for `kube-system` and `kubernetes-dashboard` namespaces in shoot clusters, selecting `Pod`s being labelled with `resources.gardener.cloud/managed-by: gardener`.
+Gardener enables this webhook for `kube-system` and `kubernetes-dashboard` namespaces in shoot clusters, selecting `Pod`s being labeled with `resources.gardener.cloud/managed-by: gardener`.
+For self-hosted shoots, it also enables the webhook for namespaces labeled with `system-components-config.resources.gardener.cloud/consider=true`. This is used for extensions which are system components.
 It adds a configuration, so that `Pod`s will get the `worker.gardener.cloud/system-components: true` node selector (step 1) as well as tolerate any custom taint (step 2) that is added to system component worker nodes (`shoot.spec.provider.workers[].systemComponents.allow: true`).
 In addition, the webhook merges these tolerations with the ones required for at that time available system component `Node`s in the cluster (step 3).
 Both is required to ensure system component `Pod`s can be _scheduled_ or _executed_ during an active shoot reconciliation that is happening due to any modifications to `shoot.spec.provider.workers[].taints`, e.g. `Pod`s must be scheduled while there are still `Node`s not having the updated taint configuration.
 
-> You can opt-out of this behaviour for `Pod`s by labeling them with `system-components-config.resources.gardener.cloud/skip=true`.
+> You can opt-out of this behavior for `Pod`s by labeling them with `system-components-config.resources.gardener.cloud/skip=true`.
 
 #### EndpointSlice Hints
 

--- a/docs/development/component-checklist.md
+++ b/docs/development/component-checklist.md
@@ -49,8 +49,12 @@ This document provides a checklist for them that you can walk through.
 
 7. **Handle shoot system components**
 
-   Shoot system components deployed by `gardener-resource-manager` are labelled with `resource.gardener.cloud/managed-by: gardener`. This makes Gardener adding required label selectors and tolerations so that non-`DaemonSet` managed `Pod`s will exclusively run on selected nodes (for more information, see [System Components Webhook](../concepts/resource-manager.md#system-components-webhook)).
-   `DaemonSet`s on the other hand, should generally tolerate any `NoSchedule` or `NoExecute` taints so that they can run on any `Node`, regardless of user added taints.
+   Shoot system components (e.g., `kube-proxy`, `coredns`, `metrics-server`, etc.) are components that are deployed by `gardenlet` and run in `kube-system` namespace of a Shoot cluster.
+   For self-hosted shoots components deployed by `gardenadm init` and `gardenlet` which are required to run the self-hosted shoot are system components as well.
+
+   Shoot system components deployed via `gardener-resource-manager` are labelled with `resource.gardener.cloud/managed-by: gardener`. This makes Gardener adding required label selectors and tolerations so that non-`DaemonSet` managed `Pod`s will exclusively run on selected nodes (for more information, see [System Components Webhook](../concepts/resource-manager.md#system-components-webhook)).
+   `DaemonSet`s on the other hand, should generally tolerate any `NoSchedule` or `NoExecute` taints so that they can run on any `Node`, regardless of user added taints. 
+   In the self-hosted shoot case the webhook is also enabled in namespaces labeled with `system-components-config.resources.gardener.cloud/consider=true`.
 
 ## Images
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -388,9 +388,18 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), meta.Namespace, fmt.Sprintf("self-hosted shoots must be in the %q namespace", v1beta1constants.GardenNamespace)))
 		}
 
+		controlPlaneWorkersZonesSet := sets.New[string]()
+		for _, worker := range spec.Provider.Workers {
+			if worker.ControlPlane != nil {
+				controlPlaneWorkersZonesSet.Insert(worker.Zones...)
+			}
+		}
+
 		for i, worker := range spec.Provider.Workers {
 			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "workers").Index(i).Child("systemComponents"), *worker.SystemComponents, "systemComponents is only allowed for the control plane worker pool for self-hosted shoots"))
+				if !controlPlaneWorkersZonesSet.HasAll(worker.Zones...) {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "workers").Index(i).Child("systemComponents"), *worker.SystemComponents, "workers that enable systemComponents must have the same zones as control plane workers"))
+				}
 			}
 		}
 	}

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -387,21 +387,6 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, opts shootV
 		if meta.Namespace != v1beta1constants.GardenNamespace {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), meta.Namespace, fmt.Sprintf("self-hosted shoots must be in the %q namespace", v1beta1constants.GardenNamespace)))
 		}
-
-		controlPlaneWorkersZonesSet := sets.New[string]()
-		for _, worker := range spec.Provider.Workers {
-			if worker.ControlPlane != nil {
-				controlPlaneWorkersZonesSet.Insert(worker.Zones...)
-			}
-		}
-
-		for i, worker := range spec.Provider.Workers {
-			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) {
-				if !controlPlaneWorkersZonesSet.HasAll(worker.Zones...) {
-					allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "workers").Index(i).Child("systemComponents"), *worker.SystemComponents, "workers that enable systemComponents must have the same zones as control plane workers"))
-				}
-			}
-		}
 	}
 
 	if spec.SchedulerName != nil {
@@ -2764,6 +2749,21 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("controlPlane"), worker.ControlPlane, "cannot have more than one worker pool marked for control plane components"))
 			}
 			foundControlPlanePool = true
+		}
+	}
+
+	if helper.IsShootSelfHosted(workers) {
+		controlPlaneWorkersZonesSet := sets.New[string]()
+		for _, worker := range workers {
+			if worker.ControlPlane != nil {
+				controlPlaneWorkersZonesSet.Insert(worker.Zones...)
+			}
+		}
+
+		for i, worker := range workers {
+			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) && !controlPlaneWorkersZonesSet.HasAll(worker.Zones...) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("systemComponents"), *worker.SystemComponents, "workers that enable systemComponents must use a subset of the zones of control plane worker"))
+			}
 		}
 	}
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -2752,21 +2752,6 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 		}
 	}
 
-	if helper.IsShootSelfHosted(workers) {
-		controlPlaneWorkersZonesSet := sets.New[string]()
-		for _, worker := range workers {
-			if worker.ControlPlane != nil {
-				controlPlaneWorkersZonesSet.Insert(worker.Zones...)
-			}
-		}
-
-		for i, worker := range workers {
-			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) && !controlPlaneWorkersZonesSet.HasAll(worker.Zones...) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("systemComponents"), *worker.SystemComponents, "workers that enable systemComponents must use a subset of the zones of control plane worker"))
-			}
-		}
-	}
-
 	return allErrs
 }
 
@@ -2869,6 +2854,21 @@ func ValidateSystemComponentWorkers(workers []core.Worker, fldPath *field.Path) 
 
 	if !atLeastOnePoolWithAllowedSystemComponents {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one active (workers[i].maximum > 0) worker pool with systemComponents.allow=true needed"))
+	}
+
+	if helper.IsShootSelfHosted(workers) {
+		controlPlaneWorkersZonesSet := sets.New[string]()
+		for _, worker := range workers {
+			if worker.ControlPlane != nil {
+				controlPlaneWorkersZonesSet.Insert(worker.Zones...)
+			}
+		}
+
+		for i, worker := range workers {
+			if worker.ControlPlane == nil && helper.SystemComponentsAllowed(&worker) && !controlPlaneWorkersZonesSet.HasAll(worker.Zones...) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("systemComponents"), *worker.SystemComponents, "workers that enable systemComponents must use a subset of the zones of control plane worker"))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1927,17 +1927,27 @@ var _ = Describe("Shoot Validation Tests", func() {
 						shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
 					})
 
-					It("should allow systemComponents only on the control plane worker pool", func() {
+					It("should allow systemComponents on control plane worker pool", func() {
+						Expect(ValidateShoot(shoot)).To(BeEmpty())
+					})
+
+					It("should allow systemComponents on non control-plane worker pool if it zones match control plane worker pool zones", func() {
+						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
+						shoot.Spec.Provider.Workers[1].Zones = []string{"1"}
+						shoot.Spec.Provider.Workers[1].SystemComponents.Allow = true
 						Expect(ValidateShoot(shoot)).To(BeEmpty())
 					})
 
 					It("should forbid systemComponents on non control-plane worker pool", func() {
+						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
+						shoot.Spec.Provider.Workers[1].Zones = []string{"1", "2"}
+						shoot.Spec.Provider.Workers[1].Maximum = 2
 						shoot.Spec.Provider.Workers[1].SystemComponents.Allow = true
 
 						Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.provider.workers[1].systemComponents"),
-							"Detail": ContainSubstring("systemComponents is only allowed for the control plane worker pool for self-hosted shoots"),
+							"Detail": ContainSubstring("workers that enable systemComponents must have the same zones as control plane workers"),
 						}))))
 					})
 				})

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1931,14 +1931,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Expect(ValidateShoot(shoot)).To(BeEmpty())
 					})
 
-					It("should allow systemComponents on non control-plane worker pool if it zones match control plane worker pool zones", func() {
+					It("should allow systemComponents on non control-plane worker pool if its zones are equal to the control-plane worker pool zones", func() {
 						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
 						shoot.Spec.Provider.Workers[1].Zones = []string{"1"}
 						shoot.Spec.Provider.Workers[1].SystemComponents.Allow = true
 						Expect(ValidateShoot(shoot)).To(BeEmpty())
 					})
 
-					It("should forbid systemComponents on non control-plane worker pool", func() {
+					It("should forbid systemComponents on worker pools whose zones are not a subset of the control-plane worker pool zones", func() {
 						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
 						shoot.Spec.Provider.Workers[1].Zones = []string{"1", "2"}
 						shoot.Spec.Provider.Workers[1].Maximum = 2
@@ -1947,7 +1947,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.provider.workers[1].systemComponents"),
-							"Detail": ContainSubstring("workers that enable systemComponents must have the same zones as control plane workers"),
+							"Detail": ContainSubstring("workers that enable systemComponents must use a subset of the zones of control plane worker"),
 						}))))
 					})
 				})

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -1917,40 +1917,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 					Expect(ValidateShoot(shoot)).To(BeEmpty())
 				})
-
-				Context("systemComponents setting", func() {
-					BeforeEach(func() {
-						nonCPWorker := *shoot.Spec.Provider.Workers[0].DeepCopy()
-						nonCPWorker.Name = "non-cp-pool"
-						nonCPWorker.SystemComponents = &core.WorkerSystemComponents{Allow: false}
-						shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, nonCPWorker)
-						shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{}
-					})
-
-					It("should allow systemComponents on control plane worker pool", func() {
-						Expect(ValidateShoot(shoot)).To(BeEmpty())
-					})
-
-					It("should allow systemComponents on non control-plane worker pool if its zones are equal to the control-plane worker pool zones", func() {
-						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
-						shoot.Spec.Provider.Workers[1].Zones = []string{"1"}
-						shoot.Spec.Provider.Workers[1].SystemComponents.Allow = true
-						Expect(ValidateShoot(shoot)).To(BeEmpty())
-					})
-
-					It("should forbid systemComponents on worker pools whose zones are not a subset of the control-plane worker pool zones", func() {
-						shoot.Spec.Provider.Workers[0].Zones = []string{"1"}
-						shoot.Spec.Provider.Workers[1].Zones = []string{"1", "2"}
-						shoot.Spec.Provider.Workers[1].Maximum = 2
-						shoot.Spec.Provider.Workers[1].SystemComponents.Allow = true
-
-						Expect(ValidateShoot(shoot)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.provider.workers[1].systemComponents"),
-							"Detail": ContainSubstring("workers that enable systemComponents must use a subset of the zones of control plane worker"),
-						}))))
-					})
-				})
 			})
 
 			Describe("ClusterAutoscaler options validation", func() {
@@ -9367,6 +9333,61 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})),
 			)),
 		)
+
+		Context("systemComponents setting", func() {
+			var workers []core.Worker
+
+			BeforeEach(func() {
+				workers = []core.Worker{
+					{
+						Name:    "control-plane",
+						Minimum: three,
+						Maximum: three,
+						SystemComponents: &core.WorkerSystemComponents{
+							Allow: true,
+						},
+						ControlPlane: &core.WorkerControlPlane{},
+					},
+					{
+						Name:    "system-components",
+						Minimum: one,
+						Maximum: three,
+						SystemComponents: &core.WorkerSystemComponents{
+							Allow: true,
+						},
+					},
+				}
+			})
+
+			It("should allow systemComponents on control plane worker pool", func() {
+				Expect(ValidateSystemComponentWorkers(workers, field.NewPath("workers"))).To(BeEmpty())
+			})
+
+			It("should allow systemComponents on non control-plane worker pool if its zones are equal to the control-plane worker pool zones", func() {
+				workers[0].Zones = []string{"1"}
+				workers[1].Zones = []string{"1"}
+
+				Expect(ValidateSystemComponentWorkers(workers, field.NewPath("workers"))).To(BeEmpty())
+			})
+
+			It("should allow systemComponents on worker pools whose zones are a subset of the control-plane worker pool zones", func() {
+				workers[0].Zones = []string{"1", "2"}
+				workers[1].Zones = []string{"1"}
+
+				Expect(ValidateSystemComponentWorkers(workers, field.NewPath("workers"))).To(BeEmpty())
+			})
+
+			It("should forbid systemComponents on worker pools whose zones are not a subset of the control-plane worker pool zones", func() {
+				workers[0].Zones = []string{"1"}
+				workers[1].Zones = []string{"1", "2"}
+
+				Expect(ValidateSystemComponentWorkers(workers, field.NewPath("workers"))).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("workers[1].systemComponents"),
+					"Detail": ContainSubstring("workers that enable systemComponents must use a subset of the zones of control plane worker"),
+				}))))
+			})
+		})
 	})
 
 	Describe("#ValidateKubeletConfiguration", func() {

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -147,6 +147,10 @@ const (
 	// environment variable.
 	KubernetesServiceHostInject = "apiserver-proxy.networking.gardener.cloud/inject"
 
+	// SystemComponentsConfigConsider is a constant for a label on a Namespace which indicates that all Pods in this
+	// Namespace should be considered for adding default node selector and tolerations for system components.
+	SystemComponentsConfigConsider = "system-components-config.resources.gardener.cloud/consider"
+
 	// SystemComponentsConfigSkip is a constant for a label on a Pod which indicates that this Pod should not be considered for
 	// adding default node selector and tolerations.
 	SystemComponentsConfigSkip = "system-components-config.resources.gardener.cloud/skip"

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -51,6 +51,18 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
+// ManagedBy describes which Gardener component manages this etcd-druid.
+type ManagedBy uint8
+
+const (
+	// ManagedByOperator means that gardener-operator manages this etcd-druid.
+	ManagedByOperator ManagedBy = iota
+	// ManagedBySeed means that the seed manages this etcd-druid.
+	ManagedBySeed
+	// ManagedBySelfHostedShoot means that a self-hosted shoot manages this etcd-druid.
+	ManagedBySelfHostedShoot
+)
+
 const (
 	// Druid is a constant for the name of the etcd-druid.
 	Druid = "etcd-druid"
@@ -106,31 +118,31 @@ func NewBootstrapper(
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
 	priorityClassName string,
-	managedbyGardenerOperator bool,
+	managedBy ManagedBy,
 ) component.DeployWaiter {
 	return &bootstrapper{
-		client:                    c,
-		namespace:                 namespace,
-		etcdConfig:                etcdConfig,
-		image:                     image,
-		imageVectorOverwrite:      imageVectorOverwrite,
-		secretsManager:            secretsManager,
-		secretNameServerCA:        secretNameServerCA,
-		priorityClassName:         priorityClassName,
-		managedbyGardenerOperator: managedbyGardenerOperator,
+		client:               c,
+		namespace:            namespace,
+		etcdConfig:           etcdConfig,
+		image:                image,
+		imageVectorOverwrite: imageVectorOverwrite,
+		secretsManager:       secretsManager,
+		secretNameServerCA:   secretNameServerCA,
+		priorityClassName:    priorityClassName,
+		managedBy:            managedBy,
 	}
 }
 
 type bootstrapper struct {
-	client                    client.Client
-	namespace                 string
-	etcdConfig                *gardenletconfigv1alpha1.ETCDConfig
-	image                     string
-	imageVectorOverwrite      *string
-	secretsManager            secretsmanager.Interface
-	secretNameServerCA        string
-	priorityClassName         string
-	managedbyGardenerOperator bool
+	client               client.Client
+	namespace            string
+	etcdConfig           *gardenletconfigv1alpha1.ETCDConfig
+	image                string
+	imageVectorOverwrite *string
+	secretsManager       secretsmanager.Interface
+	secretNameServerCA   string
+	priorityClassName    string
+	managedBy            ManagedBy
 }
 
 func (b *bootstrapper) Deploy(ctx context.Context) error {
@@ -171,8 +183,12 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, webhookServerPort))
 	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, portMetrics))
 
-	if b.managedbyGardenerOperator {
+	if b.managedBy == ManagedByOperator {
 		deployment.Spec.Template.Labels["networking.resources.gardener.cloud/to-virtual-garden-etcd-main-client-tcp-8080"] = v1beta1constants.LabelNetworkPolicyAllowed
+	}
+
+	if b.managedBy == ManagedBySelfHostedShoot {
+		deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 	}
 
 	resourcesToAdd := []client.Object{

--- a/pkg/component/etcd/etcd/bootstrap.go
+++ b/pkg/component/etcd/etcd/bootstrap.go
@@ -51,18 +51,6 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
-// ManagedBy describes which Gardener component manages this etcd-druid.
-type ManagedBy uint8
-
-const (
-	// ManagedByOperator means that gardener-operator manages this etcd-druid.
-	ManagedByOperator ManagedBy = iota
-	// ManagedBySeed means that the seed manages this etcd-druid.
-	ManagedBySeed
-	// ManagedBySelfHostedShoot means that a self-hosted shoot manages this etcd-druid.
-	ManagedBySelfHostedShoot
-)
-
 const (
 	// Druid is a constant for the name of the etcd-druid.
 	Druid = "etcd-druid"
@@ -118,31 +106,34 @@ func NewBootstrapper(
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
 	priorityClassName string,
-	managedBy ManagedBy,
+	clusterIsGarden bool,
+	clusterIsSelfHostedShoot bool,
 ) component.DeployWaiter {
 	return &bootstrapper{
-		client:               c,
-		namespace:            namespace,
-		etcdConfig:           etcdConfig,
-		image:                image,
-		imageVectorOverwrite: imageVectorOverwrite,
-		secretsManager:       secretsManager,
-		secretNameServerCA:   secretNameServerCA,
-		priorityClassName:    priorityClassName,
-		managedBy:            managedBy,
+		client:                   c,
+		namespace:                namespace,
+		etcdConfig:               etcdConfig,
+		image:                    image,
+		imageVectorOverwrite:     imageVectorOverwrite,
+		secretsManager:           secretsManager,
+		secretNameServerCA:       secretNameServerCA,
+		priorityClassName:        priorityClassName,
+		clusterIsGarden:          clusterIsGarden,
+		clusterIsSelfHostedShoot: clusterIsSelfHostedShoot,
 	}
 }
 
 type bootstrapper struct {
-	client               client.Client
-	namespace            string
-	etcdConfig           *gardenletconfigv1alpha1.ETCDConfig
-	image                string
-	imageVectorOverwrite *string
-	secretsManager       secretsmanager.Interface
-	secretNameServerCA   string
-	priorityClassName    string
-	managedBy            ManagedBy
+	client                   client.Client
+	namespace                string
+	etcdConfig               *gardenletconfigv1alpha1.ETCDConfig
+	image                    string
+	imageVectorOverwrite     *string
+	secretsManager           secretsmanager.Interface
+	secretNameServerCA       string
+	priorityClassName        string
+	clusterIsGarden          bool
+	clusterIsSelfHostedShoot bool
 }
 
 func (b *bootstrapper) Deploy(ctx context.Context) error {
@@ -183,11 +174,11 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	metav1.SetMetaDataAnnotation(&service.ObjectMeta, resourcesv1alpha1.NetworkingFromWorldToPorts, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, webhookServerPort))
 	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForSeedScrapeTargets(service, portMetrics))
 
-	if b.managedBy == ManagedByOperator {
+	if b.clusterIsGarden {
 		deployment.Spec.Template.Labels["networking.resources.gardener.cloud/to-virtual-garden-etcd-main-client-tcp-8080"] = v1beta1constants.LabelNetworkPolicyAllowed
 	}
 
-	if b.managedBy == ManagedBySelfHostedShoot {
+	if b.clusterIsSelfHostedShoot {
 		deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 	}
 

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -63,8 +63,8 @@ var _ = Describe("Etcd", func() {
 
 		priorityClassName = "some-priority-class"
 
-		featureGates map[string]bool
-		managedBy    ManagedBy
+		featureGates      map[string]bool
+		isSelfHostedShoot bool
 
 		managedResourceSecret *corev1.Secret
 		managedResource       *resourcesv1alpha1.ManagedResource
@@ -135,7 +135,7 @@ webhooks:
 	)
 
 	BeforeEach(func() {
-		managedBy = ManagedBySeed
+		isSelfHostedShoot = false
 	})
 
 	JustBeforeEach(func() {
@@ -163,7 +163,7 @@ webhooks:
 		// Create CA secret for etcd-components webhook handler
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretNameCA, Namespace: namespace}})).To(Succeed())
 
-		bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, managedBy)
+		bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, false, isSelfHostedShoot)
 
 		managedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -863,7 +863,7 @@ webhooks:
 			})
 
 			It("should successfully deploy all the resources (w/ image vector overwrite)", func() {
-				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwriteFull, sm, secretNameCA, priorityClassName, ManagedBySeed)
+				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwriteFull, sm, secretNameCA, priorityClassName, false, isSelfHostedShoot)
 
 				expectedResources = append(expectedResources,
 					deploymentWithImageVectorOverwrite,
@@ -874,7 +874,7 @@ webhooks:
 
 		Context("managed by self-hosted shoot", func() {
 			BeforeEach(func() {
-				managedBy = ManagedBySelfHostedShoot
+				isSelfHostedShoot = true
 			})
 
 			It("should successfully deploy all the resources with node selector", func() {

--- a/pkg/component/etcd/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/etcd/bootstrap_test.go
@@ -32,6 +32,7 @@ import (
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
@@ -63,6 +64,7 @@ var _ = Describe("Etcd", func() {
 		priorityClassName = "some-priority-class"
 
 		featureGates map[string]bool
+		managedBy    ManagedBy
 
 		managedResourceSecret *corev1.Secret
 		managedResource       *resourcesv1alpha1.ManagedResource
@@ -132,6 +134,10 @@ webhooks:
 `)
 	)
 
+	BeforeEach(func() {
+		managedBy = ManagedBySeed
+	})
+
 	JustBeforeEach(func() {
 		etcdConfig = &gardenletconfigv1alpha1.ETCDConfig{
 			ETCDController: &gardenletconfigv1alpha1.ETCDController{
@@ -157,7 +163,7 @@ webhooks:
 		// Create CA secret for etcd-components webhook handler
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretNameCA, Namespace: namespace}})).To(Succeed())
 
-		bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, false)
+		bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwrite, sm, secretNameCA, priorityClassName, managedBy)
 
 		managedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -857,12 +863,25 @@ webhooks:
 			})
 
 			It("should successfully deploy all the resources (w/ image vector overwrite)", func() {
-				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwriteFull, sm, secretNameCA, priorityClassName, false)
+				bootstrapper = NewBootstrapper(c, namespace, etcdConfig, etcdDruidImage, imageVectorOverwriteFull, sm, secretNameCA, priorityClassName, ManagedBySeed)
 
 				expectedResources = append(expectedResources,
 					deploymentWithImageVectorOverwrite,
 					configMapImageVectorOverwrite,
 				)
+			})
+		})
+
+		Context("managed by self-hosted shoot", func() {
+			BeforeEach(func() {
+				managedBy = ManagedBySelfHostedShoot
+			})
+
+			It("should successfully deploy all the resources with node selector", func() {
+				deploymentForSelfHostedShoot := deploymentWithoutImageVectorOverwriteFor.DeepCopy()
+				deploymentForSelfHostedShoot.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
+
+				expectedResources = append(expectedResources, deploymentForSelfHostedShoot)
 			})
 		})
 	})

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -245,10 +245,10 @@ type Values struct {
 	ClusterIdentity *string
 	// ConcurrentSyncs are the number of worker threads for concurrent reconciliation of resources
 	ConcurrentSyncs *int
-	// ForSelfHostedShoot defines if this gardener-resource-manager is deployed to manage a self-hosted shoot cluster.
-	ForSelfHostedShoot bool
 	// HighAvailabilityConfigWebhookEnabled controls whether the high availability config webhook is enabled.
 	HighAvailabilityConfigWebhookEnabled bool
+	// SystemComponentsConfigWebhookEnabled defines if the SystemComponentsConfigWebhook should be enabled.
+	SystemComponentsConfigWebhookEnabled bool
 	// DefaultNotReadyTolerationSeconds indicates the tolerationSeconds of the toleration for notReady:NoExecute
 	DefaultNotReadyToleration *int64
 	// DefaultUnreachableTolerationSeconds indicates the tolerationSeconds of the toleration for unreachable:NoExecute
@@ -681,7 +681,7 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 		config.Controllers.NodeCriticalComponents.Enabled = true
 	}
 
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden || r.values.ForSelfHostedShoot {
+	if r.values.SystemComponentsConfigWebhookEnabled {
 		config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 			Enabled: true,
 			NodeSelector: map[string]string{
@@ -1361,9 +1361,9 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden || r.values.ForSelfHostedShoot {
+	if r.values.SystemComponentsConfigWebhookEnabled {
 		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
-		if r.values.ForSelfHostedShoot {
+		if r.values.ResponsibilityMode == ForRuntime {
 			if systemComponentsNamespaceSelector.MatchLabels == nil {
 				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
 			}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -245,6 +245,8 @@ type Values struct {
 	ClusterIdentity *string
 	// ConcurrentSyncs are the number of worker threads for concurrent reconciliation of resources
 	ConcurrentSyncs *int
+	// ForSelfHostedShoot defines if this gardener-resource-manager is deployed to manage a self-hosted shoot cluster.
+	ForSelfHostedShoot bool
 	// HighAvailabilityConfigWebhookEnabled controls whether the high availability config webhook is enabled.
 	HighAvailabilityConfigWebhookEnabled bool
 	// DefaultNotReadyTolerationSeconds indicates the tolerationSeconds of the toleration for notReady:NoExecute
@@ -676,6 +678,10 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
+		config.Controllers.NodeCriticalComponents.Enabled = true
+	}
+
+	if r.values.ResponsibilityMode == ForShootOrVirtualGarden || r.values.ForSelfHostedShoot {
 		config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 			Enabled: true,
 			NodeSelector: map[string]string{
@@ -686,8 +692,6 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 			},
 			PodTolerations: r.values.SystemComponentTolerations,
 		}
-
-		config.Controllers.NodeCriticalComponents.Enabled = true
 	}
 
 	// this function should be called at the last to make sure we disable
@@ -829,6 +833,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 	}
 
 	var (
+		nodeSelectors     map[string]string
 		tolerations       []corev1.Toleration
 		env               []corev1.EnvVar
 		replicas          = r.values.Replicas
@@ -840,6 +845,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 	for _, toleration := range r.values.SystemComponentTolerations {
 		if toleration.Key == "node-role.kubernetes.io/control-plane" {
 			tolerations = append(tolerations, toleration)
+			nodeSelectors = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 			break
 		}
 	}
@@ -976,7 +982,8 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 						},
 					},
 				},
-				Tolerations: tolerations,
+				NodeSelector: nodeSelectors,
+				Tolerations:  tolerations,
 				Volumes: []corev1.Volume{
 					{
 						Name: volumeNameAPIServerAccess,
@@ -1354,8 +1361,16 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
-		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
+	if r.values.ResponsibilityMode == ForShootOrVirtualGarden || r.values.ForSelfHostedShoot {
+		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
+		if r.values.ForSelfHostedShoot {
+			if systemComponentsNamespaceSelector.MatchLabels == nil {
+				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
+			}
+			systemComponentsNamespaceSelector.MatchLabels[resourcesv1alpha1.SystemComponentsConfigConsider] = "true"
+		}
+
+		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
 	if r.values.EndpointSliceHintsEnabled {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -588,6 +588,7 @@ var _ = Describe("ResourceManager", func() {
 								},
 							},
 							ServiceAccountName: "gardener-resource-manager",
+							NodeSelector:       map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"},
 							Containers: []corev1.Container{
 								{
 									Args:            []string{"--config=/etc/gardener-resource-manager-config/config.yaml"},

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -119,7 +119,7 @@ var _ = Describe("ResourceManager", func() {
 		deployment                                           *appsv1.Deployment
 		defaultNotReadyTolerationSeconds                     *int64
 		defaultUnreachableTolerationSeconds                  *int64
-		configMapFor                                         func(watchedNamespace *string, responsibilityMode ResponsibilityMode, isWorkerless, bootstrapControlPlaneNode bool) *corev1.ConfigMap
+		configMapFor                                         func(watchedNamespace *string, responsibilityMode ResponsibilityMode, isWorkerless, bootstrapControlPlaneNode, systemComponentsConfigWebhookEnabled bool) *corev1.ConfigMap
 		deploymentFor                                        func(configMapName string, targetClusterDiffersFromSourceCluster bool, secretNameBootstrapKubeconfig *string, bootstrapControlPlaneNode bool) *appsv1.Deployment
 		defaultLabels                                        map[string]string
 		roleBinding                                          *rbacv1.RoleBinding
@@ -309,6 +309,7 @@ var _ = Describe("ResourceManager", func() {
 			ClusterIdentity:                                  &clusterIdentity,
 			ConcurrentSyncs:                                  &concurrentSyncs,
 			HighAvailabilityConfigWebhookEnabled:             true,
+			SystemComponentsConfigWebhookEnabled:             true,
 			DefaultNotReadyToleration:                        defaultNotReadyTolerationSeconds,
 			DefaultUnreachableToleration:                     defaultUnreachableTolerationSeconds,
 			NetworkPolicyAdditionalNamespaceSelectors:        additionalNetworkPolicyNamespaceSelectors,
@@ -380,7 +381,7 @@ var _ = Describe("ResourceManager", func() {
 			AutomountServiceAccountToken: ptr.To(false),
 		}
 
-		configMapFor = func(watchedNamespace *string, responsibilityMode ResponsibilityMode, isWorkerless, bootstrapControlPlaneNode bool) *corev1.ConfigMap {
+		configMapFor = func(watchedNamespace *string, responsibilityMode ResponsibilityMode, isWorkerless, bootstrapControlPlaneNode, systemComponentsConfigWebhookEnabled bool) *corev1.ConfigMap {
 			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gardener-resource-manager",
@@ -516,7 +517,7 @@ var _ = Describe("ResourceManager", func() {
 				config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled = true
 			}
 
-			if responsibilityMode == ForShootOrVirtualGarden {
+			if systemComponentsConfigWebhookEnabled {
 				config.Webhooks.SystemComponentsConfig = resourcemanagerconfigv1alpha1.SystemComponentsConfigWebhookConfig{
 					Enabled: !isWorkerless,
 					NodeSelector: map[string]string{
@@ -2127,7 +2128,7 @@ subjects:
 		Context("target cluster != source cluster; watched namespace is set", func() {
 			JustBeforeEach(func() {
 				role.Namespace = watchedNamespace
-				configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false)
+				configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false, true)
 				deployment = deploymentFor(configMap.Name, true, nil, false)
 				cfg.TargetNamespaces = targetNamespaces
 				resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2196,7 +2197,7 @@ subjects:
 					JustBeforeEach(func() {
 						matchLabelKeysInPodTopologySpreadFeatureGateDisabled = true
 						cfg.PodTopologySpreadConstraintsEnabled = true
-						configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false)
+						configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false, true)
 						deployment = deploymentFor(configMap.Name, true, nil, false)
 
 						resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2245,7 +2246,7 @@ subjects:
 						matchLabelKeysInPodTopologySpreadFeatureGateDisabled = false
 						cfg.PodTopologySpreadConstraintsEnabled = false
 
-						configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false)
+						configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false, true)
 						deployment = deploymentFor(configMap.Name, true, nil, false)
 
 						resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2375,7 +2376,7 @@ subjects:
 				cfg.ResponsibilityMode = ForShootOrVirtualGarden
 				cfg.TargetNamespaces = targetNamespaces
 				cfg.WatchedNamespace = nil
-				configMap = configMapFor(nil, ForShootOrVirtualGarden, false, false)
+				configMap = configMapFor(nil, ForShootOrVirtualGarden, false, false, true)
 				deployment = deploymentFor(configMap.Name, true, nil, false)
 
 				resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2492,7 +2493,7 @@ subjects:
 				cfg.TargetNamespaces = targetNamespaces
 				cfg.WatchedNamespace = nil
 				cfg.IsWorkerless = true
-				configMap = configMapFor(nil, ForShootOrVirtualGarden, true, false)
+				configMap = configMapFor(nil, ForShootOrVirtualGarden, true, false, true)
 				deployment = deploymentFor(configMap.Name, true, nil, false)
 
 				resourceManager = New(c, deployNamespace, sm, cfg)
@@ -2573,7 +2574,7 @@ subjects:
 				delete(service.Annotations, "networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports")
 				service.Annotations["networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports"] = `[{"protocol":"TCP","port":8080}]`
 				service.Annotations["networking.resources.gardener.cloud/from-world-to-ports"] = `[{"protocol":"TCP","port":10250}]`
-				configMap = configMapFor(&watchedNamespace, ForRuntime, false, false)
+				configMap = configMapFor(&watchedNamespace, ForRuntime, false, false, false)
 				deployment = deploymentFor(configMap.Name, false, nil, false)
 
 				deployment.Spec.Template.Spec.Volumes = deployment.Spec.Template.Spec.Volumes[:len(deployment.Spec.Template.Spec.Volumes)-1]
@@ -2603,6 +2604,7 @@ subjects:
 				cfg.ResponsibilityMode = ForRuntime
 				cfg.PodKubeAPIServerLoadBalancingWebhook.Enabled = true
 				cfg.VPAInPlaceUpdatesEnabled = true
+				cfg.SystemComponentsConfigWebhookEnabled = false
 				resourceManager = New(c, deployNamespace, sm, cfg)
 				resourceManager.SetSecrets(secrets)
 			})
@@ -2902,7 +2904,7 @@ subjects:
 
 		Context("responsibility mode is ForShootOrVirtualGarden", func() {
 			BeforeEach(func() {
-				configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false)
+				configMap = configMapFor(&watchedNamespace, ForShootOrVirtualGarden, false, false, true)
 				deployment = deploymentFor(configMap.Name, true, nil, false)
 				resourceManager = New(fakeClient, deployNamespace, nil, cfg)
 			})
@@ -2999,7 +3001,7 @@ subjects:
 				))
 
 				cfg.ResponsibilityMode = ForRuntime
-				configMap = configMapFor(nil, ForRuntime, false, false)
+				configMap = configMapFor(nil, ForRuntime, false, false, false)
 				deployment = deploymentFor(configMap.Name, false, nil, false)
 				resourceManager = New(fakeClient, deployNamespace, nil, cfg)
 

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -296,7 +296,9 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 		}
 
-		if !m.values.SelfHostedShoot {
+		if m.values.SelfHostedShoot {
+			deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
+		} else {
 			genericTokenKubeconfigSecret, found := m.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
 			if !found {
 				return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -296,7 +296,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 		}
 
-		// If machine-controller-manager runs in the kube-system namespace, then it should be scheduled only on workers that support system components.
+		// If machine-controller-manager runs in the kube-system namespace (self-hosted shoot case), then it should be scheduled only on workers that support system components.
 		if m.namespace == metav1.NamespaceSystem {
 			deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 		}

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -296,9 +296,12 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 		}
 
-		if m.values.SelfHostedShoot {
+		// If machine-controller-manager runs in the kube-system namespace, then it should be scheduled only on workers that support system components.
+		if m.namespace == metav1.NamespaceSystem {
 			deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
-		} else {
+		}
+
+		if !m.values.SelfHostedShoot {
 			genericTokenKubeconfigSecret, found := m.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
 			if !found {
 				return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -660,7 +660,6 @@ subjects:
 
 			JustBeforeEach(func() {
 				shootAccessSecret = nil
-				deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 			})
 
 			When("running the control plane (gardenadm init)", func() {
@@ -669,6 +668,7 @@ subjects:
 				})
 
 				JustBeforeEach(func() {
+					deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 					for i, s := range deployment.Spec.Template.Spec.Containers[0].Command {
 						if strings.HasPrefix(s, "--target-kubeconfig=") {
 							deployment.Spec.Template.Spec.Containers[0].Command[i] = "--target-kubeconfig="

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/component/nodemanagement/machinecontrollermanager"
@@ -659,6 +660,7 @@ subjects:
 
 			JustBeforeEach(func() {
 				shootAccessSecret = nil
+				deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"}
 			})
 
 			When("running the control plane (gardenadm init)", func() {

--- a/pkg/component/shared/etcd_druid.go
+++ b/pkg/component/shared/etcd_druid.go
@@ -26,7 +26,8 @@ func NewEtcdDruid(
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
 	priorityClassName string,
-	managedBy etcd.ManagedBy,
+	clusterIsGarden bool,
+	clusterIsSelfHostedShoot bool,
 ) (
 	component.DeployWaiter,
 	error,
@@ -50,6 +51,7 @@ func NewEtcdDruid(
 		secretsManager,
 		secretNameServerCA,
 		priorityClassName,
-		managedBy,
+		clusterIsGarden,
+		clusterIsSelfHostedShoot,
 	), nil
 }

--- a/pkg/component/shared/etcd_druid.go
+++ b/pkg/component/shared/etcd_druid.go
@@ -26,7 +26,7 @@ func NewEtcdDruid(
 	secretsManager secretsmanager.Interface,
 	secretNameServerCA string,
 	priorityClassName string,
-	managedbyGardenerOperator bool,
+	managedBy etcd.ManagedBy,
 ) (
 	component.DeployWaiter,
 	error,
@@ -50,6 +50,6 @@ func NewEtcdDruid(
 		secretsManager,
 		secretNameServerCA,
 		priorityClassName,
-		managedbyGardenerOperator,
+		managedBy,
 	), nil
 }

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -81,7 +81,7 @@ func NewRuntimeGardenerResourceManager(
 	return resourcemanager.New(c, gardenNamespaceName, secretsManager, values), nil
 }
 
-func targetGardenerResourceManagerDefaultValues(namespaceName *string) resourcemanager.Values {
+func targetGardenerResourceManagerDefaultValues(namespaceName string) resourcemanager.Values {
 	return resourcemanager.Values{
 		AlwaysUpdate:                       ptr.To(true),
 		ConcurrentSyncs:                    ptr.To(20),
@@ -90,7 +90,9 @@ func targetGardenerResourceManagerDefaultValues(namespaceName *string) resourcem
 		MaxConcurrentHealthWorkers:         ptr.To(10),
 		MaxConcurrentTokenRequestorWorkers: ptr.To(5),
 		ResponsibilityMode:                 resourcemanager.ForShootOrVirtualGarden,
-		WatchedNamespace:                   namespaceName,
+		WatchedNamespace:                   &namespaceName,
+		// The webhook should be enabled only if the target is a shoot not if it is the virtual garden.
+		SystemComponentsConfigWebhookEnabled: namespaceName != v1beta1constants.GardenNamespace,
 	}
 }
 
@@ -111,7 +113,7 @@ func NewTargetGardenerResourceManager(
 	}
 	image.WithOptionalTag(version.Get().GitVersion)
 
-	defaultValues := targetGardenerResourceManagerDefaultValues(&namespaceName)
+	defaultValues := targetGardenerResourceManagerDefaultValues(namespaceName)
 	defaultValues.Image = image.String()
 
 	applyDefaults(&values, defaultValues)

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -91,7 +91,7 @@ func targetGardenerResourceManagerDefaultValues(namespaceName string) resourcema
 		MaxConcurrentTokenRequestorWorkers: ptr.To(5),
 		ResponsibilityMode:                 resourcemanager.ForShootOrVirtualGarden,
 		WatchedNamespace:                   &namespaceName,
-		// The webhook should be enabled only if the target is a shoot not if it is the virtual garden.
+		// The webhook should be enabled only if the target is a shoot — not if it is the virtual garden.
 		SystemComponentsConfigWebhookEnabled: namespaceName != v1beta1constants.GardenNamespace,
 	}
 }

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -38,7 +38,7 @@ import (
 var _ = Describe("ResourceManager", func() {
 	var (
 		ctx       = context.TODO()
-		namespace = "fake-ns"
+		namespace string
 		sm        secretsmanager.Interface
 		ctrl      *gomock.Controller
 	)
@@ -47,7 +47,11 @@ var _ = Describe("ResourceManager", func() {
 		var fakeClient client.Client
 
 		BeforeEach(func() {
+			namespace = "fake-ns"
 			fakeClient = fakeclient.NewClientBuilder().Build()
+		})
+
+		JustBeforeEach(func() {
 			sm = fakesecretsmanager.New(fakeClient, namespace)
 		})
 
@@ -80,17 +84,17 @@ var _ = Describe("ResourceManager", func() {
 
 		It("should set ForSelfHostedShoot in the values for runtime resource managers deployed to a self-hosted shoot cluster", func() {
 			resourceManager, err := NewRuntimeGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
-				ClusterIdentity:    ptr.To("foo"),
-				ForSelfHostedShoot: true,
+				ClusterIdentity:                      ptr.To("foo"),
+				SystemComponentsConfigWebhookEnabled: true,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
-				ClusterIdentity:                   ptr.To("foo"),
-				ConcurrentSyncs:                   ptr.To(20),
-				ForSelfHostedShoot:                true,
-				HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},
-				Image:                             "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
-				MaxConcurrentNetworkPolicyWorkers: ptr.To(20),
+				ClusterIdentity:                      ptr.To("foo"),
+				ConcurrentSyncs:                      ptr.To(20),
+				SystemComponentsConfigWebhookEnabled: true,
+				HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
+				Image:                                "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
+				MaxConcurrentNetworkPolicyWorkers:    ptr.To(20),
 				NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{
 					Namespace: "garden",
 					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
@@ -113,18 +117,47 @@ var _ = Describe("ResourceManager", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
-				AlwaysUpdate:                       ptr.To(true),
-				ClusterIdentity:                    ptr.To("foo"),
-				ConcurrentSyncs:                    ptr.To(20),
-				HealthSyncPeriod:                   &metav1.Duration{Duration: time.Minute},
-				Image:                              "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
-				MaxConcurrentCSRApproverWorkers:    ptr.To(5),
-				MaxConcurrentHealthWorkers:         ptr.To(10),
-				MaxConcurrentTokenRequestorWorkers: ptr.To(5),
-				ResponsibilityMode:                 resourcemanager.ForShootOrVirtualGarden,
-				TargetNamespaces:                   []string{},
-				WatchedNamespace:                   &namespace,
+				AlwaysUpdate:                         ptr.To(true),
+				ClusterIdentity:                      ptr.To("foo"),
+				ConcurrentSyncs:                      ptr.To(20),
+				HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
+				Image:                                "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
+				MaxConcurrentCSRApproverWorkers:      ptr.To(5),
+				MaxConcurrentHealthWorkers:           ptr.To(10),
+				MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
+				ResponsibilityMode:                   resourcemanager.ForShootOrVirtualGarden,
+				TargetNamespaces:                     []string{},
+				WatchedNamespace:                     &namespace,
+				SystemComponentsConfigWebhookEnabled: true,
 			}))
+		})
+
+		Context("namespace is garden", func() {
+			BeforeEach(func() {
+				namespace = "garden"
+			})
+
+			It("should apply the defaults for new target resource managers", func() {
+				resourceManager, err := NewTargetGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
+					ClusterIdentity:  ptr.To("foo"),
+					TargetNamespaces: []string{},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
+					AlwaysUpdate:                         ptr.To(true),
+					ClusterIdentity:                      ptr.To("foo"),
+					ConcurrentSyncs:                      ptr.To(20),
+					HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
+					Image:                                "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
+					MaxConcurrentCSRApproverWorkers:      ptr.To(5),
+					MaxConcurrentHealthWorkers:           ptr.To(10),
+					MaxConcurrentTokenRequestorWorkers:   ptr.To(5),
+					ResponsibilityMode:                   resourcemanager.ForShootOrVirtualGarden,
+					TargetNamespaces:                     []string{},
+					WatchedNamespace:                     &namespace,
+					SystemComponentsConfigWebhookEnabled: false,
+				}))
+			})
 		})
 	})
 
@@ -147,6 +180,8 @@ var _ = Describe("ResourceManager", func() {
 		)
 
 		BeforeEach(func() {
+			namespace = "fake-ns"
+
 			ctrl = gomock.NewController(GinkgoT())
 			resourceManager = mockresourcemanager.NewMockInterface(ctrl)
 

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -78,6 +78,34 @@ var _ = Describe("ResourceManager", func() {
 			}))
 		})
 
+		It("should set ForSelfHostedShoot in the values for runtime resource managers deployed to a self-hosted shoot cluster", func() {
+			resourceManager, err := NewRuntimeGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
+				ClusterIdentity:    ptr.To("foo"),
+				ForSelfHostedShoot: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
+				ClusterIdentity:                   ptr.To("foo"),
+				ConcurrentSyncs:                   ptr.To(20),
+				ForSelfHostedShoot:                true,
+				HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},
+				Image:                             "europe-docker.pkg.dev/gardener-project/releases/gardener/resource-manager:v0.0.0-master+$Format:%H$",
+				MaxConcurrentNetworkPolicyWorkers: ptr.To(20),
+				NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{
+					Namespace: "garden",
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+						"app":       "nginx-ingress",
+						"component": "controller",
+					}},
+				},
+				PodTopologySpreadConstraintsEnabled: false,
+				VPAInPlaceUpdatesEnabled:            false,
+				Replicas:                            ptr.To[int32](2),
+				ResourceClass:                       ptr.To("seed"),
+				ResponsibilityMode:                  resourcemanager.ForRuntime,
+			}))
+		})
+
 		It("should apply the defaults for new target resource managers", func() {
 			resourceManager, err := NewTargetGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
 				ClusterIdentity:  ptr.To("foo"),

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -82,7 +82,7 @@ var _ = Describe("ResourceManager", func() {
 			}))
 		})
 
-		It("should set ForSelfHostedShoot in the values for runtime resource managers deployed to a self-hosted shoot cluster", func() {
+		It("should set SystemComponentsConfigWebhookEnabled in the values for runtime resource managers deployed to a self-hosted shoot cluster", func() {
 			resourceManager, err := NewRuntimeGardenerResourceManager(fakeClient, namespace, sm, resourcemanager.Values{
 				ClusterIdentity:                      ptr.To("foo"),
 				SystemComponentsConfigWebhookEnabled: true,
@@ -132,7 +132,7 @@ var _ = Describe("ResourceManager", func() {
 			}))
 		})
 
-		Context("namespace is garden", func() {
+		When("namespace is garden", func() {
 			BeforeEach(func() {
 				namespace = "garden"
 			})

--- a/pkg/gardenadm/botanist/etcd.go
+++ b/pkg/gardenadm/botanist/etcd.go
@@ -25,7 +25,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
-	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	corebackupbucket "github.com/gardener/gardener/pkg/component/garden/backupbucket"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	backupbucketcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
@@ -59,7 +58,8 @@ func (b *GardenadmBotanist) DeployEtcdDruid(ctx context.Context) error {
 		b.SecretsManager,
 		v1beta1constants.SecretNameCACluster,
 		v1beta1constants.PriorityClassNameSeedSystem800,
-		etcd.ManagedBySelfHostedShoot,
+		false,
+		true,
 	)
 	if err != nil {
 		return fmt.Errorf("failed creating etcd-druid deployer: %w", err)

--- a/pkg/gardenadm/botanist/etcd.go
+++ b/pkg/gardenadm/botanist/etcd.go
@@ -25,6 +25,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	corebackupbucket "github.com/gardener/gardener/pkg/component/garden/backupbucket"
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	backupbucketcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/backupbucket"
@@ -58,7 +59,7 @@ func (b *GardenadmBotanist) DeployEtcdDruid(ctx context.Context) error {
 		b.SecretsManager,
 		v1beta1constants.SecretNameCACluster,
 		v1beta1constants.PriorityClassNameSeedSystem800,
-		false,
+		etcd.ManagedBySelfHostedShoot,
 	)
 	if err != nil {
 		return fmt.Errorf("failed creating etcd-druid deployer: %w", err)

--- a/pkg/gardenadm/botanist/resource_manager.go
+++ b/pkg/gardenadm/botanist/resource_manager.go
@@ -17,6 +17,7 @@ import (
 func (b *GardenadmBotanist) NewRuntimeGardenerResourceManager() (resourcemanager.Interface, error) {
 	return sharedcomponent.NewRuntimeGardenerResourceManager(b.SeedClientSet.Client(), v1beta1constants.GardenNamespace, b.SecretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:         features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
+		ForSelfHostedShoot:                   true,
 		HighAvailabilityConfigWebhookEnabled: true,
 		PriorityClassName:                    v1beta1constants.PriorityClassNameShootControlPlane400,
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,

--- a/pkg/gardenadm/botanist/resource_manager.go
+++ b/pkg/gardenadm/botanist/resource_manager.go
@@ -17,7 +17,7 @@ import (
 func (b *GardenadmBotanist) NewRuntimeGardenerResourceManager() (resourcemanager.Interface, error) {
 	return sharedcomponent.NewRuntimeGardenerResourceManager(b.SeedClientSet.Client(), v1beta1constants.GardenNamespace, b.SecretsManager, resourcemanager.Values{
 		DefaultSeccompProfileEnabled:         features.DefaultFeatureGate.Enabled(features.DefaultSeccompProfile),
-		ForSelfHostedShoot:                   true,
+		SystemComponentsConfigWebhookEnabled: true,
 		HighAvailabilityConfigWebhookEnabled: true,
 		PriorityClassName:                    v1beta1constants.PriorityClassNameShootControlPlane400,
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -66,7 +66,7 @@ func AddToManager(
 		return fmt.Errorf("cluster-identity ConfigMap data does not have %q key", v1beta1constants.ClusterIdentity)
 	}
 
-	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+	seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
 	if err != nil {
 		return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -226,6 +226,10 @@ func (r *Reconciler) reconcile(
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelNetworkPolicyAccessTargetAPIServer, "allowed")
 		}
 
+		if r.SelfHostedShootMeta != nil {
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.SystemComponentsConfigConsider, "true")
+		}
+
 		if podSecurityEnforce, ok := controllerInstallation.Annotations[v1beta1constants.AnnotationPodSecurityEnforce]; ok {
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, podsecurityadmissionapi.EnforceLevelLabel, podSecurityEnforce)
 		} else {

--- a/pkg/gardenlet/controller/networkpolicy/add.go
+++ b/pkg/gardenlet/controller/networkpolicy/add.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/controller/networkpolicy"
 	"github.com/gardener/gardener/pkg/controller/networkpolicy/hostnameresolver"
 	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 )
 
@@ -55,7 +56,7 @@ func AddToManager(
 	}
 
 	if !gardenletutils.IsResponsibleForSelfHostedShoot() {
-		seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+		seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
 		if err != nil {
 			return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
 		}
@@ -120,7 +121,7 @@ func AddToManager(
 			}
 
 			if !gardenletutils.IsResponsibleForSelfHostedShoot() {
-				seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+				seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
 				if err != nil {
 					mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is a self-hosted shoot cluster")
 					return

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -140,7 +140,6 @@ func (r *Reconciler) instantiateComponents(
 	alertingSMTPSecret *corev1.Secret,
 	wildCardCertSecret *corev1.Secret,
 	seedIsShoot bool,
-	seedIsSelfHostedShoot bool,
 ) (
 	c components,
 	err error,
@@ -190,7 +189,7 @@ func (r *Reconciler) instantiateComponents(
 	// seed system components
 	c.backupBucket = r.newBackupBucket(log, seed.GetInfo())
 	c.clusterIdentity = r.newClusterIdentity(seed.GetInfo())
-	c.gardenerResourceManager, err = r.newGardenerResourceManager(seed.GetInfo(), secretsManager, seedIsSelfHostedShoot)
+	c.gardenerResourceManager, err = r.newGardenerResourceManager(seed.GetInfo(), secretsManager)
 	if err != nil {
 		return
 	}
@@ -214,7 +213,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.etcdDruid, err = r.newEtcdDruid(secretsManager, seedIsSelfHostedShoot)
+	c.etcdDruid, err = r.newEtcdDruid(secretsManager)
 	if err != nil {
 		return
 	}
@@ -305,7 +304,7 @@ func (r *Reconciler) instantiateComponents(
 	return c, nil
 }
 
-func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, secretsManager secretsmanager.Interface, seedIsSelfHostedShoot bool) (component.DeployWaiter, error) {
+func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
 	var defaultNotReadyTolerationSeconds, defaultUnreachableTolerationSeconds *int64
 	if nodeToleration := r.Config.NodeToleration; nodeToleration != nil {
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
@@ -341,8 +340,7 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 		},
 		// TODO(vitanovs): Remove the VPAInPlaceUpdates webhook once the
 		// VPAInPlaceUpdates feature gates is deprecated.
-		VPAInPlaceUpdatesEnabled:             features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
-		SystemComponentsConfigWebhookEnabled: seedIsSelfHostedShoot,
+		VPAInPlaceUpdatesEnabled: features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
 	})
 }
 
@@ -883,7 +881,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSe
 	return verticalPodAutoscaler, nil
 }
 
-func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, seedIsSelfHostedShoot bool) (component.DeployWaiter, error) {
+func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
 	return sharedcomponent.NewEtcdDruid(
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
@@ -894,7 +892,7 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, seedI
 		v1beta1constants.SecretNameCASeed,
 		v1beta1constants.PriorityClassNameSeedSystem800,
 		false,
-		seedIsSelfHostedShoot,
+		false,
 	)
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -891,7 +891,7 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (comp
 		secretsManager,
 		v1beta1constants.SecretNameCASeed,
 		v1beta1constants.PriorityClassNameSeedSystem800,
-		false,
+		etcd.ManagedBySeed,
 	)
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -140,6 +140,7 @@ func (r *Reconciler) instantiateComponents(
 	alertingSMTPSecret *corev1.Secret,
 	wildCardCertSecret *corev1.Secret,
 	seedIsShoot bool,
+	seedIsSelfHostedShoot bool,
 ) (
 	c components,
 	err error,
@@ -189,7 +190,7 @@ func (r *Reconciler) instantiateComponents(
 	// seed system components
 	c.backupBucket = r.newBackupBucket(log, seed.GetInfo())
 	c.clusterIdentity = r.newClusterIdentity(seed.GetInfo())
-	c.gardenerResourceManager, err = r.newGardenerResourceManager(seed.GetInfo(), secretsManager)
+	c.gardenerResourceManager, err = r.newGardenerResourceManager(seed.GetInfo(), secretsManager, seedIsSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -213,7 +214,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.etcdDruid, err = r.newEtcdDruid(secretsManager)
+	c.etcdDruid, err = r.newEtcdDruid(secretsManager, seedIsSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -304,7 +305,7 @@ func (r *Reconciler) instantiateComponents(
 	return c, nil
 }
 
-func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, secretsManager secretsmanager.Interface, seedIsSelfHostedShoot bool) (component.DeployWaiter, error) {
 	var defaultNotReadyTolerationSeconds, defaultUnreachableTolerationSeconds *int64
 	if nodeToleration := r.Config.NodeToleration; nodeToleration != nil {
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
@@ -340,7 +341,8 @@ func (r *Reconciler) newGardenerResourceManager(seed *gardencorev1beta1.Seed, se
 		},
 		// TODO(vitanovs): Remove the VPAInPlaceUpdates webhook once the
 		// VPAInPlaceUpdates feature gates is deprecated.
-		VPAInPlaceUpdatesEnabled: features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
+		VPAInPlaceUpdatesEnabled:             features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
+		SystemComponentsConfigWebhookEnabled: seedIsSelfHostedShoot,
 	})
 }
 
@@ -881,7 +883,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(settings *gardencorev1beta1.SeedSe
 	return verticalPodAutoscaler, nil
 }
 
-func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, seedIsSelfHostedShoot bool) (component.DeployWaiter, error) {
 	return sharedcomponent.NewEtcdDruid(
 		r.SeedClientSet.Client(),
 		r.GardenNamespace,
@@ -891,7 +893,8 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (comp
 		secretsManager,
 		v1beta1constants.SecretNameCASeed,
 		v1beta1constants.PriorityClassNameSeedSystem800,
-		etcd.ManagedBySeed,
+		false,
+		seedIsSelfHostedShoot,
 	)
 }
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}
 
-	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, r.SeedClientSet.Client())
+	seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, r.SeedClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -105,7 +105,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 	seedIsSelfHostedShoot bool,
 ) error {
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot, seedIsSelfHostedShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -105,7 +105,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 	seedIsSelfHostedShoot bool,
 ) error {
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot, seedIsSelfHostedShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -171,7 +171,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot, seedIsSelfHostedShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -171,7 +171,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot, seedIsSelfHostedShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/vpaevictionrequirements/add.go
+++ b/pkg/gardenlet/controller/vpaevictionrequirements/add.go
@@ -15,6 +15,7 @@ import (
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	"github.com/gardener/gardener/pkg/controller/vpaevictionrequirements"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 )
 
@@ -40,7 +41,7 @@ func AddToManager(
 	}
 
 	if !gardenletutils.IsResponsibleForSelfHostedShoot() {
-		seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+		seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
 		if err != nil {
 			return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
 		}
@@ -81,7 +82,7 @@ func AddToManager(
 			}
 
 			if !gardenletutils.IsResponsibleForSelfHostedShoot() {
-				seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+				seedIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
 				if err != nil {
 					mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is a self-hosted shoot cluster")
 					return

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -6,6 +6,7 @@ package botanist
 
 import (
 	"context"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +74,11 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 			newFunc = shared.NewRuntimeGardenerResourceManager
 			values.HighAvailabilityConfigWebhookEnabled = false
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
+			// When GRM does not run inside the self hosted shoot cluster, we remove the `node-role.kubernetes.io/control-plane` toleration
+			// as it is not required.
+			values.SystemComponentTolerations = slices.DeleteFunc(values.SystemComponentTolerations, func(t corev1.Toleration) bool {
+				return t.Key == "node-role.kubernetes.io/control-plane"
+			})
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -74,7 +74,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 			newFunc = shared.NewRuntimeGardenerResourceManager
 			values.HighAvailabilityConfigWebhookEnabled = false
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
-			// When GRM does not run inside the self hosted shoot cluster, we remove the `node-role.kubernetes.io/control-plane` toleration
+			// When GRM does not run inside the self-hosted shoot cluster, we remove the `node-role.kubernetes.io/control-plane` toleration
 			// as it is not required.
 			values.SystemComponentTolerations = slices.DeleteFunc(values.SystemComponentTolerations, func(t corev1.Toleration) bool {
 				return t.Key == "node-role.kubernetes.io/control-plane"

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -74,7 +74,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 			newFunc = shared.NewRuntimeGardenerResourceManager
 			values.HighAvailabilityConfigWebhookEnabled = false
 			values.PriorityClassName = v1beta1constants.PriorityClassNameSeedSystemCritical
-			// When GRM does not run inside the self-hosted shoot cluster, we remove the `node-role.kubernetes.io/control-plane` toleration
+			// When GRM does not run inside the self-hosted shoot cluster (gardenadm bootstrap case), we remove the `node-role.kubernetes.io/control-plane` toleration
 			// as it is not required.
 			values.SystemComponentTolerations = slices.DeleteFunc(values.SystemComponentTolerations, func(t corev1.Toleration) bool {
 				return t.Key == "node-role.kubernetes.io/control-plane"

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -169,6 +169,21 @@ var _ = Describe("ResourceManager", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(resourceManager.GetValues().MachineNamespace).To(HaveValue(Equal("kube-system")))
+					Expect(resourceManager.GetValues().SystemComponentTolerations).To(ContainElement(HaveField("Key", "node-role.kubernetes.io/control-plane")))
+				})
+
+				When("not running inside self hosted shoot (gardenadm bootstrap)", func() {
+					BeforeEach(func() {
+						botanist.Shoot.ControlPlaneNamespace = "shoot--foo--bar"
+					})
+
+					It("should not have `node-role.kubernetes.io/control-plane` toleration", func() {
+						resourceManager, err := botanist.DefaultResourceManager()
+						Expect(resourceManager).NotTo(BeNil())
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(resourceManager.GetValues().SystemComponentTolerations).ToNot(ContainElement(HaveField("Key", "node-role.kubernetes.io/control-plane")))
+					})
 				})
 			})
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -163,7 +163,7 @@ func (r *Reconciler) instantiateComponents(
 	wildcardCertSecret *corev1.Secret,
 	enableAdmissionControllerAuthorizers bool,
 	extensionList *operatorv1alpha1.ExtensionList,
-	isRuntimeSelfHostedShoot bool,
+	runtimeIsSelfHostedShoot bool,
 ) (
 	c components,
 	err error,
@@ -212,7 +212,7 @@ func (r *Reconciler) instantiateComponents(
 	}
 
 	// garden system components
-	c.gardenerResourceManager, err = r.newGardenerResourceManager(garden, secretsManager, isRuntimeSelfHostedShoot)
+	c.gardenerResourceManager, err = r.newGardenerResourceManager(garden, secretsManager, runtimeIsSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -221,7 +221,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.etcdDruid, err = r.newEtcdDruid(secretsManager, isRuntimeSelfHostedShoot)
+	c.etcdDruid, err = r.newEtcdDruid(secretsManager, runtimeIsSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -412,7 +412,7 @@ func (r *Reconciler) enableAdmissionControllerAuthorizers(ctx context.Context, v
 	return true, nil
 }
 
-func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, isRuntimeSelfHostedShoot bool) (component.DeployWaiter, error) {
+func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, runtimeIsSelfHostedShoot bool) (component.DeployWaiter, error) {
 	var defaultNotReadyTolerationSeconds, defaultUnreachableTolerationSeconds *int64
 	if nodeToleration := r.Config.NodeToleration; nodeToleration != nil {
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
@@ -455,8 +455,8 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 				},
 			},
 		},
-		VPAInPlaceUpdatesEnabled: features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
-		ForSelfHostedShoot:       isRuntimeSelfHostedShoot,
+		VPAInPlaceUpdatesEnabled:             features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
+		SystemComponentsConfigWebhookEnabled: runtimeIsSelfHostedShoot,
 	})
 }
 
@@ -513,12 +513,7 @@ func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, s
 	return verticalPodAutoscaler, nil
 }
 
-func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, isRuntimeSelfHostedShoot bool) (component.DeployWaiter, error) {
-	var managedBy = etcd.ManagedByOperator
-	if isRuntimeSelfHostedShoot {
-		managedBy = etcd.ManagedBySelfHostedShoot
-	}
-
+func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, runtimeIsSelfHostedShoot bool) (component.DeployWaiter, error) {
 	return sharedcomponent.NewEtcdDruid(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -528,7 +523,8 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, isRun
 		secretsManager,
 		operatorv1alpha1.SecretNameCARuntime,
 		v1beta1constants.PriorityClassNameGardenSystem300,
-		managedBy,
+		true,
+		runtimeIsSelfHostedShoot,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -521,7 +521,7 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (comp
 		secretsManager,
 		operatorv1alpha1.SecretNameCARuntime,
 		v1beta1constants.PriorityClassNameGardenSystem300,
-		true,
+		etcd.ManagedByOperator,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -163,6 +163,7 @@ func (r *Reconciler) instantiateComponents(
 	wildcardCertSecret *corev1.Secret,
 	enableAdmissionControllerAuthorizers bool,
 	extensionList *operatorv1alpha1.ExtensionList,
+	isRuntimeSelfHostedShoot bool,
 ) (
 	c components,
 	err error,
@@ -211,7 +212,7 @@ func (r *Reconciler) instantiateComponents(
 	}
 
 	// garden system components
-	c.gardenerResourceManager, err = r.newGardenerResourceManager(garden, secretsManager)
+	c.gardenerResourceManager, err = r.newGardenerResourceManager(garden, secretsManager, isRuntimeSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -220,7 +221,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.etcdDruid, err = r.newEtcdDruid(secretsManager)
+	c.etcdDruid, err = r.newEtcdDruid(secretsManager, isRuntimeSelfHostedShoot)
 	if err != nil {
 		return
 	}
@@ -411,7 +412,7 @@ func (r *Reconciler) enableAdmissionControllerAuthorizers(ctx context.Context, v
 	return true, nil
 }
 
-func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, isRuntimeSelfHostedShoot bool) (component.DeployWaiter, error) {
 	var defaultNotReadyTolerationSeconds, defaultUnreachableTolerationSeconds *int64
 	if nodeToleration := r.Config.NodeToleration; nodeToleration != nil {
 		defaultNotReadyTolerationSeconds = nodeToleration.DefaultNotReadyTolerationSeconds
@@ -455,6 +456,7 @@ func (r *Reconciler) newGardenerResourceManager(garden *operatorv1alpha1.Garden,
 			},
 		},
 		VPAInPlaceUpdatesEnabled: features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
+		ForSelfHostedShoot:       isRuntimeSelfHostedShoot,
 	})
 }
 
@@ -511,7 +513,12 @@ func (r *Reconciler) newVerticalPodAutoscaler(garden *operatorv1alpha1.Garden, s
 	return verticalPodAutoscaler, nil
 }
 
-func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface, isRuntimeSelfHostedShoot bool) (component.DeployWaiter, error) {
+	var managedBy = etcd.ManagedByOperator
+	if isRuntimeSelfHostedShoot {
+		managedBy = etcd.ManagedBySelfHostedShoot
+	}
+
 	return sharedcomponent.NewEtcdDruid(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -521,7 +528,7 @@ func (r *Reconciler) newEtcdDruid(secretsManager secretsmanager.Interface) (comp
 		secretsManager,
 		operatorv1alpha1.SecretNameCARuntime,
 		v1beta1constants.PriorityClassNameGardenSystem300,
-		etcd.ManagedByOperator,
+		managedBy,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -112,19 +112,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, garden, err, operationType)
 	}
 
-	isRuntimeSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
+	runtimeIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not determine if runtime cluster is also a self hosted shoot cluster")
 	}
 
 	if garden.DeletionTimestamp != nil {
-		if result, err := r.delete(ctx, log, garden, secretsManager, targetVersion, isRuntimeSelfHostedShoot); err != nil {
+		if result, err := r.delete(ctx, log, garden, secretsManager, targetVersion, runtimeIsSelfHostedShoot); err != nil {
 			return result, r.updateStatusOperationError(ctx, garden, err, operationType)
 		}
 		return reconcile.Result{}, nil
 	}
 
-	if result, err := r.reconcile(ctx, log, garden, secretsManager, targetVersion, isRuntimeSelfHostedShoot); err != nil {
+	if result, err := r.reconcile(ctx, log, garden, secretsManager, targetVersion, runtimeIsSelfHostedShoot); err != nil {
 		return result, r.updateStatusOperationError(ctx, garden, err, operationType)
 	} else if result.RequeueAfter > 0 {
 		return result, nil

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -38,7 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	"github.com/gardener/gardener/pkg/utils/gardener"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, garden, err, operationType)
 	}
 
-	isRuntimeSelfHostedShoot, err := gardener.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
+	isRuntimeSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not determine if runtime cluster is also a self hosted shoot cluster")
 	}

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/gardener/tokenrequest"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -111,14 +112,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, garden, err, operationType)
 	}
 
+	isRuntimeSelfHostedShoot, err := gardener.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not determine if runtime cluster is also a self hosted shoot cluster")
+	}
+
 	if garden.DeletionTimestamp != nil {
-		if result, err := r.delete(ctx, log, garden, secretsManager, targetVersion); err != nil {
+		if result, err := r.delete(ctx, log, garden, secretsManager, targetVersion, isRuntimeSelfHostedShoot); err != nil {
 			return result, r.updateStatusOperationError(ctx, garden, err, operationType)
 		}
 		return reconcile.Result{}, nil
 	}
 
-	if result, err := r.reconcile(ctx, log, garden, secretsManager, targetVersion); err != nil {
+	if result, err := r.reconcile(ctx, log, garden, secretsManager, targetVersion, isRuntimeSelfHostedShoot); err != nil {
 		return result, r.updateStatusOperationError(ctx, garden, err, operationType)
 	} else if result.RequeueAfter > 0 {
 		return result, nil

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -53,6 +53,7 @@ func (r *Reconciler) delete(
 	garden *operatorv1alpha1.Garden,
 	secretsManager secretsmanager.Interface,
 	targetVersion *semver.Version,
+	isRuntimeSelfHostedShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -72,6 +73,7 @@ func (r *Reconciler) delete(
 		nil,
 		false,
 		extensionList,
+		isRuntimeSelfHostedShoot,
 	)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -82,7 +81,7 @@ func (r *Reconciler) delete(
 	// When the runtime cluster is a self-hosted shoot, etcd-druid and the runtime gardener-resource-manager are also
 	// serving the shoot's control plane. They must not be destroyed during Garden deletion — the gardenlet will continue
 	// managing them.
-	runtimeClusterIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
+	runtimeClusterIsSelfHostedShoot, err := gardenerutils.ClusterIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -52,7 +52,7 @@ func (r *Reconciler) delete(
 	garden *operatorv1alpha1.Garden,
 	secretsManager secretsmanager.Interface,
 	targetVersion *semver.Version,
-	isRuntimeSelfHostedShoot bool,
+	runtimeIsSelfHostedShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -72,7 +72,7 @@ func (r *Reconciler) delete(
 		nil,
 		false,
 		extensionList,
-		isRuntimeSelfHostedShoot,
+		runtimeIsSelfHostedShoot,
 	)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -87,6 +87,7 @@ func (r *Reconciler) reconcile(
 	garden *operatorv1alpha1.Garden,
 	secretsManager secretsmanager.Interface,
 	targetVersion *semver.Version,
+	isRuntimeSelfHostedShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -148,6 +149,7 @@ func (r *Reconciler) reconcile(
 		wildcardCert,
 		enableAdmissionControllerAuthorizers,
 		extensionList,
+		isRuntimeSelfHostedShoot,
 	)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -87,7 +87,7 @@ func (r *Reconciler) reconcile(
 	garden *operatorv1alpha1.Garden,
 	secretsManager secretsmanager.Interface,
 	targetVersion *semver.Version,
-	isRuntimeSelfHostedShoot bool,
+	runtimeIsSelfHostedShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -149,7 +149,7 @@ func (r *Reconciler) reconcile(
 		wildcardCert,
 		enableAdmissionControllerAuthorizers,
 		extensionList,
-		isRuntimeSelfHostedShoot,
+		runtimeIsSelfHostedShoot,
 	)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -495,3 +495,12 @@ func ReconcileGardenNamespace(ctx context.Context, client client.Client, namespa
 	})
 	return err
 }
+
+// ClusterIsSelfHostedShoot returns 'true' if the cluster is a self-hosted shoot cluster.
+func ClusterIsSelfHostedShoot(ctx context.Context, c client.Reader) (bool, error) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+		return false, fmt.Errorf("failed reading %q namespace: %w", namespace.Name, err)
+	}
+	return namespace.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot, nil
+}

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -25,6 +25,7 @@ import (
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Garden", func() {
@@ -1022,56 +1023,34 @@ var _ = Describe("Garden", func() {
 		})
 	})
 
-	Describe("#RuntimeIsSelfHostedShoot", func() {
+	Describe("#ClusterIsSelfHostedShoot", func() {
 		var (
-			ctx        context.Context
+			ctx        = context.Background()
 			fakeClient client.Client
 		)
 
 		BeforeEach(func() {
-			ctx = context.Background()
-			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			fakeClient = fakeclient.NewClientBuilder().Build()
 		})
 
-		It("should return false when kube-system namespace has no garden-role label", func() {
-			Expect(fakeClient.Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem},
-			})).To(Succeed())
-
-			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
+		It("should return that the cluster is a self-hosted shoot", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "shoot"}}})).To(Succeed())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
 		})
 
-		It("should return true when kube-system namespace has garden-role=shoot label", func() {
-			Expect(fakeClient.Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   metav1.NamespaceSystem,
-					Labels: map[string]string{constants.GardenRole: constants.GardenRoleShoot},
-				},
-			})).To(Succeed())
-
-			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
+		It("should return that the cluster is not a self-hosted shoot because kube-system namespace is not labeled correctly", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "kube-system"}}})).To(Succeed())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 
-		It("should return false when kube-system namespace has a different garden-role label", func() {
-			Expect(fakeClient.Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   metav1.NamespaceSystem,
-					Labels: map[string]string{constants.GardenRole: constants.GardenRoleSeed},
-				},
-			})).To(Succeed())
-
-			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
+		It("should return that the cluster is not a self-hosted shoot because kube-system namespace is not labeled at all", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})).To(Succeed())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 
-		It("should return an error when the kube-system namespace does not exist", func() {
+		It("should return an error no kube-system namespace is found", func() {
 			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
-			Expect(err).To(MatchError(ContainSubstring(`failed reading "kube-system" namespace`)))
+			Expect(err).To(BeNotFoundError())
 			Expect(result).To(BeFalse())
 		})
 	})

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -1021,4 +1021,58 @@ var _ = Describe("Garden", func() {
 			})
 		})
 	})
+
+	Describe("#RuntimeIsSelfHostedShoot", func() {
+		var (
+			ctx        context.Context
+			fakeClient client.Client
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		})
+
+		It("should return false when kube-system namespace has no garden-role label", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem},
+			})).To(Succeed())
+
+			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return true when kube-system namespace has garden-role=shoot label", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   metav1.NamespaceSystem,
+					Labels: map[string]string{constants.GardenRole: constants.GardenRoleShoot},
+				},
+			})).To(Succeed())
+
+			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when kube-system namespace has a different garden-role label", func() {
+			Expect(fakeClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   metav1.NamespaceSystem,
+					Labels: map[string]string{constants.GardenRole: constants.GardenRoleSeed},
+				},
+			})).To(Succeed())
+
+			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return an error when the kube-system namespace does not exist", func() {
+			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
+			Expect(err).To(MatchError(ContainSubstring(`failed reading "kube-system" namespace`)))
+			Expect(result).To(BeFalse())
+		})
+	})
 })

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
@@ -38,15 +37,6 @@ func ClusterIsGarden(ctx context.Context, seedClient client.Reader) (bool, error
 		seedIsGarden = false
 	}
 	return seedIsGarden, nil
-}
-
-// SeedIsSelfHostedShoot returns 'true' if the cluster is a self-hosted shoot cluster.
-func SeedIsSelfHostedShoot(ctx context.Context, seedClient client.Reader) (bool, error) {
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}
-	if err := seedClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-		return false, fmt.Errorf("failed reading %q namespace: %w", namespace.Name, err)
-	}
-	return namespace.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleShoot, nil
 }
 
 // SetDefaultGardenClusterAddress sets the default garden cluster address in the given gardenlet configuration if it is not already set.

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -25,6 +25,7 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -84,21 +85,21 @@ var _ = Describe("Gardenlet", func() {
 
 		It("should return that the seed is a self-hosted shoot", func() {
 			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "shoot"}}})).To(Succeed())
-			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeTrue())
 		})
 
 		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled correctly", func() {
 			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system", Labels: map[string]string{"gardener.cloud/role": "kube-system"}}})).To(Succeed())
-			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 
 		It("should return that the seed is not a self-hosted shoot because kube-system namespace is not labeled at all", func() {
 			Expect(fakeClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}})).To(Succeed())
-			Expect(SeedIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
+			Expect(ClusterIsSelfHostedShoot(ctx, fakeClient)).To(BeFalse())
 		})
 
 		It("should return an error no kube-system namespace is found", func() {
-			result, err := SeedIsSelfHostedShoot(ctx, fakeClient)
+			result, err := ClusterIsSelfHostedShoot(ctx, fakeClient)
 			Expect(err).To(BeNotFoundError())
 			Expect(result).To(BeFalse())
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei
/kind enhancement

**What this PR does / why we need it**:
Ensure system components (GRM, etcd-druid, MCM, and extensions) run on system component workers when managed infrastructure scenarios or self-hosted shoots use dedicated system component workers.

**Changes**

API Validation
- Relaxed validation for `systemComponents.allow`: Workers with `systemComponents.allow=true` are now permitted as long as their zones match the control plane worker zones (previously restricted to control plane workers only)

Component Placement

- Gardener Resource Manager (GRM):
  - Configured to run on system component workers in self-hosted shoots
  - Enabled SystemComponentsConfig webhook for self-hosted shoots with namespace label selector (`system-components-config.resources.gardener.cloud/consider=true`)
  - Removed unnecessary `node-role.kubernetes.io/control-plane` toleration when not running inside the self-hosted shoot
- etcd-druid: Added node selector for system component workers when managed by self-hosted shoots
- Machine Controller Manager (MCM): When running in kube-system namespace, scheduled only on system component workers
- Extension controller installations: Namespaces labeled with `system-components-config.resources.gardener.cloud/consider=true` for proper webhook targeting

Co-authored-by: @plkokanov 

**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
