### PR TITLE
Reduce `Shoot` updates when `Seed` is not ready

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -482,9 +482,13 @@ func (r *Reconciler) checkSeed(ctx context.Context, seed *gardencorev1beta1.Seed
 
 	var seedError error
 
+	// Check if the seed is up to date and has the expected gardener version.
+	if err := health.CheckSeedIsUpToDate(seed, r.Identity); err != nil {
+		seedError = fmt.Errorf("seed is not up to date: %w", err)
+	}
+
 	// Check if the seed is healthy and has all required conditions for hosting the shoot cluster.
-	falseConditions, err := health.CheckRequiredSeedConditions(seed)
-	if err != nil {
+	if falseConditions, err := health.CheckRequiredSeedConditions(seed); err != nil && seedError == nil {
 		seedError = fmt.Errorf("error in seed conditions: %w", err)
 	} else if len(falseConditions) > 0 {
 		seedError = fmt.Errorf("seed has failing conditions: %v", slices.Collect(apisutils.TransformElements(
@@ -493,11 +497,6 @@ func (r *Reconciler) checkSeed(ctx context.Context, seed *gardencorev1beta1.Seed
 				return string(condition.Type)
 			},
 		)))
-	}
-
-	// Check if the seed is up to date and has the expected gardener version.
-	if err := health.CheckSeedIsUpToDate(seed, r.Identity); err != nil {
-		seedError = fmt.Errorf("seed is not up to date: %w", err)
 	}
 
 	// Seed errors are usually intermediate but affect all shoots that are scheduled on the seed.
@@ -1020,7 +1019,7 @@ func (r *Reconciler) patchShootStatusOperationError(
 	shoot *gardencorev1beta1.Shoot,
 	description string,
 	operationType gardencorev1beta1.LastOperationType,
-	alwaysRetry bool,
+	forceRetry bool,
 	lastErrors ...gardencorev1beta1.LastError,
 ) error {
 	var (
@@ -1031,7 +1030,7 @@ func (r *Reconciler) patchShootStatusOperationError(
 
 	statusPatch := client.StrategicMergeFrom(shoot.DeepCopy())
 
-	if willNotRetry && !alwaysRetry {
+	if willNotRetry && !forceRetry {
 		state = gardencorev1beta1.LastOperationStateFailed
 		shoot.Status.RetryCycleStartTime = nil
 	} else {

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -35,6 +35,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	apisutils "github.com/gardener/gardener/pkg/apis/utils"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -127,7 +128,7 @@ func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot 
 	r.Recorder.Eventf(shoot, nil, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, gardencorev1beta1.EventActionReconcile, "%s Shoot cluster", utils.IifString(isRestoring, "Restoring", "Reconciling"))
 	if flowErr := r.runReconcileShootFlow(ctx, o, operationType); flowErr != nil {
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, gardencorev1beta1.EventActionReconcile, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, false, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
@@ -147,7 +148,7 @@ func (r *Reconciler) reconcileShoot(ctx context.Context, log logr.Logger, shoot 
 			return reconcile.Result{}, errorsutils.WithSuppressed(syncErr, statusUpdateErr)
 		}
 
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), operationType, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), operationType, false, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(syncErr, updateErr)
 	}
 
@@ -178,7 +179,7 @@ func (r *Reconciler) migrateShoot(ctx context.Context, log logr.Logger, shoot *g
 	}
 	if hasBastions {
 		hasBastionErr := errors.New("shoot has still Bastions")
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, false, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(hasBastionErr, updateErr)
 	}
 
@@ -190,7 +191,7 @@ func (r *Reconciler) migrateShoot(ctx context.Context, log logr.Logger, shoot *g
 	r.Recorder.Eventf(shoot, nil, corev1.EventTypeNormal, gardencorev1beta1.EventPrepareMigration, gardencorev1beta1.EventActionMigrate, "Preparing Shoot cluster for migration")
 	if flowErr := r.runMigrateShootFlow(ctx, o); flowErr != nil {
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, gardencorev1beta1.EventActionMigrate, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, false, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
@@ -231,7 +232,7 @@ func (r *Reconciler) deleteShoot(ctx context.Context, log logr.Logger, shoot *ga
 		}
 
 		hasBastionErr := errors.New("shoot has still Bastions")
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), operationType, shoot.Status.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, hasBastionErr.Error(), operationType, false, shoot.Status.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(hasBastionErr, updateErr)
 	}
 
@@ -256,7 +257,7 @@ func (r *Reconciler) deleteShoot(ctx context.Context, log logr.Logger, shoot *ga
 	}
 	if flowErr != nil {
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, flowErr.Description)
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, flowErr.LastErrors...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, flowErr.Description, operationType, false, flowErr.LastErrors...)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
@@ -317,13 +318,18 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 		if i.ShouldOnlySyncClusterResource {
 			if syncErr := r.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); syncErr != nil {
 				log.Error(syncErr, "Failed syncing Cluster resource to Seed while Shoot should not be reconciled")
-				updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), i.OperationType, shoot.Status.LastErrors...)
+				updateErr := r.patchShootStatusOperationError(ctx, shoot, syncErr.Error(), i.OperationType, false, shoot.Status.LastErrors...)
 				return nil, reconcile.Result{}, errorsutils.WithSuppressed(syncErr, updateErr)
 			}
 			return nil, reconcile.Result{}, nil
 		}
 
 		return nil, i.RequeueAfter, nil
+	}
+
+	if err := r.checkSeed(ctx, seed, shoot, i.OperationType); err != nil {
+		log.Error(err, "Seed is not ready for Shoot operation")
+		return nil, reconcile.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 
 	technicalID := gardenerutils.ComputeTechnicalID(project.Name, shoot)
@@ -333,11 +339,11 @@ func (r *Reconciler) prepareOperation(ctx context.Context, log logr.Logger, shoo
 
 	o, operationErr := r.initializeOperation(ctx, log, shoot, project, cloudProfile, seed, exposureClass)
 	if operationErr != nil {
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, fmt.Sprintf("Could not initialize a new operation for Shoot cluster: %s", operationErr.Error()), i.OperationType, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, fmt.Sprintf("Could not initialize a new operation for Shoot cluster: %s", operationErr.Error()), i.OperationType, false, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
 		return nil, reconcile.Result{}, errorsutils.WithSuppressed(operationErr, updateErr)
 	}
 
-	if err := r.checkSeedAndSyncClusterResource(ctx, shoot, project, cloudProfile, seed); err != nil {
+	if err := r.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
 		log.Error(err, "Shoot cannot be synced with seed")
 
 		patch := client.MergeFrom(shoot.DeepCopy())
@@ -466,18 +472,45 @@ func (r *Reconciler) syncClusterResourceToSeed(ctx context.Context, shoot *garde
 	return gardenerextensions.SyncClusterResourceToSeed(ctx, r.SeedClientSet.Client(), clusterName, shoot, cloudProfile, seed)
 }
 
-func (r *Reconciler) checkSeedAndSyncClusterResource(ctx context.Context, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) error {
+func (r *Reconciler) checkSeed(ctx context.Context, seed *gardencorev1beta1.Seed, shoot *gardencorev1beta1.Shoot, operationType gardencorev1beta1.LastOperationType) error {
 	// Don't wait for the Seed to be ready if it is already marked for deletion. In this case
 	// it will never get ready because the bootstrap loop is never executed again.
 	// Don't block the Shoot deletion flow in this case to allow proper cleanup.
-	if seed.DeletionTimestamp == nil {
-		if err := health.CheckSeed(seed, r.Identity); err != nil {
-			return fmt.Errorf("seed is not yet ready: %w", err)
-		}
+	if seed.DeletionTimestamp != nil {
+		return nil
 	}
 
-	if err := r.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
-		return fmt.Errorf("could not sync cluster resource to seed: %w", err)
+	var seedError error
+
+	// Check if the seed is healthy and has all required conditions for hosting the shoot cluster.
+	falseConditions, err := health.CheckRequiredSeedConditions(seed)
+	if err != nil {
+		seedError = fmt.Errorf("error in seed conditions: %w", err)
+	} else if len(falseConditions) > 0 {
+		seedError = fmt.Errorf("seed has failing conditions: %v", slices.Collect(apisutils.TransformElements(
+			falseConditions,
+			func(condition gardencorev1beta1.Condition) string {
+				return string(condition.Type)
+			},
+		)))
+	}
+
+	// Check if the seed is up to date and has the expected gardener version.
+	if err := health.CheckSeedIsUpToDate(seed, r.Identity); err != nil {
+		seedError = fmt.Errorf("seed is not up to date: %w", err)
+	}
+
+	// Seed errors are usually intermediate but affect all shoots that are scheduled on the seed.
+	// To prevent massive updates of all shoots on the seed in case of a seed failure, the shoot status is only patched if the error message differs from the last one that was set.
+	if seedError != nil {
+		errDescription := fmt.Sprintf("Shoot cannot be reconciled on seed: %v", seedError)
+		if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.Description == errDescription {
+			// Do not patch the last operation again as a seed failure affects all shoots and this would potentially overload the etcd of the garden cluster.
+			return seedError
+		}
+
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, errDescription, operationType, true, shoot.Status.LastErrors...)
+		return errorsutils.WithSuppressed(seedError, updateErr)
 	}
 
 	return nil
@@ -488,7 +521,7 @@ func (r *Reconciler) finalizeShootMigration(ctx context.Context, shoot *gardenco
 		if err := o.DeleteClusterResourceFromSeed(ctx); err != nil {
 			lastErr := v1beta1helper.LastError(fmt.Sprintf("Could not delete Cluster resource in seed: %s", err))
 			r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionMigrate, lastErr.Description)
-			updateErr := r.patchShootStatusOperationError(ctx, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeMigrate, *lastErr)
+			updateErr := r.patchShootStatusOperationError(ctx, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeMigrate, false, *lastErr)
 			return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(lastErr.Description), updateErr)
 		}
 	}
@@ -506,7 +539,7 @@ func (r *Reconciler) finalizeShootMigration(ctx context.Context, shoot *gardenco
 func (r *Reconciler) finalizeShootDeletion(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) (reconcile.Result, error) {
 	if cleanErr := r.deleteClusterResourceFromSeed(ctx, shoot); cleanErr != nil {
 		lastErr := v1beta1helper.LastError(fmt.Sprintf("Could not delete Cluster resource in seed: %s", cleanErr))
-		updateErr := r.patchShootStatusOperationError(ctx, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeDelete, *lastErr)
+		updateErr := r.patchShootStatusOperationError(ctx, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeDelete, false, *lastErr)
 		r.Recorder.Eventf(shoot, nil, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, gardencorev1beta1.EventActionDelete, lastErr.Description)
 		return reconcile.Result{}, errorsutils.WithSuppressed(errors.New(lastErr.Description), updateErr)
 	}
@@ -987,6 +1020,7 @@ func (r *Reconciler) patchShootStatusOperationError(
 	shoot *gardencorev1beta1.Shoot,
 	description string,
 	operationType gardencorev1beta1.LastOperationType,
+	alwaysRetry bool,
 	lastErrors ...gardencorev1beta1.LastError,
 ) error {
 	var (
@@ -997,7 +1031,7 @@ func (r *Reconciler) patchShootStatusOperationError(
 
 	statusPatch := client.StrategicMergeFrom(shoot.DeepCopy())
 
-	if willNotRetry {
+	if willNotRetry && !alwaysRetry {
 		state = gardencorev1beta1.LastOperationStateFailed
 		shoot.Status.RetryCycleStartTime = nil
 	} else {

--- a/pkg/utils/kubernetes/health/seed.go
+++ b/pkg/utils/kubernetes/health/seed.go
@@ -22,11 +22,43 @@ var (
 
 // CheckSeed checks if the Seed is up-to-date and if its extensions have been successfully bootstrapped.
 func CheckSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
+	if err := CheckSeedIsUpToDate(seed, identity); err != nil {
+		return err
+	}
+
+	return checkSeedConditions(seed)
+}
+
+// CheckSeedIsUpToDate checks if the Seed's observed Gardener version and generation are up-to-date compared to the provided identity.
+func CheckSeedIsUpToDate(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
 	if !equality.Semantic.DeepEqual(seed.Status.Gardener, identity) {
 		return fmt.Errorf("observing Gardener version not up to date (%v/%v)", seed.Status.Gardener, identity)
 	}
 
-	return checkSeed(seed)
+	if seed.Status.ObservedGeneration < seed.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
+	}
+
+	return nil
+}
+
+// CheckRequiredSeedConditions checks if the required conditions of the Seed are set to True and returns the conditions that are not in the expected state.
+// It returns an error if any of the required conditions is missing.
+func CheckRequiredSeedConditions(seed *gardencorev1beta1.Seed) ([]gardencorev1beta1.Condition, error) {
+	var failedConditionTypes []gardencorev1beta1.Condition
+
+	for _, trueConditionType := range trueSeedConditionTypes {
+		conditionType := string(trueConditionType)
+		condition := v1beta1helper.GetCondition(seed.Status.Conditions, trueConditionType)
+		if condition == nil {
+			return nil, requiredConditionMissing(conditionType)
+		}
+		if err := checkConditionState(string(condition.Type), string(gardencorev1beta1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
+			failedConditionTypes = append(failedConditionTypes, *condition)
+		}
+	}
+
+	return failedConditionTypes, nil
 }
 
 // CheckSeedForMigration checks if the Seed is up-to-date (comparing only the versions) and if its extensions have been successfully bootstrapped.
@@ -37,23 +69,21 @@ func CheckSeedForMigration(seed *gardencorev1beta1.Seed, identity *gardencorev1b
 	if seed.Status.Gardener.Version != identity.Version {
 		return fmt.Errorf("observing Gardener version not up to date (%s/%s)", seed.Status.Gardener.Version, identity.Version)
 	}
-
-	return checkSeed(seed)
-}
-
-// checkSeed checks if the .status.observedGeneration field is not outdated and if the Seed's extensions have been
-// successfully bootstrapped.
-func checkSeed(seed *gardencorev1beta1.Seed) error {
 	if seed.Status.ObservedGeneration < seed.Generation {
 		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
 	}
 
-	for _, trueConditionType := range trueSeedConditionTypes {
-		conditionType := string(trueConditionType)
-		condition := v1beta1helper.GetCondition(seed.Status.Conditions, trueConditionType)
-		if condition == nil {
-			return requiredConditionMissing(conditionType)
-		}
+	return checkSeedConditions(seed)
+}
+
+// checkSeedConditions checks if the .status.observedGeneration field is not outdated and if the Seed's extensions have been
+// successfully bootstrapped.
+func checkSeedConditions(seed *gardencorev1beta1.Seed) error {
+	falseConditions, err := CheckRequiredSeedConditions(seed)
+	if err != nil {
+		return err
+	}
+	for _, condition := range falseConditions {
 		if err := checkConditionState(string(condition.Type), string(gardencorev1beta1.ConditionTrue), string(condition.Status), condition.Reason, condition.Message); err != nil {
 			return err
 		}

--- a/pkg/utils/kubernetes/health/seed_test.go
+++ b/pkg/utils/kubernetes/health/seed_test.go
@@ -78,6 +78,201 @@ var _ = Describe("Seed", func() {
 		)
 	})
 
+	Describe("CheckSeedIsUpToDate", func() {
+		DescribeTable("seeds",
+			func(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener, matcher types.GomegaMatcher) {
+				Expect(health.CheckSeedIsUpToDate(seed, identity)).To(matcher)
+			},
+			Entry("up-to-date with empty identity", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Gardener: &gardencorev1beta1.Gardener{},
+				},
+			},
+				&gardencorev1beta1.Gardener{},
+				Succeed(),
+			),
+			Entry("up-to-date with matching identity",
+				&gardencorev1beta1.Seed{
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener: &gardencorev1beta1.Gardener{
+							ID:      "test-gardener",
+							Name:    "gardener",
+							Version: "1.80.0",
+						},
+					},
+				},
+				&gardencorev1beta1.Gardener{
+					ID:      "test-gardener",
+					Name:    "gardener",
+					Version: "1.80.0",
+				},
+				Succeed(),
+			),
+			Entry("up-to-date with matching generation",
+				&gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 5,
+					},
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener:           &gardencorev1beta1.Gardener{},
+						ObservedGeneration: 5,
+					},
+				},
+				&gardencorev1beta1.Gardener{},
+				Succeed(),
+			),
+			Entry("outdated - non-matching identity ID",
+				&gardencorev1beta1.Seed{
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener: &gardencorev1beta1.Gardener{
+							ID:      "old-gardener",
+							Version: "1.80.0",
+						},
+					},
+				},
+				&gardencorev1beta1.Gardener{
+					ID:      "new-gardener",
+					Version: "1.80.0",
+				},
+				MatchError(ContainSubstring("observing Gardener version not up to date")),
+			),
+			Entry("outdated - non-matching identity version",
+				&gardencorev1beta1.Seed{
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener: &gardencorev1beta1.Gardener{
+							Version: "1.80.0",
+						},
+					},
+				},
+				&gardencorev1beta1.Gardener{
+					Version: "1.81.0",
+				},
+				MatchError(ContainSubstring("observing Gardener version not up to date")),
+			),
+			Entry("outdated - observed generation behind",
+				&gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 10,
+					},
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener:           &gardencorev1beta1.Gardener{},
+						ObservedGeneration: 9,
+					},
+				},
+				&gardencorev1beta1.Gardener{},
+				MatchError(ContainSubstring("observed generation outdated (9/10)")),
+			),
+			Entry("outdated - zero observed generation",
+				&gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener:           &gardencorev1beta1.Gardener{},
+						ObservedGeneration: 0,
+					},
+				},
+				&gardencorev1beta1.Gardener{},
+				MatchError(ContainSubstring("observed generation outdated (0/1)")),
+			),
+			Entry("outdated - nil gardener status",
+				&gardencorev1beta1.Seed{
+					Status: gardencorev1beta1.SeedStatus{
+						Gardener: nil,
+					},
+				},
+				&gardencorev1beta1.Gardener{},
+				MatchError(ContainSubstring("observing Gardener version not up to date")),
+			),
+		)
+	})
+
+	Describe("CheckRequiredSeedConditions", func() {
+		DescribeTable("seeds",
+			func(seed *gardencorev1beta1.Seed, expectError bool, expectedFailedConditionsCount int) {
+				failedConditions, err := health.CheckRequiredSeedConditions(seed)
+				if expectError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(failedConditions).To(HaveLen(expectedFailedConditionsCount))
+				}
+			},
+			Entry("all conditions healthy", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}, false, 0),
+			Entry("gardenlet ready condition false", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionFalse, Reason: "NotReady", Message: "Gardenlet is not ready"},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}, false, 1),
+			Entry("seed system components healthy condition false", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionFalse, Reason: "Unhealthy", Message: "Component failed"},
+					},
+				},
+			}, false, 1),
+			Entry("all conditions false", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionFalse},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionFalse},
+					},
+				},
+			}, false, 2),
+			Entry("gardenlet ready condition unknown", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionUnknown},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}, false, 1),
+			Entry("seed system components healthy condition progressing", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionProgressing},
+					},
+				},
+			}, false, 1),
+			Entry("missing gardenlet ready condition", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.SeedSystemComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}, true, 0),
+			Entry("missing seed system components healthy condition", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.GardenletReady, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}, true, 0),
+			Entry("missing all conditions", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{},
+				},
+			}, true, 0),
+			Entry("nil conditions", &gardencorev1beta1.Seed{
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: nil,
+				},
+			}, true, 0),
+		)
+	})
+
 	Describe("CheckSeedForMigration", func() {
 		DescribeTable("seeds",
 			func(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener, matcher types.GomegaMatcher) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR reduces unnecessary shoot status updates when a seed is not ready, preventing massive etcd load in large-scale Gardener landscapes.

If a seed remains unready for an extended period, for example due to a malfunctioning extension, all shoot clusters scheduled on that seed will eventually enter a failing reconciliation loop, with retries occurring every 15 seconds. This continuous retry process causes frequent revision updates in etcd, which can ultimately result in storage overload - depending on the number of affected seeds, as well as the number and size of the shoots involved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The PR moves the seed check earlier in the shoot reconciliation process. After an unready seed error is recorded in the status, the status is not updated again unless the error message changes.

/cc @dguendisch @hendrikKahl

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Status updates for `Shoot` resources during reconciliation are now minimized when the associated `Seed` is not ready. Previously, this could lead to excessive growth of the gardener's etcd key space.
```
