### PR TITLE
[release-v1.137] Automated cherry pick of #14398: Update `ingress-nginx` to v1.14.5

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -86,7 +86,7 @@ images:
   - name: nginx-ingress-controller
     sourceRepository: github.com/kubernetes/ingress-nginx
     repository: registry.k8s.io/ingress-nginx/controller-chroot
-    tag: "v1.14.3"
+    tag: "v1.14.5"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
/kind enhancement
/area networking

Cherry pick of #14398 on release-v1.137.

#14398: Update `ingress-nginx` to v1.14.5

**Release Notes:**
```other dependency
The following dependencies have been updated:
- `registry.k8s.io/ingress-nginx/controller-chroot` from `v1.14.3` to `v1.14.5`.
```