### PR TITLE
Fix apiserver-proxy connection for shoots with legacy single-dash namespace format

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/http-proxy-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/http-proxy-envoy-filter.yaml
@@ -36,7 +36,7 @@ spec:
                     - name: X-Gardener-Destination
                       string_match:
                         safe_regex:
-                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|shoot--.*--.*--kube-apiserver-socket)$'
+                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|(shoot-[a-z0-9]+(-[a-z0-9]+)*|shoot--[a-z0-9]+(-[a-z0-9]+)*--[a-z0-9]+(-[a-z0-9]+)*)--kube-apiserver-socket)$'
                 route:
                   cluster_header: X-Gardener-Destination
                   upgrade_configs:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/vpn-envoy-filter.yaml
@@ -32,7 +32,7 @@ spec:
                     - name: {{ .Values.httpProxy.legacyPort.header }}
                       string_match:
                         safe_regex:
-                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|shoot--.*--.*--kube-apiserver-socket)$'
+                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|(shoot-[a-z0-9]+(-[a-z0-9]+)*|shoot--[a-z0-9]+(-[a-z0-9]+)*--[a-z0-9]+(-[a-z0-9]+)*)--kube-apiserver-socket)$'
                 route:
                   cluster_header: {{ .Values.httpProxy.legacyPort.header }}
                   upgrade_configs:

--- a/pkg/component/networking/istio/test_charts/ingress_http_proxy_envoy_filter_unified.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_http_proxy_envoy_filter_unified.yaml
@@ -35,7 +35,7 @@ spec:
                     - name: X-Gardener-Destination
                       string_match:
                         safe_regex:
-                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|shoot--.*--.*--kube-apiserver-socket)$'
+                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|(shoot-[a-z0-9]+(-[a-z0-9]+)*|shoot--[a-z0-9]+(-[a-z0-9]+)*--[a-z0-9]+(-[a-z0-9]+)*)--kube-apiserver-socket)$'
                 route:
                   cluster_header: X-Gardener-Destination
                   upgrade_configs:

--- a/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_vpn_envoy_filter.yaml
@@ -31,7 +31,7 @@ spec:
                     - name: Reversed-VPN
                       string_match:
                         safe_regex:
-                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|shoot--.*--.*--kube-apiserver-socket)$'
+                          regex: '^(outbound\|(1194\|\|vpn-seed-server(-[0-4])?|443\|\|kube-apiserver)\..*\.svc\.cluster\.local|(shoot-[a-z0-9]+(-[a-z0-9]+)*|shoot--[a-z0-9]+(-[a-z0-9]+)*--[a-z0-9]+(-[a-z0-9]+)*)--kube-apiserver-socket)$'
                 route:
                   cluster_header: Reversed-VPN
                   upgrade_configs:


### PR DESCRIPTION
…

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:

Shoots created before the double-dash namespace naming scheme (`shoot--<project>--<name>`) was introduced retain their original single-dash namespace name (`shoot-<project>-<name>`) permanently. The `X-Gardener-Destination` header allowlist regex in both the http-proxy (port 8443) and reversed-vpn (port 8132) EnvoyFilters only matched the new double-dash format: `shoot--.--.--kube-apiserver-socket`

For legacy shoots the header value is `shoot-<project>-<name>--kube-apiserver-socket`, which did not match. The HTTP CONNECT request fell through to the catch-all rule, returning a `301 Moved Permanently` and breaking apiserver-proxy connectivity.

This PR replaces the overly specific pattern with a precise alternation that explicitly covers both naming formats while still rejecting invalid values (uppercase, special characters, triple hyphens, mixed formats).

Both the unified port filter (`http-proxy-envoy-filter.yaml`) and the legacy port filter (`vpn-envoy-filter.yaml`) are affected and fixed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I tested the change in my dev setup by hardcoding the format of a legacy shoot [here](https://github.com/gardener/gardener/blob/ea07d014bdaed19f84aaed479e192199db08b606/pkg/gardenlet/controller/shoot/shoot/reconciler.go#L335)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
apiserver-proxy connection for shoots with legacy single-dash namespace format has been fixed.
```
