### PR TITLE
Local setup: Fix `nodePort` auto-remediation targeting `ClusterIP` services

### DIFF
--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -154,7 +154,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			// for some reason this error is not of type "Invalid"
 			strings.Contains(err.Error(), "duplicate nodePort") {
 			log.Info("Patching nodePort failed because it is already allocated, enabling auto-remediation", "err", err.Error())
-			return reconcile.Result{RequeueAfter: 2 * time.Second}, r.remediateAllocatedNodePorts(ctx, log, key, nodePort, nodePortTunnel)
+			return reconcile.Result{RequeueAfter: 2 * time.Second}, r.remediateAllocatedNodePorts(ctx, log, key, nodePort, nodePortTunnel, nodePortHTTPProxy)
 		}
 		return reconcile.Result{}, err
 	}
@@ -191,7 +191,7 @@ func (r *Reconciler) remediateAllocatedNodePorts(ctx context.Context, log logr.L
 				log.Info("Found service with nodePort", "serviceCheckedForAllocation", client.ObjectKeyFromObject(&service), "nodePort", port.NodePort)
 			}
 
-			if requiredPorts.Has(port.NodePort) {
+			if port.NodePort != 0 && requiredPorts.Has(port.NodePort) {
 				var (
 					min, max    = 30000, 32767
 					newNodePort = int32(rand.N(max-min) + min) // #nosec: G115 G404 -- Value range limited in previous line, no cryptographic context.

--- a/pkg/controller/service/reconciler.go
+++ b/pkg/controller/service/reconciler.go
@@ -187,11 +187,13 @@ func (r *Reconciler) remediateAllocatedNodePorts(ctx context.Context, log logr.L
 		)
 
 		for i, port := range service.Spec.Ports {
-			if port.NodePort != 0 {
-				log.Info("Found service with nodePort", "serviceCheckedForAllocation", client.ObjectKeyFromObject(&service), "nodePort", port.NodePort)
+			if port.NodePort == 0 {
+				continue
 			}
 
-			if port.NodePort != 0 && requiredPorts.Has(port.NodePort) {
+			log.Info("Found service with nodePort", "serviceCheckedForAllocation", client.ObjectKeyFromObject(&service), "nodePort", port.NodePort)
+
+			if requiredPorts.Has(port.NodePort) {
 				var (
 					min, max    = 30000, 32767
 					newNodePort = int32(rand.N(max-min) + min) // #nosec: G115 G404 -- Value range limited in previous line, no cryptographic context.


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind bug

**What this PR does / why we need it**:

`remediateAllocatedNodePorts` matches services whose `NodePort` is in the required ports set. When `nodePortTunnel` or `nodePortHTTPProxy` are unset (zero-value for `int32`), the set contains `0` — which matches every port on every `ClusterIP` service (since those also have `NodePort: 0`). The subsequent patch then fails because `nodePort` may not be set on `ClusterIP` services. Additionally, `nodePortHTTPProxy` was never passed to the remediation function.

Example logs showing the issue — `vpa-webhook` (a `ClusterIP` service) is incorrectly targeted with `oldNodePort: 0`:

```
{"msg":"Patching nodePort failed because it is already allocated, enabling auto-remediation","err":"Service \"istio-ingressgateway\" is invalid: spec.ports[0].nodePort: Invalid value: 31443: provided port is already allocated"}
{"msg":"Assigning new nodePort to service which already allocates the nodePort","service":{"name":"vpa-webhook","namespace":"garden"},"oldNodePort":0,"newNodePort":32610}
{"msg":"Assigning new nodePort to service which already allocates the nodePort","service":{"name":"vpa-webhook","namespace":"garden"},"oldNodePort":0,"newNodePort":32289}
{"error":"Service \"vpa-webhook\" is invalid: [spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP', spec.ports[1].nodePort: Forbidden: may not be used when `type` is 'ClusterIP']"}
```

This PR adds a `port.NodePort != 0` guard and passes `nodePortHTTPProxy` to the remediation call.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```bugfix developer
The `nodePort` auto-remediation in the local setup service controller no longer incorrectly targets `ClusterIP` services.
```