### PR TITLE
[GEP-26] Fix bug where shoot care controller uses outdated DNS credentials

### DIFF
--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -177,6 +177,7 @@ func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *ga
 			WithShootObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithoutShootCredentials().
+			WithShootDNSDomain(s.Spec.DNS).
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -177,7 +177,7 @@ func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *ga
 			WithShootObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithoutShootCredentials().
-			WithShootDNS(s.Spec.DNS).
+			WithShootDNS(nil).
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -177,7 +177,7 @@ func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *ga
 			WithShootObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithoutShootCredentials().
-			WithShootDNSDomain(s.Spec.DNS).
+			WithShootDNS(s.Spec.DNS).
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/operation.go
+++ b/pkg/gardenlet/operation/operation.go
@@ -176,8 +176,11 @@ func (b *Builder) WithShootFromCluster(seedClientSet kubernetes.Interface, s *ga
 			NewBuilder().
 			WithShootObjectFromCluster(seedClientSet, controlPlaneNamespace).
 			WithCloudProfileObjectFromCluster(seedClientSet, controlPlaneNamespace).
+			// For Shoots with `spec.maintenance.confineSpecUpdateRollout=true` there could be potentially long time window when the Shoot resource in the Cluster significantly differ from the Shoot resource in the Gardener API, i.e. changed credentials references.
+			// When this shoot operation tries to read the referred infrastructure or DNS credentials as per the Shoot spec from the Cluster, the Seed Authorizer might not allow the request as it is using the Gardener API to build the authorization decision graph.
+			// To avoid potential authorization problems, we always set the infrastructure and DNS credentials to `nil`.
 			WithoutShootCredentials().
-			WithShootDNS(nil).
+			WithoutShootDNS().
 			WithSeedObject(seedObj.GetInfo()).
 			WithProjectName(gardenObj.Project.Name).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -106,9 +106,9 @@ func (b *Builder) WithSeedObject(seed *gardencorev1beta1.Seed) *Builder {
 	return b
 }
 
-// WithShootDNSDomain can be used to overwrite the `spec.DNS` configuration of a shoot resource.
-func (b *Builder) WithShootDNSDomain(dnsDomain *gardencorev1beta1.DNS) *Builder {
-	b.shootDNSDomain = &dnsDomain
+// WithShootDNS can be used to overwrite the `spec.DNS` configuration of a shoot resource.
+func (b *Builder) WithShootDNS(dns *gardencorev1beta1.DNS) *Builder {
+	b.shootDNS = &dns
 	return b
 }
 
@@ -213,8 +213,8 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		return nil, err
 	}
 
-	if b.shootDNSDomain != nil {
-		shootObject.Spec.DNS = *b.shootDNSDomain
+	if b.shootDNS != nil {
+		shootObject.Spec.DNS = *b.shootDNS
 	}
 
 	shoot.SetInfo(shootObject)

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -106,6 +106,12 @@ func (b *Builder) WithSeedObject(seed *gardencorev1beta1.Seed) *Builder {
 	return b
 }
 
+// WithShootDNSDomain can be used to overwrite the `spec.DNS` configuration of a shoot resource.
+func (b *Builder) WithShootDNSDomain(dnsDomain *gardencorev1beta1.DNS) *Builder {
+	b.shootDNSDomain = &dnsDomain
+	return b
+}
+
 // WithExposureClassObject sets the exposureClass attribute at the Builder.
 func (b *Builder) WithExposureClassObject(exposureClass *gardencorev1beta1.ExposureClass) *Builder {
 	b.exposureClass = exposureClass
@@ -206,6 +212,11 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if b.shootDNSDomain != nil {
+		shootObject.Spec.DNS = *b.shootDNSDomain
+	}
+
 	shoot.SetInfo(shootObject)
 
 	cloudProfile, err := b.cloudProfileFunc(ctx, shootObject)

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -106,9 +106,9 @@ func (b *Builder) WithSeedObject(seed *gardencorev1beta1.Seed) *Builder {
 	return b
 }
 
-// WithShootDNS can be used to overwrite the `spec.DNS` configuration of a shoot resource.
-func (b *Builder) WithShootDNS(dns *gardencorev1beta1.DNS) *Builder {
-	b.shootDNS = &dns
+// WithoutShootDNS unsets the `spec.DNS` configuration of a shoot resource.
+func (b *Builder) WithoutShootDNS() *Builder {
+	b.shootDNSFunc = func() *gardencorev1beta1.DNS { return nil }
 	return b
 }
 
@@ -213,8 +213,8 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 		return nil, err
 	}
 
-	if b.shootDNS != nil {
-		shootObject.Spec.DNS = *b.shootDNS
+	if b.shootDNSFunc != nil {
+		shootObject.Spec.DNS = b.shootDNSFunc()
 	}
 
 	shoot.SetInfo(shootObject)

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -371,7 +371,7 @@ var _ = Describe("shoot", func() {
 			})
 		})
 
-		Describe("#WithShootDNSDomain", func() {
+		Describe("#WithShootDNS", func() {
 			var (
 				ctx          context.Context
 				c            client.Client
@@ -414,21 +414,21 @@ var _ = Describe("shoot", func() {
 			})
 
 			It("should overwrite the shoot DNS domain in the builder", func() {
-				dnsDomain := &gardencorev1beta1.DNS{
+				dns := &gardencorev1beta1.DNS{
 					Domain: ptr.To("overwrite.example.com"),
 				}
 
 				shoot, err := shootBuilder.
-					WithShootDNSDomain(dnsDomain).
+					WithShootDNS(dns).
 					Build(ctx, c)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(shoot.GetInfo().Spec.DNS).To(Equal(dnsDomain))
+				Expect(shoot.GetInfo().Spec.DNS).To(Equal(dns))
 			})
 
 			It("should unset the shoot DNS domain in the builder", func() {
 				shoot, err := shootBuilder.
-					WithShootDNSDomain(nil).
+					WithShootDNS(nil).
 					Build(ctx, c)
 
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -371,7 +371,7 @@ var _ = Describe("shoot", func() {
 			})
 		})
 
-		Describe("#WithShootDNS", func() {
+		Describe("#WithoutShootDNS", func() {
 			var (
 				ctx          context.Context
 				c            client.Client
@@ -413,22 +413,9 @@ var _ = Describe("shoot", func() {
 					})
 			})
 
-			It("should overwrite the shoot DNS domain in the builder", func() {
-				dns := &gardencorev1beta1.DNS{
-					Domain: ptr.To("overwrite.example.com"),
-				}
-
-				shoot, err := shootBuilder.
-					WithShootDNS(dns).
-					Build(ctx, c)
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(shoot.GetInfo().Spec.DNS).To(Equal(dns))
-			})
-
 			It("should unset the shoot DNS domain in the builder", func() {
 				shoot, err := shootBuilder.
-					WithShootDNS(nil).
+					WithoutShootDNS().
 					Build(ctx, c)
 
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/gardenlet/operation/shoot/shoot_test.go
+++ b/pkg/gardenlet/operation/shoot/shoot_test.go
@@ -5,16 +5,22 @@
 package shoot_test
 
 import (
+	"context"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 var _ = Describe("shoot", func() {
@@ -362,6 +368,81 @@ var _ = Describe("shoot", func() {
 				result := SortByIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}, cidrs)
 				expected := []net.IPNet{ipv4CIDR1, ipv6CIDR1}
 				Expect(result).To(Equal(expected))
+			})
+		})
+
+		Describe("#WithShootDNSDomain", func() {
+			var (
+				ctx          context.Context
+				c            client.Client
+				shootBuilder *Builder
+			)
+
+			BeforeEach(func() {
+				ctx = context.Background()
+				c = fake.NewFakeClient()
+
+				uid := "057cf3ec-1b86-40b3-abc2-47ac71abbe85"
+				s := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "garden-bar",
+						UID:       types.UID(uid),
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						DNS: &gardencorev1beta1.DNS{
+							Domain: ptr.To("shoot.example.com"),
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "v1.35.0",
+						},
+					},
+					Status: gardencorev1beta1.ShootStatus{
+						TechnicalID: "shoot--bar--foo-" + uid,
+					},
+				}
+
+				shootBuilder = NewBuilder().
+					WithShootObject(s).
+					WithCloudProfileObject(nil).
+					WithoutShootCredentials().
+					WithDefaultDomains([]*gardener.Domain{
+						{
+							Domain: "example.com",
+						},
+					})
+			})
+
+			It("should overwrite the shoot DNS domain in the builder", func() {
+				dnsDomain := &gardencorev1beta1.DNS{
+					Domain: ptr.To("overwrite.example.com"),
+				}
+
+				shoot, err := shootBuilder.
+					WithShootDNSDomain(dnsDomain).
+					Build(ctx, c)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shoot.GetInfo().Spec.DNS).To(Equal(dnsDomain))
+			})
+
+			It("should unset the shoot DNS domain in the builder", func() {
+				shoot, err := shootBuilder.
+					WithShootDNSDomain(nil).
+					Build(ctx, c)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shoot.GetInfo().Spec.DNS).To(BeNil())
+			})
+
+			It("should not overwrite the shoot DNS domain in the builder", func() {
+				shoot, err := shootBuilder.
+					Build(ctx, c)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shoot.GetInfo().Spec.DNS).To(Equal(&gardencorev1beta1.DNS{
+					Domain: ptr.To("shoot.example.com"),
+				}))
 			})
 		})
 	})

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -61,6 +61,7 @@ type Builder struct {
 	projectName                  string
 	internalDomain               *gardenerutils.Domain
 	defaultDomains               []*gardenerutils.Domain
+	shootDNSDomain               **gardencorev1beta1.DNS
 }
 
 // Shoot is an object containing information about a Shoot cluster.

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -56,12 +56,12 @@ type Builder struct {
 	cloudProfileFunc             func(context.Context, *gardencorev1beta1.Shoot) (*gardencorev1beta1.CloudProfile, error)
 	shootCredentialsFunc         func(context.Context, string, string, bool) (client.Object, error)
 	serviceAccountIssuerHostname func() (*string, error)
+	shootDNSFunc                 func() *gardencorev1beta1.DNS
 	seed                         *gardencorev1beta1.Seed
 	exposureClass                *gardencorev1beta1.ExposureClass
 	projectName                  string
 	internalDomain               *gardenerutils.Domain
 	defaultDomains               []*gardenerutils.Domain
-	shootDNS                     **gardencorev1beta1.DNS
 }
 
 // Shoot is an object containing information about a Shoot cluster.

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -61,7 +61,7 @@ type Builder struct {
 	projectName                  string
 	internalDomain               *gardenerutils.Domain
 	defaultDomains               []*gardenerutils.Domain
-	shootDNSDomain               **gardencorev1beta1.DNS
+	shootDNS                     **gardencorev1beta1.DNS
 }
 
 // Shoot is an object containing information about a Shoot cluster.


### PR DESCRIPTION
**How to categorize this PR?**
/area ipcei security
/kind bug
/label ipcei/workload-identity
**What this PR does / why we need it**:
~~Overwrite~~ Unset `shoot.spec.dns` in the shoot-care controller.

~~Use the dns configuration from the Shoot resource instead of the one from the Cluster.~~ This is needed when shoots are using `confineSpecUpdateRollout=true` and the DNS credentials are changed because the seed authorizer will not allow the old credentials, still stored in the cluster.spec.shoot, to be read by `gardenlet` on shoot-care controller initialization.

The actual error fixed by this change is 

```jsonc
{
    "level": "error",
    "ts": "2026-03-13T14:02:01.078Z",
    "msg": "Reconciler error",
    "controller": "shoot-care",
    "namespace": "garden-local",
    "name": "local",
    "reconcileID": "475ef45d-ffe0-4cda-a27b-30d20ef030f7",
    "error": "could not get dns provider credentials from reference \"&CrossVersionObjectReference{Kind:Secret,Name:internal-domain,APIVersion:v1,}\": secrets \"internal-domain\" is forbidden: User \"gardener.cloud:system:seed:seed01\" cannot get resource \"secrets\" in API group \"\" in the namespace \"garden-local\": no relationship found",
    "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:495
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313"
}
```


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586
Similar to https://github.com/gardener/gardener/pull/10672/

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug where the `shoot-care` controller cannot reconcile shoots with `spec.maintenance.confineSpecUpdateRollout=true` and updated DNS credentials, i.e. `shoot.spec.dns.providers[].credentialsRef`, until the shoot is reconciled.
```
