### PR TITLE
Reduce MCM permissions

### DIFF
--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -136,7 +136,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
-				Resources: []string{"configmaps", "secrets", "endpoints", "events", "pods"},
+				Resources: []string{"configmaps", "secrets", "events"},
 				Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 			},
 			{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -136,7 +136,7 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
-				Resources: []string{"configmaps", "secrets", "events"},
+				Resources: []string{"secrets", "events"},
 				Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 			},
 			{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -15,6 +15,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -136,8 +137,13 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 			},
 			{
 				APIGroups: []string{corev1.GroupName},
-				Resources: []string{"secrets", "events"},
+				Resources: []string{"secrets"},
 				Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
+			},
+			{
+				APIGroups: []string{corev1.GroupName, eventsv1.GroupName},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "create", "patch", "update"},
 			},
 			{
 				APIGroups: []string{coordinationv1.GroupName},

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -134,7 +134,7 @@ var _ = Describe("MachineControllerManager", func() {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"configmaps", "secrets", "events"},
+					Resources: []string{"secrets", "events"},
 					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 				},
 				{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -134,7 +134,7 @@ var _ = Describe("MachineControllerManager", func() {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"configmaps", "secrets", "endpoints", "events", "pods"},
+					Resources: []string{"configmaps", "secrets", "events"},
 					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
 				},
 				{

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -17,6 +17,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -134,8 +135,13 @@ var _ = Describe("MachineControllerManager", func() {
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
-					Resources: []string{"secrets", "events"},
+					Resources: []string{"secrets"},
 					Verbs:     []string{"create", "get", "list", "patch", "update", "watch", "delete", "deletecollection"},
+				},
+				{
+					APIGroups: []string{corev1.GroupName, eventsv1.GroupName},
+					Resources: []string{"events"},
+					Verbs:     []string{"get", "list", "create", "patch", "update"},
 				},
 				{
 					APIGroups: []string{coordinationv1.GroupName},

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -251,7 +251,7 @@ func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
 			{
 				APIGroups: []string{""},
 				Resources: []string{"pods"},
-				Verbs:     []string{"get", "create", "patch", "delete"},
+				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 			},
 		},
 	}

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -248,6 +248,11 @@ func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
 				Resources: []string{"services"},
 				Verbs:     []string{"create", "patch", "delete"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "create", "patch", "delete"},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement cleanup

**What this PR does / why we need it**:
I noticed that the permissions given to MCM seem that can be reduced further, i.e. I do not expect that MCM needs access to pods or endpoints. I am not sure if those can be reduced further.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
machine-controller-manager's RBAC permissions for the source cluster have been reduced to follow the principle of least privilege.
```
