### PR TITLE
[GEP-28] `gardenadm connect`: Enable main `ControllerInstallation` controller in `gardenlet`

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -50,6 +50,7 @@ import (
 	localworker "github.com/gardener/gardener/pkg/provider-local/controller/worker"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 	prometheuswebhook "github.com/gardener/gardener/pkg/provider-local/webhook/prometheus"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var hostIP string
@@ -187,8 +188,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 		Use: fmt.Sprintf("%s-controller-manager", local.Name),
 
 		RunE: func(_ *cobra.Command, _ []string) error {
-			seedName := os.Getenv("SEED_NAME")
-
 			if err := aggOption.Complete(); err != nil {
 				return fmt.Errorf("error completing options: %w", err)
 			}
@@ -250,13 +249,17 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 					return err
 				}
 
+				seedName, shootName, shootNamespace := os.Getenv("SEED_NAME"), os.Getenv("SHOOT_NAME"), os.Getenv("SHOOT_NAMESPACE")
+
 				log.Info("Adding garden cluster to manager")
 				if err := mgr.Add(gardenCluster); err != nil {
 					return fmt.Errorf("failed adding garden cluster to manager: %w", err)
 				}
 
 				if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-					return verifyGardenAccess(ctx, log, gardenCluster.GetClient(), seedName)
+					// Use the API reader to avoid triggering a cluster-scoped list/watch for Shoots in the cache.
+					// The shoot authorizer only allows name-scoped reads for the gardenlet's own Shoot.
+					return verifyGardenAccess(ctx, log, gardenCluster.GetAPIReader(), gardenCluster.GetClient(), seedName, shootName, shootNamespace)
 				})); err != nil {
 					return fmt.Errorf("could not add garden runnable to manager: %w", err)
 				}
@@ -333,21 +336,29 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 // verifyGardenAccess uses the extension's access to the garden cluster to request objects related to the seed it is
 // running on, but doesn't do anything useful with the objects. We do this for verifying the extension's garden access
 // in e2e tests. If something fails in this runnable, the extension will crash loop.
-func verifyGardenAccess(ctx context.Context, log logr.Logger, c client.Client, seedName string) error {
-	log = log.WithName("garden-access").WithValues("seedName", seedName)
+func verifyGardenAccess(ctx context.Context, log logr.Logger, reader client.Reader, writer client.Writer, seedName, shootName, shootNamespace string) error {
+	log = log.WithName("garden-access")
 
-	log.Info("Reading Seed")
-	// NB: reading seeds is allowed by gardener.cloud:system:read-global-resources (bound to all authenticated users)
-	seed := &gardencorev1beta1.Seed{}
-	if err := c.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
-		return fmt.Errorf("failed reading seed %s: %w", seedName, err)
+	var objects []client.Object
+	if seedName != "" {
+		objects = append(objects, &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: seedName}})
+	}
+	if shootName != "" {
+		objects = append(objects, &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: shootNamespace}})
 	}
 
-	log.Info("Annotating Seed")
-	patch := client.MergeFrom(seed.DeepCopy())
-	metav1.SetMetaDataAnnotation(&seed.ObjectMeta, "provider-local-e2e-test-garden-access", time.Now().UTC().Format(time.RFC3339))
-	if err := c.Patch(ctx, seed, patch); err != nil {
-		return fmt.Errorf("failed annotating seed %s: %w", seedName, err)
+	for _, obj := range objects {
+		objectKey := client.ObjectKeyFromObject(obj)
+		log.Info("Reading and annotating object", "objectKey", objectKey, "kind", fmt.Sprintf("%T", obj))
+		if err := reader.Get(ctx, objectKey, obj); err != nil {
+			return fmt.Errorf("failed reading %T %s: %w", obj, objectKey, err)
+		}
+
+		patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
+		kubernetesutils.SetMetaDataAnnotation(obj, "provider-local-e2e-test-garden-access", time.Now().UTC().Format(time.RFC3339))
+		if err := writer.Patch(ctx, obj, patch); err != nil {
+			return fmt.Errorf("failed annotating %T %s: %w", obj, objectKey, err)
+		}
 	}
 
 	log.Info("Garden access successfully verified")

--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -415,9 +415,12 @@ func (g *garden) Start(ctx context.Context) error {
 						// Gardenlet does not have the required RBAC permissions for listing/watching the following
 						// resources on cluster level. Hence, we need to watch them individually with the help of a
 						// SingleObject cache.
-						&corev1.ConfigMap{}:      kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
-						&corev1.Secret{}:         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
-						&corev1.ServiceAccount{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
+						&corev1.ConfigMap{}:                         kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ConfigMap{}),
+						&corev1.Secret{}:                            kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.Secret{}),
+						&corev1.ServiceAccount{}:                    kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &corev1.ServiceAccount{}),
+						&gardencorev1.ControllerDeployment{}:        kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1.ControllerDeployment{}),
+						&gardencorev1beta1.ControllerRegistration{}: kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.ControllerRegistration{}),
+						&gardencorev1beta1.Seed{}:                   kubernetes.SingleObjectCacheFunc(log, kubernetes.GardenScheme, &gardencorev1beta1.Seed{}),
 					},
 					kubernetes.GardenScheme,
 				)(config, opts)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -259,6 +259,7 @@ The `ControllerInstallation` controller in the `gardenlet` reconciles `Controlle
 This reconciler is responsible for `ControllerInstallation`s referencing a `ControllerDeployment` whose `type=helm`.
 
 For each `ControllerInstallation`, it creates a namespace on the seed cluster named `extension-<controller-installation-name>`.
+For [self-hosted shoot clusters](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters), the namespace is named `extension-<controller-registration-name>` instead (matching the `ManagedResource` name created during bootstrapping).
 Then, it creates a generic garden kubeconfig and garden access secret for the extension for [accessing the garden cluster](../extensions/garden-api-access.md).
 
 After that, it unpacks the Helm chart tarball in the `ControllerDeployment`s `.providerConfig.chart` field and deploys the rendered resources to the seed cluster.
@@ -285,10 +286,19 @@ gardener:
 
 As of today, there are a few more fields in `.gardener.seed`, but it is recommended to use the `.gardener.seed.spec` if the Helm chart needs more information about the seed configuration.
 
+> [!NOTE]
+> For self-hosted shoot clusters that have not yet been promoted to a `Seed`, the `.gardener.seed` section is omitted entirely because no `Seed` object exists.
+> Instead, a `.gardener.shoot` section is populated with `name`, `namespace`, `labels`, `annotations`, `spec`, and (if available) `clusterIdentity`.
+> Extension charts deployed in such clusters must handle the absence of `.gardener.seed` gracefully (e.g., `{{ if .Values.gardener.seed }}`).
+
 The rendered chart will be deployed via a `ManagedResource` created in the `garden` namespace of the seed cluster.
 It is labeled with `controllerinstallation-name=<name>` so that one can easily find the owning `ControllerInstallation` for an existing `ManagedResource`.
 
 The reconciler maintains the `Installed` condition of the `ControllerInstallation` and sets it to `False` if the rendering or deployment fails.
+
+> [!NOTE]
+> When the seed cluster is a self-hosted shoot, the main and required reconcilers are not registered in the seed `gardenlet`.
+> In this case, all `ControllerInstallation`s use `.spec.shootRef` (not `.spec.seedRef`), and the shoot `gardenlet` handles them instead.
 
 #### ["Care" Reconciler](../../pkg/gardenlet/controller/controllerinstallation/care)
 

--- a/docs/extensions/garden-api-access.md
+++ b/docs/extensions/garden-api-access.md
@@ -39,11 +39,15 @@ They can simply read the file specified by the `GARDEN_KUBECONFIG` and construct
 When installing a [`ControllerInstallation`](registration.md#deploying-extension-controllers), gardenlet creates two secrets in the installation's namespace: a generic garden kubeconfig (`generic-garden-kubeconfig-<hash>`) and a garden access secret (`garden-access-extension`).
 Note that the `ServiceAccount` created based on this access secret will be created in the respective `seed-*` namespace in the garden cluster and labelled with `controllerregistration.core.gardener.cloud/name=<name>`.
 
-Additionally, gardenlet injects `volume`, `volumeMounts`, and two environment variables into all (init) containers in all objects in the `apps` and `batch` API groups:
+Additionally, gardenlet injects `volume`, `volumeMounts`, and environment variables into all (init) containers in all objects in the `apps` and `batch` API groups:
 
 - `GARDEN_KUBECONFIG`: points to the path where the generic garden kubeconfig is mounted.
-- `SEED_NAME`: set to the name of the `Seed` where the extension is installed. 
+- `SEED_NAME`: set to the name of the `Seed` where the extension is installed.
   This is useful for restricting watches in the garden cluster to relevant objects.
+- `SHOOT_NAME`: set to the name of the self-hosted `Shoot` when the extension is installed in a [self-hosted shoot cluster](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters).
+  Only injected when the `ControllerInstallation` references `.spec.shootRef`.
+- `SHOOT_NAMESPACE`: set to the namespace of the self-hosted `Shoot`.
+  Only injected alongside `SHOOT_NAME`.
 
 If an object already contains the `GARDEN_KUBECONFIG` environment variable, it is not overwritten and injection of `volume` and `volumeMounts` is skipped.
 

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -303,7 +303,10 @@ In order to allow extension controller deployments to get information about the 
     gardenlet:
       featureGates: <gardenlet-feature-gates>
   ```
-- If the extension is deployed in an [self-hosted shoot cluster](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters), then the `.gardener.selfHostedShootCluster` field is additionally propagated and set to `true`.
+- If the extension is deployed in a [self-hosted shoot cluster](https://github.com/gardener/enhancements/tree/main/geps/0028-self-hosted-shoot-clusters), then the `.gardener.selfHostedShootCluster` field is additionally propagated and set to `true`.
+  In addition, a `.gardener.shoot` section is populated with `name`, `namespace`, `labels`, `annotations`, `spec`, and (if available) `clusterIdentity`.
+  If the self-hosted shoot has not yet been promoted to a `Seed`, the `.gardener.seed` section is omitted entirely.
+  Extension charts should handle this gracefully (e.g., `{{ if .Values.gardener.seed }}`).
 
 Extension controller deployments can use this information in their Helm chart in case they require knowledge about the garden and the seed environment.
 The list might be extended in the future.

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer.go
@@ -76,9 +76,9 @@ var (
 	leaseResource                     = coordinationv1.Resource("leases")
 	managedSeedResource               = seedmanagementv1alpha1.Resource("managedseeds")
 	projectResource                   = gardencorev1beta1.Resource("projects")
-	seedResource                      = gardencorev1beta1.Resource("seeds")
 	secretResource                    = corev1.Resource("secrets")
 	secretBindingResource             = gardencorev1beta1.Resource("secretbindings")
+	seedResource                      = gardencorev1beta1.Resource("seeds")
 	serviceAccountResource            = corev1.Resource("serviceaccounts")
 	shootResource                     = gardencorev1beta1.Resource("shoots")
 	shootStateResource                = gardencorev1beta1.Resource("shootstates")
@@ -156,6 +156,9 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 		case configMapResource:
 			return requestAuthorizer.CheckRead(graph.VertexTypeConfigMap, attrs)
 
+		case controllerDeploymentResource:
+			return requestAuthorizer.CheckRead(graph.VertexTypeControllerDeployment, attrs)
+
 		case controllerInstallationResource:
 			return requestAuthorizer.Check(graph.VertexTypeControllerInstallation, attrs,
 				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
@@ -165,6 +168,9 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 					core.ShootRefNamespace: shootNamespace,
 				}),
 			)
+
+		case controllerRegistrationResource:
+			return requestAuthorizer.CheckRead(graph.VertexTypeControllerRegistration, attrs)
 
 		case eventCoreResource, eventResource:
 			return a.authorizeEvent(log, attrs)
@@ -191,14 +197,20 @@ func (a *authorizer) Authorize(ctx context.Context, attrs auth.Attributes) (auth
 				}),
 			)
 
+		case secretResource:
+			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
+
 		case seedResource:
+			// The self-hosted shoot gardenlet needs read access for the Seed whose name matches its shoot name.
+			if slices.Contains([]string{"get", "list", "watch"}, attrs.GetVerb()) &&
+				(attrs.GetName() == "" || attrs.GetName() == shootName) {
+				return auth.DecisionAllow, "", nil
+			}
+
 			return requestAuthorizer.Check(graph.VertexTypeSeed, attrs,
 				authwebhook.WithAllowedVerbs("get", "delete"),
 				authwebhook.WithAlwaysAllowedVerbs("list", "watch"),
 			)
-
-		case secretResource:
-			return a.authorizeSecret(ctx, requestAuthorizer, attrs)
 
 		case serviceAccountResource:
 			if userType == gardenletidentity.UserTypeExtension {

--- a/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/shoot/authorizer_test.go
@@ -744,6 +744,231 @@ var _ = Describe("Shoot", func() {
 				)
 			})
 
+			When("requested for ControllerDeployments", func() {
+				var (
+					name  string
+					attrs *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name = "foo"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "controllerdeployments",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb string) {
+						attrs.Verb = verb
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerDeployment, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				DescribeTable("should have no opinion because no allowed verb", func(verb string) {
+					attrs.Verb = verb
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch]"))
+				},
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("patch", "patch"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because path to shoot does not exist", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerDeployment, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+
+				It("should have no opinion because request is for a subresource", func() {
+					attrs.Subresource = "status"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
+				})
+
+				It("should have no opinion because no resource name is given", func() {
+					attrs.Name = ""
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("No Object name found"))
+				})
+			})
+
+			When("requested for ControllerRegistrations", func() {
+				var (
+					name  string
+					attrs *auth.AttributesRecord
+				)
+
+				BeforeEach(func() {
+					name = "foo"
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            name,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "controllerregistrations",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should return correct result if path exists",
+					func(verb string) {
+						attrs.Verb = verb
+
+						graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerRegistration, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(true)
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				DescribeTable("should have no opinion because no allowed verb", func(verb string) {
+					attrs.Verb = verb
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [get list watch]"))
+				},
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("patch", "patch"),
+					Entry("delete", "delete"),
+					Entry("deletecollection", "deletecollection"),
+				)
+
+				It("should have no opinion because path to shoot does not exist", func() {
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeControllerRegistration, "", name, graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+
+				It("should have no opinion because request is for a subresource", func() {
+					attrs.Subresource = "status"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
+				})
+
+				It("should have no opinion because no resource name is given", func() {
+					attrs.Name = ""
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("No Object name found"))
+				})
+			})
+
+			When("requested for Seeds", func() {
+				var attrs *auth.AttributesRecord
+
+				BeforeEach(func() {
+					attrs = &auth.AttributesRecord{
+						User:            gardenletUser,
+						Name:            shootName,
+						APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+						Resource:        "seeds",
+						ResourceRequest: true,
+						Verb:            "get",
+					}
+				})
+
+				DescribeTable("should allow reading the seed matching the shoot name",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionAllow))
+						Expect(reason).To(BeEmpty())
+					},
+
+					Entry("get", "get"),
+					Entry("list", "list"),
+					Entry("watch", "watch"),
+				)
+
+				It("should allow list/watch without resource name", func() {
+					attrs.Name = ""
+					attrs.Verb = "list"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
+
+				It("should have no opinion because name does not match shoot name", func() {
+					attrs.Name = "other-seed"
+
+					graph.EXPECT().HasPathFrom(graphutils.VertexTypeSeed, "", "other-seed", graphutils.VertexTypeShoot, shootNamespace, shootName).Return(false)
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("no relationship found"))
+				})
+
+				DescribeTable("should have no opinion because verb is not allowed",
+					func(verb string) {
+						attrs.Verb = verb
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(decision).To(Equal(auth.DecisionNoOpinion))
+						Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [delete get list watch]"))
+					},
+
+					Entry("create", "create"),
+					Entry("update", "update"),
+					Entry("patch", "patch"),
+				)
+			})
+
 			Context("when requested for corev1.Events", func() {
 				var (
 					name, namespace string

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -952,6 +952,12 @@ const (
 	// EnvSeedName is a constant for the environment variable which holds the name of the Seed that the extension
 	// controller is running on.
 	EnvSeedName = "SEED_NAME"
+	// EnvShootName is a constant for the environment variable which holds the name of the self-hosted Shoot that the
+	// extension controller is running for.
+	EnvShootName = "SHOOT_NAME"
+	// EnvShootNamespace is a constant for the environment variable which holds the namespace of the self-hosted Shoot
+	// that the extension controller is running for.
+	EnvShootNamespace = "SHOOT_NAMESPACE"
 
 	// IngressTLSCertificateValidity is the default validity for ingress TLS certificates.
 	IngressTLSCertificateValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/controller/bastion"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation"
 	controllerinstallationcare "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/care"
+	controllerinstallationreconciler "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/controllerinstallation"
 	controllerinstallationrequired "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation/required"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/gardenlet"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
@@ -110,6 +111,18 @@ func AddToManager(
 			ManagedResourceNamespace: metav1.NamespaceSystem,
 		}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 			return fmt.Errorf("failed adding ControllerInstallation care controller: %w", err)
+		}
+
+		// TODO(rfranzke): Remove this once all ControllerInstallation reconcilers are added via `shoot.AddToManager`.
+		if err := (&controllerinstallationreconciler.Reconciler{
+			SeedClientSet:         seedClientSet,
+			Config:                *cfg,
+			Identity:              identity,
+			GardenClusterIdentity: gardenClusterIdentity,
+			GardenNamespace:       metav1.NamespaceSystem,
+			SelfHostedShootMeta:   &types.NamespacedName{Name: selfHostedShoot.Name, Namespace: selfHostedShoot.Namespace},
+		}).AddToManager(ctx, mgr, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding ControllerInstallation controller: %w", err)
 		}
 
 		// TODO(rfranzke): Remove this once all ControllerInstallation reconcilers are added via `shoot.AddToManager`.

--- a/pkg/gardenlet/controller/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/add.go
@@ -36,15 +36,13 @@ func AddToManager(
 	}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}
+
 	// When the seed is a self-hosted shoot, all ControllerInstallations have .spec.shootRef instead of .spec.seedRef.
 	// The self-hosted gardenlet already runs the required controller with ShootRef-based filtering, so the SeedRef-based
 	// instance here would find no ControllerInstallations.
-	seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader())
-	if err != nil {
+	if seedIsSelfHostedShoot, err := gardenletutils.SeedIsSelfHostedShoot(ctx, seedCluster.GetAPIReader()); err != nil {
 		return fmt.Errorf("failed checking whether the seed is a self-hosted shoot cluster: %w", err)
-	}
-
-	if !seedIsSelfHostedShoot {
+	} else if !seedIsSelfHostedShoot {
 		if err := (&controllerinstallation.Reconciler{
 			SeedClientSet:         seedClientSet,
 			Config:                cfg,

--- a/pkg/gardenlet/controller/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/add.go
@@ -36,16 +36,6 @@ func AddToManager(
 	}).AddToManager(mgr, gardenCluster, seedCluster); err != nil {
 		return fmt.Errorf("failed adding care reconciler: %w", err)
 	}
-
-	if err := (&controllerinstallation.Reconciler{
-		SeedClientSet:         seedClientSet,
-		Config:                cfg,
-		Identity:              identity,
-		GardenClusterIdentity: gardenClusterIdentity,
-	}).AddToManager(ctx, mgr, gardenCluster); err != nil {
-		return fmt.Errorf("failed adding main reconciler: %w", err)
-	}
-
 	// When the seed is a self-hosted shoot, all ControllerInstallations have .spec.shootRef instead of .spec.seedRef.
 	// The self-hosted gardenlet already runs the required controller with ShootRef-based filtering, so the SeedRef-based
 	// instance here would find no ControllerInstallations.
@@ -55,6 +45,15 @@ func AddToManager(
 	}
 
 	if !seedIsSelfHostedShoot {
+		if err := (&controllerinstallation.Reconciler{
+			SeedClientSet:         seedClientSet,
+			Config:                cfg,
+			Identity:              identity,
+			GardenClusterIdentity: gardenClusterIdentity,
+		}).AddToManager(ctx, mgr, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding main reconciler: %w", err)
+		}
+
 		if err := (&required.Reconciler{
 			Config:   *cfg.Controllers.ControllerInstallationRequired,
 			SeedName: cfg.SeedConfig.SeedTemplate.Name,

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add.go
@@ -89,7 +89,9 @@ func (r *Reconciler) ControllerInstallationPredicate() predicate.Predicate {
 				!reflect.DeepEqual(oldControllerInstallation.Spec.DeploymentRef, controllerInstallation.Spec.DeploymentRef) ||
 				oldControllerInstallation.Spec.RegistrationRef.ResourceVersion != controllerInstallation.Spec.RegistrationRef.ResourceVersion ||
 				(oldControllerInstallation.Spec.SeedRef == nil) != (controllerInstallation.Spec.SeedRef == nil) ||
-				(oldControllerInstallation.Spec.SeedRef != nil && controllerInstallation.Spec.SeedRef != nil && oldControllerInstallation.Spec.SeedRef.ResourceVersion != controllerInstallation.Spec.SeedRef.ResourceVersion)
+				(oldControllerInstallation.Spec.SeedRef != nil && controllerInstallation.Spec.SeedRef != nil && oldControllerInstallation.Spec.SeedRef.ResourceVersion != controllerInstallation.Spec.SeedRef.ResourceVersion) ||
+				(oldControllerInstallation.Spec.ShootRef == nil) != (controllerInstallation.Spec.ShootRef == nil) ||
+				(oldControllerInstallation.Spec.ShootRef != nil && controllerInstallation.Spec.ShootRef != nil && oldControllerInstallation.Spec.ShootRef.ResourceVersion != controllerInstallation.Spec.ShootRef.ResourceVersion)
 		},
 	}
 }

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/add_test.go
@@ -88,6 +88,23 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectNew: controllerInstallation, ObjectOld: oldControllerInstallation})).To(BeTrue())
 			})
 
+			It("should return true if shoot ref changed from nil to non-nil", func() {
+				oldControllerInstallation := controllerInstallation.DeepCopy()
+				controllerInstallation.ResourceVersion = "2"
+				controllerInstallation.Spec.ShootRef = &corev1.ObjectReference{Name: "my-shoot", Namespace: "garden-my-project"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: controllerInstallation, ObjectOld: oldControllerInstallation})).To(BeTrue())
+			})
+
+			It("should return true if shoot ref's resourceVersion changed", func() {
+				controllerInstallation.Spec.ShootRef = &corev1.ObjectReference{Name: "my-shoot", Namespace: "garden-my-project"}
+				oldControllerInstallation := controllerInstallation.DeepCopy()
+				controllerInstallation.ResourceVersion = "2"
+				controllerInstallation.Spec.ShootRef = &corev1.ObjectReference{Name: "my-shoot", Namespace: "garden-my-project", ResourceVersion: "foo"}
+
+				Expect(p.Update(event.UpdateEvent{ObjectNew: controllerInstallation, ObjectOld: oldControllerInstallation})).To(BeTrue())
+			})
+
 			It("should return false if something else changed", func() {
 				oldControllerInstallation := controllerInstallation.DeepCopy()
 				controllerInstallation.ResourceVersion = "2"

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -102,7 +102,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	if controllerInstallation.Spec.SeedRef == nil {
+	if controllerInstallation.Spec.SeedRef == nil && r.SelfHostedShootMeta == nil {
 		return reconcile.Result{}, nil
 	}
 
@@ -149,14 +149,34 @@ func (r *Reconciler) reconcile(
 		return reconcile.Result{}, err
 	}
 
-	seed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
-		if apierrors.IsNotFound(err) {
-			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
-		} else {
-			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionUnknown, "SeedReadError", fmt.Sprintf("Referenced Seed cannot be read: %+v", err))
+	var seed *gardencorev1beta1.Seed
+	if controllerInstallation.Spec.SeedRef != nil {
+		seed = &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: controllerInstallation.Spec.SeedRef.Name}}
+		if err := r.GardenClient.Get(gardenCtx, client.ObjectKeyFromObject(seed), seed); err != nil {
+			if apierrors.IsNotFound(err) {
+				conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
+			} else {
+				conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionUnknown, "SeedReadError", fmt.Sprintf("Referenced Seed cannot be read: %+v", err))
+			}
+			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, err
+	} else if r.SelfHostedShootMeta != nil {
+		// The self-hosted shoot might be a Seed as well - we don't know and have to check.
+		seed = &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: r.SelfHostedShootMeta.Name}}
+		if err := r.GardenClient.Get(gardenCtx, client.ObjectKeyFromObject(seed), seed); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return reconcile.Result{}, fmt.Errorf("failed while checking if self-hosted shoot is a seed: %w", err)
+			}
+			seed = nil
+		}
+	}
+
+	var shoot *gardencorev1beta1.Shoot
+	if r.SelfHostedShootMeta != nil {
+		shoot = &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: r.SelfHostedShootMeta.Name, Namespace: r.SelfHostedShootMeta.Namespace}}
+		if err := r.GardenClient.Get(gardenCtx, client.ObjectKeyFromObject(shoot), shoot); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed reading self-hosted Shoot: %w", err)
+		}
 	}
 
 	controllerDeployment := &gardencorev1.ControllerDeployment{}
@@ -187,7 +207,13 @@ func (r *Reconciler) reconcile(
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleExtension)
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelControllerRegistrationName, controllerRegistration.Name)
 		metav1.SetMetaDataLabel(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigConsider, "true")
-		metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(seed.Spec.Provider.Zones, ","))
+		if seed != nil {
+			metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(seed.Spec.Provider.Zones, ","))
+		} else if shoot != nil {
+			if controlPlanePool := v1beta1helper.ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers); controlPlanePool != nil && len(controlPlanePool.Zones) > 0 {
+				metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(controlPlanePool.Zones, ","))
+			}
+		}
 
 		if seedIsGarden {
 			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelNetworkPolicyAccessTargetAPIServer, "allowed")
@@ -204,8 +230,8 @@ func (r *Reconciler) reconcile(
 		return reconcile.Result{}, err
 	}
 
-	if seed.Status.ClusterIdentity == nil {
-		return reconcile.Result{}, fmt.Errorf("cluster-identity of seed '%s' not set", seed.Name)
+	if seed != nil && seed.Status.ClusterIdentity == nil {
+		return reconcile.Result{}, fmt.Errorf("cluster-identity of seed %q not set", seed.Name)
 	}
 
 	var (
@@ -232,63 +258,82 @@ func (r *Reconciler) reconcile(
 			WithServiceAccountLabels(map[string]string{v1beta1constants.LabelControllerRegistrationName: controllerRegistration.Name})
 	}
 
-	var (
-		volumeProvider  string
-		volumeProviders []gardencorev1beta1.SeedVolumeProvider
-	)
-
-	if seed.Spec.Volume != nil {
-		volumeProviders = seed.Spec.Volume.Providers
-		if len(seed.Spec.Volume.Providers) > 0 {
-			volumeProvider = seed.Spec.Volume.Providers[0].Name
-		}
-	}
-
 	featureToEnabled := make(map[featuregate.Feature]bool)
 	for feature := range features.DefaultFeatureGate.GetAll() {
 		featureToEnabled[feature] = features.DefaultFeatureGate.Enabled(feature)
 	}
 
 	// Mix-in some standard values for garden and seed.
-	gardenerValues := map[string]any{
-		"gardener": map[string]any{
-			"version": r.Identity.Version,
-			"garden": map[string]any{
-				"clusterIdentity": r.GardenClusterIdentity,
-			},
-			"seed": map[string]any{
-				"name":            seed.Name,
-				"clusterIdentity": *seed.Status.ClusterIdentity,
-				"annotations":     seed.Annotations,
-				"labels":          seed.Labels,
-				"provider":        seed.Spec.Provider.Type,
-				"region":          seed.Spec.Provider.Region,
-				"volumeProvider":  volumeProvider,
-				"volumeProviders": volumeProviders,
-				"protected":       v1beta1helper.TaintsHave(seed.Spec.Taints, gardencorev1beta1.SeedTaintProtected),
-				"visible":         seed.Spec.Settings.Scheduling.Visible,
-				"taints":          seed.Spec.Taints,
-				"networks":        seed.Spec.Networks,
-				"blockCIDRs":      seed.Spec.Networks.BlockCIDRs,
-				"spec":            seed.Spec,
-			},
-			"gardenlet": map[string]any{
-				"featureGates": featureToEnabled,
-			},
+	gardenerMap := map[string]any{
+		"version": r.Identity.Version,
+		"garden": map[string]any{
+			"clusterIdentity": r.GardenClusterIdentity,
+		},
+		"gardenlet": map[string]any{
+			"featureGates": featureToEnabled,
 		},
 	}
 
-	if metav1.HasLabel(seed.ObjectMeta, v1beta1constants.LabelSelfHostedShootCluster) {
-		gardenerValues["gardener"].(map[string]any)["selfHostedShootCluster"] = true
+	if seed != nil {
+		var (
+			volumeProvider  string
+			volumeProviders []gardencorev1beta1.SeedVolumeProvider
+		)
+
+		if seed.Spec.Volume != nil {
+			volumeProviders = seed.Spec.Volume.Providers
+			if len(seed.Spec.Volume.Providers) > 0 {
+				volumeProvider = seed.Spec.Volume.Providers[0].Name
+			}
+		}
+
+		seedValues := map[string]any{
+			"name":            seed.Name,
+			"clusterIdentity": *seed.Status.ClusterIdentity,
+			"annotations":     seed.Annotations,
+			"labels":          seed.Labels,
+			"provider":        seed.Spec.Provider.Type,
+			"region":          seed.Spec.Provider.Region,
+			"volumeProvider":  volumeProvider,
+			"volumeProviders": volumeProviders,
+			"protected":       v1beta1helper.TaintsHave(seed.Spec.Taints, gardencorev1beta1.SeedTaintProtected),
+			"visible":         seed.Spec.Settings.Scheduling.Visible,
+			"taints":          seed.Spec.Taints,
+			"networks":        seed.Spec.Networks,
+			"blockCIDRs":      seed.Spec.Networks.BlockCIDRs,
+			"spec":            seed.Spec,
+		}
+
+		if seed.Spec.Ingress != nil {
+			seedValues["ingressDomain"] = &seed.Spec.Ingress.Domain
+		}
+
+		gardenerMap["seed"] = seedValues
+	}
+
+	if r.SelfHostedShootMeta != nil {
+		gardenerMap["selfHostedShootCluster"] = true
+
+		shootValues := map[string]any{
+			"name":        shoot.Name,
+			"namespace":   shoot.Namespace,
+			"labels":      shoot.Labels,
+			"annotations": shoot.Annotations,
+			"spec":        shoot.Spec,
+		}
+
+		if shoot.Status.ClusterIdentity != nil {
+			shootValues["clusterIdentity"] = *shoot.Status.ClusterIdentity
+		}
+
+		gardenerMap["shoot"] = shootValues
 	}
 
 	if genericGardenKubeconfigSecretName != "" {
-		gardenerValues["gardener"].(map[string]any)["garden"].(map[string]any)["genericKubeconfigSecretName"] = genericGardenKubeconfigSecretName
+		gardenerMap["garden"].(map[string]any)["genericKubeconfigSecretName"] = genericGardenKubeconfigSecretName
 	}
 
-	if seed.Spec.Ingress != nil {
-		gardenerValues["gardener"].(map[string]any)["seed"].(map[string]any)["ingressDomain"] = &seed.Spec.Ingress.Domain
-	}
+	gardenerValues := map[string]any{"gardener": gardenerMap}
 
 	if r.BootstrapControlPlaneNode {
 		ports, err := r.CalculateUsablePorts()
@@ -348,12 +393,9 @@ func (r *Reconciler) reconcile(
 		}
 	}
 
-	if err := gardenerutils.MutateObjectsInSecretData(
-		secretData,
-		namespace.Name,
-		[]string{appsv1.GroupName, batchv1.GroupName},
-		// Set seed name
-		func(obj runtime.Object) error {
+	mutators := []func(runtime.Object) error{r.MutateSpecForSelfHostedShootExtensions}
+	if seed != nil {
+		mutators = append([]func(runtime.Object) error{func(obj runtime.Object) error {
 			return kubernetesutils.VisitPodSpec(obj, func(podSpec *corev1.PodSpec) {
 				kubernetesutils.VisitContainers(podSpec, func(container *corev1.Container) {
 					kubernetesutils.AddEnvVar(container, corev1.EnvVar{
@@ -362,8 +404,30 @@ func (r *Reconciler) reconcile(
 					}, true)
 				})
 			})
-		},
-		r.MutateSpecForSelfHostedShootExtensions,
+		}}, mutators...)
+	}
+	if shoot != nil {
+		mutators = append([]func(runtime.Object) error{func(obj runtime.Object) error {
+			return kubernetesutils.VisitPodSpec(obj, func(podSpec *corev1.PodSpec) {
+				kubernetesutils.VisitContainers(podSpec, func(container *corev1.Container) {
+					kubernetesutils.AddEnvVar(container, corev1.EnvVar{
+						Name:  v1beta1constants.EnvShootName,
+						Value: shoot.Name,
+					}, true)
+					kubernetesutils.AddEnvVar(container, corev1.EnvVar{
+						Name:  v1beta1constants.EnvShootNamespace,
+						Value: shoot.Namespace,
+					}, true)
+				})
+			})
+		}}, mutators...)
+	}
+
+	if err := gardenerutils.MutateObjectsInSecretData(
+		secretData,
+		namespace.Name,
+		[]string{appsv1.GroupName, batchv1.GroupName},
+		mutators...,
 	); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to inject garden access secrets: %w", err)
 	}
@@ -420,14 +484,17 @@ func (r *Reconciler) delete(
 		}
 	}()
 
-	seed := &gardencorev1beta1.Seed{}
-	if err := r.GardenClient.Get(gardenCtx, client.ObjectKey{Name: controllerInstallation.Spec.SeedRef.Name}, seed); err != nil {
-		if apierrors.IsNotFound(err) {
-			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
-		} else {
-			conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionUnknown, "SeedReadError", fmt.Sprintf("Referenced Seed cannot be read: %+v", err))
+	var seed *gardencorev1beta1.Seed
+	if controllerInstallation.Spec.SeedRef != nil {
+		seed = &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: controllerInstallation.Spec.SeedRef.Name}}
+		if err := r.GardenClient.Get(gardenCtx, client.ObjectKeyFromObject(seed), seed); err != nil {
+			if apierrors.IsNotFound(err) {
+				conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
+			} else {
+				conditionValid = v1beta1helper.UpdatedConditionWithClock(r.Clock, conditionValid, gardencorev1beta1.ConditionUnknown, "SeedReadError", fmt.Sprintf("Referenced Seed cannot be read: %+v", err))
+			}
+			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, err
 	}
 
 	managedResourceName := gardenerutils.ManagedResourceNameForControllerInstallation(controllerInstallation)

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -210,8 +211,14 @@ func (r *Reconciler) reconcile(
 		if seed != nil {
 			metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(seed.Spec.Provider.Zones, ","))
 		} else if shoot != nil {
-			if controlPlanePool := v1beta1helper.ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers); controlPlanePool != nil && len(controlPlanePool.Zones) > 0 {
-				metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(controlPlanePool.Zones, ","))
+			zones := sets.New[string]()
+			for _, pool := range shoot.Spec.Provider.Workers {
+				if pool.ControlPlane != nil || v1beta1helper.SystemComponentsAllowed(&pool) {
+					zones.Insert(pool.Zones...)
+				}
+			}
+			if len(zones) > 0 {
+				metav1.SetMetaDataAnnotation(&namespace.ObjectMeta, resourcesv1alpha1.HighAvailabilityConfigZones, strings.Join(sets.List(zones), ","))
 			}
 		}
 

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
@@ -361,8 +363,14 @@ func (r *Reconciler) delete(
 			Fn:           component.OpDestroyAndWait(c.victoriaOperator).Destroy,
 			Dependencies: flow.NewTaskIDs(destroyVictoriaLogs),
 		})
+		resetExtensionRequiredVirtualCondition = g.Add(flow.Task{
+			Name:         "Resetting RequiredVirtual condition on extensions since virtual cluster has been destroyed",
+			Fn:           r.resetExtensionRequiredVirtualCondition,
+			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+		})
 		syncPointCleanedUp = flow.NewTaskIDs(
 			waitUntilExtensionResourcesDeleted,
+			resetExtensionRequiredVirtualCondition,
 			destroyDNSRecords,
 			destroyMainETCDBackupBucket,
 			destroyEtcdDruid,
@@ -585,4 +593,33 @@ func (r *Reconciler) cleanupIstioInternalLoadBalancingConfigMap(ctx context.Cont
 		[]string{},
 		false,
 	)
+}
+
+func (r *Reconciler) resetExtensionRequiredVirtualCondition(ctx context.Context) error {
+	extensionList := &operatorv1alpha1.ExtensionList{}
+	if err := r.RuntimeClientSet.Client().List(ctx, extensionList); err != nil {
+		return err
+	}
+
+	for _, extension := range extensionList.Items {
+		condition := v1beta1helper.GetCondition(extension.Status.Conditions, operatorv1alpha1.ExtensionRequiredVirtual)
+		if condition == nil || condition.Status == gardencorev1beta1.ConditionFalse {
+			continue
+		}
+
+		patch := client.MergeFromWithOptions(extension.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		extension.Status.Conditions = v1beta1helper.MergeConditions(extension.Status.Conditions, v1beta1helper.UpdatedConditionWithClock(
+			r.Clock,
+			*condition,
+			gardencorev1beta1.ConditionFalse,
+			"GardenDeleted",
+			"Virtual cluster has been destroyed",
+		))
+
+		if err := r.RuntimeClientSet.Client().Status().Patch(ctx, &extension, patch); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -337,9 +337,9 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 			Eventually(ctx, gardenKomega.Object(backupEntry)).Should(BeHealthy(health.CheckBackupEntry))
 		}, SpecTimeout(time.Minute))
 
-		It("should observe created ControllerInstallations for the self-hosted Shoot", func(ctx SpecContext) {
+		It("should deploy and reconcile the ControllerInstallations for the self-hosted Shoot", func(ctx SpecContext) {
+			controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 			Eventually(ctx, func(g Gomega) []gardencorev1beta1.ControllerInstallation {
-				controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 				g.Expect(gardenClientSet.Client().List(ctx, controllerInstallationList, client.MatchingFields{
 					core.ShootRefName:      shoot.Name,
 					core.ShootRefNamespace: shoot.Namespace,
@@ -349,7 +349,20 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 				MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("provider-local")})})}),
 				MatchFields(IgnoreExtras, Fields{"Spec": MatchFields(IgnoreExtras, Fields{"RegistrationRef": MatchFields(IgnoreExtras, Fields{"Name": Equal("networking-calico")})})}),
 			))
-		}, SpecTimeout(time.Minute))
+
+			for _, controllerInstallation := range controllerInstallationList.Items {
+				By("Waiting for ControllerInstallation " + controllerInstallation.Name + " to become healthy")
+				Eventually(ctx, func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(gardenClientSet.Client().Get(ctx, client.ObjectKeyFromObject(&controllerInstallation), &controllerInstallation)).To(Succeed())
+					return controllerInstallation.Status.Conditions
+				}).Should(And(
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationValid), WithStatus(gardencorev1beta1.ConditionTrue)),
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionTrue)),
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationHealthy), WithStatus(gardencorev1beta1.ConditionTrue)),
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationProgressing), WithStatus(gardencorev1beta1.ConditionFalse)),
+				))
+			}
+		}, SpecTimeout(5*time.Minute))
 	})
 })
 

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_suite_test.go
@@ -94,7 +94,7 @@ var _ = BeforeSuite(func() {
 			ErrorIfCRDPathMissing: true,
 		},
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction,ShootDNS,ShootMutator,ShootResourceReservation"},
 		},
 	}
 

--- a/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
+++ b/test/integration/gardenlet/controllerinstallation/controllerinstallation/controllerinstallation_test.go
@@ -530,9 +530,202 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 			})
 		})
 
+		When("reconciler is configured for a self-hosted shoot with `ShootRef`-based `ControllerInstallation`", func() {
+			var (
+				selfHostedShoot                *gardencorev1beta1.Shoot
+				selfHostedControllerDeployment *gardencorev1.ControllerDeployment
+				selfHostedControllerInstall    *gardencorev1beta1.ControllerInstallation
+				selfHostedShootName            = "my-shoot"
+				r                              *controllerinstallation.Reconciler
+			)
+
+			BeforeEach(func() {
+				selfHostedShoot = &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      selfHostedShootName,
+						Namespace: gardenNamespace.Name,
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						CloudProfileName: ptr.To("test-cloudprofile"),
+						Region:           "foo-region",
+						Provider: gardencorev1beta1.Provider{
+							Type: "foo-provider",
+							Workers: []gardencorev1beta1.Worker{{
+								Name:    "control-plane",
+								Minimum: 1,
+								Maximum: 1,
+								Machine: gardencorev1beta1.Machine{
+									Type:  "large",
+									Image: &gardencorev1beta1.ShootMachineImage{Name: "gardenlinux", Version: ptr.To("1.0.0")},
+								},
+								Zones:        []string{"zone-a"},
+								ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+							}},
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.31.1"},
+						Networking: &gardencorev1beta1.Networking{Type: ptr.To("foo-networking")},
+					},
+				}
+				Expect(testClient.Create(ctx, selfHostedShoot)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedShoot))).To(Succeed())
+				})
+
+				selfHostedControllerDeployment = &gardencorev1.ControllerDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "deploy-sh-",
+					},
+					Helm: &gardencorev1.HelmControllerDeployment{
+						RawChart: chartWithGardenKubeconfig,
+					},
+					InjectGardenKubeconfig: ptr.To(true),
+				}
+				Expect(testClient.Create(ctx, selfHostedControllerDeployment)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedControllerDeployment))).To(Succeed())
+				})
+
+				selfHostedControllerInstall = &gardencorev1beta1.ControllerInstallation{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "install-sh-",
+					},
+				}
+
+				r = &controllerinstallation.Reconciler{
+					GardenClient:          testClient,
+					GardenConfig:          restConfig,
+					SeedClientSet:         testClientSet,
+					HelmRegistry:          fakeRegistry,
+					Clock:                 clock.RealClock{},
+					Config:                gardenletconfigv1alpha1.GardenletConfiguration{Controllers: &gardenletconfigv1alpha1.GardenletControllerConfiguration{ControllerInstallation: &gardenletconfigv1alpha1.ControllerInstallationControllerConfiguration{ConcurrentSyncs: ptr.To(5)}}},
+					Identity:              identity,
+					GardenClusterIdentity: gardenClusterIdentity,
+					GardenNamespace:       "garden",
+					SelfHostedShootMeta: &types.NamespacedName{
+						Name:      selfHostedShootName,
+						Namespace: gardenNamespace.Name,
+					},
+				}
+			})
+
+			JustBeforeEach(func() {
+				selfHostedControllerInstall.Spec.ShootRef = &corev1.ObjectReference{Name: selfHostedShootName, Namespace: gardenNamespace.Name}
+				selfHostedControllerInstall.Spec.RegistrationRef = corev1.ObjectReference{Name: controllerRegistration.Name}
+				selfHostedControllerInstall.Spec.DeploymentRef = &corev1.ObjectReference{Name: selfHostedControllerDeployment.Name}
+				Expect(testClient.Create(ctx, selfHostedControllerInstall)).To(Succeed())
+				log.Info("Created self-hosted ControllerInstallation with ShootRef", "controllerInstallation", client.ObjectKeyFromObject(selfHostedControllerInstall))
+
+				DeferCleanup(func() {
+					By("Remove finalizer from self-hosted ControllerInstallation to allow deletion")
+					patch := client.MergeFrom(selfHostedControllerInstall.DeepCopy())
+					selfHostedControllerInstall.Finalizers = nil
+					Expect(client.IgnoreNotFound(testClient.Patch(ctx, selfHostedControllerInstall, patch))).To(Succeed())
+
+					By("Delete self-hosted ControllerInstallation")
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedControllerInstall))).To(Succeed())
+				})
+			})
+
+			It("should deploy with correct namespace, ManagedResource name, Helm values, and garden access secret", func() {
+				By("Reconcile the self-hosted ControllerInstallation")
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: selfHostedControllerInstall.Name}})
+				Expect(err).NotTo(HaveOccurred())
+
+				extensionNamespace := "extension-" + controllerRegistration.Name
+
+				By("Ensure namespace uses the registration name")
+				namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: extensionNamespace}}
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace)).To(Succeed())
+				Expect(namespace.Labels).To(And(
+					HaveKeyWithValue("gardener.cloud/role", "extension"),
+					HaveKeyWithValue("controllerregistration.core.gardener.cloud/name", controllerRegistration.Name),
+					HaveKeyWithValue("high-availability-config.resources.gardener.cloud/consider", "true"),
+				))
+				Expect(namespace.Annotations).To(HaveKeyWithValue("high-availability-config.resources.gardener.cloud/zones", "zone-a"))
+
+				By("Ensure garden access secret has self-hosted shoot SA name and namespace annotation")
+				secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "garden-access-extension", Namespace: extensionNamespace}}
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+				Expect(secret.Annotations).To(And(
+					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/name", v1beta1constants.ExtensionShootServiceAccountPrefix+selfHostedShootName+"--"+selfHostedControllerInstall.Name),
+					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/namespace", gardenNamespace.Name),
+				))
+
+				By("Ensure ManagedResource uses the registration name")
+				managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name, Namespace: "garden"}}
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+
+				By("Ensure chart was deployed with correct Helm values")
+				mrSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedResource.Spec.SecretRefs[0].Name, Namespace: managedResource.Namespace}}
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(mrSecret), mrSecret)).To(Succeed())
+
+				values := make(map[string]any)
+				configMap := &corev1.ConfigMap{}
+				Expect(runtime.DecodeInto(newCodec(), mrSecret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
+				Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
+
+				gardenerValues := values["gardener"].(map[string]any)
+				Expect(gardenerValues).To(HaveKeyWithValue("selfHostedShootCluster", true))
+				Expect(gardenerValues).To(HaveKeyWithValue("version", "1.2.3"))
+				Expect(gardenerValues).NotTo(HaveKey("seed"))
+				Expect(gardenerValues).To(HaveKey("shoot"))
+
+				By("Ensure deployment has SHOOT_NAME and SHOOT_NAMESPACE env vars but no SEED_NAME")
+				deployment := &appsv1.Deployment{}
+				Expect(runtime.DecodeInto(newCodec(), mrSecret.Data["test_templates_deployment.yaml"], deployment)).To(Succeed())
+				Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(HaveExactElements(
+					corev1.EnvVar{Name: "GARDEN_KUBECONFIG", Value: "/var/run/secrets/gardener.cloud/garden/generic-kubeconfig/kubeconfig"},
+					corev1.EnvVar{Name: "SHOOT_NAME", Value: selfHostedShootName},
+					corev1.EnvVar{Name: "SHOOT_NAMESPACE", Value: gardenNamespace.Name},
+				))
+
+				By("Ensure conditions are maintained correctly")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(selfHostedControllerInstall), selfHostedControllerInstall)).To(Succeed())
+				Expect(selfHostedControllerInstall.Status.Conditions).To(And(
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationValid), WithStatus(gardencorev1beta1.ConditionTrue), WithReason("RegistrationValid")),
+					ContainCondition(OfType(gardencorev1beta1.ControllerInstallationInstalled), WithStatus(gardencorev1beta1.ConditionFalse), WithReason("InstallationPending")),
+				))
+			})
+
+			It("should properly clean up on deletion", func() {
+				By("Reconcile the self-hosted ControllerInstallation")
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: selfHostedControllerInstall.Name}})
+				Expect(err).NotTo(HaveOccurred())
+
+				extensionNamespace := "extension-" + controllerRegistration.Name
+
+				By("Ensure resources were created")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: extensionNamespace}}), &corev1.Namespace{})).To(Succeed())
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(&resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name, Namespace: "garden"}}), &resourcesv1alpha1.ManagedResource{})).To(Succeed())
+
+				By("Create ServiceAccount for garden access secret")
+				gardenClusterServiceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.ExtensionShootServiceAccountPrefix + selfHostedShootName + "--" + selfHostedControllerInstall.Name,
+					Namespace: gardenNamespace.Name,
+				}}
+				Expect(testClient.Create(ctx, gardenClusterServiceAccount)).To(Succeed())
+
+				By("Delete the self-hosted ControllerInstallation")
+				Expect(testClient.Delete(ctx, selfHostedControllerInstall)).To(Succeed())
+
+				By("Reconcile the deletion")
+				Eventually(func(g Gomega) {
+					result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: selfHostedControllerInstall.Name}})
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(result).To(Equal(reconcile.Result{}))
+				}).Should(Succeed())
+
+				By("Verify controller artefacts were removed")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: extensionNamespace}}), &corev1.Namespace{})).To(BeNotFoundError())
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(&resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: controllerRegistration.Name, Namespace: "garden"}}), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(gardenClusterServiceAccount), gardenClusterServiceAccount)).To(BeNotFoundError())
+			})
+		})
+
 		When("reconciler is configured for a self-hosted shoot", func() {
 			var (
 				projectNamespace               *corev1.Namespace
+				selfHostedShoot                *gardencorev1beta1.Shoot
 				selfHostedControllerDeployment *gardencorev1.ControllerDeployment
 				selfHostedControllerInstall    *gardencorev1beta1.ControllerInstallation
 			)
@@ -546,6 +739,23 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 				Expect(testClient.Create(ctx, projectNamespace)).To(Succeed())
 				DeferCleanup(func() {
 					Expect(client.IgnoreNotFound(testClient.Delete(ctx, projectNamespace))).To(Succeed())
+				})
+
+				selfHostedShoot = &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-shoot",
+						Namespace: projectNamespace.Name,
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						CloudProfileName: ptr.To("test-cloudprofile"),
+						Region:           "foo-region",
+						Provider:         gardencorev1beta1.Provider{Type: "foo-provider"},
+						Kubernetes:       gardencorev1beta1.Kubernetes{Version: "1.31.1"},
+					},
+				}
+				Expect(testClient.Create(ctx, selfHostedShoot)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(testClient.Delete(ctx, selfHostedShoot))).To(Succeed())
 				})
 
 				selfHostedControllerDeployment = &gardencorev1.ControllerDeployment{
@@ -601,8 +811,8 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					GardenClusterIdentity: gardenClusterIdentity,
 					GardenNamespace:       v1beta1constants.GardenNamespace,
 					SelfHostedShootMeta: &types.NamespacedName{
-						Namespace: projectNamespace.Name,
 						Name:      "my-shoot",
+						Namespace: projectNamespace.Name,
 					},
 				}
 
@@ -618,64 +828,6 @@ var _ = Describe("ControllerInstallation controller tests", func() {
 					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/name", v1beta1constants.ExtensionShootServiceAccountPrefix+"my-shoot--"+selfHostedControllerInstall.Name),
 					HaveKeyWithValue("serviceaccount.resources.gardener.cloud/namespace", projectNamespace.Name),
 				))
-			})
-		})
-
-		When("seed is marked as self-hosted shoot clusters", func() {
-			BeforeEach(func() {
-				// Use a dedicated seed with the label pre-set so the suite-global seed remains unaffected.
-				// The label cannot be removed once set (enforced by GAPI validation), so a throwaway seed
-				// is the only way to cleanly isolate this test.
-				selfHostedSeed := seed.DeepCopy()
-				selfHostedSeed.Name = ""
-				selfHostedSeed.ResourceVersion = ""
-				selfHostedSeed.Labels = map[string]string{
-					testID: testRunID,
-					"seed.gardener.cloud/self-hosted-shoot-cluster": "true",
-				}
-
-				By("Create self-hosted seed")
-				Expect(testClient.Create(ctx, selfHostedSeed)).To(Succeed())
-
-				By("Patch self-hosted seed status")
-				statusPatch := client.MergeFrom(selfHostedSeed.DeepCopy())
-				selfHostedSeed.Status.ClusterIdentity = ptr.To(seedClusterIdentity)
-				Expect(testClient.Status().Patch(ctx, selfHostedSeed, statusPatch)).To(Succeed())
-
-				By("Create self-hosted seed namespace")
-				selfHostedSeedNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "seed-" + selfHostedSeed.Name}}
-				Expect(testClient.Create(ctx, selfHostedSeedNamespace)).To(Succeed())
-
-				DeferCleanup(func() {
-					By("Delete self-hosted seed")
-					Expect(testClient.Delete(ctx, selfHostedSeed)).To(Or(Succeed(), BeNotFoundError()))
-
-					By("Delete self-hosted seed namespace")
-					Expect(testClient.Delete(ctx, selfHostedSeedNamespace)).To(Or(Succeed(), BeNotFoundError()))
-				})
-
-				// Wire the ControllerInstallation (created in JustBeforeEach) to the self-hosted seed.
-				controllerInstallation.Spec.SeedRef = &corev1.ObjectReference{Name: selfHostedSeed.Name}
-			})
-
-			It("should set the selfHostedShootCluster value in the chart", func() {
-				values := make(map[string]any)
-				Eventually(func(g Gomega) {
-					managedResource := &resourcesv1alpha1.ManagedResource{}
-					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: "garden", Name: controllerInstallation.Name}, managedResource)).To(Succeed())
-
-					secret := &corev1.Secret{}
-					g.Expect(testClient.Get(ctx, client.ObjectKey{Namespace: managedResource.Namespace, Name: managedResource.Spec.SecretRefs[0].Name}, secret)).To(Succeed())
-
-					configMap := &corev1.ConfigMap{}
-					g.Expect(runtime.DecodeInto(newCodec(), secret.Data["test_templates_config.yaml"], configMap)).To(Succeed())
-					g.Expect(yaml.Unmarshal([]byte(configMap.Data["values"]), &values)).To(Succeed())
-				}).Should(Succeed())
-
-				valuesBytes, err := yaml.Marshal(values)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(string(valuesBytes)).To(ContainSubstring("selfHostedShootCluster: true"))
 			})
 		})
 


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is based on #14316 which must be merged first. This PR remains in draft state until then. ✅

**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Enables the main `ControllerInstallation` reconciler in the self-hosted shoot `gardenlet`. This reconciler deploys extension charts via `ManagedResource`s. Without it, extensions are only deployed during `gardenadm init`, but not after `gardenadm connect` when the `gardener-controller-manager` creates new `ControllerInstallation`s.

Key changes:
- **Reconciler**: The `Seed` lookup is now optional — when the self-hosted shoot hasn't been promoted to a `Seed` yet, the `.gardener.seed` Helm values section is omitted entirely. Extension charts should handle this with `{{ if .Values.gardener.seed }}`.
- **Env var injection**: `SHOOT_NAME` and `SHOOT_NAMESPACE` environment variables are injected into extension pods (analogous to `SEED_NAME`), allowing extensions to verify their garden cluster access by reading the `Shoot` resource.
- **Authorizer**: The shoot authorizer now allows graph-based reads for `ControllerDeployment`, `ControllerRegistration`, and `Seed` (name-scoped) for self-hosted shoot `gardenlet`s.
- **Cache config**: `ControllerDeployment`, `ControllerRegistration`, and `Seed` are added to the `SingleObjectCacheFunc` map in the `gardenlet` so the controller-runtime cache uses field-selector-based per-object watches instead of cluster-scoped list/watch.
- **Seed-side skip**: The main and required `ControllerInstallation` reconcilers are skipped in the seed `gardenlet` when the seed is a self-hosted shoot (all `ControllerInstallation`s are managed by the shoot `gardenlet`).
- **E2e test**: The `gardenadm` e2e test now verifies that `ControllerInstallation` conditions converge to the healthy state (`Valid=Installed=Healthy=True`, `Progressing=False`).

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
The `provider-local` extension's `verifyGardenAccess` uses the API reader (not the cached client) for `Get` calls. Using the cached client would trigger a cluster-scoped list/watch for `Shoot` resources, which the shoot authorizer denies (only name-scoped reads are allowed for shoots).

**Release note**:
```noteworthy dependency
Extension charts deployed on self-hosted shoot clusters may not receive `.Values.gardener.seed` when the shoot has not yet been promoted to a `Seed`. Charts should guard Seed-dependent values with `{{ if .Values.gardener.seed }}`.
```