### PR TITLE
[GEP-28] `gardenadm connect`: Enable `ControllerInstallation` required controller in `gardenlet`

### DIFF
--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -27,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/bastion"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation"
 	controllerinstallationcare "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
+	controllerinstallationrequired "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/required"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/gardenlet"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy"
@@ -108,6 +110,14 @@ func AddToManager(
 			ManagedResourceNamespace: metav1.NamespaceSystem,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding ControllerInstallation care controller: %w", err)
+		}
+
+		// TODO(rfranzke): Remove this once all ControllerInstallation reconcilers are added via `shoot.AddToManager`.
+		if err := (&controllerinstallationrequired.Reconciler{
+			Config:              *cfg.Controllers.ControllerInstallationRequired,
+			SelfHostedShootMeta: &types.NamespacedName{Name: selfHostedShoot.Name, Namespace: selfHostedShoot.Namespace},
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding ControllerInstallation required controller: %w", err)
 		}
 
 		if err := (&gardenlet.Reconciler{

--- a/pkg/gardenlet/controller/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/add.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/required"
+	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 )
 
 // AddToManager adds all ControllerInstallation controllers to the given manager.
@@ -45,11 +46,21 @@ func AddToManager(
 		return fmt.Errorf("failed adding main reconciler: %w", err)
 	}
 
-	if err := (&required.Reconciler{
-		Config:   *cfg.Controllers.ControllerInstallationRequired,
-		SeedName: cfg.SeedConfig.SeedTemplate.Name,
-	}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
-		return fmt.Errorf("failed adding required reconciler: %w", err)
+	// When the seed is a self-hosted shoot, all ControllerInstallations have .spec.shootRef instead of .spec.seedRef.
+	// The self-hosted gardenlet already runs the required controller with ShootRef-based filtering, so the SeedRef-based
+	// instance here would find no ControllerInstallations.
+	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
+	if err != nil {
+		return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
+	}
+
+	if !seedIsSelfHostedShoot {
+		if err := (&required.Reconciler{
+			Config:   *cfg.Controllers.ControllerInstallationRequired,
+			SeedName: cfg.SeedConfig.SeedTemplate.Name,
+		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
+			return fmt.Errorf("failed adding required reconciler: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -87,6 +87,19 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 		return err
 	}
 
+	// Watch ControllerInstallation objects to enqueue them when created. This ensures that newly created
+	// ControllerInstallations are reconciled regardless of whether HandleOnce has already fired. Without this watch,
+	// ControllerInstallations created after startup would only be reconciled when an extension object changes.
+	// The gardenlet cache already restricts ControllerInstallation objects to the relevant seed or shoot, so no
+	// additional filtering is needed here.
+	if err = c.Watch(source.Kind[client.Object](
+		gardenCluster.GetCache(),
+		&gardencorev1beta1.ControllerInstallation{},
+		&handler.EnqueueRequestForObject{},
+	)); err != nil {
+		return err
+	}
+
 	for _, extension := range []struct {
 		objectKind        string
 		object            client.Object
@@ -111,22 +124,12 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 			extension.newObjectListFunc,
 		))
 
-		// Execute the mapper function at least once to initialize the `KindToRequiredTypes` map.
-		// This is necessary for extension kinds which are registered but for which no extension objects exist in the
-		// seed (e.g. when backups are disabled). In such cases, no regular watch event would be triggered. Hence, the
-		// mapping function would never be executed. Hence, the extension kind would never be part of the
-		// `KindToRequiredTypes` map. Hence, the reconciler would not be able to decide whether the
-		// ControllerInstallation is required.
-		if err = c.Watch(&controllerutils.HandleOnce[client.Object, reconcile.Request]{Handler: eventHandler}); err != nil {
-			return err
-		}
-
 		// Since the EnqueueRequestsFromMapFunc is costly, actual watches need to be registered after the manager was started.
 		// Registering them here might otherwise cause cache sync timeouts, esp. in large seed clusters.
 		// See https://github.com/kubernetes-sigs/controller-runtime/issues/3466 and https://github.com/gardener/gardener/issues/14391 for more information.
 		r.deferredEventHandlerRegistrations = append(r.deferredEventHandlerRegistrations, &eventHandlerRegistration{
 			registerFn: func() error {
-				return c.Watch(
+				if err := c.Watch(
 					source.Kind[client.Object](
 						seedCluster.GetCache(),
 						extension.object,
@@ -134,7 +137,15 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 						extensions.ObjectPredicate(),
 						predicateutils.HasClass(extensionsv1alpha1.ExtensionClassShoot, extensionsv1alpha1.ExtensionClassSeed),
 					),
-				)
+				); err != nil {
+					return err
+				}
+
+				// Execute the mapper function to initialize `KindToRequiredTypes` for this extension kind. This
+				// is necessary for kinds with no extension objects in the seed (e.g. when backups are disabled),
+				// as the source.Kind watch above would never deliver events for them. Without this, the
+				// reconciler could not decide whether a ControllerInstallation is required.
+				return c.Watch(&controllerutils.HandleOnce[client.Object, reconcile.Request]{Handler: eventHandler})
 			},
 		})
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -215,7 +215,15 @@ func (r *Reconciler) MapObjectKindToControllerInstallations(log logr.Logger, obj
 		// the other reconciler to decide whether it is required or not.
 
 		controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-		if err := r.GardenClient.List(ctx, controllerInstallationList, client.MatchingFields{core.SeedRefName: r.SeedName}); err != nil {
+
+		var listOptions client.MatchingFields
+		if r.SelfHostedShootMeta != nil {
+			listOptions = client.MatchingFields{core.ShootRefName: r.SelfHostedShootMeta.Name, core.ShootRefNamespace: r.SelfHostedShootMeta.Namespace}
+		} else {
+			listOptions = client.MatchingFields{core.SeedRefName: r.SeedName}
+		}
+
+		if err := r.GardenClient.List(ctx, controllerInstallationList, listOptions); err != nil {
 			log.Error(err, "Failed to list ControllerInstallations")
 			return nil
 		}

--- a/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add_test.go
@@ -212,5 +212,66 @@ var _ = Describe("Add", func() {
 			Expect(mapFn(ctx, nil)).To(ConsistOf(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation1.Name}})))
 			Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New(type1)))
 		})
+
+		When("running in self-hosted shoot mode", func() {
+			var (
+				shootName      = "my-shoot"
+				shootNamespace = "garden-my-project"
+			)
+
+			BeforeEach(func() {
+				fakeGardenClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithIndex(&gardencorev1beta1.ControllerInstallation{}, core.ShootRefName, indexer.ControllerInstallationShootRefNameIndexerFunc).
+					WithIndex(&gardencorev1beta1.ControllerInstallation{}, core.ShootRefNamespace, indexer.ControllerInstallationShootRefNamespaceIndexerFunc).
+					Build()
+				reconciler.GardenClient = fakeGardenClient
+				reconciler.SelfHostedShootMeta = &types.NamespacedName{Name: shootName, Namespace: shootNamespace}
+				mapFn = reconciler.MapObjectKindToControllerInstallations(log, extensionsv1alpha1.InfrastructureResource, func() client.ObjectList { return &extensionsv1alpha1.InfrastructureList{} })
+
+				controllerInstallation1.Spec.SeedRef = nil
+				controllerInstallation1.Spec.ShootRef = &corev1.ObjectReference{Name: shootName, Namespace: shootNamespace}
+				controllerInstallation2.Spec.SeedRef = nil
+				controllerInstallation2.Spec.ShootRef = &corev1.ObjectReference{Name: shootName, Namespace: shootNamespace}
+				controllerInstallation3.Spec.SeedRef = nil
+				controllerInstallation3.Spec.ShootRef = &corev1.ObjectReference{Name: shootName, Namespace: shootNamespace}
+			})
+
+			It("should return the expected names of controllerinstallations", func() {
+				Expect(fakeGardenClient.Create(ctx, controllerRegistration1)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerRegistration2)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerRegistration3)).To(Succeed())
+
+				Expect(fakeGardenClient.Create(ctx, controllerInstallation1)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerInstallation2)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerInstallation3)).To(Succeed())
+
+				Expect(fakeSeedClient.Create(ctx, infrastructure)).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
+
+				Expect(mapFn(ctx, nil)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation1.Name}},
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation2.Name}},
+				))
+				Expect(reconciler.KindToRequiredTypes).To(HaveKeyWithValue(extensionsv1alpha1.InfrastructureResource, sets.New(type1, type2)))
+			})
+
+			It("should not return controllerinstallations for other shoots", func() {
+				controllerInstallation2.Spec.ShootRef = &corev1.ObjectReference{Name: "other-shoot", Namespace: shootNamespace}
+
+				Expect(fakeGardenClient.Create(ctx, controllerRegistration1)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerRegistration2)).To(Succeed())
+
+				Expect(fakeGardenClient.Create(ctx, controllerInstallation1)).To(Succeed())
+				Expect(fakeGardenClient.Create(ctx, controllerInstallation2)).To(Succeed())
+
+				Expect(fakeSeedClient.Create(ctx, infrastructure)).To(Succeed())
+				Expect(fakeSeedClient.Create(ctx, infrastructure2)).To(Succeed())
+
+				Expect(mapFn(ctx, nil)).To(ConsistOf(
+					reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerInstallation1.Name}},
+				))
+			})
+		})
 	})
 })

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -30,6 +31,9 @@ type Reconciler struct {
 	Config       gardenletconfigv1alpha1.ControllerInstallationRequiredControllerConfiguration
 	Clock        clock.Clock
 	SeedName     string
+	// SelfHostedShootMeta is set when running in self-hosted shoot mode. It is used to filter
+	// ControllerInstallations by their .spec.shootRef instead of .spec.seedRef.
+	SelfHostedShootMeta *types.NamespacedName
 
 	Lock                *sync.RWMutex
 	KindToRequiredTypes map[string]sets.Set[string]

--- a/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_suite_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -56,6 +57,10 @@ var (
 	testNamespace *corev1.Namespace
 	testRunID     string
 	seedName      string
+
+	selfHostedShootName      string
+	selfHostedShootNamespace string
+	selfHostedMgrClient      client.Client
 )
 
 var _ = BeforeSuite(func() {
@@ -164,5 +169,48 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(func() {
 		By("Stop manager")
 		mgrCancel()
+	})
+
+	By("Setup self-hosted shoot manager")
+	selfHostedShootName = "my-shoot"
+	selfHostedShootNamespace = testRunID
+
+	selfHostedMgr, err := manager.New(restConfig, manager.Options{
+		Scheme:  testScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			DefaultNamespaces:    map[string]cache.Config{testNamespace.Name: {}},
+			DefaultLabelSelector: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+		},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: ptr.To(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	selfHostedMgrClient = selfHostedMgr.GetClient()
+
+	By("Setup self-hosted field indexes")
+	Expect(indexer.AddControllerInstallationShootRefName(ctx, selfHostedMgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddControllerInstallationShootRefNamespace(ctx, selfHostedMgr.GetFieldIndexer())).To(Succeed())
+
+	By("Register self-hosted controller")
+	Expect((&required.Reconciler{
+		Config: gardenletconfigv1alpha1.ControllerInstallationRequiredControllerConfiguration{
+			ConcurrentSyncs: ptr.To(5),
+		},
+		SelfHostedShootMeta: &types.NamespacedName{Name: selfHostedShootName, Namespace: selfHostedShootNamespace},
+	}).AddToManager(selfHostedMgr, selfHostedMgr, selfHostedMgr)).To(Succeed())
+
+	By("Start self-hosted manager")
+	selfHostedMgrContext, selfHostedMgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(selfHostedMgr.Start(selfHostedMgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop self-hosted manager")
+		selfHostedMgrCancel()
 	})
 })

--- a/test/integration/gardenlet/controllerinstallation/required/required_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_test.go
@@ -150,3 +150,121 @@ var _ = Describe("ControllerInstallation Required controller tests", func() {
 		})
 	})
 })
+
+var _ = Describe("ControllerInstallation Required controller tests (self-hosted shoot)", func() {
+	var (
+		extensionType = "type1"
+
+		controllerRegistration *gardencorev1beta1.ControllerRegistration
+		controllerInstallation *gardencorev1beta1.ControllerInstallation
+		infrastructure         *extensionsv1alpha1.Infrastructure
+	)
+
+	BeforeEach(func() {
+		By("Create ControllerRegistration")
+		controllerRegistration = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ctrlreg1-",
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{Kind: extensionsv1alpha1.InfrastructureResource, Type: extensionType},
+				},
+			},
+		}
+
+		Expect(testClient.Create(ctx, controllerRegistration)).To(Succeed())
+		log.Info("Created ControllerRegistration for test", "controllerRegistration", client.ObjectKeyFromObject(controllerRegistration))
+
+		DeferCleanup(func() {
+			By("Delete ControllerRegistration")
+			Expect(testClient.Delete(ctx, controllerRegistration)).To(Succeed())
+		})
+
+		By("Wait until manager has observed ControllerRegistration")
+		Eventually(func() error {
+			return selfHostedMgrClient.Get(ctx, client.ObjectKeyFromObject(controllerRegistration), controllerRegistration)
+		}).Should(Succeed())
+
+		By("Create ControllerInstallation with ShootRef")
+		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "ctrlinst-",
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				ShootRef: &corev1.ObjectReference{
+					Name:      selfHostedShootName,
+					Namespace: selfHostedShootNamespace,
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: controllerRegistration.Name,
+				},
+				DeploymentRef: &corev1.ObjectReference{
+					Name: "foo-deployment",
+				},
+			},
+		}
+		Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())
+		log.Info("Created ControllerInstallation for test", "controllerInstallation", client.ObjectKeyFromObject(controllerInstallation))
+
+		DeferCleanup(func() {
+			By("Delete ControllerInstallation")
+			Expect(testClient.Delete(ctx, controllerInstallation)).To(Succeed())
+		})
+
+		By("Wait until manager has observed ControllerInstallation")
+		Eventually(func() error {
+			return selfHostedMgrClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)
+		}).Should(Succeed())
+
+		infrastructure = &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "infra1-",
+				Namespace:    testNamespace.Name,
+				Labels:       map[string]string{testID: testRunID},
+			},
+			Spec: extensionsv1alpha1.InfrastructureSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: extensionType,
+				},
+			},
+		}
+	})
+
+	It("should set the Required condition to True when extension resources exist", func() {
+		By("Create Infrastructure")
+		Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
+		log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
+
+		DeferCleanup(func() {
+			By("Delete Infrastructure")
+			Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			return controllerInstallation.Status.Conditions
+		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
+	})
+
+	It("should set the Required condition to False when all extension resources get deleted", func() {
+		By("Create Infrastructure")
+		Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
+		log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
+
+		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			return controllerInstallation.Status.Conditions
+		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
+
+		By("Delete Infrastructure")
+		Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+
+		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			return controllerInstallation.Status.Conditions
+		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("NoExtensionObjects")))
+	})
+})

--- a/test/integration/gardenlet/controllerinstallation/required/required_test.go
+++ b/test/integration/gardenlet/controllerinstallation/required/required_test.go
@@ -233,38 +233,49 @@ var _ = Describe("ControllerInstallation Required controller tests (self-hosted 
 		}
 	})
 
-	It("should set the Required condition to True when extension resources exist", func() {
-		By("Create Infrastructure")
-		Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
-		log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
-
-		DeferCleanup(func() {
-			By("Delete Infrastructure")
-			Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+	Context("when no extension resources exist", func() {
+		It("should set the Required condition to False", func() {
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				return controllerInstallation.Status.Conditions
+			}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("NoExtensionObjects")))
 		})
-
-		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
-			return controllerInstallation.Status.Conditions
-		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
 	})
 
-	It("should set the Required condition to False when all extension resources get deleted", func() {
-		By("Create Infrastructure")
-		Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
-		log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
+	Context("when extension resources exist", func() {
+		It("should set the Required condition to True", func() {
+			By("Create Infrastructure")
+			Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
+			log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
 
-		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
-			return controllerInstallation.Status.Conditions
-		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
+			DeferCleanup(func() {
+				By("Delete Infrastructure")
+				Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+			})
 
-		By("Delete Infrastructure")
-		Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				return controllerInstallation.Status.Conditions
+			}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
+		})
 
-		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
-			return controllerInstallation.Status.Conditions
-		}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("NoExtensionObjects")))
+		It("should set the Required condition to False when all extension resources get deleted", func() {
+			By("Create Infrastructure")
+			Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
+			log.Info("Created Infrastructure for test", "infrastructure", client.ObjectKeyFromObject(infrastructure))
+
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				return controllerInstallation.Status.Conditions
+			}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("ExtensionObjectsExist")))
+
+			By("Delete Infrastructure")
+			Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				return controllerInstallation.Status.Conditions
+			}).Should(ContainCondition(OfType(gardencorev1beta1.ControllerInstallationRequired), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("NoExtensionObjects")))
+		})
 	})
 })


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is based on #14316 which must be merged first. This PR remains in draft state until then. ✅

**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Enables the `ControllerInstallation` required controller in self-hosted shoot `gardenlet`s so that the `ControllerInstallationRequired` condition is set correctly based on existing extension objects. Without it, stale `ControllerInstallation`s would never be detected. Additionally, the required controller is skipped in the seed `gardenlet` when the `Seed` is a self-hosted `Shoot`, since all `ControllerInstallation`s use `.spec.shootRef` in that case.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```
NONE
```