### PR TITLE
Fix `KubePodNotReadyControlPlane` alert

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
@@ -40,7 +40,7 @@ spec:
         description: Pod {{ $labels.pod }} is not ready for more than 1 hour.
         summary: Shoot pod is in a not ready state
     - alert: KubePodNotReadyControlPlane
-      expr: (kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0 and on (namespace, pod) kube_pod_status_phase{phase!="Succeeded"} == 1
+      expr: (kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0 and on (namespace, pod) kube_pod_status_phase{phase!="Succeeded"} == 1)
       for: 30m
       labels:
         service: kube-kubelet

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/kube-pods.yaml
@@ -40,7 +40,7 @@ spec:
         description: Pod {{ $labels.pod }} is not ready for more than 1 hour.
         summary: Shoot pod is in a not ready state
     - alert: KubePodNotReadyControlPlane
-      expr: kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0
+      expr: (kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0 and on (namespace, pod) kube_pod_status_phase{phase!="Succeeded"} == 1
       for: 30m
       labels:
         service: kube-kubelet

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/kube-pods.yaml
@@ -18,7 +18,7 @@ spec:
         description: Pod {{ $labels.pod }} is stuck in "Pending" state for more than 30 minutes.
         summary: Control plane pod stuck in "Pending" state
     - alert: KubePodNotReadyControlPlane
-      expr: kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0
+      expr: (kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0 and on (namespace, pod) kube_pod_status_phase{phase!="Succeeded"} == 1)
       for: 30m
       labels:
         service: kube-kubelet

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/kube-pods.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/kube-pods.prometheusrule.test.yaml
@@ -23,7 +23,12 @@ tests:
   - series: 'kube_pod_status_ready{condition="true", type="seed", pod="cpPodNotReady"}'
     values: '0+0x60'
   - series: 'kube_pod_status_phase{phase="Running", type="seed", pod="cpPodNotReady"}'
-    values: '1+0x60'    
+    values: '1+0x60'
+  # cpPodCompleted should NOT trigger KubePodNotReadyControlPlane
+  - series: 'kube_pod_status_ready{condition="true", type="seed", pod="cpPodCompleted"}'
+    values: '0+0x60'
+  - series: 'kube_pod_status_phase{phase="Succeeded", type="seed", pod="cpPodCompleted"}'
+    values: '1+0x60'
   alert_rule_test:
   - eval_time: 1h
     alertname: KubePodPendingShoot

--- a/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/kube-pods.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/testdata/worker/kube-pods.prometheusrule.test.yaml
@@ -22,6 +22,8 @@ tests:
   # KubePodNotReadyControlPlane
   - series: 'kube_pod_status_ready{condition="true", type="seed", pod="cpPodNotReady"}'
     values: '0+0x60'
+  - series: 'kube_pod_status_phase{phase="Running", type="seed", pod="cpPodNotReady"}'
+    values: '1+0x60'    
   alert_rule_test:
   - eval_time: 1h
     alertname: KubePodPendingShoot


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Enhance the alert to not fire on pods that are in status "Completed". This provides fatigue to operation teams looking into triggered alerts. 

**Which issue(s) this PR fixes**:
With the existing configuration the alert is firing on pods that are in status `Completed`. This should not be considered a problem.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix `KubePodNotReadyControlPlane` alert to not trigger for pods in `Completed` state.
```
