### PR TITLE
fix name of componentImageVectorOverwrite for gardenlet in example files

### DIFF
--- a/example/55-gardenlet.yaml
+++ b/example/55-gardenlet.yaml
@@ -17,7 +17,7 @@ spec:
   #   pullPolicy: IfNotPresent
   # imageVectorOverwrite: | # here you can overwrite the image repos + tags of the components deployed by gardenlet, e.g. etcd-druid, machine-controller-manager, kube-apiserver, etc.
   #   Please find documentation in /docs/deployment/image_vector.md#overwriting-image-vector
-  # componentImageVectorOverwrites: |
+  # componentImageVectorOverwrite: |
   #   Please find documentation in /docs/deployment/image_vector.md#image-vectors-for-dependent-components
     replicaCount: 2
     revisionHistoryLimit: 2


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind bug

**What this PR does / why we need it**:
The `componentImageVectorOverwrite` for the `gardenlet` is singular (no trailing s) in contrast to the `gardener-operator`, for which it is `componentImageVectorOverwrites`. This adjusts the example files accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I'm not sure if this is intentional. Might be better to align the syntax with the `gardener-operator` but this requires code changes I don't want to do

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
