### PR TITLE
feat: Add Conditions field to Project Status subresource

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -4383,6 +4383,7 @@ Kubernetes meta/v1.Duration
 <p>
 (<em>Appears on:</em>
 <a href="#core.gardener.cloud/v1beta1.ControllerInstallationStatus">ControllerInstallationStatus</a>, 
+<a href="#core.gardener.cloud/v1beta1.ProjectStatus">ProjectStatus</a>, 
 <a href="#core.gardener.cloud/v1beta1.SeedStatus">SeedStatus</a>, 
 <a href="#core.gardener.cloud/v1beta1.ShootStatus">ShootStatus</a>)
 </p>
@@ -11160,6 +11161,20 @@ Kubernetes meta/v1.Time
 <td>
 <em>(Optional)</em>
 <p>LastActivityTimestamp contains the timestamp from the last activity performed in this project.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="#core.gardener.cloud/v1beta1.Condition">
+[]Condition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions represents the latest available observations of a Project&rsquo;s current state.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/types_project.go
+++ b/pkg/apis/core/types_project.go
@@ -78,6 +78,8 @@ type ProjectStatus struct {
 	StaleAutoDeleteTimestamp *metav1.Time
 	// LastActivityTimestamp contains the timestamp from the last activity performed in this project.
 	LastActivityTimestamp *metav1.Time
+	// Conditions represents the latest available observations of a Project's current state.
+	Conditions []Condition
 }
 
 // ProjectMember is a member of a project.

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -8921,6 +8921,20 @@ func (m *ProjectStatus) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.Conditions) > 0 {
+		for iNdEx := len(m.Conditions) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Conditions[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenerated(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if m.LastActivityTimestamp != nil {
 		{
 			size, err := m.LastActivityTimestamp.MarshalToSizedBuffer(dAtA[:i])
@@ -16784,6 +16798,12 @@ func (m *ProjectStatus) Size() (n int) {
 		l = m.LastActivityTimestamp.Size()
 		n += 1 + l + sovGenerated(uint64(l))
 	}
+	if len(m.Conditions) > 0 {
+		for _, e := range m.Conditions {
+			l = e.Size()
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -20626,12 +20646,18 @@ func (this *ProjectStatus) String() string {
 	if this == nil {
 		return "nil"
 	}
+	repeatedStringForConditions := "[]Condition{"
+	for _, f := range this.Conditions {
+		repeatedStringForConditions += strings.Replace(strings.Replace(f.String(), "Condition", "Condition", 1), `&`, ``, 1) + ","
+	}
+	repeatedStringForConditions += "}"
 	s := strings.Join([]string{`&ProjectStatus{`,
 		`ObservedGeneration:` + fmt.Sprintf("%v", this.ObservedGeneration) + `,`,
 		`Phase:` + fmt.Sprintf("%v", this.Phase) + `,`,
 		`StaleSinceTimestamp:` + strings.Replace(fmt.Sprintf("%v", this.StaleSinceTimestamp), "Time", "v11.Time", 1) + `,`,
 		`StaleAutoDeleteTimestamp:` + strings.Replace(fmt.Sprintf("%v", this.StaleAutoDeleteTimestamp), "Time", "v11.Time", 1) + `,`,
 		`LastActivityTimestamp:` + strings.Replace(fmt.Sprintf("%v", this.LastActivityTimestamp), "Time", "v11.Time", 1) + `,`,
+		`Conditions:` + repeatedStringForConditions + `,`,
 		`}`,
 	}, "")
 	return s
@@ -46728,6 +46754,40 @@ func (m *ProjectStatus) Unmarshal(dAtA []byte) error {
 				m.LastActivityTimestamp = &v11.Time{}
 			}
 			if err := m.LastActivityTimestamp.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Conditions", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Conditions = append(m.Conditions, Condition{})
+			if err := m.Conditions[len(m.Conditions)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2687,6 +2687,12 @@ message ProjectStatus {
   // LastActivityTimestamp contains the timestamp from the last activity performed in this project.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastActivityTimestamp = 5;
+
+  // Conditions represents the latest available observations of a Project's current state.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
+  // +optional
+  repeated Condition conditions = 6;
 }
 
 // ProjectTolerations contains the tolerations for taints on seed clusters.

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -98,6 +98,11 @@ type ProjectStatus struct {
 	// LastActivityTimestamp contains the timestamp from the last activity performed in this project.
 	// +optional
 	LastActivityTimestamp *metav1.Time `json:"lastActivityTimestamp,omitempty" protobuf:"bytes,5,opt,name=lastActivityTimestamp"`
+	// Conditions represents the latest available observations of a Project's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +optional
+	Conditions []Condition `json:"conditions,omitempty" patchMergeKey:"type" patchStrategy:"merge" protobuf:"bytes,6,rep,name=conditions"`
 }
 
 // ProjectMember is a member of a project.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -6141,6 +6141,7 @@ func autoConvert_v1beta1_ProjectStatus_To_core_ProjectStatus(in *ProjectStatus, 
 	out.StaleSinceTimestamp = (*metav1.Time)(unsafe.Pointer(in.StaleSinceTimestamp))
 	out.StaleAutoDeleteTimestamp = (*metav1.Time)(unsafe.Pointer(in.StaleAutoDeleteTimestamp))
 	out.LastActivityTimestamp = (*metav1.Time)(unsafe.Pointer(in.LastActivityTimestamp))
+	out.Conditions = *(*[]core.Condition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
 
@@ -6155,6 +6156,7 @@ func autoConvert_core_ProjectStatus_To_v1beta1_ProjectStatus(in *core.ProjectSta
 	out.StaleSinceTimestamp = (*metav1.Time)(unsafe.Pointer(in.StaleSinceTimestamp))
 	out.StaleAutoDeleteTimestamp = (*metav1.Time)(unsafe.Pointer(in.StaleAutoDeleteTimestamp))
 	out.LastActivityTimestamp = (*metav1.Time)(unsafe.Pointer(in.LastActivityTimestamp))
+	out.Conditions = *(*[]Condition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -4603,6 +4603,13 @@ func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 		in, out := &in.LastActivityTimestamp, &out.LastActivityTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -4603,6 +4603,13 @@ func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 		in, out := &in.LastActivityTimestamp, &out.LastActivityTimestamp
 		*out = (*in).DeepCopy()
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apiserver/openapi/api_violations.report
+++ b/pkg/apiserver/openapi/api_violations.report
@@ -55,6 +55,7 @@ API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectMember,Roles
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectSpec,DualApprovalForDeletion
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectSpec,Members
+API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectStatus,Conditions
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectTolerations,Defaults
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,ProjectTolerations,Whitelist
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/core/v1beta1,Provider,Workers

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -7770,11 +7770,31 @@ func schema_pkg_apis_core_v1beta1_ProjectStatus(ref common.ReferenceCallback) co
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions represents the latest available observations of a Project's current state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref(v1beta1.Condition{}.OpenAPIModelName()),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			metav1.Time{}.OpenAPIModelName()},
+			v1beta1.Condition{}.OpenAPIModelName(), metav1.Time{}.OpenAPIModelName()},
 	}
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind api-change

**What this PR does / why we need it**:

Adds `status.conditions` to the `Project` resource.

This allows provider-specific controllers to report conditions on `Project` objects - for example, tracking the status of provider-side project setup that is coupled to the Gardener project lifecycle. Gardener's own controllers will not touch this field (as of now).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

I checked that the existing `Project` controllers only patch the status subresource (and own distinct fields) so there should be no conflict.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `Project` API now has a `.status.conditions` field for allowing controllers to report conditions on `Project` objects.
```
