### PR TITLE
Add victorialogs stream headers to the collector exporter

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -471,6 +471,9 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 						},
 						"otlphttp/victorialogs": map[string]any{
 							"logs_endpoint": "http://" + victorialogsconstants.ServiceName + ":" + strconv.Itoa(victorialogsconstants.VictoriaLogsPort) + victorialogsconstants.PushEndpoint,
+							"headers": map[string]any{
+								"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin",
+							},
 						},
 					},
 				},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -474,6 +474,9 @@ var _ = Describe("OpenTelemetry Collector", func() {
 							},
 							"otlphttp/victorialogs": map[string]any{
 								"logs_endpoint": "http://logging-vl:9428/insert/opentelemetry/v1/logs",
+								"headers": map[string]any{
+									"VL-Stream-Fields": "host.name,k8s.node.name,k8s.namespace.name,k8s.pod.name,k8s.container.name,k8s.deployment.name,k8s.daemonset.name,k8s.statefulset.name,severity,unit,origin",
+								},
 							},
 						},
 					},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR adds `victoria-logs` headers configuration for the collector exporter.
It is required to define the correct streams in vl following the opentelemetry semantic conventions.
More information can be found at [VL Stream Fields](https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Now victorialogs streams follow opentelemetry semantic convention fields.
```
