### PR TITLE
[GEP-28] Always produce shoot webhook configs (in case self-hosted `Shoot` gets promoted to a `Seed`)

### DIFF
--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -124,18 +124,7 @@ func BuildWebhookConfigs(
 			rules = append(rules, *rule)
 		}
 
-		target := webhook.Target
-		webhookCABundle := caBundle
-		failurePolicy := getFailurePolicy(admissionregistrationv1.Fail, webhook.FailurePolicy)
-
-		// Handle extra settings when shoot webhooks are merged into seed webhooks (self-hosted shoot case).
-		if mergeShootWebhooksIntoSeedWebhooks && target == TargetShoot {
-			target = TargetSeed
-			webhookCABundle = nil
-			failurePolicy = getFailurePolicy(admissionregistrationv1.Ignore, webhook.FailurePolicy)
-		}
-
-		switch target {
+		switch webhook.Target {
 		case TargetSeed:
 			// if all webhooks for one target are removed in a new version, extensions need to explicitly delete the respective
 			// webhook config
@@ -145,13 +134,29 @@ func BuildWebhookConfigs(
 				*webhook,
 				providerName,
 				rules,
-				failurePolicy,
+				getFailurePolicy(admissionregistrationv1.Fail, webhook.FailurePolicy),
 				&exact,
-				BuildClientConfigFor(webhook.Path, namespace, providerName, doNotPrefixComponentName, servicePort, mode, url, webhookCABundle),
+				BuildClientConfigFor(webhook.Path, namespace, providerName, doNotPrefixComponentName, servicePort, mode, url, caBundle),
 				&sideEffects,
 			)
 
 		case TargetShoot:
+			// When merging shoot webhooks into seed webhooks (self-hosted shoot), additionally register
+			// them in the seed webhook config so the shoot kube-apiserver can reach them.
+			if mergeShootWebhooksIntoSeedWebhooks {
+				createAndAddToWebhookConfig(
+					&seedWebhookConfigs,
+					name,
+					*webhook,
+					providerName,
+					rules,
+					getFailurePolicy(admissionregistrationv1.Ignore, webhook.FailurePolicy),
+					&exact,
+					BuildClientConfigFor(webhook.Path, namespace, providerName, doNotPrefixComponentName, servicePort, mode, url, nil),
+					&sideEffects,
+				)
+			}
+
 			createAndAddToWebhookConfig(
 				&shootWebhookConfigs,
 				name+NameSuffixShoot,

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -352,46 +352,42 @@ var _ = Describe("Registration", func() {
 				Expect(seedWebhookConfig.MutatingWebhookConfig).To(Equal(expectedSeedMutatingWebhookConfig))
 
 				// Check shoot mutating webhooks
-				if !mergeShootWithSeedWebhooks {
-					Expect(shootWebhookConfig.MutatingWebhookConfig).To(Equal(&admissionregistrationv1.MutatingWebhookConfiguration{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gardener-extension-" + providerName + "-shoot",
-							Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
-						},
-						Webhooks: []admissionregistrationv1.MutatingWebhook{
-							buildMutatingWebhook(
-								mutatingWebhooks[2],
-								buildShootClientConfig,
-								[]admissionregistrationv1.RuleWithOperations{
-									{
-										Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"serviceaccounts/token"}},
-										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-									},
+				Expect(shootWebhookConfig.MutatingWebhookConfig).To(Equal(&admissionregistrationv1.MutatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "gardener-extension-" + providerName + "-shoot",
+						Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
+					},
+					Webhooks: []admissionregistrationv1.MutatingWebhook{
+						buildMutatingWebhook(
+							mutatingWebhooks[2],
+							buildShootClientConfig,
+							[]admissionregistrationv1.RuleWithOperations{
+								{
+									Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"serviceaccounts/token"}},
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
 								},
-								failurePolicyIgnore,
-								matchPolicyExact,
-								sideEffectsNone,
-								*mutatingWebhooks[2].TimeoutSeconds,
-							),
-							buildMutatingWebhook(
-								mutatingWebhooks[3],
-								buildShootClientConfig,
-								[]admissionregistrationv1.RuleWithOperations{
-									{
-										Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"services"}},
-										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-									},
+							},
+							failurePolicyIgnore,
+							matchPolicyExact,
+							sideEffectsNone,
+							*mutatingWebhooks[2].TimeoutSeconds,
+						),
+						buildMutatingWebhook(
+							mutatingWebhooks[3],
+							buildShootClientConfig,
+							[]admissionregistrationv1.RuleWithOperations{
+								{
+									Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"services"}},
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
 								},
-								*mutatingWebhooks[3].FailurePolicy,
-								matchPolicyExact,
-								sideEffectsNone,
-								defaultTimeoutSeconds,
-							),
-						},
-					}))
-				} else {
-					Expect(shootWebhookConfig.MutatingWebhookConfig).To(BeNil())
-				}
+							},
+							*mutatingWebhooks[3].FailurePolicy,
+							matchPolicyExact,
+							sideEffectsNone,
+							defaultTimeoutSeconds,
+						),
+					},
+				}))
 
 				// Check seed validating webhooks
 				expectedSeedValidatingWebhookConfig := &admissionregistrationv1.ValidatingWebhookConfiguration{
@@ -467,51 +463,46 @@ var _ = Describe("Registration", func() {
 						),
 					)
 
-					Expect(shootWebhookConfig.ValidatingWebhookConfig).To(BeNil())
 				}
 				Expect(seedWebhookConfig.ValidatingWebhookConfig).To(Equal(expectedSeedValidatingWebhookConfig))
 
 				// Check shoot validating webhooks
-				if !mergeShootWithSeedWebhooks {
-					Expect(shootWebhookConfig.ValidatingWebhookConfig).To(Equal(&admissionregistrationv1.ValidatingWebhookConfiguration{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gardener-extension-" + providerName + "-shoot",
-							Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
-						},
-						Webhooks: []admissionregistrationv1.ValidatingWebhook{
-							buildValidatingWebhook(
-								validatingWebhooks[2],
-								buildShootClientConfig,
-								[]admissionregistrationv1.RuleWithOperations{
-									{
-										Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"serviceaccounts/token"}},
-										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-									},
+				Expect(shootWebhookConfig.ValidatingWebhookConfig).To(Equal(&admissionregistrationv1.ValidatingWebhookConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "gardener-extension-" + providerName + "-shoot",
+						Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
+					},
+					Webhooks: []admissionregistrationv1.ValidatingWebhook{
+						buildValidatingWebhook(
+							validatingWebhooks[2],
+							buildShootClientConfig,
+							[]admissionregistrationv1.RuleWithOperations{
+								{
+									Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"serviceaccounts/token"}},
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
 								},
-								failurePolicyIgnore,
-								matchPolicyExact,
-								sideEffectsNone,
-								*validatingWebhooks[2].TimeoutSeconds,
-							),
-							buildValidatingWebhook(
-								validatingWebhooks[3],
-								buildShootClientConfig,
-								[]admissionregistrationv1.RuleWithOperations{
-									{
-										Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"services"}},
-										Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
-									},
+							},
+							failurePolicyIgnore,
+							matchPolicyExact,
+							sideEffectsNone,
+							*validatingWebhooks[2].TimeoutSeconds,
+						),
+						buildValidatingWebhook(
+							validatingWebhooks[3],
+							buildShootClientConfig,
+							[]admissionregistrationv1.RuleWithOperations{
+								{
+									Rule:       admissionregistrationv1.Rule{APIGroups: []string{""}, APIVersions: []string{"v1"}, Resources: []string{"services"}},
+									Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
 								},
-								*validatingWebhooks[3].FailurePolicy,
-								matchPolicyExact,
-								sideEffectsNone,
-								defaultTimeoutSeconds,
-							),
-						},
-					}))
-				} else {
-					Expect(shootWebhookConfig.ValidatingWebhookConfig).To(BeNil())
-				}
+							},
+							*validatingWebhooks[3].FailurePolicy,
+							matchPolicyExact,
+							sideEffectsNone,
+							defaultTimeoutSeconds,
+						),
+					},
+				}))
 			},
 
 			Entry("service mode", ModeService, "", false),


### PR DESCRIPTION
**How to categorize this PR?**

/area ipcei
/kind bug

**What this PR does / why we need it**:
When `mergeShootWebhooksIntoSeedWebhooks` is `true` (self-hosted shoot case), `BuildWebhookConfigs` previously replaced `TargetShoot` with `TargetSeed` — the shoot webhooks were merged into the seed config but the original shoot webhook configs were not produced. This is wrong because when the self-hosted `Shoot` is later promoted to a `Seed`, it will host its own shoots and those shoots need the extension's shoot webhooks to be properly registered. With this change, the `TargetShoot` case now both merges into the seed config (existing behavior) and produces the shoot webhook configs (new behavior).

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```bugfix dependency
Extension shoot webhook configs are now always produced even when `mergeShootWebhooksIntoSeedWebhooks` is `true`, so that a self-hosted `Shoot` promoted to a `Seed` has the correct shoot webhooks registered.
```