### PR TITLE
[renovate] Do not create update PRs for etcd images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -428,7 +428,7 @@
       ],
       enabled: false,
       matchPackageNames: [
-        '/quay.io/coreos/etcd/',
+        '/gcr.io/etcd-development/etcd/',
       ],
     },
     {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The version of `etcd` image must be in sync with the `etcd-druid` version, so we can deactivate update PRs for it (https://github.com/gardener/gardener/pull/14371, https://github.com/gardener/gardener/pull/14375).
The repository was changed from `quay.io/coreos/etcd/` to `gcr.io/etcd-development/etcd` in https://github.com/gardener/gardener/pull/14352/

Similar to https://github.com/gardener/gardener/pull/12073/

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
