### PR TITLE
fix: show pod name in vpn-shoot dashboard panel

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/vpn-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/vpn-dashboard.json
@@ -173,7 +173,7 @@
           "expr": "sort_desc(sum by (pod) (rate (container_network_receive_bytes_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]) ))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Received",
+          "legendFormat": "Received {{pod}}",
           "refId": "A",
           "step": 20
         },
@@ -181,7 +181,7 @@
           "expr": "-sort_desc(sum by (pod) (rate (container_network_transmit_bytes_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]) ))",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Transmitted",
+          "legendFormat": "Transmitted {{pod}}",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
- Small improvement that adds the pod name to displayed I/O metric on the VPN dashboard


Turns this

<img width="252" height="145" alt="image" src="https://github.com/user-attachments/assets/954b0c91-8e5f-4350-b64e-c8ae30c156de" />


Into this

<img width="320" height="157" alt="image" src="https://github.com/user-attachments/assets/2fb6ec5d-a635-4817-833d-d81c96d87d9a" />



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
VPN Dashboard now displays the pod name in the legend for the VPN Shoot Network I/O panel
```
