### PR TITLE
[GEP-28] Persist bootstrap secrets as `ShootState` to survive `gardenadm init` retries

### DIFF
--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -401,17 +401,17 @@ func initializeShootResource(resources gardenadm.Resources, fs afero.Afero, runs
 		}
 		shoot.Status.UID = uid
 
-		if v1beta1helper.HasManagedInfrastructure(resources.Shoot) {
-			// When running `gardenadm init` for a shoot with managed infrastructure, we need to restore state (secrets,
-			// extensions, etc.) from the ShootState exported by `gardenadm bootstrap`.
-			if resources.ShootState == nil {
-				return fmt.Errorf("shoot has managed infrastructure, but ShootState is missing " +
-					"(the ShootState is usually exported by `gardenadm bootstrap` and read by `gardenadm init`): " +
-					"you should either use `gardenadm bootstrap` to create the self-hosted shoot cluster with managed infrastructure or " +
-					"remove the `Shoot.spec.{secret,credentials}BindingName` field to mark the shoot as having unmanaged infrastructure")
-			}
+		if v1beta1helper.HasManagedInfrastructure(resources.Shoot) && resources.ShootState == nil {
+			return fmt.Errorf("shoot has managed infrastructure, but ShootState is missing " +
+				"(the ShootState is usually exported by `gardenadm bootstrap` and read by `gardenadm init`): " +
+				"you should either use `gardenadm bootstrap` to create the self-hosted shoot cluster with managed infrastructure or " +
+				"remove the `Shoot.spec.{secret,credentials}BindingName` field to mark the shoot as having unmanaged infrastructure")
+		}
 
+		if resources.ShootState != nil {
 			// Instruct the botanist and shoot package to read the ShootState and restore the state of extensions, secrets, etc.
+			// For managed infrastructure, this restores the state exported by `gardenadm bootstrap`.
+			// For unmanaged infrastructure on retry, this restores the bootstrap secrets persisted by `gardenadm init`.
 			shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				Type: gardencorev1beta1.LastOperationTypeRestore,
 			}

--- a/pkg/gardenadm/botanist/botanist_test.go
+++ b/pkg/gardenadm/botanist/botanist_test.go
@@ -68,6 +68,21 @@ var _ = Describe("GardenadmBotanist", func() {
 					))
 					Expect(b.Seed.GetInfo()).To(HaveField("ObjectMeta.Labels", HaveKeyWithValue("seed.gardener.cloud/self-hosted-shoot-cluster", "true")))
 				})
+
+				It("should set the LastOperation to Restore when a bootstrap ShootState exists", func() {
+					fsys[configDir+"/bootstrap-shootstate.yaml"] = &fstest.MapFile{Data: []byte(`apiVersion: core.gardener.cloud/v1beta1
+kind: ShootState
+metadata:
+  name: gardenadm
+`)}
+
+					b, err := NewGardenadmBotanistFromManifests(ctx, log, nil, configDir, true)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(b.Shoot.GetInfo().Status.LastOperation).NotTo(BeNil())
+					Expect(b.Shoot.GetInfo().Status.LastOperation.Type).To(Equal(gardencorev1beta1.LastOperationTypeRestore))
+					Expect(b.IsRestorePhase()).To(BeTrue())
+				})
 			})
 
 			Context("with managed infrastructure", func() {

--- a/pkg/gardenadm/botanist/secrets.go
+++ b/pkg/gardenadm/botanist/secrets.go
@@ -6,12 +6,19 @@ package botanist
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
@@ -26,7 +33,7 @@ func (b *GardenadmBotanist) MigrateSecrets(ctx context.Context, fakeClient, real
 
 	for _, secret := range secretList.Items {
 		taskFns = append(taskFns, func(ctx context.Context) error {
-			return realClient.Create(ctx, &corev1.Secret{
+			return client.IgnoreAlreadyExists(realClient.Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        secret.Name,
 					Namespace:   secret.Namespace,
@@ -36,9 +43,66 @@ func (b *GardenadmBotanist) MigrateSecrets(ctx context.Context, fakeClient, real
 				Type:      secret.Type,
 				Immutable: secret.Immutable,
 				Data:      secret.Data,
-			})
+			}))
 		})
 	}
 
 	return flow.Parallel(taskFns...)(ctx)
+}
+
+const bootstrapShootStateFileName = "bootstrap-shootstate.yaml"
+
+// PersistBootstrapSecrets exports all secrets from the fake client into a ShootState file in the config directory.
+// On retry, `ReadManifests` picks up this file, the botanist enters the restore phase, and the existing
+// `restoreSecretsFromShootState` restores the same secrets (including derived certs, not just CAs).
+func (b *GardenadmBotanist) PersistBootstrapSecrets(ctx context.Context, configDir string) error {
+	secretList := &corev1.SecretList{}
+	if err := b.SeedClientSet.Client().List(ctx, secretList, client.InNamespace(b.Shoot.ControlPlaneNamespace)); err != nil {
+		return fmt.Errorf("failed listing secrets: %w", err)
+	}
+
+	var gardenerData []gardencorev1beta1.GardenerResourceData
+	for _, secret := range secretList.Items {
+		if len(secret.Data) == 0 {
+			continue
+		}
+
+		dataJSON, err := json.Marshal(secret.Data)
+		if err != nil {
+			return fmt.Errorf("failed marshalling secret data for %s: %w", secret.Name, err)
+		}
+
+		gardenerData = append(gardenerData, gardencorev1beta1.GardenerResourceData{
+			Name:   secret.Name,
+			Labels: secret.Labels,
+			Type:   v1beta1constants.DataTypeSecret,
+			Data:   runtime.RawExtension{Raw: dataJSON},
+		})
+	}
+
+	shoot := b.Shoot.GetInfo()
+	shootState := &gardencorev1beta1.ShootState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shoot.Name,
+			Namespace: shoot.Namespace,
+		},
+		Spec: gardencorev1beta1.ShootStateSpec{
+			Gardener: gardenerData,
+		},
+	}
+
+	shootStateBytes, err := runtime.Encode(kubernetes.GardenCodec.EncoderForVersion(kubernetes.GardenSerializer, gardencorev1beta1.SchemeGroupVersion), shootState)
+	if err != nil {
+		return fmt.Errorf("failed encoding ShootState: %w", err)
+	}
+
+	return b.FS.WriteFile(filepath.Join(configDir, bootstrapShootStateFileName), shootStateBytes, 0600)
+}
+
+// CleanupBootstrapSecrets removes the bootstrap ShootState file from the config directory.
+func (b *GardenadmBotanist) CleanupBootstrapSecrets(configDir string) error {
+	if err := b.FS.Remove(filepath.Join(configDir, bootstrapShootStateFileName)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed removing bootstrap ShootState file: %w", err)
+	}
+	return nil
 }

--- a/pkg/gardenadm/botanist/secrets_test.go
+++ b/pkg/gardenadm/botanist/secrets_test.go
@@ -6,21 +6,25 @@ package botanist_test
 
 import (
 	"context"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
 var _ = Describe("Secrets", func() {
@@ -99,6 +103,116 @@ var _ = Describe("Secrets", func() {
 					Data:       map[string][]byte{"baz": []byte("bar")},
 				},
 			))
+		})
+
+		It("should tolerate already existing secrets in the target", func() {
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "kube-system"},
+				Type:       corev1.SecretTypeOpaque,
+				Data:       map[string][]byte{"old": []byte("data")},
+			}
+			Expect(fakeClient2.Create(ctx, existingSecret)).To(Succeed())
+
+			sourceSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "kube-system"},
+				Type:       corev1.SecretTypeOpaque,
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}
+			Expect(fakeClient1.Create(ctx, sourceSecret)).To(Succeed())
+
+			Expect(b.MigrateSecrets(ctx, fakeClient1, fakeClient2)).To(Succeed())
+		})
+	})
+
+	Describe("#PersistBootstrapSecrets", func() {
+		const configDir = "/config"
+
+		var fakeSeedClient client.Client
+
+		BeforeEach(func() {
+			fakeSeedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-shoot", Namespace: "garden-my-project"},
+			}
+
+			b.FS = afero.Afero{Fs: afero.NewMemMapFs()}
+			b.SeedClientSet = fakekubernetes.
+				NewClientSetBuilder().
+				WithClient(fakeSeedClient).
+				WithRESTConfig(&rest.Config{}).
+				Build()
+			b.Shoot.SetInfo(shoot)
+			b.Shoot.ControlPlaneNamespace = "kube-system"
+		})
+
+		It("should persist all secrets into a ShootState file", func() {
+			caSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ca-cluster",
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						secretsmanager.LabelKeyPersist:   secretsmanager.LabelValueTrue,
+						secretsmanager.LabelKeyManagedBy: secretsmanager.LabelValueSecretsManager,
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{"tls.crt": []byte("cert"), "tls.key": []byte("key")},
+			}
+			derivedSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-server",
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						secretsmanager.LabelKeyManagedBy: secretsmanager.LabelValueSecretsManager,
+					},
+				},
+				Type: corev1.SecretTypeTLS,
+				Data: map[string][]byte{"tls.crt": []byte("server-cert"), "tls.key": []byte("server-key")},
+			}
+			emptyDataSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-data", Namespace: "kube-system"},
+			}
+			otherNSSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"},
+				Data:       map[string][]byte{"key": []byte("val")},
+			}
+
+			Expect(fakeSeedClient.Create(ctx, caSecret)).To(Succeed())
+			Expect(fakeSeedClient.Create(ctx, derivedSecret)).To(Succeed())
+			Expect(fakeSeedClient.Create(ctx, emptyDataSecret)).To(Succeed())
+			Expect(fakeSeedClient.Create(ctx, otherNSSecret)).To(Succeed())
+
+			Expect(b.PersistBootstrapSecrets(ctx, configDir)).To(Succeed())
+
+			fileBytes, err := b.FS.ReadFile(filepath.Join(configDir, "bootstrap-shootstate.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(fileBytes)).To(ContainSubstring("ca-cluster"))
+			Expect(string(fileBytes)).To(ContainSubstring("kube-apiserver-server"))
+			Expect(string(fileBytes)).NotTo(ContainSubstring("other"))
+			Expect(string(fileBytes)).NotTo(ContainSubstring("empty-data"))
+		})
+	})
+
+	Describe("#CleanupBootstrapSecrets", func() {
+		const configDir = "/config"
+
+		BeforeEach(func() {
+			b.FS = afero.Afero{Fs: afero.NewMemMapFs()}
+		})
+
+		It("should remove the bootstrap ShootState file", func() {
+			Expect(b.FS.WriteFile(filepath.Join(configDir, "bootstrap-shootstate.yaml"), []byte("test"), 0600)).To(Succeed())
+
+			Expect(b.CleanupBootstrapSecrets(configDir)).To(Succeed())
+
+			exists, err := b.FS.Exists(filepath.Join(configDir, "bootstrap-shootstate.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeFalse())
+		})
+
+		It("should not fail if the file does not exist", func() {
+			Expect(b.CleanupBootstrapSecrets(configDir)).To(Succeed())
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -483,7 +483,7 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 		initializeSecretsManagement = g.Add(flow.Task{
 			Name:   "Initializing secrets management",
 			Fn:     b.InitializeSecretsManagement,
-			SkipIf: kubeconfigFileExists,
+			SkipIf: kubeconfigFileExists && !b.IsRestorePhase(),
 		})
 		writeKubeletBootstrapKubeconfig = g.Add(flow.Task{
 			Name:         "Writing kubelet bootstrap kubeconfig with a fake token to disk to make kubelet start",
@@ -497,11 +497,19 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 			SkipIf:       kubeconfigFileExists,
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement),
 		})
+		persistBootstrapSecrets = g.Add(flow.Task{
+			Name: "Persisting bootstrap secrets as ShootState for retry resilience",
+			Fn: func(ctx context.Context) error {
+				return b.PersistBootstrapSecrets(ctx, opts.ConfigDir)
+			},
+			SkipIf:       b.IsRestorePhase(),
+			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfigSecretForNodeAgent),
+		})
 		applyOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Applying OperatingSystemConfig using gardener-node-agent's reconciliation logic",
 			Fn:           b.ApplyOperatingSystemConfig,
 			SkipIf:       kubeconfigFileExists,
-			Dependencies: flow.NewTaskIDs(writeKubeletBootstrapKubeconfig, deployOperatingSystemConfigSecretForNodeAgent),
+			Dependencies: flow.NewTaskIDs(writeKubeletBootstrapKubeconfig, persistBootstrapSecrets),
 		})
 		initializeClientSet = g.Add(flow.Task{
 			Name: "Initializing connection to Kubernetes control plane",
@@ -514,10 +522,13 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 		_ = g.Add(flow.Task{
 			Name: "Importing secrets into control plane",
 			Fn: func(ctx context.Context) error {
-				return b.MigrateSecrets(ctx, b.SeedClientSet.Client(), clientSet.Client())
+				if err := b.MigrateSecrets(ctx, b.SeedClientSet.Client(), clientSet.Client()); err != nil {
+					return err
+				}
+				return b.CleanupBootstrapSecrets(opts.ConfigDir)
 			},
-			SkipIf:       kubeconfigFileExists,
-			Dependencies: flow.NewTaskIDs(initializeClientSet),
+			SkipIf:       kubeconfigFileExists && !b.IsRestorePhase(),
+			Dependencies: flow.NewTaskIDs(persistBootstrapSecrets, initializeClientSet),
 		})
 	)
 

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1178,7 +1178,7 @@ deploy:
               - |
                 for i in 0 1 2 3; do
                   pod="machine-$i"
-                  kubectl -n "$SKAFFOLD_NAMESPACES" exec "$pod" -- sh -c 'rm -rf /gardenadm/resources && mkdir -p /gardenadm/resources'
+                  kubectl -n "$SKAFFOLD_NAMESPACES" exec "$pod" -- sh -c 'rm -f /gardenadm/imagevector-overwrite.yaml /gardenadm/imagevector-overwrite-charts.yaml /gardenadm/resources/manifests.yaml && mkdir -p /gardenadm/resources'
                   kubectl -n "$SKAFFOLD_NAMESPACES" cp dev-setup/gardenadm/resources/generated/.skaffold-image                    "$pod:/tmp/.skaffold-image"
                   kubectl -n "$SKAFFOLD_NAMESPACES" cp dev-setup/gardenadm/resources/generated/.imagevector-overwrite.yaml        "$pod:/gardenadm/imagevector-overwrite.yaml"
                   kubectl -n "$SKAFFOLD_NAMESPACES" cp dev-setup/gardenadm/resources/generated/.imagevector-overwrite-charts.yaml "$pod:/gardenadm/imagevector-overwrite-charts.yaml"


### PR DESCRIPTION
> [!IMPORTANT]
> ~~This pull request is based on #14339 which must be merged first. This PR remains in draft state until then.~~

**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

When `gardenadm init` fails after generating secrets but before migrating them to the real API server (e.g., transient issue at `initializeClientSet`), secrets are lost because they lived only in the ephemeral fake client. On retry, the kubeconfig already exists, so secrets management and migration were skipped entirely.

This PR persists all generated secrets as a `bootstrap-shootstate.yaml` file in the config directory. On retry, `ReadManifests` picks it up, the botanist enters the restore phase, and the existing `restoreSecretsFromShootState` loads the same secrets — including derived certs, not just CAs. After successful migration to the API server, the file is cleaned up.

**Which issue(s) this PR fixes**:

Part of #2906

**Special notes for your reviewer**:

All secrets are persisted (not just `persist=true` CAs) to avoid TLS mismatches with static pods from the first run that reference the original derived certs. `MigrateSecrets` is made idempotent with `IgnoreAlreadyExists` so that a failed cleanup after successful migration is safe on retry.

**Release note**:
```other developer
NONE
```