### PR TITLE
Configure `EtcdDbSizeLimitApproaching`  and `EtcdDbSizeLimitCrossed` for seeds

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -264,7 +264,7 @@ spec:
           A seed etcd-main in landscape {{$externalLabels.landscape}} is approaching its current DB size limit.
         description: >-
           Seed {{$labels.name}} etcd-main DB size is approaching its current limit in landscape {{$externalLabels.landscape}}. 
-          Current DB size: {{ $value }}. Etcd quota might need to be increased.
+          Etcd quota might need to be increased.
 
     - alert: SeedKubeEtcd3MainDbSizeLimitCrossed
       expr: |

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -253,7 +253,7 @@ spec:
           Port-forward to `prometheus-garden-0` in the `garden` namespace and open:
           http://localhost:9090/targets?search={{$labels.instance}}
 
-    - alert: EtcdDbSizeLimitApproaching
+    - alert: SeedKubeEtcd3MainDbSizeLimitApproaching
       expr: |
         ALERTS{alertname="KubeEtcd3MainDbSizeLimitApproaching",alertstate="firing",namespace=~"shoot--garden--.+"}
       for: 5m

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -253,6 +253,21 @@ spec:
           Port-forward to `prometheus-garden-0` in the `garden` namespace and open:
           http://localhost:9090/targets?search={{$labels.instance}}
 
+    - alert: EtcdDbSizeLimitApproaching
+      expr: |
+        ALERTS{alertname="KubeEtcd3MainDbSizeLimitApproaching",alertstate="firing", namespace=~"shoot--garden--.+"}
+      for: 5m
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: >-
+          Seed {{$labels.name}} etcd {{$labels.role}} DB size is approaching its current
+          practical limit in landscape {{$externalLabels.landscape}}. Current DB size: {{ $value }}.
+        description: >-
+          Seed {{$labels.name}} etcd {{$labels.role}} DB size is approaching its current
+          practical limit of 8GB. Current DB size: {{ $value }}. Etcd quota might need to be increased.
+    
     - alert: SeedPodStuckInPending
       expr: |
         ALERTS{alertname="PodStuckInPending",alertstate="firing"}

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -277,7 +277,7 @@ spec:
           A seed etcd-main in landscape {{$externalLabels.landscape}} has crossed its current DB size limit.
         description: >-
           Seed {{$labels.name}} etcd-main DB size has crossed its current practical limit in landscape {{$externalLabels.landscape}}. 
-          Current DB size: {{ $value }}. Etcd quota must be increased to allow updates. 
+          Etcd quota must be increased to allow updates. 
     
     - alert: SeedPodStuckInPending
       expr: |

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -255,7 +255,7 @@ spec:
 
     - alert: EtcdDbSizeLimitApproaching
       expr: |
-        ALERTS{alertname="KubeEtcd3MainDbSizeLimitApproaching",alertstate="firing", namespace=~"shoot--garden--.+"}
+        ALERTS{alertname="KubeEtcd3MainDbSizeLimitApproaching",alertstate="firing",namespace=~"shoot--garden--.+"}
       for: 5m
       labels:
         severity: warning

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/seed.yaml
@@ -256,17 +256,28 @@ spec:
     - alert: SeedKubeEtcd3MainDbSizeLimitApproaching
       expr: |
         ALERTS{alertname="KubeEtcd3MainDbSizeLimitApproaching",alertstate="firing",namespace=~"shoot--garden--.+"}
-      for: 5m
       labels:
         severity: warning
         topology: garden
       annotations:
         summary: >-
-          Seed {{$labels.name}} etcd {{$labels.role}} DB size is approaching its current
-          practical limit in landscape {{$externalLabels.landscape}}. Current DB size: {{ $value }}.
+          A seed etcd-main in landscape {{$externalLabels.landscape}} is approaching its current DB size limit.
         description: >-
-          Seed {{$labels.name}} etcd {{$labels.role}} DB size is approaching its current
-          practical limit of 8GB. Current DB size: {{ $value }}. Etcd quota might need to be increased.
+          Seed {{$labels.name}} etcd-main DB size is approaching its current limit in landscape {{$externalLabels.landscape}}. 
+          Current DB size: {{ $value }}. Etcd quota might need to be increased.
+
+    - alert: SeedKubeEtcd3MainDbSizeLimitCrossed
+      expr: |
+        ALERTS{alertname="KubeEtcd3MainDbSizeLimitCrossed",alertstate="firing",namespace=~"shoot--garden--.+"}
+      labels:
+        severity: warning
+        topology: garden
+      annotations:
+        summary: >-
+          A seed etcd-main in landscape {{$externalLabels.landscape}} has crossed its current DB size limit.
+        description: >-
+          Seed {{$labels.name}} etcd-main DB size has crossed its current practical limit in landscape {{$externalLabels.landscape}}. 
+          Current DB size: {{ $value }}. Etcd quota must be increased to allow updates. 
     
     - alert: SeedPodStuckInPending
       expr: |


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the garden Prometheus configuration to alert when a seed etcd reaches its DB limit. 

Because the seed is managed by the `gardenlet` which doesn't expose configuration settings for alerting or monitoring in general, we make use of Gardener logic that federates the alerts to the garden Prometheus. This way, the alerts can be routed to notification channels we have in place. 

**Which issue(s) this PR fixes**:
Allow notification flexibility for the seed etcd limit alert. 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enable notification flexibility of `EtcdDbSizeLimitApproaching` and `EtcdDbSizeLimitCrossed` alert for seeds
```
