### PR TITLE
[GEP-28] Enable deployment of `gardener-operator` (and `Garden`) inside self-hosted `Shoot`s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,10 @@ test-e2e-local-gardenadm-managed-infra: $(GINKGO)
 	./hack/test-e2e-local.sh gardenadm --procs=1 --label-filter="managed-infra" ./test/e2e/gardenadm/...
 test-e2e-local-gardenadm-unmanaged-infra: $(GINKGO)
 	./hack/test-e2e-local.sh gardenadm --procs=1 --label-filter="unmanaged-infra" ./test/e2e/gardenadm/...
+test-e2e-local-gardenadm-unmanaged-infra-initjoin: $(GINKGO)
+	./hack/test-e2e-local.sh gardenadm --procs=1 --label-filter="unmanaged-infra && initjoin" ./test/e2e/gardenadm/...
+test-e2e-local-gardenadm-unmanaged-infra-connect: $(GINKGO)
+	./hack/test-e2e-local.sh gardenadm --procs=1 --label-filter="unmanaged-infra && connect" ./test/e2e/gardenadm/...
 
 test-non-ha-pre-upgrade: $(GINKGO)
 	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter="pre-upgrade && !high-availability" ./test/e2e/gardener/...
@@ -477,6 +481,8 @@ ci-e2e-kind-operator: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-operator.sh
 ci-e2e-kind-gardenadm-unmanaged-infra: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
+ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh: $(KIND) $(YQ)
+	./hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
 ci-e2e-kind-gardenadm-managed-infra: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-gardenadm-managed-infra.sh
 

--- a/charts/gardener/gardenlet/templates/configmap-selfupgrade-config.yaml
+++ b/charts/gardener/gardenlet/templates/configmap-selfupgrade-config.yaml
@@ -23,6 +23,14 @@ data:
         helm:
           ociRepository:
 {{ required ".Values.selfUpgrade.deployment.helm.ociRepository is required" .Values.selfUpgrade.deployment.helm.ociRepository | toYaml | indent 12 }}
+        {{- if .Values.imageVectorOverwrite }}
+        imageVectorOverwrite: |
+          {{- .Values.imageVectorOverwrite | nindent 10 }}
+        {{- end }}
+        {{- if .Values.componentImageVectorOverwrite }}
+        componentImageVectorOverwrite: |
+          {{- .Values.componentImageVectorOverwrite | nindent 10 }}
+        {{- end }}
         replicaCount: {{ .Values.replicaCount }}
         {{- if .Values.revisionHistoryLimit }}
         revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -799,7 +799,7 @@ const virtualGardenService = operatorv1alpha1.DeploymentNameVirtualGardenKubeAPI
 // overwriteGardenHostWhenDeployedInRuntimeCluster overwrites the garden REST config host to the internal service host
 // if the gardenlet is deployed in the runtime cluster of the garden and L7 load balancing is not active.
 func (g *garden) overwriteGardenHostWhenDeployedInRuntimeCluster(ctx context.Context, log logr.Logger, gardenRESTConfig *rest.Config) error {
-	seedIsGarden, err := gardenlet.SeedIsGarden(ctx, g.mgr.GetClient())
+	seedIsGarden, err := gardenlet.ClusterIsGarden(ctx, g.mgr.GetClient())
 	if err != nil {
 		return fmt.Errorf("failed to check whether seed is garden: %w", err)
 	}

--- a/dev-setup/garden/components/gardenadm/kustomization.yaml
+++ b/dev-setup/garden/components/gardenadm/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - patch: |
+      # The spec here must match the respective fields in the Shoot object for the self-hosted cluster:
+      # /dev-setup/gardenadm/resources/base/shoot.yaml
+      - op: replace
+        path: /spec/runtimeCluster/networking/nodes
+        value:
+        - 10.0.0.0/16
+      - op: replace
+        path: /spec/runtimeCluster/networking/pods
+        value:
+        - 10.3.0.0/16
+      - op: replace
+        path: /spec/runtimeCluster/networking/services
+        value:
+        - 10.4.0.0/16
+      - op: remove
+        path: /spec/runtimeCluster/provider/zones
+    target:
+      group: operator.gardener.cloud
+      kind: Garden
+      name: local

--- a/dev-setup/garden/overlays/multi-node-gardenadm/kustomization.yaml
+++ b/dev-setup/garden/overlays/multi-node-gardenadm/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+components:
+- ../../components/gardenadm

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -10,7 +10,7 @@ COMMAND="${1:-up}"
 VALID_COMMANDS=("up" "down")
 
 SCENARIO="${SCENARIO:-unmanaged-infra}"
-VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect")
+VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect" "connect-kind")
 
 valid_scenario=false
 for scenario in "${VALID_SCENARIOS[@]}"; do
@@ -24,9 +24,15 @@ if ! $valid_scenario; then
   exit 1
 fi
 
+garden_runtime_cluster_kubeconfig="$KUBECONFIG"
+if [[ "$SCENARIO" == "connect" ]]; then
+  garden_runtime_cluster_kubeconfig="$(dirname "$0")/kubeconfigs/self-hosted-shoot/kubeconfig"
+  ./hack/usage/generate-admin-kubeconfig-local.sh self-hosted-shoot > "$garden_runtime_cluster_kubeconfig"
+fi
+
 case "$COMMAND" in
   up)
-    if [[ "$SCENARIO" != "connect" ]]; then
+    if [[ "$SCENARIO" != connect* ]]; then
       # Prepare resources and generate manifests.
       # The manifests are copied to the unmanaged-infra machine pods or can be passed to the `--config-dir` flag of `gardenadm bootstrap`.
       skaffold build \
@@ -61,9 +67,26 @@ case "$COMMAND" in
         exit 1
       fi
 
+      if [[ "$SCENARIO" == "connect" ]]; then
+        # Used to talk to the virtual-garden API server from the host machine via the following network path:
+        # Host:172.18.255.3:443
+        #   → Docker (hostPort 443 → containerPort 31443)
+        #     → KinD node, NodePort 31443
+        #       → machine-0 pod IP 10.0.212.0:31443
+        #         → istio-ingressgateway pod exposed via NodePort 31443 in the machine-0 node
+        # In the 'connect-kind' scenario, the istio-ingressgateway runs directly in the KinD node and gets exposed via
+        # node port 31443 directly, hence, no need to patch this Service in this scenario.
+        if ! kubectl --kubeconfig "$KUBECONFIG" -n gardenadm-unmanaged-infra get service control-plane-machine \
+          -o jsonpath='{.spec.ports[*].name}' | grep -qw virtual-garden-apiserver; then
+          kubectl --kubeconfig "$KUBECONFIG" -n gardenadm-unmanaged-infra patch service control-plane-machine \
+            --type=json \
+            -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"virtual-garden-apiserver","port":4432,"targetPort":31443,"nodePort":31443}}]'
+        fi
+      fi
+
       make operator-up garden-up \
         -f "$(dirname "$0")/../Makefile" \
-        KUBECONFIG="$KUBECONFIG"
+        KUBECONFIG="$garden_runtime_cluster_kubeconfig"
 
       echo "Creating global resources in the virtual garden cluster as preparation for running 'gardenadm connect'..."
       kubectl --kubeconfig="$VIRTUAL_GARDEN_KUBECONFIG" apply -f "$(dirname "$0")/gardenadm/resources/generated/connect/manifests.yaml"
@@ -77,7 +100,7 @@ case "$COMMAND" in
     else
       make garden-down operator-down \
         -f "$(dirname "$0")/../Makefile" \
-        KUBECONFIG="$KUBECONFIG"
+        KUBECONFIG="$garden_runtime_cluster_kubeconfig"
     fi
     ;;
 

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -80,7 +80,7 @@ case "$COMMAND" in
           -o jsonpath='{.spec.ports[*].name}' | grep -qw virtual-garden-apiserver; then
           kubectl --kubeconfig "$KUBECONFIG" -n gardenadm-unmanaged-infra patch service control-plane-machine \
             --type=json \
-            -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"virtual-garden-apiserver","port":4432,"targetPort":31443,"nodePort":31443}}]'
+            -p '[{"op":"add","path":"/spec/ports/-","value":{"name":"virtual-garden-apiserver","port":31443,"targetPort":31443,"nodePort":31443}}]'
         fi
       fi
 

--- a/dev-setup/scenario.sh
+++ b/dev-setup/scenario.sh
@@ -11,8 +11,8 @@ function detect_scenario() {
   zones=$(kubectl get nodes -o jsonpath='{.items[*].metadata.labels.topology\.kubernetes\.io/zone}' | tr ' ' '\n' | sort -u)
   provider_ids=$(kubectl get nodes -o jsonpath='{.items[*].spec.providerID}' | tr ' ' '\n')
 
-  # Check if all providerIDs do NOT start with kind://
-  if [[ -n "$provider_ids" && $(echo "$provider_ids" | grep -cv '^kind://') -eq $(echo "$provider_ids" | wc -l) ]]; then
+  # Check if all providerIDs have a scheme (contain "://") but none start with kind://
+  if [[ -n "$provider_ids" && $(echo "$provider_ids" | grep -c '://') -eq $(echo "$provider_ids" | wc -l) && $(echo "$provider_ids" | grep -cv '^kind://') -eq $(echo "$provider_ids" | wc -l) ]]; then
     export SCENARIO="remote"
   elif [[ $(echo "$nodes" | wc -l) -eq 1 ]]; then
     export SCENARIO="single-node"
@@ -31,6 +31,10 @@ function detect_scenario() {
     export SCENARIO="${SCENARIO}-ipv6"
   elif [[ "$IPFAMILY" == "dual" ]]; then
     export SCENARIO="${SCENARIO}-dual"
+  fi
+
+  if [[ "$(kubectl get namespace kube-system -o jsonpath='{.metadata.labels.gardener\.cloud/role}')" == "shoot" ]]; then
+    export SCENARIO="${SCENARIO}-gardenadm"
   fi
 
   echo "DETECTED SCENARIO: $SCENARIO"

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -189,6 +189,15 @@ make gardenadm-up SCENARIO=connect
 
 This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Garden` resource (which will then be reconciled and results in a full Gardener deployment) inside the self-hosted shoot cluster.
 Find all information about it [here](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
+
+> [!NOTE]
+> There is an alternative way of deploying Gardener outside the self-hosted shoot but inside the KinD cluster in the
+> `garden` namespace.
+>
+> `make gardenadm-up SCENARIO=connect-kind`
+>
+> The following steps from above are the same.
+
 Note, that in this setup, no `Seed` will be registered in the Gardener - it's just a plain garden cluster without the ability to create regular shoot clusters.
 
 Once above command is finished, you can generate a bootstrap token using `gardenadm` to connect the shoot cluster to this Gardener instance.
@@ -235,14 +244,6 @@ kubectl --kubeconfig=./dev-setup/kubeconfigs/virtual-garden/kubeconfig get shoot
 NAMESPACE   NAME   CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPERATION   STATUS    AGE
 garden      root   local          local      local    1.33.0        Awake         <pending>        healthy   42m
 ```
-
-> [!NOTE]
-> There is an alternative way of deploying Gardener outside the self-hosted shoot but inside the KinD cluster in the
-> `garden` namespace.
->
-> `make gardenadm-up SCENARIO=connect-kind`
->
-> The following steps from above are the same.
 
 ## Running E2E Tests for `gardenadm`
 

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -180,14 +180,14 @@ machine-0   Ready    <none>   10m   v1.32.0
 ## Connecting the Self-Hosted Shoot Cluster to Gardener
 
 After you have successfully bootstrapped a self-hosted shoot cluster (either via the [unmanaged infrastructure](#unmanaged-infrastructure-scenario) or the [managed infrastructure](#managed-infrastructure-scenario) scenario), you can connect it to an existing Gardener system.
-For this, you need to have a Gardener running locally in your KinD cluster.
+For this, you need to deploy Gardener to your self-hosted shoot cluster.
 In order to deploy it, you can run
 
 ```shell
 make gardenadm-up SCENARIO=connect
 ```
 
-This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Garden` resource (which will then be reconciled and results in a full Gardener deployment).
+This will deploy [`gardener-operator`](../concepts/operator.md) and create a `Garden` resource (which will then be reconciled and results in a full Gardener deployment) inside the self-hosted shoot cluster.
 Find all information about it [here](getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
 Note, that in this setup, no `Seed` will be registered in the Gardener - it's just a plain garden cluster without the ability to create regular shoot clusters.
 
@@ -200,13 +200,10 @@ make gardenadm
 
 This will install it to `./bin/gardenadm`, from where you can call it.
 
-After you have completed this, you need to get a kubeconfig for [the Gardener instance](../concepts/operator.md#accessing-the-virtual-garden-cluster) you want to connect the self-hosted shoot to.
-We will refer to the path of this kubeconfig as `<path-to-garden-kubeconfig>` in the following.
-
 Now you can generate the bootstrap token and the full `gardenadm connect` command like this:
 
 ```shell
-$ KUBECONFIG=<path-to-garden-kubeconfig> ./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root
+$ KUBECONFIG=./dev-setup/kubeconfigs/virtual-garden/kubeconfig ./bin/gardenadm token create --print-connect-command --shoot-namespace=garden --shoot-name=root
 # This will output a command similar to:
 gardenadm connect --bootstrap-token ... --ca-certificate ... https://api.virtual-garden.local.gardener.cloud
 ```
@@ -226,7 +223,7 @@ root@machine-0:/# gardenadm connect --bootstrap-token ... --ca-certificate ... h
 Once this is done, you can observe that there is now a `gardenlet` running in the self-hosted shoot cluster, which connects it to the Gardener instance:
 
 ```shell
-root@machine-0:/# kubectl get pods -n kube-system | grep gardenlet
+root@machine-0:/# kubectl get pods -n kube-system -l app=gardener,role=gardenlet
 gardenlet-6cbcb676f5-prh8f                           1/1     Running   0             40m
 gardenlet-6cbcb676f5-wwn8w                           1/1     Running   0             40m
 ````
@@ -234,10 +231,18 @@ gardenlet-6cbcb676f5-wwn8w                           1/1     Running   0        
 You can also observe that the self-hosted shoot cluster is now registered as a shoot cluster in Gardener:
 
 ```shell
-kubectl --kubeconfig=<path-to-garden-kubeconfig> get Shoots -A
+kubectl --kubeconfig=./dev-setup/kubeconfigs/virtual-garden/kubeconfig get shoots -A
 NAMESPACE   NAME   CLOUDPROFILE   PROVIDER   REGION   K8S VERSION   HIBERNATION   LAST OPERATION   STATUS    AGE
 garden      root   local          local      local    1.33.0        Awake         <pending>        healthy   42m
 ```
+
+> [!NOTE]
+> There is an alternative way of deploying Gardener outside the self-hosted shoot but inside the KinD cluster in the
+> `garden` namespace.
+>
+> `make gardenadm-up SCENARIO=connect-kind`
+>
+> The following steps from above are the same.
 
 ## Running E2E Tests for `gardenadm`
 

--- a/hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
+++ b/hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
@@ -17,15 +17,13 @@ trap "
   ( export_artifacts_host_services; export_artifacts_infra )
   ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden )
   ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig; export cluster_name='virtual-garden'; export_resource_yamls_for seeds shoots )
-  ( make gardenadm-down SCENARIO=connect )
+  ( make gardenadm-down SCENARIO=connect-kind )
   ( make gardenadm-down SCENARIO=unmanaged-infra )
   ( make kind-single-node-down )
 " EXIT
 
 make kind-single-node-up
-
 make gardenadm-up SCENARIO=unmanaged-infra
-make test-e2e-local-gardenadm-unmanaged-infra-initjoin
+make gardenadm-up SCENARIO=connect-kind
 
-make gardenadm-up SCENARIO=connect
-make test-e2e-local-gardenadm-unmanaged-infra-connect
+make test-e2e-local-gardenadm-unmanaged-infra

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -879,6 +879,10 @@ func (r *resourceManager) ensureDeployment(ctx context.Context, configMap *corev
 		deployment.Spec.Replicas = replicas
 		deployment.Spec.RevisionHistoryLimit = ptr.To[int32](2)
 		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: r.appLabel()}
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type:          appsv1.RollingUpdateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{},
+		}
 
 		if r.values.BootstrapControlPlaneNode {
 			deployment.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -564,6 +564,10 @@ var _ = Describe("ResourceManager", func() {
 							"app": "gardener-resource-manager",
 						},
 					},
+					Strategy: appsv1.DeploymentStrategy{
+						Type:          appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{},
+					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{

--- a/pkg/controller/gardenletdeployer/actuator.go
+++ b/pkg/controller/gardenletdeployer/actuator.go
@@ -689,7 +689,7 @@ func PrepareGardenletChartValues(
 	}
 
 	// Set network policy label
-	isGarden, err := gardenletutils.SeedIsGarden(ctx, targetClusterClient)
+	isGarden, err := gardenletutils.ClusterIsGarden(ctx, targetClusterClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if seed is garden: %w", err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -84,7 +84,7 @@ func run(ctx context.Context, opts *Options) error {
 
 	// If the self-hosted shoot is also the garden runtime cluster, then gardener-operator is taking over
 	// responsibility of some components (e.g., etcd-druid). Detect this by checking whether a Garden resource exists.
-	shootIsGarden, err := gardenletutils.SeedIsGarden(ctx, b.SeedClientSet.Client())
+	shootIsGarden, err := gardenletutils.ClusterIsGarden(ctx, b.SeedClientSet.Client())
 	if err != nil {
 		return fmt.Errorf("failed checking whether shoot is garden: %w", err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 )
 
 // NewCommand creates a new cobra.Command.
@@ -79,6 +80,13 @@ func run(ctx context.Context, opts *Options) error {
 	podNetworkAvailable, err := b.IsPodNetworkAvailable(ctx)
 	if err != nil {
 		return fmt.Errorf("failed checking whether pod network is already available: %w", err)
+	}
+
+	// If the self-hosted shoot is also the garden runtime cluster, then gardener-operator is taking over
+	// responsibility of some components (e.g., etcd-druid). Detect this by checking whether a Garden resource exists.
+	shootIsGarden, err := gardenletutils.SeedIsGarden(ctx, b.SeedClientSet.Client())
+	if err != nil {
+		return fmt.Errorf("failed checking whether shoot is garden: %w", err)
 	}
 
 	var (
@@ -139,6 +147,10 @@ func run(ctx context.Context, opts *Options) error {
 				b.Components.RuntimeResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
 				b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(!podNetworkAvailable)
 
+				if shootIsGarden {
+					return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
+				}
+
 				return flow.Parallel(
 					b.Components.RuntimeResourceManager.Deploy,
 					b.Shoot.Components.ControlPlane.ResourceManager.Deploy,
@@ -148,10 +160,16 @@ func run(ctx context.Context, opts *Options) error {
 		})
 		waitUntilGardenerResourceManagerReady = g.Add(flow.Task{
 			Name: "Waiting until gardener-resource-manager reports readiness",
-			Fn: flow.Parallel(
-				b.Components.RuntimeResourceManager.Wait,
-				b.Shoot.Components.ControlPlane.ResourceManager.Wait,
-			),
+			Fn: func(ctx context.Context) error {
+				if shootIsGarden {
+					return b.Shoot.Components.ControlPlane.ResourceManager.Wait(ctx)
+				}
+
+				return flow.Parallel(
+					b.Components.RuntimeResourceManager.Wait,
+					b.Shoot.Components.ControlPlane.ResourceManager.Wait,
+				)(ctx)
+			},
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
@@ -238,6 +256,10 @@ func run(ctx context.Context, opts *Options) error {
 				b.Components.RuntimeResourceManager.SetBootstrapControlPlaneNode(false)
 				b.Shoot.Components.ControlPlane.ResourceManager.SetBootstrapControlPlaneNode(false)
 
+				if shootIsGarden {
+					return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
+				}
+
 				return flow.Parallel(
 					b.Components.RuntimeResourceManager.Deploy,
 					b.Shoot.Components.ControlPlane.ResourceManager.Deploy,
@@ -248,10 +270,16 @@ func run(ctx context.Context, opts *Options) error {
 		})
 		waitUntilGardenerResourceManagerInPodNetworkReady = g.Add(flow.Task{
 			Name: "Waiting until gardener-resource-manager (in pod network) reports readiness",
-			Fn: flow.Parallel(
-				b.Components.RuntimeResourceManager.Wait,
-				b.Shoot.Components.ControlPlane.ResourceManager.Wait,
-			),
+			Fn: func(ctx context.Context) error {
+				if shootIsGarden {
+					return b.Shoot.Components.ControlPlane.ResourceManager.Wait(ctx)
+				}
+
+				return flow.Parallel(
+					b.Components.RuntimeResourceManager.Wait,
+					b.Shoot.Components.ControlPlane.ResourceManager.Wait,
+				)(ctx)
+			},
 			SkipIf:       podNetworkAvailable,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManagerIntoPodNetwork),
 		})
@@ -310,7 +338,7 @@ func run(ctx context.Context, opts *Options) error {
 		deployEtcdDruid = g.Add(flow.Task{
 			Name:         "Deploying ETCD Druid",
 			Fn:           b.DeployEtcdDruid,
-			SkipIf:       opts.UseBootstrapEtcd,
+			SkipIf:       opts.UseBootstrapEtcd || shootIsGarden,
 			Dependencies: flow.NewTaskIDs(syncPointBootstrapped),
 		})
 		deployEtcds = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -198,7 +198,7 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	seedIsGarden, err := gardenletutils.SeedIsGarden(seedCtx, r.SeedClientSet.Client())
+	seedIsGarden, err := gardenletutils.ClusterIsGarden(seedCtx, r.SeedClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed checking whether the seed is the garden cluster at the same time: %w", err)
 	}

--- a/pkg/gardenlet/controller/networkpolicy/add.go
+++ b/pkg/gardenlet/controller/networkpolicy/add.go
@@ -45,7 +45,7 @@ func AddToManager(
 	networks gardencorev1beta1.SeedNetworks,
 	resolver hostnameresolver.HostResolver,
 ) error {
-	seedIsGarden, err := gardenletutils.SeedIsGarden(ctx, seedCluster.GetAPIReader())
+	seedIsGarden, err := gardenletutils.ClusterIsGarden(ctx, seedCluster.GetAPIReader())
 	if err != nil {
 		return fmt.Errorf("failed checking whether the seed is the garden cluster: %w", err)
 	}
@@ -107,7 +107,7 @@ func AddToManager(
 	// way, gardenlet will restart and not add the controller again.
 	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		wait.Until(func() {
-			seedIsGarden, err = gardenletutils.SeedIsGarden(ctx, seedCluster.GetClient())
+			seedIsGarden, err = gardenletutils.ClusterIsGarden(ctx, seedCluster.GetClient())
 			if err != nil {
 				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster")
 				return

--- a/pkg/gardenlet/controller/seed/seed/reconciler.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	seedIsGarden, err := gardenletutils.SeedIsGarden(ctx, r.SeedClientSet.Client())
+	seedIsGarden, err := gardenletutils.ClusterIsGarden(ctx, r.SeedClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, r.updateStatusOperationError(ctx, seed, err, operationType)
 	}

--- a/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_delete.go
@@ -429,7 +429,7 @@ func ensureNoControllerInstallations(c client.Client, seedName string) func(ctx 
 
 func ensureNoManagedResources(c client.Client) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
-		managedResourcesStillExist, err := managedresources.CheckIfManagedResourcesExist(ctx, c, ptr.To(v1beta1constants.SeedResourceManagerClass))
+		managedResourcesStillExist, err := managedresources.CheckIfManagedResourcesExist(ctx, c, ptr.To(v1beta1constants.SeedResourceManagerClass), nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/gardenlet/controller/vpaevictionrequirements/add.go
+++ b/pkg/gardenlet/controller/vpaevictionrequirements/add.go
@@ -30,7 +30,7 @@ func AddToManager(
 	cfg gardenletconfigv1alpha1.VPAEvictionRequirementsControllerConfiguration,
 	seedCluster cluster.Cluster,
 ) error {
-	seedIsGarden, err := gardenletutils.SeedIsGarden(ctx, seedCluster.GetAPIReader())
+	seedIsGarden, err := gardenletutils.ClusterIsGarden(ctx, seedCluster.GetAPIReader())
 	if err != nil {
 		return fmt.Errorf("failed checking whether the seed is the garden cluster: %w", err)
 	}
@@ -68,7 +68,7 @@ func AddToManager(
 	// way, gardenlet will restart and not add the controller again.
 	return mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		wait.Until(func() {
-			seedIsGarden, err = gardenletutils.SeedIsGarden(ctx, seedCluster.GetClient())
+			seedIsGarden, err = gardenletutils.ClusterIsGarden(ctx, seedCluster.GetClient())
 			if err != nil {
 				mgr.GetLogger().Error(err, "Failed checking whether the seed cluster is the garden cluster")
 				return

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -313,6 +313,7 @@ func (r *Reconciler) delete(
 		destroyEtcdDruid = g.Add(flow.Task{
 			Name:         "Destroying ETCD Druid",
 			Fn:           component.OpDestroyAndWait(c.etcdDruid).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
 		destroyIstio = g.Add(flow.Task{
@@ -414,26 +415,31 @@ func (r *Reconciler) delete(
 		destroyGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Destroying and waiting for gardener-resource-manager to be deleted",
 			Fn:           component.OpWait(c.gardenerResourceManager).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(ensureNoManagedResourcesExistAnymore),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for extensions",
 			Fn:           component.OpWait(c.extensionCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for prometheus-operator",
 			Fn:           component.OpWait(c.prometheusCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for opentelemetry-operator",
 			Fn:           component.OpWait(c.openTelemetryCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for fluent-operator",
 			Fn:           component.OpWait(c.fluentCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
@@ -444,22 +450,25 @@ func (r *Reconciler) delete(
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for VPA",
 			Fn:           component.OpWait(c.vpaCRD).Destroy,
-			SkipIf:       !vpaEnabled(garden.Spec.RuntimeCluster.Settings),
+			SkipIf:       !vpaEnabled(garden.Spec.RuntimeCluster.Settings) || runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying ETCD-related custom resource definitions",
 			Fn:           component.OpWait(c.etcdCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for perses-operator",
 			Fn:           component.OpWait(c.persesCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying custom resource definition for victoria-operator",
 			Fn:           component.OpWait(c.victoriaCRD).Destroy,
+			SkipIf:       runtimeClusterIsSelfHostedShoot,
 			Dependencies: flow.NewTaskIDs(destroyGardenerResourceManager),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,6 +26,7 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/component/extensions/dnsrecord"
 	"github.com/gardener/gardener/pkg/component/garden/system/virtual"
 	gardeneraccess "github.com/gardener/gardener/pkg/component/gardener/access"
@@ -39,6 +41,7 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	gardenletutils "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -70,6 +73,14 @@ func (r *Reconciler) delete(
 		false,
 		extensionList,
 	)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// When the runtime cluster is a self-hosted shoot, etcd-druid and the runtime gardener-resource-manager are also
+	// serving the shoot's control plane. They must not be destroyed during Garden deletion — the gardenlet will continue
+	// managing them.
+	runtimeClusterIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, r.RuntimeClientSet.Client())
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -397,7 +408,7 @@ func (r *Reconciler) delete(
 		})
 		ensureNoManagedResourcesExistAnymore = g.Add(flow.Task{
 			Name:         "Ensuring no ManagedResources exist anymore",
-			Fn:           r.checkIfManagedResourcesExist(),
+			Fn:           r.checkIfManagedResourcesExist(runtimeClusterIsSelfHostedShoot),
 			Dependencies: flow.NewTaskIDs(destroyRuntimeSystemResources),
 		})
 		destroyGardenerResourceManager = g.Add(flow.Task{
@@ -492,7 +503,11 @@ func (r *Reconciler) checkIfVirtualGardenManagedResourcesAreGone(excludedNames .
 			ctx,
 			r.RuntimeClientSet.Client(),
 			nil,
-			append(excludedNames, resourcemanager.ManagedResourceName)...,
+			append(excludedNames, resourcemanager.ManagedResourceName),
+			// When the runtime cluster is a self-hosted shoot, kube-system contains classless ManagedResources for the
+			// shoot's control plane components (managed by gardenlet). These must be excluded to prevent blocking the
+			// Garden deletion flow.
+			[]string{metav1.NamespaceSystem},
 		)
 		if err != nil {
 			return err
@@ -509,12 +524,26 @@ func (r *Reconciler) checkIfVirtualGardenManagedResourcesAreGone(excludedNames .
 	}
 }
 
-func (r *Reconciler) checkIfManagedResourcesExist() func(context.Context) error {
+func (r *Reconciler) checkIfManagedResourcesExist(runtimeClusterIsSelfHostedShoot bool) func(context.Context) error {
 	return func(ctx context.Context) error {
+		var excludeNames, excludeNamespaces []string
+		if runtimeClusterIsSelfHostedShoot {
+			// When the runtime cluster is a self-hosted shoot, kube-system contains seed-class ManagedResources for the
+			// shoot's control plane components (managed by gardenlet). These must be excluded to prevent blocking the
+			// Garden deletion flow.
+			excludeNamespaces = append(excludeNamespaces, metav1.NamespaceSystem)
+			// Additionally, the garden namespace may contain ManagedResource of components which are part of the
+			// self-hosted shoot's control plane. These muss be excluded as well to prevent blocking to the Garden
+			// deletion flow.
+			excludeNames = append(excludeNames, etcd.Druid)
+		}
+
 		managedResourcesStillExist, err := managedresources.CheckIfManagedResourcesExist(
 			ctx,
 			r.RuntimeClientSet.Client(),
 			ptr.To(v1beta1constants.SeedResourceManagerClass),
+			excludeNames,
+			excludeNamespaces,
 		)
 		if err != nil {
 			return err
@@ -526,7 +555,7 @@ func (r *Reconciler) checkIfManagedResourcesExist() func(context.Context) error 
 
 		return &reconcilerutils.RequeueAfterError{
 			RequeueAfter: 5 * time.Second,
-			Cause:        errors.New("at least one ManagedResource still exists"),
+			Cause:        fmt.Errorf("at least one ManagedResource with class %q still exists", v1beta1constants.SeedResourceManagerClass),
 		}
 	}
 }

--- a/pkg/utils/gardener/gardenlet/gardenlet.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet.go
@@ -28,8 +28,8 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 )
 
-// SeedIsGarden returns 'true' if the cluster is registered as a Garden cluster.
-func SeedIsGarden(ctx context.Context, seedClient client.Reader) (bool, error) {
+// ClusterIsGarden returns 'true' if the cluster is registered as a Garden cluster.
+func ClusterIsGarden(ctx context.Context, seedClient client.Reader) (bool, error) {
 	seedIsGarden, err := kubernetesutils.ResourcesExist(ctx, seedClient, &operatorv1alpha1.GardenList{}, operatorclient.RuntimeScheme)
 	if err != nil {
 		if !meta.IsNoMatchError(err) {

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("Gardenlet", func() {
-	Describe("#SeedIsGarden", func() {
+	Describe("#ClusterIsGarden", func() {
 		var (
 			ctx        context.Context
 			mockReader *mockclient.MockReader
@@ -52,12 +52,12 @@ var _ = Describe("Gardenlet", func() {
 					list.Items = []metav1.PartialObjectMetadata{{}}
 					return nil
 				})
-			Expect(SeedIsGarden(ctx, mockReader)).To(BeTrue())
+			Expect(ClusterIsGarden(ctx, mockReader)).To(BeTrue())
 		})
 
 		It("should return that seed is a not a garden cluster because no garden object found", func() {
 			mockReader.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.Limit(1))
-			Expect(SeedIsGarden(ctx, mockReader)).To(BeFalse())
+			Expect(ClusterIsGarden(ctx, mockReader)).To(BeFalse())
 		})
 
 		It("should return that seed is a not a garden cluster because of a no match error", func() {
@@ -65,7 +65,7 @@ var _ = Describe("Gardenlet", func() {
 				func(_ context.Context, _ *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
 					return &meta.NoResourceMatchError{}
 				})
-			Expect(SeedIsGarden(ctx, mockReader)).To(BeFalse())
+			Expect(ClusterIsGarden(ctx, mockReader)).To(BeFalse())
 		})
 	})
 

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -443,10 +443,10 @@ func CheckIfManagedResourcesExist(ctx context.Context, c client.Client, class *s
 		return false, err
 	}
 
-	excludedNamespaces := sets.New(excludeNamespaces...)
+	excludeNamespaceSet := sets.New(excludeNamespaces...)
 
 	for _, managedResource := range managedResourceList.Items {
-		if excludedNamespaces.Has(managedResource.Namespace) {
+		if excludeNamespaceSet.Has(managedResource.Namespace) {
 			continue
 		}
 		if ptr.Equal(managedResource.Spec.Class, class) && !sets.New(excludeNames...).Has(managedResource.Name) {

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -437,13 +437,18 @@ func checkConfigurationError(err error) []gardencorev1beta1.ErrorCode {
 }
 
 // CheckIfManagedResourcesExist checks if some ManagedResources of the given class still exist. If yes it returns true.
-func CheckIfManagedResourcesExist(ctx context.Context, c client.Client, class *string, excludeNames ...string) (bool, error) {
+func CheckIfManagedResourcesExist(ctx context.Context, c client.Client, class *string, excludeNames, excludeNamespaces []string) (bool, error) {
 	managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
 	if err := c.List(ctx, managedResourceList); err != nil {
 		return false, err
 	}
 
+	excludedNamespaces := sets.New(excludeNamespaces...)
+
 	for _, managedResource := range managedResourceList.Items {
+		if excludedNamespaces.Has(managedResource.Namespace) {
+			continue
+		}
 		if ptr.Equal(managedResource.Spec.Class, class) && !sets.New(excludeNames...).Has(managedResource.Name) {
 			return true, nil
 		}

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -749,7 +749,7 @@ var _ = Describe("managedresources", func() {
 
 		Context("w/o class", func() {
 			It("should return false because no resources exist", func() {
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeFalse())
 			})
@@ -759,7 +759,7 @@ var _ = Describe("managedresources", func() {
 				obj.Spec.Class = &class
 				Expect(fakeClient.Create(ctx, obj)).To(Succeed())
 
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeFalse())
 			})
@@ -767,7 +767,7 @@ var _ = Describe("managedresources", func() {
 			It("should return true because resources exist", func() {
 				Expect(fakeClient.Create(ctx, managedResource(false))).To(Succeed())
 
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeTrue())
 			})
@@ -775,7 +775,7 @@ var _ = Describe("managedresources", func() {
 
 		Context("w/ class", func() {
 			It("should return false because no resources exist", func() {
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeFalse())
 			})
@@ -785,7 +785,7 @@ var _ = Describe("managedresources", func() {
 				obj.Spec.Class = ptr.To("bar")
 				Expect(fakeClient.Create(ctx, obj)).To(Succeed())
 
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeFalse())
 			})
@@ -795,7 +795,25 @@ var _ = Describe("managedresources", func() {
 				obj.Spec.Class = &class
 				Expect(fakeClient.Create(ctx, obj)).To(Succeed())
 
-				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class)
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, &class, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resourcesExist).To(BeTrue())
+			})
+		})
+
+		Context("w/ excluded namespaces", func() {
+			It("should return false because the matching resource is in an excluded namespace", func() {
+				Expect(fakeClient.Create(ctx, managedResource(false))).To(Succeed())
+
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil, nil, []string{namespace})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resourcesExist).To(BeFalse())
+			})
+
+			It("should return true because the matching resource is not in an excluded namespace", func() {
+				Expect(fakeClient.Create(ctx, managedResource(false))).To(Succeed())
+
+				resourcesExist, err := CheckIfManagedResourcesExist(ctx, fakeClient, nil, nil, []string{"other-namespace"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resourcesExist).To(BeTrue())
 			})

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -832,7 +832,22 @@ build:
               - bash
               - -c
               - >
-                kubectl --kubeconfig="$VIRTUAL_GARDEN_KUBECONFIG" -n garden patch gardenlet self-hosted-shoot-root --type=merge -p "{\"spec\":{\"deployment\":{\"helm\":{\"ociRepository\":{\"ref\":\"$SKAFFOLD_IMAGE\"}}}}}" || true
+                kubectl --kubeconfig="$VIRTUAL_GARDEN_KUBECONFIG" -n garden patch gardenlet self-hosted-shoot-root --type=merge -p "$(jq -n \
+                  --arg image "$SKAFFOLD_IMAGE" \
+                  --arg imagevector_overwrite "$(cat ./dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml)" \
+                  '{
+                    spec: {
+                      deployment: {
+                        helm: {
+                          ociRepository: {
+                            ref: $image
+                          }
+                        },
+                        imageVectorOverwrite: $imagevector_overwrite,
+                      }
+                    }
+                  }'
+                )" || true
 
   insecureRegistries:
     - registry.local.gardener.cloud:5001

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -46,37 +46,6 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 		controlPlaneNamespace = "kube-system"
 	)
 
-	BeforeEach(OncePerOrdered, func(ctx SpecContext) {
-		testRunID := utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
-
-		By("Ensuring fresh machine pods for test execution")
-		statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: namespace}}
-		Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
-
-		By("Deleting machine state PVCs to ensure clean state")
-		pvcList := &corev1.PersistentVolumeClaimList{}
-		Expect(RuntimeClient.Client().List(ctx, pvcList, client.InNamespace(namespace), client.MatchingLabels{"app": statefulSetName})).To(Succeed())
-		for _, pvc := range pvcList.Items {
-			// Only delete machine-state PVCs (shoot cluster state). The gardenadm PVCs hold the
-			// gardenadm binary and imagevectors populated by skaffold and must not be wiped.
-			if !strings.HasPrefix(pvc.Name, "machine-state-") {
-				continue
-			}
-			Expect(client.IgnoreNotFound(RuntimeClient.Client().Delete(ctx, &pvc))).To(Succeed())
-		}
-
-		patch := client.MergeFrom(statefulSet.DeepCopy())
-		metav1.SetMetaDataAnnotation(&statefulSet.Spec.Template.ObjectMeta, "test-run-id", testRunID)
-		Expect(RuntimeClient.Client().Patch(ctx, statefulSet, patch)).To(Succeed())
-
-		Eventually(ctx, func(g Gomega) {
-			g.Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
-			progressing, _ := health.IsStatefulSetProgressing(statefulSet)
-			g.Expect(progressing).To(BeFalse())
-			g.Expect(health.CheckStatefulSet(statefulSet)).To(Succeed())
-		}).Should(Succeed())
-	}, NodeTimeout(2*time.Minute))
-
 	Describe("Single-node control plane", Ordered, Label("single"), func() {
 		var (
 			portForwardCtx    context.Context
@@ -84,11 +53,6 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 			shootClientSet    kubernetes.Interface
 
 			configDirectory = "/gardenadm/resources"
-
-			gardenClientSet                      kubernetes.Interface
-			gardenKomega                         Komega
-			gardenClusterKubeconfigPathOnHost    = filepath.Join("..", "..", "..", "dev-setup", "kubeconfigs", "virtual-garden", "kubeconfig")
-			gardenClusterKubeconfigPathOnMachine = "/tmp/virtual-garden-kubeconfig"
 		)
 
 		BeforeAll(func() {
@@ -96,273 +60,315 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 			DeferCleanup(func() { cancelPortForward() })
 		})
 
-		It("should initialize as control plane node", func(ctx SpecContext) {
-			stdOut, _, err := execute(ctx, 0, "gardenadm", "--log-level=debug", "init", "-d", configDirectory)
-			Expect(err).NotTo(HaveOccurred())
+		Context("gardenadm init + join", Ordered, Label("initjoin"), func() {
+			BeforeAll(func(ctx SpecContext) {
+				testRunID := utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
 
-			Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
-		}, SpecTimeout(10*time.Minute))
+				By("Ensuring fresh machine pods for test execution")
+				statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: namespace}}
+				Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
 
-		It("copy admin kubeconfig and create client", func(ctx SpecContext) {
-			tempDir, err := os.MkdirTemp("", "tmp")
-			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(func() { Expect(os.RemoveAll(tempDir)).To(Succeed()) })
-			adminKubeconfigFile := filepath.Join(tempDir, "admin.conf")
-
-			By("Copy admin kubeconfig to local file")
-			localPort := 6443
-			Eventually(ctx, func(g Gomega) error {
-				stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
-				g.Expect(err).NotTo(HaveOccurred())
-
-				kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), fmt.Sprintf("api.%s.%s.external.local.gardener.cloud", shootName, shootNamespace), fmt.Sprintf("localhost:%d", localPort))
-				return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
-			}).Should(Succeed())
-
-			By("Forward port to control plane machine pod")
-			fw, err := kubernetes.SetupPortForwarder(portForwardCtx, RuntimeClient.RESTConfig(), namespace, machinePodName(0), localPort, 443)
-			Expect(err).NotTo(HaveOccurred())
-
-			go func() {
-				if err := fw.ForwardPorts(); err != nil {
-					Fail("Error forwarding ports: " + err.Error())
+				By("Deleting machine state PVCs to ensure clean state")
+				pvcList := &corev1.PersistentVolumeClaimList{}
+				Expect(RuntimeClient.Client().List(ctx, pvcList, client.InNamespace(namespace), client.MatchingLabels{"app": statefulSetName})).To(Succeed())
+				for _, pvc := range pvcList.Items {
+					// Only delete machine-state PVCs (shoot cluster state). The gardenadm PVCs hold the
+					// gardenadm binary and imagevectors populated by skaffold and must not be wiped.
+					if !strings.HasPrefix(pvc.Name, "machine-state-") {
+						continue
+					}
+					Expect(client.IgnoreNotFound(RuntimeClient.Client().Delete(ctx, &pvc))).To(Succeed())
 				}
-			}()
 
-			Eventually(func() chan struct{} { return fw.Ready() }).Should(BeClosed())
+				patch := client.MergeFrom(statefulSet.DeepCopy())
+				metav1.SetMetaDataAnnotation(&statefulSet.Spec.Template.ObjectMeta, "test-run-id", testRunID)
+				Expect(RuntimeClient.Client().Patch(ctx, statefulSet, patch)).To(Succeed())
 
-			By("Create client set")
-			Eventually(func() error {
-				shootClientSet, err = kubernetes.NewClientFromFile("", adminKubeconfigFile,
-					kubernetes.WithDisabledCachedClient(),
-					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
-				)
-				return err
-			}).Should(Succeed())
-		})
+				Eventually(ctx, func(g Gomega) {
+					g.Expect(RuntimeClient.Client().Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
+					progressing, _ := health.IsStatefulSetProgressing(statefulSet)
+					g.Expect(progressing).To(BeFalse())
+					g.Expect(health.CheckStatefulSet(statefulSet)).To(Succeed())
+				}).Should(Succeed())
+			}, NodeTimeout(2*time.Minute))
 
-		It("should be able to communicate with the API server and see the node and the control plane pods", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) []corev1.Node {
-				nodeList := &corev1.NodeList{}
-				g.Expect(shootClientSet.Client().List(ctx, nodeList)).To(Succeed())
-				return nodeList.Items
-			}).Should(HaveLen(1))
+			It("should initialize as control plane node", func(ctx SpecContext) {
+				stdOut, _, err := execute(ctx, 0, "gardenadm", "--log-level=debug", "init", "-d", configDirectory)
+				Expect(err).NotTo(HaveOccurred())
 
-			Eventually(ctx, func(g Gomega) []corev1.Pod {
-				podList := &corev1.PodList{}
-				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(controlPlaneNamespace))).To(Succeed())
-				return podList.Items
-			}).Should(ContainElements(
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("kube-proxy")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("calico")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("coredns")})}),
-				MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("local-path-provisioner")})}),
-			))
-		}, SpecTimeout(time.Minute))
+				Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
+			}, SpecTimeout(10*time.Minute))
 
-		It("should ensure the control plane namespace is properly labeled", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) map[string]string {
-				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: controlPlaneNamespace}}
-				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(Succeed())
-				return namespace.Labels
-			}).Should(HaveKeyWithValue("gardener.cloud/role", "shoot"))
-		}, SpecTimeout(time.Minute))
+			It("copy admin kubeconfig and create client", func(ctx SpecContext) {
+				tempDir, err := os.MkdirTemp("", "tmp")
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() { Expect(os.RemoveAll(tempDir)).To(Succeed()) })
+				adminKubeconfigFile := filepath.Join(tempDir, "admin.conf")
 
-		It("should ensure extensions and gardener-resource-manager run in pod network", func(ctx SpecContext) {
-			By("Check extensions")
-			Eventually(ctx, func(g Gomega) {
-				namespaceList := &corev1.NamespaceList{}
-				g.Expect(shootClientSet.Client().List(ctx, namespaceList, client.MatchingLabels{"gardener.cloud/role": "extension"})).To(Succeed())
+				By("Copy admin kubeconfig to local file")
+				localPort := 6443
+				Eventually(ctx, func(g Gomega) error {
+					stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
+					g.Expect(err).NotTo(HaveOccurred())
 
-				for _, namespace := range namespaceList.Items {
+					kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), fmt.Sprintf("api.%s.%s.external.local.gardener.cloud", shootName, shootNamespace), fmt.Sprintf("localhost:%d", localPort))
+					return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
+				}).Should(Succeed())
+
+				By("Forward port to control plane machine pod")
+				fw, err := kubernetes.SetupPortForwarder(portForwardCtx, RuntimeClient.RESTConfig(), namespace, machinePodName(0), localPort, 443)
+				Expect(err).NotTo(HaveOccurred())
+
+				go func() {
+					if err := fw.ForwardPorts(); err != nil {
+						Fail("Error forwarding ports: " + err.Error())
+					}
+				}()
+
+				Eventually(func() chan struct{} { return fw.Ready() }).Should(BeClosed())
+
+				By("Create client set")
+				Eventually(func() error {
+					shootClientSet, err = kubernetes.NewClientFromFile("", adminKubeconfigFile,
+						kubernetes.WithDisabledCachedClient(),
+						kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
+					)
+					return err
+				}).Should(Succeed())
+			})
+
+			It("should be able to communicate with the API server and see the node and the control plane pods", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) []corev1.Node {
+					nodeList := &corev1.NodeList{}
+					g.Expect(shootClientSet.Client().List(ctx, nodeList)).To(Succeed())
+					return nodeList.Items
+				}).Should(HaveLen(1))
+
+				Eventually(ctx, func(g Gomega) []corev1.Pod {
 					podList := &corev1.PodList{}
-					g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(namespace.Name))).To(Succeed())
+					g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(controlPlaneNamespace))).To(Succeed())
+					return podList.Items
+				}).Should(ContainElements(
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-events-machine-0")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-main-machine-0")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-apiserver-machine-0")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-controller-manager-machine-0")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": Equal("kube-scheduler-machine-0")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("kube-proxy")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("gardener-resource-manager")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("calico")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("coredns")})}),
+					MatchFields(IgnoreExtras, Fields{"ObjectMeta": MatchFields(IgnoreExtras, Fields{"Name": HavePrefix("local-path-provisioner")})}),
+				))
+			}, SpecTimeout(time.Minute))
+
+			It("should ensure the control plane namespace is properly labeled", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) map[string]string {
+					namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: controlPlaneNamespace}}
+					g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(Succeed())
+					return namespace.Labels
+				}).Should(HaveKeyWithValue("gardener.cloud/role", "shoot"))
+			}, SpecTimeout(time.Minute))
+
+			It("should ensure extensions and gardener-resource-manager run in pod network", func(ctx SpecContext) {
+				By("Check extensions")
+				Eventually(ctx, func(g Gomega) {
+					namespaceList := &corev1.NamespaceList{}
+					g.Expect(shootClientSet.Client().List(ctx, namespaceList, client.MatchingLabels{"gardener.cloud/role": "extension"})).To(Succeed())
+
+					for _, namespace := range namespaceList.Items {
+						podList := &corev1.PodList{}
+						g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(namespace.Name))).To(Succeed())
+
+						for _, pod := range podList.Items {
+							g.Expect(pod.Spec.HostNetwork).To(BeFalse(), "pod %s", client.ObjectKeyFromObject(&pod))
+						}
+					}
+				}).Should(Succeed())
+
+				By("Check gardener-resource-manager")
+				Eventually(ctx, func(g Gomega) {
+					podList := &corev1.PodList{}
+					g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(controlPlaneNamespace), client.MatchingLabels{"app": "gardener-resource-manager"})).To(Succeed())
 
 					for _, pod := range podList.Items {
 						g.Expect(pod.Spec.HostNetwork).To(BeFalse(), "pod %s", client.ObjectKeyFromObject(&pod))
 					}
-				}
-			}).Should(Succeed())
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
 
-			By("Check gardener-resource-manager")
-			Eventually(ctx, func(g Gomega) {
-				podList := &corev1.PodList{}
-				g.Expect(shootClientSet.Client().List(ctx, podList, client.InNamespace(controlPlaneNamespace), client.MatchingLabels{"app": "gardener-resource-manager"})).To(Succeed())
+			It("should ensure gardener-node-agent is running", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) *gbytes.Buffer {
+					stdOut, _, err := execute(ctx, 0, "systemctl", "status", "gardener-node-agent")
+					g.Expect(err).NotTo(HaveOccurred())
+					return stdOut
+				}).Should(gbytes.Say(`Active: active \(running\)`))
+			}, SpecTimeout(time.Minute))
 
-				for _, pod := range podList.Items {
-					g.Expect(pod.Spec.HostNetwork).To(BeFalse(), "pod %s", client.ObjectKeyFromObject(&pod))
-				}
-			}).Should(Succeed())
-		}, SpecTimeout(time.Minute))
+			It("should ensure that extension webhooks on control plane components are functioning", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) map[string]string {
+					pod := &corev1.Pod{}
+					g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKey{Name: "kube-scheduler-machine-0", Namespace: controlPlaneNamespace}, pod)).To(Succeed())
+					return pod.Labels
+				}).Should(HaveKeyWithValue("injected-by", "provider-local"))
+			}, SpecTimeout(time.Minute))
 
-		It("should ensure gardener-node-agent is running", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) *gbytes.Buffer {
-				stdOut, _, err := execute(ctx, 0, "systemctl", "status", "gardener-node-agent")
-				g.Expect(err).NotTo(HaveOccurred())
-				return stdOut
-			}).Should(gbytes.Say(`Active: active \(running\)`))
-		}, SpecTimeout(time.Minute))
+			It("should ensure that the config dir location has been stored in the well-known location", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) string {
+					stdOut, _, err := execute(ctx, 0, "cat", "/var/lib/gardenadm/config-directory")
+					g.Expect(err).NotTo(HaveOccurred())
+					return string(stdOut.Contents())
+				}).Should(Equal(configDirectory))
+			}, SpecTimeout(time.Minute))
 
-		It("should ensure that extension webhooks on control plane components are functioning", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) map[string]string {
-				pod := &corev1.Pod{}
-				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKey{Name: "kube-scheduler-machine-0", Namespace: controlPlaneNamespace}, pod)).To(Succeed())
-				return pod.Labels
-			}).Should(HaveKeyWithValue("injected-by", "provider-local"))
-		}, SpecTimeout(time.Minute))
+			It("should generate a bootstrap token and join the worker node", func(ctx SpecContext) {
+				stdOut, _, err := execute(ctx, 0, "gardenadm", "token", "create", "--print-join-command")
+				Expect(err).NotTo(HaveOccurred())
+				joinCommand := strings.Split(strings.ReplaceAll(string(stdOut.Contents()), `"`, ``), " ")
 
-		It("should ensure that the config dir location has been stored in the well-known location", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) string {
-				stdOut, _, err := execute(ctx, 0, "cat", "/var/lib/gardenadm/config-directory")
-				g.Expect(err).NotTo(HaveOccurred())
-				return string(stdOut.Contents())
-			}).Should(Equal(configDirectory))
-		}, SpecTimeout(time.Minute))
+				stdOut, _, err = execute(ctx, 1, append(joinCommand, "--log-level=debug")...)
+				Expect(err).NotTo(HaveOccurred())
 
-		It("should generate a bootstrap token and join the worker node", func(ctx SpecContext) {
-			stdOut, _, err := execute(ctx, 0, "gardenadm", "token", "create", "--print-join-command")
-			Expect(err).NotTo(HaveOccurred())
-			joinCommand := strings.Split(strings.ReplaceAll(string(stdOut.Contents()), `"`, ``), " ")
+				Eventually(ctx, stdOut).Should(gbytes.Say("Your node has successfully joined the cluster as a worker!"))
+			}, SpecTimeout(time.Minute))
 
-			stdOut, _, err = execute(ctx, 1, append(joinCommand, "--log-level=debug")...)
-			Expect(err).NotTo(HaveOccurred())
+			It("should see the joined node and observe its readiness", func(ctx SpecContext) {
+				Eventually(ctx, func(g Gomega) {
+					node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: machinePodName(1)}}
+					g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
 
-			Eventually(ctx, stdOut).Should(gbytes.Say("Your node has successfully joined the cluster as a worker!"))
-		}, SpecTimeout(time.Minute))
+					g.Expect(node.Status.Conditions).To(ContainCondition(
+						MatchFields(IgnoreExtras, Fields{"Type": Equal(corev1.NodeReady)}),
+						MatchFields(IgnoreExtras, Fields{"Status": Equal(corev1.ConditionTrue)}),
+					))
+					g.Expect(node.Spec.Taints).NotTo(ContainElement(corev1.Taint{
+						Key:    v1beta1constants.TaintNodeCriticalComponentsNotReady,
+						Effect: corev1.TaintEffectNoSchedule,
+					}))
+				}).Should(Succeed())
+			}, SpecTimeout(2*time.Minute))
+		})
 
-		It("should see the joined node and observe its readiness", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) {
-				node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: machinePodName(1)}}
-				g.Expect(shootClientSet.Client().Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
+		Context("gardenadm init + join", Ordered, Label("connect"), func() {
+			var (
+				gardenClientSet                      kubernetes.Interface
+				gardenKomega                         Komega
+				gardenClusterKubeconfigPathOnHost    = filepath.Join("..", "..", "..", "dev-setup", "kubeconfigs", "virtual-garden", "kubeconfig")
+				gardenClusterKubeconfigPathOnMachine = "/tmp/virtual-garden-kubeconfig"
+			)
 
-				g.Expect(node.Status.Conditions).To(ContainCondition(
-					MatchFields(IgnoreExtras, Fields{"Type": Equal(corev1.NodeReady)}),
-					MatchFields(IgnoreExtras, Fields{"Status": Equal(corev1.ConditionTrue)}),
-				))
-				g.Expect(node.Spec.Taints).NotTo(ContainElement(corev1.Taint{
-					Key:    v1beta1constants.TaintNodeCriticalComponentsNotReady,
-					Effect: corev1.TaintEffectNoSchedule,
-				}))
-			}).Should(Succeed())
-		}, SpecTimeout(2*time.Minute))
+			It("should create a client for garden cluster", func(ctx SpecContext) {
+				By("Create client set")
+				Eventually(ctx, func() error {
+					var err error
+					gardenClientSet, err = kubernetes.NewClientFromFile("", gardenClusterKubeconfigPathOnHost,
+						kubernetes.WithDisabledCachedClient(),
+						kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
+					)
+					return err
+				}).Should(Succeed())
 
-		It("should create a client for garden cluster", func(ctx SpecContext) {
-			By("Create client set")
-			Eventually(ctx, func() error {
-				var err error
-				gardenClientSet, err = kubernetes.NewClientFromFile("", gardenClusterKubeconfigPathOnHost,
-					kubernetes.WithDisabledCachedClient(),
-					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
-				)
-				return err
-			}).Should(Succeed())
+				gardenKomega = New(gardenClientSet.Client())
+			}, SpecTimeout(time.Minute))
 
-			gardenKomega = New(gardenClientSet.Client())
-		}, SpecTimeout(time.Minute))
+			It("should copy the garden cluster kubeconfig to the machine pod", func(ctx SpecContext) {
+				// In the test setup via Skaffold, we build the 'gardenadm' binary and copy it to the machine pods. Hence,
+				// the binary is not available on the host without further ado. For simplicity, we copy the garden cluster
+				// kubeconfig from the host into the machine pod here. This enables us to execute
+				// 'gardenadm token create --print-connect-command' from the machine pod.
+				By("Copy local garden cluster kubeconfig to file in machine pod")
+				gardenClusterKubeconfig, err := os.ReadFile(gardenClusterKubeconfigPathOnHost) // #nosec: G304 -- variable points to a static file path
+				Expect(err).NotTo(HaveOccurred())
 
-		It("should copy the garden cluster kubeconfig to the machine pod", func(ctx SpecContext) {
-			// In the test setup via Skaffold, we build the 'gardenadm' binary and copy it to the machine pods. Hence,
-			// the binary is not available on the host without further ado. For simplicity, we copy the garden cluster
-			// kubeconfig from the host into the machine pod here. This enables us to execute
-			// 'gardenadm token create --print-connect-command' from the machine pod.
-			By("Copy local garden cluster kubeconfig to file in machine pod")
-			gardenClusterKubeconfig, err := os.ReadFile(gardenClusterKubeconfigPathOnHost) // #nosec: G304 -- variable points to a static file path
-			Expect(err).NotTo(HaveOccurred())
+				Eventually(ctx, func() error {
+					_, _, err := execute(ctx, 0, "sh", "-c", fmt.Sprintf("echo '%s' > %s", string(gardenClusterKubeconfig), gardenClusterKubeconfigPathOnMachine))
+					return err
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
 
-			Eventually(ctx, func() error {
-				_, _, err := execute(ctx, 0, "sh", "-c", fmt.Sprintf("echo '%s' > %s", string(gardenClusterKubeconfig), gardenClusterKubeconfigPathOnMachine))
-				return err
-			}).Should(Succeed())
-		}, SpecTimeout(time.Minute))
+			It("should generate a bootstrap token and connect the self-hosted shoot to Gardener", func(ctx SpecContext) {
+				stdOut, _, err := execute(ctx, 0, "sh", "-c", fmt.Sprintf("KUBECONFIG=%s gardenadm token create --print-connect-command --shoot-namespace=%s --shoot-name=%s", gardenClusterKubeconfigPathOnMachine, shootNamespace, shootName))
+				Expect(err).NotTo(HaveOccurred())
+				connectCommand := strings.Split(strings.ReplaceAll(string(stdOut.Contents()), `"`, ``), " ")
 
-		It("should generate a bootstrap token and connect the self-hosted shoot to Gardener", func(ctx SpecContext) {
-			stdOut, _, err := execute(ctx, 0, "sh", "-c", fmt.Sprintf("KUBECONFIG=%s gardenadm token create --print-connect-command --shoot-namespace=%s --shoot-name=%s", gardenClusterKubeconfigPathOnMachine, shootNamespace, shootName))
-			Expect(err).NotTo(HaveOccurred())
-			connectCommand := strings.Split(strings.ReplaceAll(string(stdOut.Contents()), `"`, ``), " ")
+				stdOut, _, err = execute(ctx, 0, append(connectCommand, "--log-level=debug")...)
+				Expect(err).NotTo(HaveOccurred())
 
-			stdOut, _, err = execute(ctx, 0, append(connectCommand, "--log-level=debug")...)
-			Expect(err).NotTo(HaveOccurred())
+				Eventually(ctx, stdOut).Should(gbytes.Say("Your self-hosted shoot cluster has successfully been connected to Gardener!"))
 
-			Eventually(ctx, stdOut).Should(gbytes.Say("Your self-hosted shoot cluster has successfully been connected to Gardener!"))
+				Eventually(ctx, func(g Gomega) {
+					csrList := &certificatesv1.CertificateSigningRequestList{}
+					g.Expect(gardenClientSet.Client().List(ctx, csrList)).To(Succeed())
 
-			Eventually(ctx, func(g Gomega) {
-				csrList := &certificatesv1.CertificateSigningRequestList{}
-				g.Expect(gardenClientSet.Client().List(ctx, csrList)).To(Succeed())
-
-				var gardenletCSR *certificatesv1.CertificateSigningRequest
-				for i := range csrList.Items {
-					if strings.HasPrefix(csrList.Items[i].Name, "shoot-csr") {
-						gardenletCSR = &csrList.Items[i]
-						break
+					var gardenletCSR *certificatesv1.CertificateSigningRequest
+					for i := range csrList.Items {
+						if strings.HasPrefix(csrList.Items[i].Name, "shoot-csr") {
+							gardenletCSR = &csrList.Items[i]
+							break
+						}
 					}
+
+					g.Expect(gardenletCSR).NotTo(BeNil())
+					g.Expect(gardenletCSR.Status.Conditions).To(ContainCondition(
+						MatchFields(IgnoreExtras, Fields{"Type": Equal(certificatesv1.CertificateApproved)}),
+						MatchFields(IgnoreExtras, Fields{"Status": Equal(corev1.ConditionTrue)}),
+						MatchFields(IgnoreExtras, Fields{"Message": Equal("Auto approving gardenlet client certificate after SubjectAccessReview.")}),
+						MatchFields(IgnoreExtras, Fields{"Reason": Equal("AutoApproved")}),
+					))
+				}).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			It("should see the Shoot resource in the Gardener API with the correct UID", func(ctx SpecContext) {
+				stdOut, _, err := execute(ctx, 0, "cat", "/var/lib/gardenadm/shoot-uid")
+				Expect(err).NotTo(HaveOccurred())
+				expectedShootStatusUID := types.UID(stdOut.Contents())
+
+				Eventually(ctx, func(g Gomega) types.UID {
+					g.Expect(gardenClientSet.Client().Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+					return shoot.Status.UID
+				}).Should(Equal(expectedShootStatusUID))
+			}, SpecTimeout(time.Minute))
+
+			It("should deploy and reconcile the BackupBucket resource", func(ctx SpecContext) {
+				backupBucket := &gardencorev1beta1.BackupBucket{ObjectMeta: metav1.ObjectMeta{Name: string(shoot.Status.UID)}}
+				Eventually(ctx, gardenKomega.Object(backupBucket)).Should(BeHealthy(health.CheckBackupBucket))
+			}, SpecTimeout(time.Minute))
+
+			It("should deploy and reconcile the BackupEntry resource", func(ctx SpecContext) {
+				backupEntryName, err := gardenerutils.GenerateBackupEntryName(controlPlaneNamespace, shoot.Status.UID, shoot.UID)
+				Expect(err).NotTo(HaveOccurred())
+
+				backupEntry := &gardencorev1beta1.BackupEntry{ObjectMeta: metav1.ObjectMeta{Name: backupEntryName, Namespace: shootNamespace}}
+				Eventually(ctx, gardenKomega.Object(backupEntry)).Should(BeHealthy(health.CheckBackupEntry))
+			}, SpecTimeout(time.Minute))
+
+			It("should deploy and reconcile the ControllerInstallations for the self-hosted Shoot", func(ctx SpecContext) {
+				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
+				Eventually(ctx, func(g Gomega) []gardencorev1beta1.ControllerInstallation {
+					g.Expect(gardenClientSet.Client().List(ctx, controllerInstallationList, client.MatchingFields{
+						core.ShootRefName:      shoot.Name,
+						core.ShootRefNamespace: shoot.Namespace,
+					})).To(Succeed())
+					return controllerInstallationList.Items
+				}).Should(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})}),
+					MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("networking-calico")})})}),
+				))
+
+				for _, controllerInstallation := range controllerInstallationList.Items {
+					By("Waiting for ControllerInstallation " + controllerInstallation.Name + " to become healthy")
+					Eventually(ctx, func(g Gomega) []gardencorev1beta1.Condition {
+						g.Expect(gardenClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&controllerInstallation), &controllerInstallation)).To(Succeed())
+						return controllerInstallation.Status.Conditions
+					}).Should(And(
+						ContainCondition(OfType(gardencorev1beta1.ControllerInstallationValid), WithStatus(gardencorev1beta1.ConditionTrue)),
+						ContainCondition(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionTrue)),
+						ContainCondition(OfType(gardencorev1beta1.ControllerInstallationHealthy), WithStatus(gardencorev1beta1.ConditionTrue)),
+						ContainCondition(OfType(gardencorev1beta1.ControllerInstallationProgressing), WithStatus(gardencorev1beta1.ConditionFalse)),
+					))
 				}
-
-				g.Expect(gardenletCSR).NotTo(BeNil())
-				g.Expect(gardenletCSR.Status.Conditions).To(ContainCondition(
-					MatchFields(IgnoreExtras, Fields{"Type": Equal(certificatesv1.CertificateApproved)}),
-					MatchFields(IgnoreExtras, Fields{"Status": Equal(corev1.ConditionTrue)}),
-					MatchFields(IgnoreExtras, Fields{"Message": Equal("Auto approving gardenlet client certificate after SubjectAccessReview.")}),
-					MatchFields(IgnoreExtras, Fields{"Reason": Equal("AutoApproved")}),
-				))
-			}).Should(Succeed())
-		}, SpecTimeout(time.Minute))
-
-		It("should see the Shoot resource in the Gardener API with the correct UID", func(ctx SpecContext) {
-			stdOut, _, err := execute(ctx, 0, "cat", "/var/lib/gardenadm/shoot-uid")
-			Expect(err).NotTo(HaveOccurred())
-			expectedShootStatusUID := types.UID(stdOut.Contents())
-
-			Eventually(ctx, func(g Gomega) types.UID {
-				g.Expect(gardenClientSet.Client().Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
-				return shoot.Status.UID
-			}).Should(Equal(expectedShootStatusUID))
-		}, SpecTimeout(time.Minute))
-
-		It("should deploy and reconcile the BackupBucket resource", func(ctx SpecContext) {
-			backupBucket := &gardencorev1beta1.BackupBucket{ObjectMeta: metav1.ObjectMeta{Name: string(shoot.Status.UID)}}
-			Eventually(ctx, gardenKomega.Object(backupBucket)).Should(BeHealthy(health.CheckBackupBucket))
-		}, SpecTimeout(time.Minute))
-
-		It("should deploy and reconcile the BackupEntry resource", func(ctx SpecContext) {
-			backupEntryName, err := gardenerutils.GenerateBackupEntryName(controlPlaneNamespace, shoot.Status.UID, shoot.UID)
-			Expect(err).NotTo(HaveOccurred())
-
-			backupEntry := &gardencorev1beta1.BackupEntry{ObjectMeta: metav1.ObjectMeta{Name: backupEntryName, Namespace: shootNamespace}}
-			Eventually(ctx, gardenKomega.Object(backupEntry)).Should(BeHealthy(health.CheckBackupEntry))
-		}, SpecTimeout(time.Minute))
-
-		It("should deploy and reconcile the ControllerInstallations for the self-hosted Shoot", func(ctx SpecContext) {
-			controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-			Eventually(ctx, func(g Gomega) []gardencorev1beta1.ControllerInstallation {
-				g.Expect(gardenClientSet.Client().List(ctx, controllerInstallationList, client.MatchingFields{
-					core.ShootRefName:      shoot.Name,
-					core.ShootRefNamespace: shoot.Namespace,
-				})).To(Succeed())
-				return controllerInstallationList.Items
-			}).Should(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})}),
-				MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("networking-calico")})})}),
-			))
-
-			for _, controllerInstallation := range controllerInstallationList.Items {
-				By("Waiting for ControllerInstallation " + controllerInstallation.Name + " to become healthy")
-				Eventually(ctx, func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(gardenClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&controllerInstallation), &controllerInstallation)).To(Succeed())
-					return controllerInstallation.Status.Conditions
-				}).Should(And(
-					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationValid), WithStatus(gardencorev1beta1.ConditionTrue)),
-					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionTrue)),
-					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationHealthy), WithStatus(gardencorev1beta1.ConditionTrue)),
-					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationProgressing), WithStatus(gardencorev1beta1.ConditionFalse)),
-				))
-			}
-		}, SpecTimeout(5*time.Minute))
+			}, SpecTimeout(5*time.Minute))
+		})
 	})
 })
 


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is based on #14370 and requires #14451 which must both be merged first. This PR remains in draft state until then.

**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
When a self-hosted shoot is also the garden runtime cluster, `gardener-operator` takes over responsibility for components like etcd-druid and the `RuntimeResourceManager` in the `garden` namespace. This PR teaches `gardenadm init` to detect this situation (via `ClusterIsGarden()`) and skip deploying those components. It also improves the local dev setup so that `make gardenadm-up SCENARIO=connect` deploys Gardener into the self-hosted shoot (the realistic default), fixes the `gardener-resource-manager` deployment strategy to revert from `Recreate` to `RollingUpdate` after bootstrapping, and ensures the gardenlet self-upgrade config respects `imageVectorOverwrite` settings.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```breaking developer
`make gardenadm-up SCENARIO=connect` now deploys the Gardener (`gardener-operator` and `Garden` resource) directly into the self-hosted shoot. Previously, it was deploying them next to the machine pods of the self-hosted shoot in the kind cluster. Use `make gardenadm-up SCENARIO=connect-kind` for the out-of-self-hosted-shoot deployment mode.
```