### PR TITLE
[GEP-28] `gardenadm connect`: Enable `ManagedSeed` controller in `gardenlet`

### DIFF
--- a/charts/gardener/gardenlet/templates/clusterrole-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-apiserver-sni.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:gardenlet:apiserver-sni
+  name: gardener.cloud:system:gardenlet:apiserver-sni{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet

--- a/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-gardenlet.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:gardenlet
+  name: gardener.cloud:system:gardenlet{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet

--- a/charts/gardener/gardenlet/templates/clusterrole-istio.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrole-istio.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:gardenlet:managed-istio
+  name: gardener.cloud:system:gardenlet:managed-istio{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-apiserver-sni.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:system:gardenlet:apiserver-sni
+  name: gardener.cloud:system:gardenlet:apiserver-sni{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:system:gardenlet:apiserver-sni
+  name: gardener.cloud:system:gardenlet:apiserver-sni{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
 subjects:
 - kind: ServiceAccount
   name: "{{ required ".Values.serviceAccountName is required" .Values.serviceAccountName }}"

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-gardenlet.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-gardenlet.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:system:gardenlet
+  name: gardener.cloud:system:gardenlet{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:system:gardenlet
+  name: gardener.cloud:system:gardenlet{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
 subjects:
 - kind: ServiceAccount
   name: "{{ required ".Values.serviceAccountName is required" .Values.serviceAccountName }}"

--- a/charts/gardener/gardenlet/templates/clusterrolebinding-istio.yaml
+++ b/charts/gardener/gardenlet/templates/clusterrolebinding-istio.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:system:gardenlet:managed-istio
+  name: gardener.cloud:system:gardenlet:managed-istio{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
   labels:
     app: gardener
     role: gardenlet
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:system:gardenlet:managed-istio
+  name: gardener.cloud:system:gardenlet:managed-istio{{ if .Values.isolateClusterResources }}:{{ .Release.Namespace }}{{ end }}
 subjects:
 - kind: ServiceAccount
   name: "{{ required ".Values.serviceAccountName is required" .Values.serviceAccountName }}"

--- a/charts/gardener/gardenlet/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/templates/priorityclass.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.isolateClusterResources }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -5,3 +6,4 @@ metadata:
 value: 999998950
 globalDefault: false
 description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."
+{{- end }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -1,5 +1,6 @@
 replicaCount: 2
 revisionHistoryLimit: 2
+isolateClusterResources: false
 serviceAccountName: gardenlet
 invalidateServiceAccountToken: true
 image:

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -53,8 +53,10 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
 	kubeapiserverexposure "github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -398,6 +400,13 @@ func (g *garden) Start(ctx context.Context) error {
 						Field:      fields.SelectorFromSet(fields.Set{metav1.ObjectNameField: gardenlet.ResourcePrefixSelfHostedShoot + g.selfHostedShootInfo.Meta.Name}),
 						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
 					},
+					&seedmanagementv1alpha1.ManagedSeed{}: {
+						Field: fields.SelectorFromSet(fields.Set{
+							seedmanagement.ManagedSeedShootName: g.selfHostedShootInfo.Meta.Name,
+						}),
+						Namespaces: map[string]cache.Config{g.selfHostedShootInfo.Meta.Namespace: {}},
+					},
+					&gardencorev1beta1.Seed{}: {},
 				}
 
 				return kubernetes.AggregatorCacheFunc(
@@ -491,15 +500,31 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	log.Info("Setting up shoot client map")
-	shootClientMap, err := clientmapbuilder.
-		NewShootClientMapBuilder().
-		WithGardenClient(gardenCluster.GetClient()).
-		WithSeedClient(g.mgr.GetClient()).
-		WithClientConnectionConfig(&g.config.ShootClientConnection.ClientConnectionConfiguration).
-		Build(log)
+	seedClientSet, err := kubernetes.NewWithConfig(
+		kubernetes.WithRESTConfig(g.mgr.GetConfig()),
+		kubernetes.WithRuntimeAPIReader(g.mgr.GetAPIReader()),
+		kubernetes.WithRuntimeClient(g.mgr.GetClient()),
+		kubernetes.WithRuntimeCache(g.mgr.GetCache()),
+	)
 	if err != nil {
-		return fmt.Errorf("failed to build shoot ClientMap: %w", err)
+		return fmt.Errorf("failed creating seed clientset: %w", err)
+	}
+
+	log.Info("Setting up shoot client map")
+	var shootClientMap clientmap.ClientMap
+	if g.selfHostedShootInfo != nil {
+		shootClientMap = clientmap.NewSelfHostedShootClientMap(seedClientSet)
+	} else {
+		var err error
+		shootClientMap, err = clientmapbuilder.
+			NewShootClientMapBuilder().
+			WithGardenClient(gardenCluster.GetClient()).
+			WithSeedClient(g.mgr.GetClient()).
+			WithClientConnectionConfig(&g.config.ShootClientConnection.ClientConnectionConfiguration).
+			Build(log)
+		if err != nil {
+			return fmt.Errorf("failed to build shoot ClientMap: %w", err)
+		}
 	}
 
 	log.Info("Adding runnables now that bootstrapping is finished")
@@ -548,6 +573,7 @@ func (g *garden) Start(ctx context.Context) error {
 		g.cancel,
 		gardenCluster,
 		g.mgr,
+		seedClientSet,
 		shootClientMap,
 		g.config,
 		g.healthManager,
@@ -835,6 +861,8 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 			indexer.AddControllerInstallationRegistrationRefName,
 			indexer.AddControllerInstallationShootRefName,
 			indexer.AddControllerInstallationShootRefNamespace,
+			// seedmanagement API group
+			indexer.AddManagedSeedShootName,
 		}
 	}
 

--- a/docs/api-reference/seedmanagement.md
+++ b/docs/api-reference/seedmanagement.md
@@ -936,6 +936,18 @@ Kubernetes core/v1.PullPolicy
 Defaults to Always if latest tag is specified, or IfNotPresent otherwise.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ref is the full image reference.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="seedmanagement.gardener.cloud/v1alpha1.ManagedSeedSetSpec">ManagedSeedSetSpec

--- a/docs/api-reference/seedmanagement.md
+++ b/docs/api-reference/seedmanagement.md
@@ -887,7 +887,8 @@ generation, which is updated on mutation by the API Server.</p>
 <a href="#seedmanagement.gardener.cloud/v1alpha1.GardenletDeployment">GardenletDeployment</a>)
 </p>
 <p>
-<p>Image specifies container image parameters.</p>
+<p>Image specifies container image parameters.
+Either Repository/Tag or Ref must be set, but not both.</p>
 </p>
 <table>
 <thead>

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler.go
@@ -17,8 +17,10 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -29,6 +31,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
@@ -43,6 +46,7 @@ var (
 	configMapResource                 = corev1.Resource("configmaps")
 	gardenletResource                 = seedmanagementv1alpha1.Resource("gardenlets")
 	leaseResource                     = coordinationv1.Resource("leases")
+	managedSeedResource               = seedmanagementv1alpha1.Resource("managedseeds")
 	projectResource                   = gardencorev1beta1.Resource("projects")
 	secretResource                    = corev1.Resource("secrets")
 	serviceAccountResource            = corev1.Resource("serviceaccounts")
@@ -84,6 +88,9 @@ func (h *Handler) Handle(ctx context.Context, request admission.Request) admissi
 
 	case leaseResource:
 		return h.admitLease(gardenletShootInfo, userType, request)
+
+	case managedSeedResource:
+		return h.admitManagedSeed(ctx, gardenletShootInfo, request)
 
 	case secretResource:
 		return h.admitSecret(ctx, gardenletShootInfo, request)
@@ -133,6 +140,22 @@ func (h *Handler) admitCertificateSigningRequest(gardenletShootInfo types.Namesp
 	return h.admit(gardenletShootInfo, types.NamespacedName{Name: name, Namespace: namespace})
 }
 
+func (h *Handler) admitManagedSeed(ctx context.Context, gardenletShootInfo types.NamespacedName, request admission.Request) admission.Response {
+	if request.Operation != admissionv1.Update {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
+	}
+
+	managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: request.Namespace}}
+	if err := h.Client.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
+		if apierrors.IsNotFound(err) {
+			return admission.Errored(http.StatusForbidden, err)
+		}
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return h.admit(gardenletShootInfo, types.NamespacedName{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace})
+}
+
 func (h *Handler) admitSecret(ctx context.Context, gardenletShootInfo types.NamespacedName, request admission.Request) admission.Response {
 	if request.Operation != admissionv1.Create {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
@@ -153,6 +176,27 @@ func (h *Handler) admitSecret(ctx context.Context, gardenletShootInfo types.Name
 		}
 
 		return h.admit(gardenletShootInfo, types.NamespacedName{Name: backupBucket.Spec.ShootRef.Name, Namespace: backupBucket.Spec.ShootRef.Namespace})
+	}
+
+	// Check if the secret is a bootstrap token for a ManagedSeed referencing the gardenlet's shoot.
+	if request.Namespace == metav1.NamespaceSystem && strings.HasPrefix(request.Name, bootstraptokenapi.BootstrapTokenSecretPrefix) {
+		secret := &corev1.Secret{}
+		if err := h.Decoder.Decode(request, secret); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		kind, namespace, name := gardenletbootstraputil.MetadataFromDescription(string(secret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey]))
+		if kind == gardenletbootstraputil.KindManagedSeed {
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+			if err := h.Client.Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed); err != nil {
+				if apierrors.IsNotFound(err) {
+					return admission.Errored(http.StatusForbidden, err)
+				}
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+
+			return h.admit(gardenletShootInfo, types.NamespacedName{Name: managedSeed.Spec.Shoot.Name, Namespace: managedSeed.Namespace})
+		}
 	}
 
 	return admission.Errored(http.StatusForbidden, fmt.Errorf("object does not belong to shoot %s", gardenletShootInfo))

--- a/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/shootrestriction/handler_test.go
@@ -359,6 +359,88 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 				})
 			})
 
+			When("requested for ManagedSeeds", func() {
+				BeforeEach(func() {
+					request.Name = "foo"
+					request.Namespace = shootNamespace
+					request.UserInfo = gardenletUser
+					request.Resource = metav1.GroupVersionResource{
+						Group:    seedmanagementv1alpha1.SchemeGroupVersion.Group,
+						Version:  seedmanagementv1alpha1.SchemeGroupVersion.Version,
+						Resource: "managedseeds",
+					}
+				})
+
+				DescribeTable("should not allow the request because no allowed verb",
+					func(operation admissionv1.Operation) {
+						request.Operation = operation
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusBadRequest),
+									Message: fmt.Sprintf("unexpected operation: %q", operation),
+								},
+							},
+						}))
+					},
+
+					Entry("create", admissionv1.Create),
+					Entry("delete", admissionv1.Delete),
+				)
+
+				When("operation is update", func() {
+					BeforeEach(func() {
+						request.Operation = admissionv1.Update
+					})
+
+					It("should return an error because the ManagedSeed was not found", func() {
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("managedseeds.seedmanagement.gardener.cloud %q not found", "foo"),
+								},
+							},
+						}))
+					})
+
+					It("should forbid because the ManagedSeed does not belong to gardenlet's shoot", func() {
+						managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: shootNamespace},
+							Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+								Shoot: &seedmanagementv1alpha1.Shoot{Name: "other-shoot"},
+							},
+						}
+						Expect(fakeClient.Create(ctx, managedSeed)).To(Succeed())
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("object does not belong to shoot %s/%s", shootNamespace, shootName),
+								},
+							},
+						}))
+					})
+
+					It("should allow because the ManagedSeed belongs to gardenlet's shoot", func() {
+						managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+							ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: shootNamespace},
+							Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+								Shoot: &seedmanagementv1alpha1.Shoot{Name: shootName},
+							},
+						}
+						Expect(fakeClient.Create(ctx, managedSeed)).To(Succeed())
+
+						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+					})
+				})
+			})
+
 			Context("when requested for Leases", func() {
 				var name string
 
@@ -562,6 +644,67 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 							Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 
 							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+						})
+					})
+
+					Context("ManagedSeed bootstrap token secret", func() {
+						BeforeEach(func() {
+							request.Name = "bootstrap-token-abcdef"
+							request.Namespace = metav1.NamespaceSystem
+						})
+
+						It("should allow because the ManagedSeed belongs to gardenlet's shoot", func() {
+							managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+								ObjectMeta: metav1.ObjectMeta{Name: "my-managed-seed", Namespace: shootNamespace},
+								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+									Shoot: &seedmanagementv1alpha1.Shoot{Name: shootName},
+								},
+							}
+							Expect(fakeClient.Create(ctx, managedSeed)).To(Succeed())
+
+							secret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-token-abcdef", Namespace: metav1.NamespaceSystem},
+								Type:       corev1.SecretTypeBootstrapToken,
+								Data: map[string][]byte{
+									"description": []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.ManagedSeed resource " + shootNamespace + "/my-managed-seed."),
+								},
+							}
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+						})
+
+						It("should forbid because the ManagedSeed does not belong to gardenlet's shoot", func() {
+							managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+								ObjectMeta: metav1.ObjectMeta{Name: "my-managed-seed", Namespace: "other-namespace"},
+								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+									Shoot: &seedmanagementv1alpha1.Shoot{Name: "other-shoot"},
+								},
+							}
+							Expect(fakeClient.Create(ctx, managedSeed)).To(Succeed())
+
+							secret := &corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{Name: "bootstrap-token-abcdef", Namespace: metav1.NamespaceSystem},
+								Type:       corev1.SecretTypeBootstrapToken,
+								Data: map[string][]byte{
+									"description": []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.ManagedSeed resource other-namespace/my-managed-seed."),
+								},
+							}
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("object does not belong to shoot %s/%s", shootNamespace, shootName),
+									},
+								},
+							}))
 						})
 					})
 				})

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -15,6 +15,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
@@ -30,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	"github.com/gardener/gardener/pkg/utils/graph"
@@ -72,7 +74,9 @@ var (
 	eventResource                     = eventsv1.Resource("events")
 	gardenletResource                 = seedmanagementv1alpha1.Resource("gardenlets")
 	leaseResource                     = coordinationv1.Resource("leases")
+	managedSeedResource               = seedmanagementv1alpha1.Resource("managedseeds")
 	projectResource                   = gardencorev1beta1.Resource("projects")
+	seedResource                      = gardencorev1beta1.Resource("seeds")
 	secretResource                    = corev1.Resource("secrets")
 	secretBindingResource             = gardencorev1beta1.Resource("secretbindings")
 	serviceAccountResource            = corev1.Resource("serviceaccounts")
@@ -177,6 +181,22 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 		case leaseResource:
 			return a.authorizeLease(requestAuthorizer, userType, shootNamespace, shootName, attrs)
 
+		case managedSeedResource:
+			return requestAuthorizer.Check(graph.VertexTypeManagedSeed, attrs,
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
+				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithAllowedNamespaces(requestAuthorizer.ToNamespace),
+				authwebhook.WithFieldSelectors(map[string]string{
+					seedmanagement.ManagedSeedShootName: shootName,
+				}),
+			)
+
+		case seedResource:
+			return requestAuthorizer.Check(graph.VertexTypeSeed, attrs,
+				authwebhook.WithAllowedVerbs("get", "delete"),
+				authwebhook.WithAlwaysAllowedVerbs("list", "watch"),
+			)
+
 		case secretResource:
 			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
 
@@ -279,18 +299,21 @@ func (a *authorizer) authorizeServiceAccount(requestAuthorizer *authwebhook.Requ
 }
 
 func (a *authorizer) authorizeSecret(ctx context.Context, requestAuthorizer *authwebhook.RequestAuthorizer, attrs auth.Attributes) (auth.Decision, string, error) {
-	// Allow gardenlet to delete its bootstrap token.
+	// Allow gardenlet to delete bootstrap tokens for its own shoot or for ManagedSeeds referencing its shoot.
 	if attrs.GetVerb() == "delete" && attrs.GetNamespace() == metav1.NamespaceSystem && strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix) {
-		shootMeta, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, a.client, attrs.GetName())
+		shootMeta, found, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, a.client, attrs.GetName())
 		if err != nil {
-			return auth.DecisionNoOpinion, "", fmt.Errorf("failed fetching shoot meta from bootstrap token description: %w", err)
-		}
-
-		if shootMeta.Namespace == requestAuthorizer.ToNamespace && shootMeta.Name == requestAuthorizer.ToName {
-			return auth.DecisionAllow, "", nil
-		} else {
+			if !apierrors.IsNotFound(err) {
+				return auth.DecisionNoOpinion, "", err
+			}
+		} else if found {
+			if shootMeta.Namespace == requestAuthorizer.ToNamespace && shootMeta.Name == requestAuthorizer.ToName {
+				return auth.DecisionAllow, "", nil
+			}
 			return auth.DecisionNoOpinion, fmt.Sprintf("shoot meta in bootstrap token secret %s does not match with identity of requestor %s/%s", shootMeta, requestAuthorizer.ToNamespace, requestAuthorizer.ToName), nil
 		}
+		// No shoot meta found — fall through to graph-based authorization which handles ManagedSeed bootstrap
+		// tokens via the Secret → ManagedSeed → Shoot edges.
 	}
 
 	return requestAuthorizer.Check(graph.VertexTypeSecret, attrs,

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -28,12 +28,12 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
 	graphutils "github.com/gardener/gardener/pkg/utils/graph"
 	mockgraph "github.com/gardener/gardener/pkg/utils/graph/mock"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	authorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer"
 	fakeauthorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer/fake"
 )
@@ -988,6 +988,206 @@ var _ = Describe("Shoot", func() {
 				)
 			})
 
+			When("requested for Seeds", func() {
+				var (
+					name  string
+					attrs *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name = "foo"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "seeds",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should have no opinion because verb is not allowed",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [delete get list watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("patch", "patch"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because no allowed subresource", func() {
+					attrs.Subresource = "foo"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
+				})
+
+				DescribeTable("should always allow list/watch requests",
+					func(verb string) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				It("should allow when verb is delete and resource does not exist", func() {
+					attrs.Verb = "delete"
+
+					graph.EXPECT().HasVertex(graphutils.VertexTypeSeed, "", name).Return(false)
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb string) {
+						attrs.Verb = verb
+
+						if verb == "delete" {
+							graph.EXPECT().HasVertex(graphutils.VertexTypeSeed, "", name).Return(true).Times(2)
+						}
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeSeed, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeSeed, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+						decision, reason, err = authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
+					},
+
+					Entry("get", "get"),
+					Entry("delete", "delete"),
+				)
+			})
+
+			When("requested for ManagedSeeds", func() {
+				var (
+					name, namespace string
+					attrs           *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name, namespace = "foo", shootNamespace
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						Namespace:       namespace,
+						APIGroup:        seedmanagementv1alpha1.SchemeGroupVersion.Group,
+						Resource:        "managedseeds",
+						ResourceRequest: true,
+						Verb:            "list",
+					}
+				})
+
+				DescribeTable("should have no opinion because verb is not allowed",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list patch update watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because no allowed subresource", func() {
+					attrs.Subresource = "foo"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+				})
+
+				It("should have no opinion because namespace does not match", func() {
+					attrs.Namespace = "not-allowed"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring(fmt.Sprintf("only the following namespaces are allowed for this resource type: [%s]", shootNamespace)))
+				})
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector(seedmanagement.ManagedSeedShootName + "=" + shootName)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+				)
+
+				DescribeTable("should return correct result if path exists",
+					func(verb, subresource string) {
+						attrs.Verb = verb
+						attrs.Subresource = subresource
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeManagedSeed, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeManagedSeed, namespace, name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+						decision, reason, err = authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("no relationship found"))
+					},
+
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
+					Entry("patch w/o subresource", "patch", ""),
+					Entry("patch w/ subresource", "patch", "status"),
+					Entry("update w/o subresource", "update", ""),
+					Entry("update w/ subresource", "update", "status"),
+				)
+			})
+
 			Context("when requested for Leases", func() {
 				var (
 					name, namespace string
@@ -1362,19 +1562,22 @@ var _ = Describe("Shoot", func() {
 						Expect(reason).To(ContainSubstring(`shoot meta in bootstrap token secret not-the-namespace/not-the-name does not match with identity of requestor`))
 					})
 
-					It("should return an error if description cannot be fetched", func() {
+					It("should fall through to graph-based authorization if description is not a self-hosted shoot token", func() {
 						Expect(fakeClient.Create(ctx, bootstrapTokenSecret)).To(Succeed())
 
+						graph.EXPECT().HasVertex(graphutils.VertexTypeSecret, bootstrapTokenSecret.Namespace, bootstrapTokenSecret.Name).Return(true)
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeSecret, bootstrapTokenSecret.Namespace, bootstrapTokenSecret.Name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).To(MatchError(ContainSubstring(`failed fetching shoot meta from bootstrap token description: bootstrap token description does not start with "Used for connecting the self-hosted Shoot "`)))
-						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
 						Expect(reason).To(BeEmpty())
 					})
 
-					It("should return an error if secret is not found", func() {
+					It("should fall through to graph-based authorization if secret is not found", func() {
+						graph.EXPECT().HasVertex(graphutils.VertexTypeSecret, bootstrapTokenSecret.Namespace, bootstrapTokenSecret.Name).Return(false)
 						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).To(BeNotFoundError())
-						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
 						Expect(reason).To(BeEmpty())
 					})
 				})

--- a/pkg/api/seedmanagement/validation/gardenlet_test.go
+++ b/pkg/api/seedmanagement/validation/gardenlet_test.go
@@ -278,6 +278,34 @@ var _ = Describe("Gardenlet Validation Tests", func() {
 				))
 			})
 
+			It("should forbid empty ref in image", func() {
+				gardenlet.Spec.Deployment.Image = &seedmanagement.Image{
+					Ref: ptr.To(""),
+				}
+
+				Expect(ValidateGardenlet(gardenlet)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.deployment.image.ref"),
+					})),
+				))
+			})
+
+			It("should forbid specifying both ref and repository/tag in image", func() {
+				gardenlet.Spec.Deployment.Image = &seedmanagement.Image{
+					Ref:        ptr.To("registry.example.com/gardenlet:v1.0.0"),
+					Repository: ptr.To("registry.example.com/gardenlet"),
+					Tag:        ptr.To("v1.0.0"),
+				}
+
+				Expect(ValidateGardenlet(gardenlet)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.deployment.image"),
+					})),
+				))
+			})
+
 			It("should forbid garden client connection kubeconfig if bootstrap is specified", func() {
 				gardenlet.Spec.Config = gardenletConfiguration(seedx,
 					&gardenletconfigv1alpha1.GardenClientConnection{

--- a/pkg/api/seedmanagement/validation/managedseed.go
+++ b/pkg/api/seedmanagement/validation/managedseed.go
@@ -235,11 +235,17 @@ func ValidateGardenletDeployment(deployment *seedmanagement.GardenletDeployment,
 func validateImage(image *seedmanagement.Image, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	if image.Ref != nil && *image.Ref == "" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ref"), *image.Ref, "ref must not be empty if specified"))
+	}
 	if image.Repository != nil && *image.Repository == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("repository"), *image.Repository, "repository must not be empty if specified"))
 	}
 	if image.Tag != nil && *image.Tag == "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("tag"), *image.Tag, "tag must not be empty if specified"))
+	}
+	if image.Ref != nil && (image.Repository != nil || image.Tag != nil) {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "ref and repository/tag are mutually exclusive"))
 	}
 	if image.PullPolicy != nil {
 		validValues := []string{string(corev1.PullAlways), string(corev1.PullIfNotPresent), string(corev1.PullNever)}

--- a/pkg/api/seedmanagement/validation/managedseed_test.go
+++ b/pkg/api/seedmanagement/validation/managedseed_test.go
@@ -306,6 +306,42 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 				))
 			})
 
+			It("should forbid empty ref in image", func() {
+				managedSeed.Spec.Gardenlet.Deployment = &seedmanagement.GardenletDeployment{
+					Image: &seedmanagement.Image{
+						Ref: ptr.To(""),
+					},
+				}
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.deployment.image.ref"),
+					})),
+				))
+			})
+
+			It("should forbid specifying both ref and repository/tag in image", func() {
+				managedSeed.Spec.Gardenlet.Deployment = &seedmanagement.GardenletDeployment{
+					Image: &seedmanagement.Image{
+						Ref:        ptr.To("registry.example.com/gardenlet:v1.0.0"),
+						Repository: ptr.To("registry.example.com/gardenlet"),
+						Tag:        ptr.To("v1.0.0"),
+					},
+				}
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.gardenlet.deployment.image"),
+					})),
+				))
+			})
+
 			It("should forbid garden client connection kubeconfig if bootstrap is specified", func() {
 				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedx,
 					&gardenletconfigv1alpha1.GardenClientConnection{

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -117,6 +117,8 @@ type Image struct {
 	// PullPolicy is the image pull policy. One of Always, Never, IfNotPresent.
 	// Defaults to Always if latest tag is specified, or IfNotPresent otherwise.
 	PullPolicy *corev1.PullPolicy
+	// Ref is the full image reference.
+	Ref *string
 }
 
 // Bootstrap describes a mechanism for bootstrapping gardenlet connection to the Garden cluster.

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -109,6 +109,7 @@ type GardenletDeployment struct {
 }
 
 // Image specifies container image parameters.
+// Either Repository/Tag or Ref must be set, but not both.
 type Image struct {
 	// Repository is the image repository.
 	Repository *string

--- a/pkg/apis/seedmanagement/v1alpha1/generated.pb.go
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.pb.go
@@ -602,6 +602,13 @@ func (m *Image) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Ref != nil {
+		i -= len(*m.Ref)
+		copy(dAtA[i:], *m.Ref)
+		i = encodeVarintGenerated(dAtA, i, uint64(len(*m.Ref)))
+		i--
+		dAtA[i] = 0x22
+	}
 	if m.PullPolicy != nil {
 		i -= len(*m.PullPolicy)
 		copy(dAtA[i:], *m.PullPolicy)
@@ -1472,6 +1479,10 @@ func (m *Image) Size() (n int) {
 		l = len(*m.PullPolicy)
 		n += 1 + l + sovGenerated(uint64(l))
 	}
+	if m.Ref != nil {
+		l = len(*m.Ref)
+		n += 1 + l + sovGenerated(uint64(l))
+	}
 	return n
 }
 
@@ -1864,6 +1875,7 @@ func (this *Image) String() string {
 		`Repository:` + valueToStringGenerated(this.Repository) + `,`,
 		`Tag:` + valueToStringGenerated(this.Tag) + `,`,
 		`PullPolicy:` + valueToStringGenerated(this.PullPolicy) + `,`,
+		`Ref:` + valueToStringGenerated(this.Ref) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -3725,6 +3737,39 @@ func (m *Image) Unmarshal(dAtA []byte) error {
 			}
 			s := k8s_io_api_core_v1.PullPolicy(dAtA[iNdEx:postIndex])
 			m.PullPolicy = &s
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ref", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(dAtA[iNdEx:postIndex])
+			m.Ref = &s
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -187,6 +187,10 @@ message Image {
   // Defaults to Always if latest tag is specified, or IfNotPresent otherwise.
   // +optional
   optional string pullPolicy = 3;
+
+  // Ref is the full image reference.
+  // +optional
+  optional string ref = 4;
 }
 
 // ManagedSeed represents a Shoot that is registered as Seed.

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -174,6 +174,7 @@ message GardenletStatus {
 }
 
 // Image specifies container image parameters.
+// Either Repository/Tag or Ref must be set, but not both.
 message Image {
   // Repository is the image repository.
   // +optional

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -146,6 +146,9 @@ type Image struct {
 	// Defaults to Always if latest tag is specified, or IfNotPresent otherwise.
 	// +optional
 	PullPolicy *corev1.PullPolicy `json:"pullPolicy,omitempty" protobuf:"bytes,3,opt,name=pullPolicy"`
+	// Ref is the full image reference.
+	// +optional
+	Ref *string `json:"ref,omitempty" protobuf:"bytes,4,opt,name=ref"`
 }
 
 // Bootstrap describes a mechanism for bootstrapping gardenlet connection to the Garden cluster.

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -135,6 +135,7 @@ type GardenletDeployment struct {
 }
 
 // Image specifies container image parameters.
+// Either Repository/Tag or Ref must be set, but not both.
 type Image struct {
 	// Repository is the image repository.
 	// +optional

--- a/pkg/apis/seedmanagement/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/seedmanagement/v1alpha1/zz_generated.conversion.go
@@ -521,6 +521,7 @@ func autoConvert_v1alpha1_Image_To_seedmanagement_Image(in *Image, out *seedmana
 	out.Repository = (*string)(unsafe.Pointer(in.Repository))
 	out.Tag = (*string)(unsafe.Pointer(in.Tag))
 	out.PullPolicy = (*corev1.PullPolicy)(unsafe.Pointer(in.PullPolicy))
+	out.Ref = (*string)(unsafe.Pointer(in.Ref))
 	return nil
 }
 
@@ -533,6 +534,7 @@ func autoConvert_seedmanagement_Image_To_v1alpha1_Image(in *seedmanagement.Image
 	out.Repository = (*string)(unsafe.Pointer(in.Repository))
 	out.Tag = (*string)(unsafe.Pointer(in.Tag))
 	out.PullPolicy = (*corev1.PullPolicy)(unsafe.Pointer(in.PullPolicy))
+	out.Ref = (*string)(unsafe.Pointer(in.Ref))
 	return nil
 }
 

--- a/pkg/apis/seedmanagement/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/seedmanagement/v1alpha1/zz_generated.deepcopy.go
@@ -300,6 +300,11 @@ func (in *Image) DeepCopyInto(out *Image) {
 		*out = new(v1.PullPolicy)
 		**out = **in
 	}
+	if in.Ref != nil {
+		in, out := &in.Ref, &out.Ref
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/seedmanagement/zz_generated.deepcopy.go
+++ b/pkg/apis/seedmanagement/zz_generated.deepcopy.go
@@ -304,6 +304,11 @@ func (in *Image) DeepCopyInto(out *Image) {
 		*out = new(v1.PullPolicy)
 		**out = **in
 	}
+	if in.Ref != nil {
+		in, out := &in.Ref, &out.Ref
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -12662,7 +12662,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_Image(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Image specifies container image parameters.",
+				Description: "Image specifies container image parameters. Either Repository/Tag or Ref must be set, but not both.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"repository": {

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -12687,6 +12687,13 @@ func schema_pkg_apis_seedmanagement_v1alpha1_Image(ref common.ReferenceCallback)
 							Enum:        []interface{}{"Always", "IfNotPresent", "Never"},
 						},
 					},
+					"ref": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ref is the full image reference.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/client/kubernetes/clientmap/self_hosted_shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/self_hosted_shoot_clientmap.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientmap
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+)
+
+// NewSelfHostedShootClientMap returns a ClientMap that always returns the given clientSet. This is used for self-hosted
+// shoot clusters where the shoot IS the local (seed) cluster — no remote kubeconfig lookup is needed.
+func NewSelfHostedShootClientMap(clientSet kubernetes.Interface) ClientMap {
+	return &selfHostedShootClientMap{clientSet: clientSet}
+}
+
+type selfHostedShootClientMap struct {
+	clientSet kubernetes.Interface
+}
+
+func (m *selfHostedShootClientMap) GetClient(_ context.Context, _ ClientSetKey) (kubernetes.Interface, error) {
+	return m.clientSet, nil
+}
+
+func (m *selfHostedShootClientMap) InvalidateClient(_ ClientSetKey) error {
+	return nil
+}
+
+func (m *selfHostedShootClientMap) Start(_ context.Context) error {
+	return nil
+}

--- a/pkg/client/kubernetes/clientmap/self_hosted_shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/self_hosted_shoot_clientmap_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientmap_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+)
+
+var _ = Describe("SelfHostedShootClientMap", func() {
+	var (
+		ctx       context.Context
+		clientSet *fake.ClientSet
+		cm        clientmap.ClientMap
+		key       clientmap.ClientSetKey
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		clientSet = fake.NewClientSet()
+		cm = clientmap.NewSelfHostedShootClientMap(clientSet)
+		key = keys.ForShoot(&gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: "shoot", Namespace: "garden"}})
+	})
+
+	Describe("#GetClient", func() {
+		It("should always return the same client set", func() {
+			result, err := cm.GetClient(ctx, key)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeIdenticalTo(clientSet))
+		})
+	})
+
+	Describe("#InvalidateClient", func() {
+		It("should return nil", func() {
+			Expect(cm.InvalidateClient(key)).To(Succeed())
+		})
+	})
+
+	Describe("#Start", func() {
+		It("should return nil", func() {
+			Expect(cm.Start(ctx)).To(Succeed())
+		})
+	})
+})

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -624,7 +624,7 @@ func (a *Actuator) prepareGardenletChartValues(
 		a.ValuesHelper,
 		bootstrap,
 		a.BootstrapToken,
-		ensureGardenletEnvironment(deployment, a.GetTargetDomain()),
+		a.ensureGardenletEnvironment(deployment),
 		componentConfig,
 		a.GardenletNamespaceTarget,
 	)
@@ -748,7 +748,11 @@ func PrepareGardenletChartValues(
 // ensureGardenletEnvironment sets the KUBERNETES_SERVICE_HOST to the provided domain.
 // This may be needed so that the deployed gardenlet can properly set the network policies allowing access of control
 // plane components of the hosted shoots to the API server of the seed.
-func ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDeployment, domain string) *seedmanagementv1alpha1.GardenletDeployment {
+func (a *Actuator) ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDeployment) *seedmanagementv1alpha1.GardenletDeployment {
+	if a.SkipGardenNamespaceDeletion {
+		return deployment
+	}
+
 	const kubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
 	var serviceHost = ""
 
@@ -762,6 +766,7 @@ func ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDepl
 		}
 	}
 
+	domain := a.GetTargetDomain()
 	if len(domain) != 0 {
 		serviceHost = v1beta1helper.GetAPIServerDomain(domain)
 	}

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -62,18 +62,19 @@ type Interface interface {
 
 // Actuator is a concrete implementation of Interface.
 type Actuator struct {
-	GardenConfig             *rest.Config
-	GardenClient             client.Client
-	GetTargetClientFunc      func(ctx context.Context) (kubernetes.Interface, error)
-	CheckIfVPAAlreadyExists  func(ctx context.Context) (bool, error)
-	GetTargetDomain          func() string
-	ApplyGardenletChart      func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
-	DeleteGardenletChart     func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
-	Clock                    clock.Clock
-	ValuesHelper             ValuesHelper
-	Recorder                 events.EventRecorder
-	GardenletNamespaceTarget string
-	BootstrapToken           string
+	GardenConfig                *rest.Config
+	GardenClient                client.Client
+	GetTargetClientFunc         func(ctx context.Context) (kubernetes.Interface, error)
+	CheckIfVPAAlreadyExists     func(ctx context.Context) (bool, error)
+	GetTargetDomain             func() string
+	ApplyGardenletChart         func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
+	DeleteGardenletChart        func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
+	Clock                       clock.Clock
+	ValuesHelper                ValuesHelper
+	Recorder                    events.EventRecorder
+	GardenletNamespaceTarget    string
+	BootstrapToken              string
+	SkipGardenNamespaceDeletion bool
 }
 
 // Reconcile deploys or updates gardenlets.
@@ -261,26 +262,28 @@ func (a *Actuator) Delete(
 	}
 
 	// Delete garden namespace from the target cluster if it still exists and is not already deleting
-	gardenNamespace, err := a.getGardenNamespace(ctx, targetClient)
-	if err != nil {
-		a.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, err.Error())
-		return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error()), false, false, fmt.Errorf("could not check if garden namespace exists in target cluster: %w", err)
-	}
-
-	if gardenNamespace != nil {
-		if gardenNamespace.DeletionTimestamp == nil {
-			log.Info("Deleting garden namespace from target cluster")
-			a.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, gardencorev1beta1.EventActionDelete, "Deleting garden namespace from target cluster")
-			if err := a.deleteGardenNamespace(ctx, targetClient); err != nil {
-				a.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, err.Error())
-				return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error()), false, false, fmt.Errorf("could not delete garden namespace from target cluster: %w", err)
-			}
-		} else {
-			log.Info("Waiting for garden namespace to be deleted from target cluster")
-			a.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, gardencorev1beta1.EventActionDelete, "Waiting for garden namespace to be deleted from target cluster")
+	if !a.SkipGardenNamespaceDeletion {
+		gardenNamespace, err := a.getGardenNamespace(ctx, targetClient)
+		if err != nil {
+			a.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, err.Error())
+			return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error()), false, false, fmt.Errorf("could not check if garden namespace exists in target cluster: %w", err)
 		}
 
-		return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleting, "Waiting for garden namespace to be deleted from target cluster"), true, false, nil
+		if gardenNamespace != nil {
+			if gardenNamespace.DeletionTimestamp == nil {
+				log.Info("Deleting garden namespace from target cluster")
+				a.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, gardencorev1beta1.EventActionDelete, "Deleting garden namespace from target cluster")
+				if err := a.deleteGardenNamespace(ctx, targetClient); err != nil {
+					a.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, err.Error())
+					return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error()), false, false, fmt.Errorf("could not delete garden namespace from target cluster: %w", err)
+				}
+			} else {
+				log.Info("Waiting for garden namespace to be deleted from target cluster")
+				a.Recorder.Eventf(obj, nil, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, gardencorev1beta1.EventActionDelete, "Waiting for garden namespace to be deleted from target cluster")
+			}
+
+			return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleting, "Waiting for garden namespace to be deleted from target cluster"), true, false, nil
+		}
 	}
 
 	return updateCondition(a.Clock, conditions, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleted, fmt.Sprintf("Seed %s has been unregistered", obj.GetName())), false, true, nil

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -62,19 +62,19 @@ type Interface interface {
 
 // Actuator is a concrete implementation of Interface.
 type Actuator struct {
-	GardenConfig                *rest.Config
-	GardenClient                client.Client
-	GetTargetClientFunc         func(ctx context.Context) (kubernetes.Interface, error)
-	CheckIfVPAAlreadyExists     func(ctx context.Context) (bool, error)
-	GetTargetDomain             func() string
-	ApplyGardenletChart         func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
-	DeleteGardenletChart        func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
-	Clock                       clock.Clock
-	ValuesHelper                ValuesHelper
-	Recorder                    events.EventRecorder
-	GardenletNamespaceTarget    string
-	BootstrapToken              string
-	SkipGardenNamespaceDeletion bool
+	GardenConfig             *rest.Config
+	GardenClient             client.Client
+	GetTargetClientFunc      func(ctx context.Context) (kubernetes.Interface, error)
+	CheckIfVPAAlreadyExists  func(ctx context.Context) (bool, error)
+	GetTargetDomain          func() string
+	ApplyGardenletChart      func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
+	DeleteGardenletChart     func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error
+	Clock                    clock.Clock
+	ValuesHelper             ValuesHelper
+	Recorder                 events.EventRecorder
+	GardenletNamespaceTarget string
+	BootstrapToken           string
+	SeedIsSelfHostedShoot    bool
 }
 
 // Reconcile deploys or updates gardenlets.
@@ -262,7 +262,7 @@ func (a *Actuator) Delete(
 	}
 
 	// Delete garden namespace from the target cluster if it still exists and is not already deleting
-	if !a.SkipGardenNamespaceDeletion {
+	if !a.SeedIsSelfHostedShoot {
 		gardenNamespace, err := a.getGardenNamespace(ctx, targetClient)
 		if err != nil {
 			a.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, err.Error())
@@ -748,8 +748,10 @@ func PrepareGardenletChartValues(
 // ensureGardenletEnvironment sets the KUBERNETES_SERVICE_HOST to the provided domain.
 // This may be needed so that the deployed gardenlet can properly set the network policies allowing access of control
 // plane components of the hosted shoots to the API server of the seed.
+// In self-hosted shoot clusters, the seed gardenlet runs inside the shoot cluster and communicates with the API server
+// directly, so KUBERNETES_SERVICE_HOST does not need to be set explicitly.
 func (a *Actuator) ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDeployment) *seedmanagementv1alpha1.GardenletDeployment {
-	if a.SkipGardenNamespaceDeletion {
+	if a.SeedIsSelfHostedShoot {
 		return deployment
 	}
 

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -1158,10 +1158,10 @@ var _ = Describe("Utils", func() {
 			Expect(ensuredDeploymentWithoutDomain.Env[1].Value).To(Equal(v1beta1helper.GetAPIServerDomain(domain)))
 		})
 
-		It("should skip when SkipGardenNamespaceDeletion is set", func() {
+		It("should skip when SeedIsSelfHostedShoot is set", func() {
 			a := &Actuator{
-				GetTargetDomain:             func() string { return domain },
-				SkipGardenNamespaceDeletion: true,
+				GetTargetDomain:       func() string { return domain },
+				SeedIsSelfHostedShoot: true,
 			}
 			deployment := &seedmanagementv1alpha1.GardenletDeployment{
 				Env: []corev1.EnvVar{

--- a/pkg/controller/gardenletdeployer/actuator_test.go
+++ b/pkg/controller/gardenletdeployer/actuator_test.go
@@ -1126,9 +1126,13 @@ var _ = Describe("Utils", func() {
 			domain = "my-shoot.example.com"
 		)
 
+		newActuator := func(domain string) *Actuator {
+			return &Actuator{GetTargetDomain: func() string { return domain }}
+		}
+
 		It("should not overwrite existing KUBERNETES_SERVICE_HOST environment", func() {
-			ensuredDeploymentWithDomain := ensureGardenletEnvironment(kubernetesServiceHostEnvDeployment, domain)
-			ensuredDeploymentWithoutDomain := ensureGardenletEnvironment(kubernetesServiceHostEnvDeployment, "")
+			ensuredDeploymentWithDomain := newActuator(domain).ensureGardenletEnvironment(kubernetesServiceHostEnvDeployment)
+			ensuredDeploymentWithoutDomain := newActuator("").ensureGardenletEnvironment(kubernetesServiceHostEnvDeployment)
 
 			Expect(ensuredDeploymentWithDomain.Env[0].Name).To(Equal(kubernetesServiceHost))
 			Expect(ensuredDeploymentWithDomain.Env[0].Value).To(Equal(preserveDomain))
@@ -1139,19 +1143,35 @@ var _ = Describe("Utils", func() {
 		})
 
 		It("should should not inject KUBERNETES_SERVICE_HOST environment", func() {
-			ensuredDeploymentWithoutDomain := ensureGardenletEnvironment(otherEnvDeployment, "")
+			ensuredDeploymentWithoutDomain := newActuator("").ensureGardenletEnvironment(otherEnvDeployment)
 
 			Expect(ensuredDeploymentWithoutDomain.Env).To(HaveLen(1))
 			Expect(ensuredDeploymentWithoutDomain.Env[0].Name).ToNot(Equal(kubernetesServiceHost))
 		})
 
 		It("should should inject KUBERNETES_SERVICE_HOST environment", func() {
-			ensuredDeploymentWithoutDomain := ensureGardenletEnvironment(otherEnvDeployment, domain)
+			ensuredDeploymentWithoutDomain := newActuator(domain).ensureGardenletEnvironment(otherEnvDeployment)
 
 			Expect(ensuredDeploymentWithoutDomain.Env).To(HaveLen(2))
 			Expect(ensuredDeploymentWithoutDomain.Env[0].Name).ToNot(Equal(kubernetesServiceHost))
 			Expect(ensuredDeploymentWithoutDomain.Env[1].Name).To(Equal(kubernetesServiceHost))
 			Expect(ensuredDeploymentWithoutDomain.Env[1].Value).To(Equal(v1beta1helper.GetAPIServerDomain(domain)))
+		})
+
+		It("should skip when SkipGardenNamespaceDeletion is set", func() {
+			a := &Actuator{
+				GetTargetDomain:             func() string { return domain },
+				SkipGardenNamespaceDeletion: true,
+			}
+			deployment := &seedmanagementv1alpha1.GardenletDeployment{
+				Env: []corev1.EnvVar{
+					{Name: "TEST_VAR", Value: "TEST_VALUE"},
+				},
+			}
+			result := a.ensureGardenletEnvironment(deployment)
+
+			Expect(result.Env).To(HaveLen(1))
+			Expect(result.Env[0].Name).To(Equal("TEST_VAR"))
 		})
 	})
 })

--- a/pkg/controller/gardenletdeployer/valueshelper.go
+++ b/pkg/controller/gardenletdeployer/valueshelper.go
@@ -278,6 +278,7 @@ func getParentGardenletDeployment() (*seedmanagementv1alpha1.GardenletDeployment
 
 	return &seedmanagementv1alpha1.GardenletDeployment{
 		Image: &seedmanagementv1alpha1.Image{
+			Ref:        gardenletImage.Ref,
 			Repository: gardenletImage.Repository,
 			Tag:        gardenletImage.Tag,
 		},

--- a/pkg/controller/gardenletdeployer/valueshelper.go
+++ b/pkg/controller/gardenletdeployer/valueshelper.go
@@ -87,8 +87,12 @@ func (vp *valuesHelper) MergeGardenletConfiguration(config *gardenletconfigv1alp
 		return nil, err
 	}
 
-	// Delete gardenClientConnection.bootstrapKubeconfig, seedClientConnection.kubeconfig, and seedConfig in parent config values
+	// Delete gardenClientConnection.bootstrapKubeconfig, gardenClientConnection.kubeconfigSecret, seedClientConnection.kubeconfig, and seedConfig in parent config values
 	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "gardenClientConnection", "bootstrapKubeconfig")
+	if err != nil {
+		return nil, err
+	}
+	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "gardenClientConnection", "kubeconfigSecret")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
@@ -143,12 +143,15 @@ func (r *Reconciler) isBootstrapTokenForThisCSR(ctx context.Context, csr *certif
 		return false, "CSR does not seem to be requested via a bootstrap token", nil
 	}
 
-	shootMeta, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, r.Client, bootstraptokenutil.BootstrapTokenSecretName(strings.TrimPrefix(csr.Spec.Username, bootstraptokenapi.BootstrapUserPrefix)))
+	shootMeta, found, err := gardenletutils.ShootMetaFromBootstrapToken(ctx, r.Client, bootstraptokenutil.BootstrapTokenSecretName(strings.TrimPrefix(csr.Spec.Username, bootstraptokenapi.BootstrapUserPrefix)))
 	if err != nil {
-		// Intentionally, we don't return the err as error here, but rather as reason. This will lead to denial of the
-		// CSR if we cannot extract the shoot metadata from the bootstrap token secret.
-		//nolint:nilerr
-		return false, err.Error(), nil
+		if apierrors.IsNotFound(err) {
+			return false, "bootstrap token secret not found", nil
+		}
+		return false, "", err
+	}
+	if !found {
+		return false, "bootstrap token does not contain shoot metadata", nil
 	}
 
 	return ensureCSRSubjectMatchesBootstrapTokenDescription(shootMeta, csr.Spec.Request)

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler.go
@@ -148,7 +148,7 @@ func (r *Reconciler) isBootstrapTokenForThisCSR(ctx context.Context, csr *certif
 		if apierrors.IsNotFound(err) {
 			return false, "bootstrap token secret not found", nil
 		}
-		return false, "", err
+		return false, err.Error(), nil
 	}
 	if !found {
 		return false, "bootstrap token does not contain shoot metadata", nil

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -214,9 +214,9 @@ func AddToManager(
 		return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
 	}
 
+	// When the seed is a self-hosted shoot cluster, the gardenlet responsible for the self-hosted shoot in the
+	// kube-system namespace runs this controller.
 	if !seedIsSelfHostedShoot {
-		// When the seed is a self-hosted shoot cluster, the gardenlet responsible for the self-hosted shoot in the
-		// kube-system namespace runs this controller.
 		if err := (&tokenrequestor.Reconciler{
 			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
 			Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -50,6 +50,7 @@ func AddToManager(
 	gardenletCancel context.CancelFunc,
 	gardenCluster cluster.Cluster,
 	seedCluster cluster.Cluster,
+	seedClientSet kubernetes.Interface,
 	shootClientMap clientmap.ClientMap,
 	cfg *gardenletconfigv1alpha1.GardenletConfiguration,
 	healthManager healthz.Manager,
@@ -74,16 +75,6 @@ func AddToManager(
 		if !ok {
 			return fmt.Errorf("cluster-identity ConfigMap data does not have %q key", v1beta1constants.ClusterIdentity)
 		}
-	}
-
-	seedClientSet, err := kubernetes.NewWithConfig(
-		kubernetes.WithRESTConfig(seedCluster.GetConfig()),
-		kubernetes.WithRuntimeAPIReader(seedCluster.GetAPIReader()),
-		kubernetes.WithRuntimeClient(seedCluster.GetClient()),
-		kubernetes.WithRuntimeCache(seedCluster.GetCache()),
-	)
-	if err != nil {
-		return fmt.Errorf("failed creating seed clientset: %w", err)
 	}
 
 	seedNetworks := networkConfigForNetworkPolicyController(cfg, selfHostedShoot)
@@ -130,6 +121,18 @@ func AddToManager(
 			return fmt.Errorf("failed adding shoot-lease reconciler: %w", err)
 		}
 
+		if err := (&managedseed.Reconciler{
+			Config:              *cfg,
+			ShootClientMap:      shootClientMap,
+			GardenNamespaceSeed: metav1.NamespaceSystem,
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding ManagedSeed controller: %w", err)
+		}
+
+		if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, seedNetworks, nil); err != nil {
+			return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
+		}
+
 		// TODO(tobschli): Remove this once all shoot reconcilers are added via `shoot.AddToManager`.
 		if err := (&state.Reconciler{
 			Config: *cfg.Controllers.ShootState,
@@ -143,8 +146,13 @@ func AddToManager(
 			return fmt.Errorf("failed adding status reconciler: %w", err)
 		}
 
-		if err := networkpolicy.AddToManager(ctx, mgr, gardenletCancel, seedCluster, *cfg.Controllers.NetworkPolicy, seedNetworks, nil); err != nil {
-			return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
+		// TargetNamespace is intentionally left empty: the SA namespace is provided via the
+		// serviceaccount.resources.gardener.cloud/namespace annotation set by AccessSecret.Reconcile().
+		if err := (&tokenrequestor.Reconciler{
+			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
+			Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),
+		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding TokenRequestorServiceAccount controller: %w", err)
 		}
 
 		if err := vpaevictionrequirements.AddToManager(ctx, mgr, gardenletCancel, *cfg.Controllers.VPAEvictionRequirements, seedCluster); err != nil {
@@ -155,15 +163,6 @@ func AddToManager(
 			Config: cfg.Controllers.TokenRequestorWorkloadIdentity,
 		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
 			return fmt.Errorf("failed adding TokenRequestorWorkloadIdentity controller: %w", err)
-		}
-
-		// TargetNamespace is intentionally left empty: the SA namespace is provided via the
-		// serviceaccount.resources.gardener.cloud/namespace annotation set by AccessSecret.Reconcile().
-		if err := (&tokenrequestor.Reconciler{
-			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
-			Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),
-		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
-			return fmt.Errorf("failed adding TokenRequestorServiceAccount controller: %w", err)
 		}
 
 		return nil

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -168,6 +168,11 @@ func AddToManager(
 		return nil
 	}
 
+	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+	if err != nil {
+		return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
+	}
+
 	if err := (&backupbucket.Reconciler{
 		Config:   *cfg.Controllers.BackupBucket,
 		SeedName: cfg.SeedConfig.Name,
@@ -209,6 +214,18 @@ func AddToManager(
 		return fmt.Errorf("failed adding NetworkPolicy controller: %w", err)
 	}
 
+	if !seedIsSelfHostedShoot {
+		// When the seed is a self-hosted shoot cluster, the gardenlet responsible for the self-hosted shoot in the
+		// kube-system namespace runs this controller.
+		if err := (&tokenrequestor.Reconciler{
+			ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
+			Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),
+			TargetNamespace: gardenerutils.ComputeGardenNamespace(cfg.SeedConfig.Name),
+		}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding TokenRequestorServiceAccount controller: %w", err)
+		}
+	}
+
 	if err := seed.AddToManager(mgr, gardenCluster, seedCluster, seedClientSet, *cfg, identity, healthManager); err != nil {
 		return fmt.Errorf("failed adding Seed controller: %w", err)
 	}
@@ -219,14 +236,6 @@ func AddToManager(
 
 	if err := vpaevictionrequirements.AddToManager(ctx, mgr, gardenletCancel, *cfg.Controllers.VPAEvictionRequirements, seedCluster); err != nil {
 		return fmt.Errorf("failed adding VPAEvictionRequirements controller: %w", err)
-	}
-
-	if err := (&tokenrequestor.Reconciler{
-		ConcurrentSyncs: ptr.Deref(cfg.Controllers.TokenRequestorServiceAccount.ConcurrentSyncs, 0),
-		Class:           ptr.To(resourcesv1alpha1.ResourceManagerClassGarden),
-		TargetNamespace: gardenerutils.ComputeGardenNamespace(cfg.SeedConfig.Name),
-	}).AddToManager(mgr, seedCluster, gardenCluster); err != nil {
-		return fmt.Errorf("failed adding TokenRequestorServiceAccount controller: %w", err)
 	}
 
 	if err := (&workloadidentity.Reconciler{

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -119,15 +119,22 @@ func (r *Reconciler) newActuator(ctx context.Context, shoot *gardencorev1beta1.S
 			return ptr.Deref(shoot.Spec.DNS.Domain, "")
 		},
 		ApplyGardenletChart: func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error {
+			if r.GardenNamespaceSeed == metav1.NamespaceSystem {
+				values["isolateClusterResources"] = true
+			}
 			return targetChartApplier.ApplyFromEmbeddedFS(ctx, charts.ChartGardenlet, charts.ChartPathGardenlet, r.GardenNamespaceShoot, "gardenlet", kubernetes.Values(values))
 		},
 		DeleteGardenletChart: func(ctx context.Context, targetChartApplier kubernetes.ChartApplier, values map[string]any) error {
+			if r.GardenNamespaceSeed == metav1.NamespaceSystem {
+				values["isolateClusterResources"] = true
+			}
 			return targetChartApplier.DeleteFromEmbeddedFS(ctx, charts.ChartGardenlet, charts.ChartPathGardenlet, r.GardenNamespaceShoot, "gardenlet", kubernetes.Values(values))
 		},
-		Clock:                    r.Clock,
-		ValuesHelper:             gardenletdeployer.NewValuesHelper(&r.Config),
-		Recorder:                 r.Recorder,
-		GardenletNamespaceTarget: r.GardenNamespaceShoot,
+		Clock:                       r.Clock,
+		ValuesHelper:                gardenletdeployer.NewValuesHelper(&r.Config),
+		Recorder:                    r.Recorder,
+		GardenletNamespaceTarget:    r.GardenNamespaceShoot,
+		SkipGardenNamespaceDeletion: r.GardenNamespaceSeed == metav1.NamespaceSystem,
 	}, nil
 }
 

--- a/pkg/gardenlet/controller/managedseed/reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/reconciler.go
@@ -130,11 +130,11 @@ func (r *Reconciler) newActuator(ctx context.Context, shoot *gardencorev1beta1.S
 			}
 			return targetChartApplier.DeleteFromEmbeddedFS(ctx, charts.ChartGardenlet, charts.ChartPathGardenlet, r.GardenNamespaceShoot, "gardenlet", kubernetes.Values(values))
 		},
-		Clock:                       r.Clock,
-		ValuesHelper:                gardenletdeployer.NewValuesHelper(&r.Config),
-		Recorder:                    r.Recorder,
-		GardenletNamespaceTarget:    r.GardenNamespaceShoot,
-		SkipGardenNamespaceDeletion: r.GardenNamespaceSeed == metav1.NamespaceSystem,
+		Clock:                    r.Clock,
+		ValuesHelper:             gardenletdeployer.NewValuesHelper(&r.Config),
+		Recorder:                 r.Recorder,
+		GardenletNamespaceTarget: r.GardenNamespaceShoot,
+		SeedIsSelfHostedShoot:    r.GardenNamespaceSeed == metav1.NamespaceSystem,
 	}, nil
 }
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -139,6 +139,7 @@ func (r *Reconciler) instantiateComponents(
 	alertingSMTPSecret *corev1.Secret,
 	wildCardCertSecret *corev1.Secret,
 	seedIsShoot bool,
+	_ bool,
 ) (
 	c components,
 	err error,

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -139,7 +139,6 @@ func (r *Reconciler) instantiateComponents(
 	alertingSMTPSecret *corev1.Secret,
 	wildCardCertSecret *corev1.Secret,
 	seedIsShoot bool,
-	_ bool,
 ) (
 	c components,
 	err error,

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -109,15 +109,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}
 
+	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, r.SeedClientSet.Client())
+	if err != nil {
+		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
+	}
+
 	if seed.DeletionTimestamp != nil {
-		result, err := r.delete(ctx, log, seedObj, seedIsGarden, seedIsShoot)
+		result, err := r.delete(ctx, log, seedObj, seedIsGarden, seedIsShoot, seedIsSelfHostedShoot)
 		if err != nil {
 			return result, r.updateStatusOperationError(ctx, seed, err, operationType)
 		}
 		return result, nil
 	}
 
-	if err := r.reconcile(ctx, log, seedObj, seedIsGarden, seedIsShoot); err != nil {
+	if err := r.reconcile(ctx, log, seedObj, seedIsGarden, seedIsShoot, seedIsSelfHostedShoot); err != nil {
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -105,7 +105,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 	seedIsSelfHostedShoot bool,
 ) error {
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot, seedIsSelfHostedShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -35,6 +35,7 @@ func (r *Reconciler) delete(
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
 	seedIsShoot bool,
+	seedIsSelfHostedShoot bool,
 ) (
 	reconcile.Result,
 	error,
@@ -80,7 +81,7 @@ func (r *Reconciler) delete(
 	}
 
 	log.Info("No Shoots or BackupBuckets are referencing the Seed, deletion accepted")
-	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot); err != nil {
+	if err := r.runDeleteSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot, seedIsSelfHostedShoot); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -101,9 +102,10 @@ func (r *Reconciler) runDeleteSeedFlow(
 	seed *seedpkg.Seed,
 	seedIsGarden bool,
 	seedIsShoot bool,
+	seedIsSelfHostedShoot bool,
 ) error {
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, nil, seedIsGarden, nil, nil, nil, seedIsShoot, seedIsSelfHostedShoot)
 	if err != nil {
 		return err
 	}
@@ -185,7 +187,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 		destroyEtcdDruid = g.Add(flow.Task{
 			Name:   "Destroying etcd druid",
 			Fn:     component.OpDestroyAndWait(c.etcdDruid).Destroy,
-			SkipIf: seedIsGarden,
+			SkipIf: seedIsGarden || seedIsSelfHostedShoot,
 		})
 		destroyVPA = g.Add(flow.Task{
 			Name:   "Destroy Kubernetes vertical pod autoscaler",
@@ -323,7 +325,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name:         "Destroying ETCD-related custom resource definitions",
 			Fn:           component.OpDestroyAndWait(c.etcdCRD).Destroy,
 			Dependencies: flow.NewTaskIDs(ensureNoControllerInstallationsExist),
-			SkipIf:       seedIsGarden,
+			SkipIf:       seedIsGarden || seedIsSelfHostedShoot,
 		})
 		destroyIstioCRDs = g.Add(flow.Task{
 			Name:         "Destroying Istio custom resource definitions",
@@ -396,7 +398,7 @@ func (r *Reconciler) runDeleteSeedFlow(
 			Name:         "Destroying gardener-resource-manager",
 			Fn:           c.gardenerResourceManager.Destroy,
 			Dependencies: flow.NewTaskIDs(ensureNoManagedResourcesExist),
-			SkipIf:       seedIsGarden,
+			SkipIf:       seedIsGarden || seedIsSelfHostedShoot,
 		})
 	)
 

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -52,6 +52,7 @@ func (r *Reconciler) reconcile(
 	seedObj *seedpkg.Seed,
 	seedIsGarden bool,
 	seedIsShoot bool,
+	seedIsSelfHostedShoot bool,
 ) error {
 	seed := seedObj.GetInfo()
 
@@ -67,7 +68,7 @@ func (r *Reconciler) reconcile(
 		return err
 	}
 
-	return r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot)
+	return r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot, seedIsSelfHostedShoot)
 }
 
 func (r *Reconciler) checkMinimumK8SVersion(version string) error {
@@ -90,6 +91,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	seed *seedpkg.Seed,
 	seedIsGarden bool,
 	seedIsShoot bool,
+	seedIsSelfHostedShoot bool,
 ) error {
 	// VPA is a prerequisite. If it's enabled then we deploy the CRD (and later also the related components) as part of
 	// the flow. However, when it's disabled then we check whether it is indeed available (and fail, otherwise).
@@ -174,7 +176,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot, seedIsSelfHostedShoot)
 	if err != nil {
 		return err
 	}
@@ -203,7 +205,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 		deployEtcdCRDs = g.Add(flow.Task{
 			Name:   "Deploying ETCD-related custom resource definitions",
 			Fn:     component.OpWait(c.etcdCRD).Deploy,
-			SkipIf: seedIsGarden,
+			SkipIf: seedIsGarden || seedIsSelfHostedShoot,
 		})
 		deployIstioCRDs = g.Add(flow.Task{
 			Name:   "Deploying Istio-related custom resource definitions",
@@ -263,7 +265,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name:         "Deploying and waiting for gardener-resource-manager to be healthy",
 			Fn:           component.OpWait(c.gardenerResourceManager).Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointCRDs),
-			SkipIf:       seedIsGarden,
+			SkipIf:       seedIsGarden || seedIsSelfHostedShoot,
 		})
 		deploySystemResources = g.Add(flow.Task{
 			Name:         "Deploying system resources",
@@ -418,7 +420,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 			Name:         "Deploying ETCD Druid",
 			Fn:           c.etcdDruid.Deploy,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForSystemComponents),
-			SkipIf:       seedIsGarden,
+			SkipIf:       seedIsGarden || seedIsSelfHostedShoot,
 		})
 
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -176,7 +176,7 @@ func (r *Reconciler) runReconcileSeedFlow(
 	}
 
 	log.Info("Instantiating component deployers")
-	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot, seedIsSelfHostedShoot)
+	c, err := r.instantiateComponents(ctx, log, seed, secretsManager, seedIsGarden, globalMonitoringSecretSeed, alertingSMTPSecret, wildcardCertSecret, seedIsShoot)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -98,32 +98,33 @@ type SelfHostedShootInfo struct {
 }
 
 // ShootMetaFromBootstrapToken extracts the shoot namespace and name from the description of the given bootstrap token
-// secret. This only works if the secret has been created with 'gardenadm token create' which writes a proper
-// description.
-func ShootMetaFromBootstrapToken(ctx context.Context, reader client.Reader, bootstrapTokenSecretName string) (types.NamespacedName, error) {
+// secret. The returned bool indicates whether the secret contains shoot metadata (i.e., it is a self-hosted shoot
+// bootstrap token). If false, the token is likely for a ManagedSeed rather than a self-hosted shoot.
+func ShootMetaFromBootstrapToken(ctx context.Context, reader client.Reader, bootstrapTokenSecretName string) (types.NamespacedName, bool, error) {
 	bootstrapTokenSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: bootstrapTokenSecretName, Namespace: metav1.NamespaceSystem}}
 	if err := reader.Get(ctx, client.ObjectKeyFromObject(bootstrapTokenSecret), bootstrapTokenSecret); err != nil {
-		return types.NamespacedName{}, fmt.Errorf("failed to read bootstrap token secret %s: %w", client.ObjectKeyFromObject(bootstrapTokenSecret), err)
+		return types.NamespacedName{}, false, fmt.Errorf("failed to read bootstrap token secret %s: %w", client.ObjectKeyFromObject(bootstrapTokenSecret), err)
 	}
 
-	return extractShootMetaFromBootstrapToken(bootstrapTokenSecret)
+	shootMeta, found := extractShootMetaFromBootstrapToken(bootstrapTokenSecret)
+	return shootMeta, found, nil
 }
 
-func extractShootMetaFromBootstrapToken(bootstrapTokenSecret *corev1.Secret) (types.NamespacedName, error) {
+func extractShootMetaFromBootstrapToken(bootstrapTokenSecret *corev1.Secret) (types.NamespacedName, bool) {
 	description := string(bootstrapTokenSecret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey])
 	if !strings.HasPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix) {
-		return types.NamespacedName{}, fmt.Errorf("bootstrap token description does not start with %q: %s", bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix, description)
+		return types.NamespacedName{}, false
 	}
 
 	parts := strings.Fields(strings.TrimPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix))
 	if len(parts) == 0 {
-		return types.NamespacedName{}, fmt.Errorf("could not extract shoot meta from bootstrap token description: %s", description)
+		return types.NamespacedName{}, false
 	}
 
 	split := strings.Split(parts[0], "/")
 	if len(split) != 2 {
-		return types.NamespacedName{}, fmt.Errorf("could not extract shoot namespace and name from bootstrap token description: %s", description)
+		return types.NamespacedName{}, false
 	}
 
-	return types.NamespacedName{Namespace: split[0], Name: split[1]}, nil
+	return types.NamespacedName{Namespace: split[0], Name: split[1]}, true
 }

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -106,25 +106,24 @@ func ShootMetaFromBootstrapToken(ctx context.Context, reader client.Reader, boot
 		return types.NamespacedName{}, false, fmt.Errorf("failed to read bootstrap token secret %s: %w", client.ObjectKeyFromObject(bootstrapTokenSecret), err)
 	}
 
-	shootMeta, found := extractShootMetaFromBootstrapToken(bootstrapTokenSecret)
-	return shootMeta, found, nil
+	return extractShootMetaFromBootstrapToken(bootstrapTokenSecret)
 }
 
-func extractShootMetaFromBootstrapToken(bootstrapTokenSecret *corev1.Secret) (types.NamespacedName, bool) {
+func extractShootMetaFromBootstrapToken(bootstrapTokenSecret *corev1.Secret) (types.NamespacedName, bool, error) {
 	description := string(bootstrapTokenSecret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey])
 	if !strings.HasPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix) {
-		return types.NamespacedName{}, false
+		return types.NamespacedName{}, false, nil
 	}
 
 	parts := strings.Fields(strings.TrimPrefix(description, bootstraptoken.SelfHostedShootBootstrapTokenSecretDescriptionPrefix))
 	if len(parts) == 0 {
-		return types.NamespacedName{}, false
+		return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot meta from bootstrap token description: %s", description)
 	}
 
 	split := strings.Split(parts[0], "/")
 	if len(split) != 2 {
-		return types.NamespacedName{}, false
+		return types.NamespacedName{}, false, fmt.Errorf("could not extract shoot namespace and name from bootstrap token description: %s", description)
 	}
 
-	return types.NamespacedName{Namespace: split[0], Name: split[1]}, true
+	return types.NamespacedName{Namespace: split[0], Name: split[1]}, true, nil
 }

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -236,7 +236,7 @@ var _ = Describe("Gardenlet", func() {
 			Expect(found).To(BeFalse())
 		})
 
-		It("should return found=false when description has no shoot meta after prefix", func() {
+		It("should return an error when description has no shoot meta after prefix", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -250,11 +250,11 @@ var _ = Describe("Gardenlet", func() {
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
 			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("could not extract shoot meta from bootstrap token description")))
 			Expect(found).To(BeFalse())
 		})
 
-		It("should return found=false when description has only whitespace after prefix", func() {
+		It("should return an error when description has only whitespace after prefix", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -268,11 +268,11 @@ var _ = Describe("Gardenlet", func() {
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
 			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("could not extract shoot meta from bootstrap token description")))
 			Expect(found).To(BeFalse())
 		})
 
-		It("should return found=false when shoot meta format is invalid (no slash)", func() {
+		It("should return an error when shoot meta format is invalid (no slash)", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -286,11 +286,11 @@ var _ = Describe("Gardenlet", func() {
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
 			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("could not extract shoot namespace and name from bootstrap token description")))
 			Expect(found).To(BeFalse())
 		})
 
-		It("should return found=false when shoot meta format has multiple slashes", func() {
+		It("should return an error when shoot meta format has multiple slashes", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -304,7 +304,7 @@ var _ = Describe("Gardenlet", func() {
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
 			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("could not extract shoot namespace and name from bootstrap token description")))
 			Expect(found).To(BeFalse())
 		})
 

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -206,19 +206,19 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			result, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
 			Expect(result).To(Equal(expectedNamespacedName))
 		})
 
-		It("should return error when bootstrap token secret is not found", func() {
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to read bootstrap token secret"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+		It("should return an error when bootstrap token secret is not found", func() {
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).To(BeNotFoundError())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when description does not start with required prefix", func() {
+		It("should return found=false when description does not start with required prefix", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -231,13 +231,12 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("bootstrap token description does not start with"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when description has no shoot meta after prefix", func() {
+		It("should return found=false when description has no shoot meta after prefix", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -250,13 +249,12 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("could not extract shoot meta from bootstrap token description"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when description has only whitespace after prefix", func() {
+		It("should return found=false when description has only whitespace after prefix", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -269,13 +267,12 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("could not extract shoot meta from bootstrap token description"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when shoot meta format is invalid (no slash)", func() {
+		It("should return found=false when shoot meta format is invalid (no slash)", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -288,13 +285,12 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("could not extract shoot namespace and name from bootstrap token description"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when shoot meta format has multiple slashes", func() {
+		It("should return found=false when shoot meta format has multiple slashes", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -307,13 +303,12 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("could not extract shoot namespace and name from bootstrap token description"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 
-		It("should return error when shoot meta format has empty namespace", func() {
+		It("should extract shoot meta when namespace is empty", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -326,12 +321,13 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			result, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
 			Expect(result).To(Equal(types.NamespacedName{Namespace: "", Name: "my-shoot"}))
 		})
 
-		It("should return error when shoot meta format has empty name", func() {
+		It("should extract shoot meta when name is empty", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -344,8 +340,9 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			result, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
 			Expect(result).To(Equal(types.NamespacedName{Namespace: "my-namespace", Name: ""}))
 		})
 
@@ -362,12 +359,13 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			result, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
 			Expect(result).To(Equal(expectedNamespacedName))
 		})
 
-		It("should return error when description key is missing", func() {
+		It("should return found=false when description key is missing", func() {
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      bootstrapTokenSecretName,
@@ -380,10 +378,9 @@ var _ = Describe("Gardenlet", func() {
 
 			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("bootstrap token description does not start with"))
-			Expect(result).To(Equal(types.NamespacedName{}))
+			_, found, err := ShootMetaFromBootstrapToken(ctx, fakeClient, bootstrapTokenSecretName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
 		})
 	})
 })

--- a/pkg/utils/graph/eventhandler_managedseed.go
+++ b/pkg/utils/graph/eventhandler_managedseed.go
@@ -73,14 +73,17 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 }
 
 func (g *graph) handleManagedSeedCreateOrUpdateForShoots(managedSeed *seedmanagementv1alpha1.ManagedSeed) {
+	g.deleteAllIncomingEdges(VertexTypeSeed, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 	g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 	g.deleteAllOutgoingEdges(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name, VertexTypeShoot)
 
 	var (
+		seedVertex        = g.getOrCreateVertex(VertexTypeSeed, "", managedSeed.Name)
 		managedSeedVertex = g.getOrCreateVertex(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 		shootVertex       = g.getOrCreateVertex(VertexTypeShoot, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
 	)
 
+	g.addEdge(seedVertex, managedSeedVertex)
 	g.addEdge(managedSeedVertex, shootVertex)
 
 	// Always add the bootstrap token edge for self-hosted shoots. The Seed typically doesn't exist yet at this point,
@@ -187,8 +190,9 @@ func (g *graph) handleManagedSeedDelete(managedSeed *seedmanagementv1alpha1.Mana
 	defer g.lock.Unlock()
 
 	if g.forSelfHostedShoots {
-		g.deleteAllOutgoingEdges(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name, VertexTypeShoot)
+		g.deleteAllIncomingEdges(VertexTypeSeed, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 		g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+		g.deleteAllOutgoingEdges(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name, VertexTypeShoot)
 	} else {
 		g.deleteVertex(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 	}

--- a/pkg/utils/graph/eventhandler_managedseed.go
+++ b/pkg/utils/graph/eventhandler_managedseed.go
@@ -65,6 +65,33 @@ func (g *graph) handleManagedSeedCreateOrUpdate(ctx context.Context, managedSeed
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
+	if g.forSelfHostedShoots {
+		g.handleManagedSeedCreateOrUpdateForShoots(managedSeed)
+	} else {
+		g.handleManagedSeedCreateOrUpdateForSeeds(ctx, managedSeed)
+	}
+}
+
+func (g *graph) handleManagedSeedCreateOrUpdateForShoots(managedSeed *seedmanagementv1alpha1.ManagedSeed) {
+	g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+	g.deleteAllOutgoingEdges(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name, VertexTypeShoot)
+
+	var (
+		managedSeedVertex = g.getOrCreateVertex(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+		shootVertex       = g.getOrCreateVertex(VertexTypeShoot, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
+	)
+
+	g.addEdge(managedSeedVertex, shootVertex)
+
+	// Always add the bootstrap token edge for self-hosted shoots. The Seed typically doesn't exist yet at this point,
+	// and the self-hosted cache doesn't include Seeds, so we skip the allowBootstrap check.
+	if managedSeed.Spec.Gardenlet.Bootstrap != nil && *managedSeed.Spec.Gardenlet.Bootstrap == seedmanagementv1alpha1.BootstrapToken {
+		secretVertex := g.getOrCreateVertex(VertexTypeSecret, metav1.NamespaceSystem, bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraptoken.TokenID(managedSeed.ObjectMeta))
+		g.addEdge(secretVertex, managedSeedVertex)
+	}
+}
+
+func (g *graph) handleManagedSeedCreateOrUpdateForSeeds(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) {
 	g.deleteAllIncomingEdges(VertexTypeSeed, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
 	g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeSeed, managedSeed.Namespace, managedSeed.Name)
 	g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
@@ -159,5 +186,10 @@ func (g *graph) handleManagedSeedDelete(managedSeed *seedmanagementv1alpha1.Mana
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	g.deleteVertex(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+	if g.forSelfHostedShoots {
+		g.deleteAllOutgoingEdges(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name, VertexTypeShoot)
+		g.deleteAllIncomingEdges(VertexTypeSecret, VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+	} else {
+		g.deleteVertex(VertexTypeManagedSeed, managedSeed.Namespace, managedSeed.Name)
+	}
 }

--- a/pkg/utils/graph/graph.go
+++ b/pkg/utils/graph/graph.go
@@ -77,6 +77,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 			resourceSetup{&certificatesv1.CertificateSigningRequest{}, g.setupCertificateSigningRequestWatch},
 			resourceSetup{&gardencorev1beta1.ControllerInstallation{}, g.setupControllerInstallationWatch},
 			resourceSetup{&seedmanagementv1alpha1.Gardenlet{}, g.setupGardenletWatch},
+			resourceSetup{&seedmanagementv1alpha1.ManagedSeed{}, g.setupManagedSeedWatch},
 			resourceSetup{&corev1.ServiceAccount{}, g.setupServiceAccountWatch},
 			resourceSetup{&gardencorev1beta1.Shoot{}, g.setupShootWatch},
 			resourceSetup{&securityv1alpha1.CredentialsBinding{}, g.setupCredentialsBindingWatch},

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -2971,8 +2971,9 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 	It("should behave as expected for seedmanagementv1alpha1.ManagedSeed", func() {
 		By("Add")
 		fakeInformerManagedSeed.Add(managedSeed1)
-		Expect(graph.graph.Nodes().Len()).To(Equal(3))
-		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.graph.Nodes().Len()).To(Equal(4))
+		Expect(graph.graph.Edges().Len()).To(Equal(3))
+		Expect(graph.HasPathFrom(VertexTypeSeed, "", managedSeed1.Name, VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeTrue())
 		Expect(graph.HasPathFrom(VertexTypeSecret, "kube-system", "bootstrap-token-"+bootstraptoken.TokenID(managedSeed1.ObjectMeta), VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeTrue())
 
@@ -2980,6 +2981,7 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 		fakeInformerManagedSeed.Delete(managedSeed1)
 		Expect(graph.graph.Nodes().Len()).To(BeZero())
 		Expect(graph.graph.Edges().Len()).To(BeZero())
+		Expect(graph.HasPathFrom(VertexTypeSeed, "", managedSeed1.Name, VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeFalse())
 		Expect(graph.HasPathFrom(VertexTypeSecret, "kube-system", "bootstrap-token-"+bootstraptoken.TokenID(managedSeed1.ObjectMeta), VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeFalse())
 	})

--- a/pkg/utils/graph/graph_test.go
+++ b/pkg/utils/graph/graph_test.go
@@ -40,6 +40,7 @@ import (
 	gardenletbootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/logger"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
 var _ = Describe("graph for seeds", func() {
@@ -2553,6 +2554,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeInformerBastion                   *controllertest.FakeInformer
 		fakeInformerCertificateSigningRequest *controllertest.FakeInformer
 		fakeInformerGardenlet                 *controllertest.FakeInformer
+		fakeInformerManagedSeed               *controllertest.FakeInformer
 		fakeInformerServiceAccount            *controllertest.FakeInformer
 		fakeInformerShoot                     *controllertest.FakeInformer
 		fakeInformers                         *informertest.FakeInformers
@@ -2562,6 +2564,8 @@ var _ = Describe("graph for shoots", func() {
 
 		shootNamespace = "shoot-namespace"
 		shootName      = "shoot-name"
+
+		managedSeed1 *seedmanagementv1alpha1.ManagedSeed
 
 		serviceAccount1 *corev1.ServiceAccount
 
@@ -2614,6 +2618,7 @@ var _ = Describe("graph for shoots", func() {
 		fakeInformerBastion = &controllertest.FakeInformer{}
 		fakeInformerCertificateSigningRequest = &controllertest.FakeInformer{}
 		fakeInformerGardenlet = &controllertest.FakeInformer{}
+		fakeInformerManagedSeed = &controllertest.FakeInformer{}
 		fakeInformerServiceAccount = &controllertest.FakeInformer{}
 		fakeInformerShoot = &controllertest.FakeInformer{}
 
@@ -2625,6 +2630,7 @@ var _ = Describe("graph for shoots", func() {
 				operationsv1alpha1.SchemeGroupVersion.WithKind("Bastion"):               fakeInformerBastion,
 				certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
 				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("Gardenlet"):         fakeInformerGardenlet,
+				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed"):       fakeInformerManagedSeed,
 				corev1.SchemeGroupVersion.WithKind("ServiceAccount"):                    fakeInformerServiceAccount,
 				gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"):                  fakeInformerShoot,
 			},
@@ -2664,6 +2670,16 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 
 		gardenlet1 = &seedmanagementv1alpha1.Gardenlet{
 			ObjectMeta: metav1.ObjectMeta{Name: "self-hosted-shoot-" + shootName, Namespace: shootNamespace},
+		}
+
+		managedSeed1 = &seedmanagementv1alpha1.ManagedSeed{
+			ObjectMeta: metav1.ObjectMeta{Name: "managedseed1", Namespace: shootNamespace},
+			Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+				Shoot: &seedmanagementv1alpha1.Shoot{Name: shootName},
+				Gardenlet: seedmanagementv1alpha1.GardenletConfig{
+					Bootstrap: ptr.To(seedmanagementv1alpha1.BootstrapToken),
+				},
+			},
 		}
 
 		serviceAccount1 = &corev1.ServiceAccount{
@@ -2950,6 +2966,22 @@ Foj/rmOanFj5g6QF3GRDrqaNc1GNEXDU6fW7JsTx6+Anj1M/aDNxOXYqIqUN0s3d
 		Expect(graph.graph.Nodes().Len()).To(BeZero())
 		Expect(graph.graph.Edges().Len()).To(BeZero())
 		Expect(graph.HasPathFrom(VertexTypeGardenlet, gardenlet1.Namespace, gardenlet1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeFalse())
+	})
+
+	It("should behave as expected for seedmanagementv1alpha1.ManagedSeed", func() {
+		By("Add")
+		fakeInformerManagedSeed.Add(managedSeed1)
+		Expect(graph.graph.Nodes().Len()).To(Equal(3))
+		Expect(graph.graph.Edges().Len()).To(Equal(2))
+		Expect(graph.HasPathFrom(VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeTrue())
+		Expect(graph.HasPathFrom(VertexTypeSecret, "kube-system", "bootstrap-token-"+bootstraptoken.TokenID(managedSeed1.ObjectMeta), VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeTrue())
+
+		By("Delete")
+		fakeInformerManagedSeed.Delete(managedSeed1)
+		Expect(graph.graph.Nodes().Len()).To(BeZero())
+		Expect(graph.graph.Edges().Len()).To(BeZero())
+		Expect(graph.HasPathFrom(VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name, VertexTypeShoot, shootNamespace, shootName)).To(BeFalse())
+		Expect(graph.HasPathFrom(VertexTypeSecret, "kube-system", "bootstrap-token-"+bootstraptoken.TokenID(managedSeed1.ObjectMeta), VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeFalse())
 	})
 
 	It("should behave as expected for corev1.ServiceAccount", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
In self-hosted shoot clusters (`gardenadm` scenario), the shoot `gardenlet` in `kube-system` now runs the `ManagedSeed` controller. It deploys a second "seed `gardenlet`" into the `garden` namespace of the same cluster. This seed `gardenlet` manages seed workloads (other shoots' control planes).

Key changes:
- `isolateClusterResources` chart value: suffixes cluster-scoped RBAC names with the release namespace and skips `PriorityClass` to avoid collisions between the two `gardenlet`s.
- `SelfHostedShootClientMap`: minimal `ClientMap` returning the local clientset (no tunnel needed — shoot IS the seed).
- `Ref` field on `seedmanagementv1alpha1.Image`: supports fully qualified image references used in `gardenadm` image vector overwrites.
- Skips `garden` namespace deletion, `KUBERNETES_SERVICE_HOST` env injection, `etcd-druid`/`gardener-resource-manager` deployment, and `tokenrequestor` controller for the seed `gardenlet` — the shoot `gardenlet` already handles these.
- Deletes parent's `gardenClientConnection.kubeconfigSecret` before config merge to prevent `namespace: kube-system` from leaking into seed `gardenlet` config.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```release-note NONE
```