### PR TITLE
Fix `gardenlet` cache sync timeout

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -38,14 +37,25 @@ import (
 const ControllerName = "controllerinstallation-required"
 
 type eventHandlerRegistration struct {
-	once       sync.Once
+	lock       sync.Mutex
+	registered bool
 	registerFn func() error
 }
 
-func (e *eventHandlerRegistration) registerOnce() {
-	e.once.Do(func() {
-		utilruntime.Must(e.registerFn())
-	})
+func (e *eventHandlerRegistration) registerOnce() error {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	if e.registered {
+		return nil
+	}
+
+	if err := e.registerFn(); err != nil {
+		return err
+	}
+
+	e.registered = true
+	return nil
 }
 
 // AddToManager adds Reconciler to the given manager.

--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -35,6 +36,17 @@ import (
 
 // ControllerName is the name of this controller.
 const ControllerName = "controllerinstallation-required"
+
+type eventHandlerRegistration struct {
+	once       sync.Once
+	registerFn func() error
+}
+
+func (e *eventHandlerRegistration) registerOnce() {
+	e.once.Do(func() {
+		utilruntime.Must(e.registerFn())
+	})
+}
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluster cluster.Cluster) error {
@@ -99,17 +111,22 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster, seedCluste
 			return err
 		}
 
-		if err := c.Watch(
-			source.Kind[client.Object](
-				seedCluster.GetCache(),
-				extension.object,
-				eventHandler,
-				extensions.ObjectPredicate(),
-				predicateutils.HasClass(extensionsv1alpha1.ExtensionClassShoot, extensionsv1alpha1.ExtensionClassSeed),
-			),
-		); err != nil {
-			return err
-		}
+		// Since the EnqueueRequestsFromMapFunc is costly, actual watches need to be registered after the manager was started.
+		// Registering them here might otherwise cause cache sync timeouts, esp. in large seed clusters.
+		// See https://github.com/kubernetes-sigs/controller-runtime/issues/3466 and https://github.com/gardener/gardener/issues/14391 for more information.
+		r.deferredEventHandlerRegistrations = append(r.deferredEventHandlerRegistrations, &eventHandlerRegistration{
+			registerFn: func() error {
+				return c.Watch(
+					source.Kind[client.Object](
+						seedCluster.GetCache(),
+						extension.object,
+						eventHandler,
+						extensions.ObjectPredicate(),
+						predicateutils.HasClass(extensionsv1alpha1.ExtensionClassShoot, extensionsv1alpha1.ExtensionClassSeed),
+					),
+				)
+			},
+		})
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -41,8 +41,11 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
+	// Some event handlers are too expensive to be registered during the manager startup. Register them once during the first reconciliation.
 	for _, handler := range r.deferredEventHandlerRegistrations {
-		handler.registerOnce()
+		if err := handler.registerOnce(); err != nil {
+			return reconcile.Result{}, fmt.Errorf("error registering event handler: %w", err)
+		}
 	}
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}

--- a/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/reconciler.go
@@ -33,11 +33,17 @@ type Reconciler struct {
 
 	Lock                *sync.RWMutex
 	KindToRequiredTypes map[string]sets.Set[string]
+
+	deferredEventHandlerRegistrations []*eventHandlerRegistration
 }
 
 // Reconcile performs the main reconciliation logic.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
+
+	for _, handler := range r.deferredEventHandlerRegistrations {
+		handler.registerOnce()
+	}
 
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := r.GardenClient.Get(ctx, request.NamespacedName, controllerInstallation); err != nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
Fixes the `gardenlet` cache sync timeout in large seed clusters by deferring the registration of the complex `controllerinstallation-required` mapping functions. The registration now happens in the first reconciliation run, after the cache was successfully synced.

**Which issue(s) this PR fixes**:
Fixes #14391

**Special notes for your reviewer**:
Thanks @rfranzke for the suggestion.

This is a minimal change, easy to review, with a reduced risk for cherry-picks. Consider it a special workaround for overcoming the regression introduced with https://github.com/kubernetes-sigs/controller-runtime/pull/3406. 
On the long run, we should consider eliminating the complex mapper function by offloading the calculation of required extension kind/type combinations to the reconciler.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the `gardenlet` to crash during startup was fixed. Earlier, the startup procedure occasionally failed on large-scale seed clusters due to cache sync timeouts.
```
