### PR TITLE
[release-v1.138] Automated cherry pick of #14380: Update dependency gardener/dashboard to v1.83.10

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -54,7 +54,7 @@ images:
   - name: gardener-dashboard
     sourceRepository: github.com/gardener/dashboard
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-    tag: "1.83.8"
+    tag: "1.83.10"
   - name: terminal-controller-manager
     sourceRepository: github.com/gardener/terminal-controller-manager
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager


### PR DESCRIPTION
/kind enhancement

Cherry pick of #14380 on release-v1.138.

#14380: Update dependency gardener/dashboard to v1.83.10

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `gardener/dashboard` from `1.83.8` to `1.83.10`. [Release Notes](https://redirect.github.com/gardener/dashboard/releases/tag/1.83.10)
```