### PR TITLE
Adapt `NetworkPolicy` controller to only create policies for namespaces with matching `Pod`s

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -249,6 +249,7 @@ func addAllFieldIndexes(ctx context.Context, i client.FieldIndexer) error {
 	for _, fn := range []func(context.Context, client.FieldIndexer) error{
 		// core/v1 API group
 		indexer.AddPodNodeName,
+		indexer.AddServiceNamespaceSelectors,
 	} {
 		if err := fn(ctx, i); err != nil {
 			return err

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -535,7 +535,9 @@ Otherwise, once approved, the `kube-controller-manager`'s `csrsigner` controller
 ### [`NetworkPolicy` Controller](../../pkg/resourcemanager/controller/networkpolicy)
 
 This controller reconciles `Service`s with a non-empty `.spec.podSelector`.
-It creates two `NetworkPolicy`s for each port in the `.spec.ports[]` list.
+It creates two `NetworkPolicy`s for each port in the `.spec.ports[]` list, but only if there are pods in the target namespace carrying the corresponding `networking.resources.gardener.cloud/to-*` label.
+When no matching pods exist, the policies are not created (or are deleted if they existed before).
+Pods appearing or disappearing with these labels trigger re-reconciliation of the affected services.
 For example:
 
 ```yaml

--- a/pkg/api/indexer/kubernetes_core.go
+++ b/pkg/api/indexer/kubernetes_core.go
@@ -10,6 +10,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 // PodNodeName is a constant for the spec.nodeName field selector in pods.
@@ -28,6 +30,29 @@ var PodNodeNameIndexerFunc = func(obj client.Object) []string {
 func AddPodNodeName(ctx context.Context, indexer client.FieldIndexer) error {
 	if err := indexer.IndexField(ctx, &corev1.Pod{}, PodNodeName, PodNodeNameIndexerFunc); err != nil {
 		return fmt.Errorf("failed to add indexer for %s to Pod Informer: %w", PodNodeName, err)
+	}
+	return nil
+}
+
+// ServiceNamespaceSelectors is a constant for the namespace-selectors annotation field index on Services.
+const ServiceNamespaceSelectors = "metadata.annotations.networking.resources.gardener.cloud/namespace-selectors"
+
+// ServiceNamespaceSelectorsIndexerFunc returns "true" if the Service has the namespace-selectors annotation.
+var ServiceNamespaceSelectorsIndexerFunc = func(obj client.Object) []string {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		return nil
+	}
+	if _, hasAnnotation := service.Annotations[resourcesv1alpha1.NetworkingNamespaceSelectors]; hasAnnotation {
+		return []string{"true"}
+	}
+	return nil
+}
+
+// AddServiceNamespaceSelectors adds an index for ServiceNamespaceSelectors to the given indexer.
+func AddServiceNamespaceSelectors(ctx context.Context, indexer client.FieldIndexer) error {
+	if err := indexer.IndexField(ctx, &corev1.Service{}, ServiceNamespaceSelectors, ServiceNamespaceSelectorsIndexerFunc); err != nil {
+		return fmt.Errorf("failed to add indexer for %s to Service Informer: %w", ServiceNamespaceSelectors, err)
 	}
 	return nil
 }

--- a/pkg/api/indexer/kubernetes_core_test.go
+++ b/pkg/api/indexer/kubernetes_core_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/gardener/gardener/pkg/api/indexer"
@@ -36,5 +37,23 @@ var _ = Describe("Kubernetes", func() {
 		Entry("no Pod", &corev1.Secret{}, ConsistOf("")),
 		Entry("Pod w/o nodeName", &corev1.Pod{}, ConsistOf("")),
 		Entry("Pod w/ nodeName", &corev1.Pod{Spec: corev1.PodSpec{NodeName: "node-foo"}}, ConsistOf("node-foo")),
+	)
+
+	DescribeTable("#AddServiceNamespaceSelectors",
+		func(obj client.Object, matcher gomegatypes.GomegaMatcher) {
+			Expect(AddServiceNamespaceSelectors(context.TODO(), indexer)).To(Succeed())
+
+			Expect(indexer.obj).To(Equal(&corev1.Service{}))
+			Expect(indexer.field).To(Equal("metadata.annotations.networking.resources.gardener.cloud/namespace-selectors"))
+			Expect(indexer.extractValue).NotTo(BeNil())
+			Expect(indexer.extractValue(obj)).To(matcher)
+		},
+
+		Entry("no Service", &corev1.Secret{}, BeNil()),
+		Entry("Service w/o annotation", &corev1.Service{}, BeNil()),
+		Entry("Service w/ annotation",
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"networking.resources.gardener.cloud/namespace-selectors": `[{"matchLabels":{"foo":"bar"}}]`}}},
+			ConsistOf("true"),
+		),
 	)
 })

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -103,7 +103,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 		WatchesRawSource(source.Kind[client.Object](
 			targetCluster.GetCache(),
 			pod,
-			handler.EnqueueRequestsFromMapFunc(r.MapPodToServices(mgr.GetLogger().WithValues("controller", ControllerName))),
+			r.EventHandlerForPod(mgr.GetLogger().WithValues("controller", ControllerName)),
 			r.PodPredicate(),
 		)).
 		Build(r)
@@ -332,17 +332,81 @@ func (r *Reconciler) PodPredicate() predicate.Predicate {
 	}
 }
 
-// MapPodToServices returns a handler.MapFunc for mapping a pod to the services that create policies in its namespace.
-func (r *Reconciler) MapPodToServices(log logr.Logger) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		namespace := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: obj.GetNamespace()}}
-		namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
-		if err := r.TargetClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
-			log.Error(err, "Failed to get namespace for pod", "pod", client.ObjectKeyFromObject(obj))
-			return nil
+// EventHandlerForPod returns an EventHandler that tracks seen network policy label keys per
+// namespace, only enqueueing services when a namespace's key coverage changes.
+// This avoids redundant lookups during cache warmup where many pods per namespace would
+// trigger identical service mappings (cf. https://github.com/kubernetes-sigs/controller-runtime/issues/3466).
+// The event handler functions are called sequentially by the informer's processorListener
+// goroutine (cf. https://github.com/kubernetes/client-go/blob/v0.35.3/tools/cache/shared_informer.go),
+// so no synchronization is needed for the tracking map.
+func (r *Reconciler) EventHandlerForPod(log logr.Logger) handler.EventHandler {
+	var (
+		namespaceNameToPodLabelKeys = make(map[string]sets.Set[string])
+
+		enqueueForNamespace = func(ctx context.Context, namespaceName string, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			namespace := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+			namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+			if err := r.TargetClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+				log.Error(err, "Failed to get namespace for pod", "namespace", namespaceName)
+				return
+			}
+			r.requeueServicesForNamespace(ctx, namespace, q, log)
 		}
 
-		return r.getRelevantServiceForNamespace(ctx, namespace, log)
+		enqueueIfNewKeys = func(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			var (
+				podKeys   = networkPolicyToLabelKeys(obj.GetLabels())
+				namespace = obj.GetNamespace()
+			)
+
+			existing := namespaceNameToPodLabelKeys[namespace]
+			if existing != nil && existing.HasAll(podKeys.UnsortedList()...) {
+				return
+			}
+
+			if existing == nil {
+				namespaceNameToPodLabelKeys[namespace] = podKeys
+			} else {
+				namespaceNameToPodLabelKeys[namespace] = existing.Union(podKeys)
+			}
+			enqueueForNamespace(ctx, namespace, q)
+		}
+	)
+
+	return handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueueIfNewKeys(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			var (
+				oldKeys   = networkPolicyToLabelKeys(e.ObjectOld.GetLabels())
+				newKeys   = networkPolicyToLabelKeys(e.ObjectNew.GetLabels())
+				namespace = e.ObjectNew.GetNamespace()
+			)
+
+			existing := namespaceNameToPodLabelKeys[namespace]
+			if existing == nil {
+				existing = sets.New[string]()
+			}
+
+			namespaceNameToPodLabelKeys[namespace] = existing.Difference(oldKeys).Union(newKeys)
+			enqueueForNamespace(ctx, namespace, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			var (
+				podKeys   = networkPolicyToLabelKeys(e.Object.GetLabels())
+				namespace = e.Object.GetNamespace()
+			)
+
+			if existing, ok := namespaceNameToPodLabelKeys[namespace]; ok {
+				namespaceNameToPodLabelKeys[namespace] = existing.Difference(podKeys)
+			}
+
+			enqueueForNamespace(ctx, namespace, q)
+		},
+		GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueueIfNewKeys(ctx, e.Object, q)
+		},
 	}
 }
 
@@ -360,6 +424,16 @@ func getNetworkPolicyToLabels(labels map[string]string) map[string]string {
 	for k, v := range labels {
 		if strings.HasPrefix(k, resourcesv1alpha1.NetworkPolicyLabelKeyPrefix+"to-") {
 			result[k] = v
+		}
+	}
+	return result
+}
+
+func networkPolicyToLabelKeys(podLabels map[string]string) sets.Set[string] {
+	result := sets.New[string]()
+	for k := range podLabels {
+		if strings.HasPrefix(k, resourcesv1alpha1.NetworkPolicyLabelKeyPrefix+"to-") {
+			result.Insert(k)
 		}
 	}
 	return result

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 )
@@ -240,19 +241,27 @@ func (r *Reconciler) requeueServicesForNamespace(ctx context.Context, namespace 
 }
 
 func (r *Reconciler) getRelevantServiceForNamespace(ctx context.Context, namespace client.Object, log logr.Logger) []reconcile.Request {
-	serviceList := &metav1.PartialObjectMetadataList{}
-	serviceList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ServiceList"))
-	if err := r.TargetClient.List(ctx, serviceList); err != nil {
-		log.Error(err, "Failed to list services")
-		return nil
-	}
-
 	var requests []reconcile.Request
 
-	for _, service := range serviceList.Items {
-		// enqueue all the services in the same namespace
+	// Enqueue all services in the same namespace (uses the informer's built-in namespace index).
+	sameNsServiceList := &corev1.ServiceList{}
+	if err := r.TargetClient.List(ctx, sameNsServiceList, client.InNamespace(namespace.GetName())); err != nil {
+		log.Error(err, "Failed to list services in namespace", "namespace", namespace.GetName())
+		return nil
+	}
+	for _, service := range sameNsServiceList.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: service.Name, Namespace: service.Namespace}})
+	}
+
+	// Enqueue cross-namespace services that have namespace-selectors matching this namespace (uses the field index).
+	crossNsServiceList := &corev1.ServiceList{}
+	if err := r.TargetClient.List(ctx, crossNsServiceList, client.MatchingFields{indexer.ServiceNamespaceSelectors: "true"}); err != nil {
+		log.Error(err, "Failed to list services with namespace-selectors")
+		return requests
+	}
+
+	for _, service := range crossNsServiceList.Items {
 		if service.Namespace == namespace.GetName() {
-			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: service.Name, Namespace: service.Namespace}})
 			continue
 		}
 
@@ -273,7 +282,7 @@ func (r *Reconciler) getRelevantServiceForNamespace(ctx context.Context, namespa
 
 			if selector.Matches(labels.Set(namespace.GetLabels())) {
 				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: service.Name, Namespace: service.Namespace}})
-				break // no need to check other selectors
+				break
 			}
 		}
 	}

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -44,9 +44,6 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
 	}
-	if r.TargetScheme == nil {
-		r.TargetScheme = targetCluster.GetScheme()
-	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorder(ControllerName + "-controller")
 	}

--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 	if r.TargetClient == nil {
 		r.TargetClient = targetCluster.GetClient()
 	}
+	if r.TargetScheme == nil {
+		r.TargetScheme = targetCluster.GetScheme()
+	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorder(ControllerName + "-controller")
 	}
@@ -71,6 +75,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 	namespace := &metav1.PartialObjectMetadata{}
 	namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
 
+	pod := &metav1.PartialObjectMetadata{}
+	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
 	c, err := builder.
 		ControllerManagedBy(mgr).
 		Named(ControllerName).
@@ -94,6 +101,12 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, targetCluster cluster.Clu
 			targetCluster.GetCache(),
 			namespace,
 			r.EventHandlerForNamespace(mgr.GetLogger().WithValues("controller", ControllerName)),
+		)).
+		WatchesRawSource(source.Kind[client.Object](
+			targetCluster.GetCache(),
+			pod,
+			handler.EnqueueRequestsFromMapFunc(r.MapPodToServices(mgr.GetLogger().WithValues("controller", ControllerName))),
+			r.PodPredicate(),
 		)).
 		Build(r)
 	if err != nil {
@@ -293,4 +306,55 @@ func (r *Reconciler) MapIngressToServices(_ context.Context, obj client.Object) 
 	}
 
 	return requests
+}
+
+// PodPredicate returns a predicate which filters for pods with `networking.resources.gardener.cloud/to-*` labels.
+func (r *Reconciler) PodPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return hasNetworkPolicyToLabels(e.Object.GetLabels())
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !maps.Equal(getNetworkPolicyToLabels(e.ObjectOld.GetLabels()), getNetworkPolicyToLabels(e.ObjectNew.GetLabels()))
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return hasNetworkPolicyToLabels(e.Object.GetLabels())
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return hasNetworkPolicyToLabels(e.Object.GetLabels())
+		},
+	}
+}
+
+// MapPodToServices returns a handler.MapFunc for mapping a pod to the services that create policies in its namespace.
+func (r *Reconciler) MapPodToServices(log logr.Logger) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		namespace := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: obj.GetNamespace()}}
+		namespace.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace"))
+		if err := r.TargetClient.Get(ctx, client.ObjectKeyFromObject(namespace), namespace); err != nil {
+			log.Error(err, "Failed to get namespace for pod", "pod", client.ObjectKeyFromObject(obj))
+			return nil
+		}
+
+		return r.getRelevantServiceForNamespace(ctx, namespace, log)
+	}
+}
+
+func hasNetworkPolicyToLabels(labels map[string]string) bool {
+	for k := range labels {
+		if strings.HasPrefix(k, resourcesv1alpha1.NetworkPolicyLabelKeyPrefix+"to-") {
+			return true
+		}
+	}
+	return false
+}
+
+func getNetworkPolicyToLabels(labels map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range labels {
+		if strings.HasPrefix(k, resourcesv1alpha1.NetworkPolicyLabelKeyPrefix+"to-") {
+			result[k] = v
+		}
+	}
+	return result
 }

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -327,6 +327,107 @@ var _ = Describe("Add", func() {
 		})
 	})
 
+	Describe("#PodPredicate", func() {
+		var (
+			p   predicate.Predicate
+			pod *corev1.Pod
+		)
+
+		BeforeEach(func() {
+			p = reconciler.PodPredicate()
+			pod = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"}}
+		})
+
+		Describe("#Create", func() {
+			It("should return false for pod without netpol labels", func() {
+				pod.Labels = map[string]string{"app": "foo"}
+				Expect(p.Create(event.CreateEvent{Object: pod})).To(BeFalse())
+			})
+
+			It("should return true for pod with netpol to-label", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				Expect(p.Create(event.CreateEvent{Object: pod})).To(BeTrue())
+			})
+		})
+
+		Describe("#Update", func() {
+			It("should return false when netpol labels did not change", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed", "app": "old"}
+				newPod := pod.DeepCopy()
+				newPod.Labels["app"] = "new"
+				Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: newPod})).To(BeFalse())
+			})
+
+			It("should return true when netpol label is added", func() {
+				newPod := pod.DeepCopy()
+				newPod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: newPod})).To(BeTrue())
+			})
+
+			It("should return true when netpol label is removed", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				newPod := pod.DeepCopy()
+				newPod.Labels = nil
+				Expect(p.Update(event.UpdateEvent{ObjectOld: pod, ObjectNew: newPod})).To(BeTrue())
+			})
+		})
+
+		Describe("#Delete", func() {
+			It("should return false for pod without netpol labels", func() {
+				Expect(p.Delete(event.DeleteEvent{Object: pod})).To(BeFalse())
+			})
+
+			It("should return true for pod with netpol to-label", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				Expect(p.Delete(event.DeleteEvent{Object: pod})).To(BeTrue())
+			})
+		})
+
+		Describe("#Generic", func() {
+			It("should return false for pod without netpol labels", func() {
+				Expect(p.Generic(event.GenericEvent{Object: pod})).To(BeFalse())
+			})
+
+			It("should return true for pod with netpol to-label", func() {
+				pod.Labels = map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"}
+				Expect(p.Generic(event.GenericEvent{Object: pod})).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("#MapPodToServices", func() {
+		var (
+			nsName  = "test-ns"
+			svcName = "test-svc"
+		)
+
+		It("should return services relevant for the pod's namespace", func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName, Labels: map[string]string{"foo": "bar"}}}
+			Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+
+			namespaceSelectors := []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}}
+			encoded, _ := json.Marshal(namespaceSelectors)
+
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: "other-ns",
+					Annotations: map[string]string{
+						"networking.resources.gardener.cloud/namespace-selectors": string(encoded),
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+
+			pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: nsName}}
+			pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+			mapFn := reconciler.MapPodToServices(log)
+			requests := mapFn(ctx, pod)
+			Expect(requests).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: svcName, Namespace: "other-ns"}}))
+		})
+	})
+
 	Describe("#MapIngressToServices", func() {
 		It("should map to all referenced services", func() {
 			var (

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	resourcemanagerclient "github.com/gardener/gardener/pkg/resourcemanager/client"
 	. "github.com/gardener/gardener/pkg/resourcemanager/controller/networkpolicy"
 )
@@ -37,7 +38,10 @@ var _ = Describe("Add", func() {
 
 	BeforeEach(func() {
 		log = logr.Discard()
-		fakeClient = fakeclient.NewClientBuilder().WithScheme(resourcemanagerclient.TargetScheme).Build()
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(resourcemanagerclient.TargetScheme).
+			WithIndex(&corev1.Service{}, indexer.ServiceNamespaceSelectors, indexer.ServiceNamespaceSelectorsIndexerFunc).
+			Build()
 		reconciler = &Reconciler{
 			TargetClient: fakeClient,
 		}

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -399,13 +399,19 @@ var _ = Describe("Add", func() {
 		})
 	})
 
-	Describe("#MapPodToServices", func() {
+	Describe("#EventHandlerForPod", func() {
 		var (
 			nsName  = "test-ns"
 			svcName = "test-svc"
+			queue   workqueue.TypedRateLimitingInterface[reconcile.Request]
+			handler handler.EventHandler
 		)
 
-		It("should return services relevant for the pod's namespace", func() {
+		BeforeEach(func() {
+			queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			DeferCleanup(func() { queue.ShutDown() })
+			handler = reconciler.EventHandlerForPod(log)
+
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName, Labels: map[string]string{"foo": "bar"}}}
 			Expect(fakeClient.Create(ctx, ns)).To(Succeed())
 
@@ -422,13 +428,129 @@ var _ = Describe("Add", func() {
 				},
 			}
 			Expect(fakeClient.Create(ctx, service)).To(Succeed())
+		})
 
-			pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: nsName}}
-			pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+		Describe("#Create", func() {
+			It("should enqueue services when pod with new label keys is created", func() {
+				pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
 
-			mapFn := reconciler.MapPodToServices(log)
-			requests := mapFn(ctx, pod)
-			Expect(requests).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: svcName, Namespace: "other-ns"}}))
+				handler.Create(ctx, event.CreateEvent{Object: pod}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+			})
+
+			It("should not enqueue when all label keys are already tracked", func() {
+				pod1 := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod1.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Create(ctx, event.CreateEvent{Object: pod1}, queue)
+				item, _ := queue.Get()
+				queue.Done(item)
+
+				pod2 := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-2", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod2.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Create(ctx, event.CreateEvent{Object: pod2}, queue)
+				Expect(queue.Len()).To(Equal(0))
+			})
+
+			It("should enqueue when pod brings a new label key", func() {
+				pod1 := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod1.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Create(ctx, event.CreateEvent{Object: pod1}, queue)
+				item, _ := queue.Get()
+				queue.Done(item)
+
+				pod2 := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-2", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-bar-tcp-9090": "allowed"},
+				}}
+				pod2.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Create(ctx, event.CreateEvent{Object: pod2}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+			})
+		})
+
+		Describe("#Delete", func() {
+			It("should always enqueue and clear tracking so re-create enqueues again", func() {
+				pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Create(ctx, event.CreateEvent{Object: pod}, queue)
+				item, _ := queue.Get()
+				queue.Done(item)
+
+				handler.Delete(ctx, event.DeleteEvent{Object: pod}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+
+				// Re-create with the same key should enqueue again since delete cleared tracking.
+				handler.Create(ctx, event.CreateEvent{Object: pod}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+			})
+		})
+
+		Describe("#Update", func() {
+			It("should enqueue when labels change", func() {
+				oldPod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				oldPod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				newPod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-bar-tcp-9090": "allowed"},
+				}}
+				newPod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Update(ctx, event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+			})
+		})
+
+		Describe("#Generic", func() {
+			It("should enqueue when keys are new", func() {
+				pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Generic(ctx, event.GenericEvent{Object: pod}, queue)
+				verifyRequests(queue, 1, svcName, "other-ns")
+			})
+
+			It("should not enqueue when keys are already tracked", func() {
+				pod := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-1", Namespace: nsName,
+					Labels: map[string]string{"networking.resources.gardener.cloud/to-foo-tcp-8080": "allowed"},
+				}}
+				pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
+
+				handler.Generic(ctx, event.GenericEvent{Object: pod}, queue)
+				item, _ := queue.Get()
+				queue.Done(item)
+
+				handler.Generic(ctx, event.GenericEvent{Object: pod}, queue)
+				Expect(queue.Len()).To(Equal(0))
+			})
 		})
 	})
 

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -17,7 +17,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +38,6 @@ var fromPolicyRegexp = regexp.MustCompile(resourcesv1alpha1.NetworkPolicyFromPol
 // Reconciler reconciles Service objects and creates NetworkPolicy objects.
 type Reconciler struct {
 	TargetClient client.Client
-	TargetScheme *runtime.Scheme
 	Config       resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig
 	Recorder     events.EventRecorder
 
@@ -158,6 +156,18 @@ func (r *Reconciler) fetchRelevantNamespaceNames(ctx context.Context, service *c
 }
 
 func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logger, service *corev1.Service, namespaceNames sets.Set[string]) ([]flow.TaskFn, []string, error) {
+	// If the namespace of the Service is terminating, we don't want to create or maintain any policies. The Service
+	// itself is expected to disappear soon (namespace controller cleans up all resources on namespace deletion), so
+	// whatever we would do here will become obsolete very soon.
+	if !namespaceNames.Has(service.Namespace) {
+		return nil, nil, nil
+	}
+
+	podLabelKeysByNamespace, err := r.podNetworkPolicyLabelKeysByNamespace(ctx, namespaceNames)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var (
 		taskFns               []flow.TaskFn
 		desiredObjectMetaKeys []string
@@ -186,7 +196,7 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 			}
 		}
 
-		addTasksForRelevantNamespacesAndPort = func(port networkingv1.NetworkPolicyPort, customPodLabelSelector string) error {
+		addTasksForRelevantNamespacesAndPort = func(port networkingv1.NetworkPolicyPort, customPodLabelSelector string) {
 			policyID := policyIDFor(service.Name, port)
 			podLabelSelector := policyID
 
@@ -199,32 +209,29 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 				matchLabels := matchLabelsForServiceAndNamespace(podLabelSelector, service, namespaceName)
 				effectiveLabels, _ := shortenPodSelectorKeysIfTooLong(metav1.LabelSelector{MatchLabels: matchLabels})
 
-				podsExist, err := kubernetesutils.ResourcesExist(ctx, r.TargetClient, &corev1.PodList{}, r.TargetScheme, client.InNamespace(namespaceName), client.MatchingLabels(effectiveLabels.MatchLabels))
-				if err != nil {
-					return fmt.Errorf("failed checking if pods exist with labels %v in namespace %s: %w", effectiveLabels.MatchLabels, namespaceName, err)
+				// Check whether any pod in this namespace carries the effective label key — using the
+				// pre-fetched per-namespace label key set instead of listing pods again for every
+				// (namespace, port) combination.
+				labelKeys := podLabelKeysByNamespace[namespaceName]
+				hasPods := false
+				for k := range effectiveLabels.MatchLabels {
+					if labelKeys.Has(k) {
+						hasPods = true
+						break
+					}
 				}
-				if !podsExist {
+
+				if !hasPods {
 					continue
 				}
 
 				addTasksForPort(port, policyID, namespaceName, metav1.LabelSelector{MatchLabels: matchLabels}, ingressPolicyObjectMetaFor, egressPolicyObjectMetaFor)
 			}
-
-			return nil
 		}
 	)
 
-	// If the namespace of the Service is terminating, we don't want to create or maintain any policies. The Service
-	// itself is expected to disappear soon (namespace controller cleans up all resources on namespace deletion), so
-	// whatever we would do here will become obsolete very soon.
-	if !namespaceNames.Has(service.Namespace) {
-		return nil, nil, nil
-	}
-
 	for _, port := range service.Spec.Ports {
-		if err := addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, ""); err != nil {
-			return nil, nil, err
-		}
+		addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, "")
 	}
 
 	for k, allowedPorts := range service.Annotations {
@@ -243,9 +250,7 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 		}
 
 		for _, port := range ports {
-			if err := addTasksForRelevantNamespacesAndPort(port, customPodLabelSelector); err != nil {
-				return nil, nil, err
-			}
+			addTasksForRelevantNamespacesAndPort(port, customPodLabelSelector)
 		}
 	}
 
@@ -544,4 +549,32 @@ func egressNamespaceSelectorFor(serviceNamespace, namespaceName string) *metav1.
 
 func key(meta metav1.ObjectMeta) string {
 	return meta.Namespace + "/" + meta.Name
+}
+
+// podNetworkPolicyLabelKeysByNamespace lists pods in each namespace once and collects the network policy label keys
+// (prefix "networking.resources.gardener.cloud/to-" with value "allowed") into a set per namespace. This avoids
+// repeated informer scans when checking multiple ports per namespace.
+func (r *Reconciler) podNetworkPolicyLabelKeysByNamespace(ctx context.Context, namespaceNames sets.Set[string]) (map[string]sets.Set[string], error) {
+	result := make(map[string]sets.Set[string], namespaceNames.Len())
+
+	for _, ns := range namespaceNames.UnsortedList() {
+		podList := &metav1.PartialObjectMetadataList{}
+		podList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
+		if err := r.TargetClient.List(ctx, podList, client.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("failed listing pods in namespace %s: %w", ns, err)
+		}
+
+		labelKeys := sets.New[string]()
+		for _, pod := range podList.Items {
+			for k, v := range pod.Labels {
+				if v == v1beta1constants.LabelNetworkPolicyAllowed && strings.HasPrefix(k, resourcesv1alpha1.NetworkPolicyLabelKeyPrefix+"to-") {
+					labelKeys.Insert(k)
+				}
+			}
+		}
+
+		result[ns] = labelKeys
+	}
+
+	return result, nil
 }

--- a/pkg/resourcemanager/controller/networkpolicy/reconciler.go
+++ b/pkg/resourcemanager/controller/networkpolicy/reconciler.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +39,7 @@ var fromPolicyRegexp = regexp.MustCompile(resourcesv1alpha1.NetworkPolicyFromPol
 // Reconciler reconciles Service objects and creates NetworkPolicy objects.
 type Reconciler struct {
 	TargetClient client.Client
+	TargetScheme *runtime.Scheme
 	Config       resourcemanagerconfigv1alpha1.NetworkPolicyControllerConfig
 	Recorder     events.EventRecorder
 
@@ -175,17 +177,16 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 				{objectMetaFunc: ingressObjectMetaFunc, reconcileFunc: r.reconcileIngressPolicy},
 				{objectMetaFunc: egressObjectMetaFunc, reconcileFunc: r.reconcileEgressPolicy},
 			} {
-				reconcileFn := fns.reconcileFunc
 				objectMeta := fns.objectMetaFunc(policyID, service.Namespace, namespaceName)
 				desiredObjectMetaKeys = append(desiredObjectMetaKeys, key(objectMeta))
 
 				taskFns = append(taskFns, func(ctx context.Context) error {
-					return reconcileFn(ctx, log, service, port, objectMeta, namespaceName, podLabelSelector)
+					return fns.reconcileFunc(ctx, log, service, port, objectMeta, namespaceName, podLabelSelector)
 				})
 			}
 		}
 
-		addTasksForRelevantNamespacesAndPort = func(port networkingv1.NetworkPolicyPort, customPodLabelSelector string) {
+		addTasksForRelevantNamespacesAndPort = func(port networkingv1.NetworkPolicyPort, customPodLabelSelector string) error {
 			policyID := policyIDFor(service.Name, port)
 			podLabelSelector := policyID
 
@@ -194,11 +195,22 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 				podLabelSelector = customPodLabelSelector
 			}
 
-			for _, n := range namespaceNames.UnsortedList() {
-				namespaceName := n
+			for _, namespaceName := range namespaceNames.UnsortedList() {
 				matchLabels := matchLabelsForServiceAndNamespace(podLabelSelector, service, namespaceName)
+				effectiveLabels, _ := shortenPodSelectorKeysIfTooLong(metav1.LabelSelector{MatchLabels: matchLabels})
+
+				podsExist, err := kubernetesutils.ResourcesExist(ctx, r.TargetClient, &corev1.PodList{}, r.TargetScheme, client.InNamespace(namespaceName), client.MatchingLabels(effectiveLabels.MatchLabels))
+				if err != nil {
+					return fmt.Errorf("failed checking if pods exist with labels %v in namespace %s: %w", effectiveLabels.MatchLabels, namespaceName, err)
+				}
+				if !podsExist {
+					continue
+				}
+
 				addTasksForPort(port, policyID, namespaceName, metav1.LabelSelector{MatchLabels: matchLabels}, ingressPolicyObjectMetaFor, egressPolicyObjectMetaFor)
 			}
+
+			return nil
 		}
 	)
 
@@ -209,9 +221,10 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 		return nil, nil, nil
 	}
 
-	for _, p := range service.Spec.Ports {
-		port := p
-		addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, "")
+	for _, port := range service.Spec.Ports {
+		if err := addTasksForRelevantNamespacesAndPort(networkingv1.NetworkPolicyPort{Protocol: &port.Protocol, Port: &port.TargetPort}, ""); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	for k, allowedPorts := range service.Annotations {
@@ -230,7 +243,9 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 		}
 
 		for _, port := range ports {
-			addTasksForRelevantNamespacesAndPort(port, customPodLabelSelector)
+			if err := addTasksForRelevantNamespacesAndPort(port, customPodLabelSelector); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 
@@ -247,8 +262,7 @@ func (r *Reconciler) reconcileDesiredPolicies(ctx context.Context, log logr.Logg
 		return nil, nil, err
 	}
 
-	for _, p := range portsExposedViaIngresses {
-		port := p
+	for _, port := range portsExposedViaIngresses {
 		policyID := policyIDFor(service.Name, port)
 		addTasksForPort(port, policyID, r.Config.IngressControllerSelector.Namespace, r.Config.IngressControllerSelector.PodSelector, ingressPolicyObjectMetaWhenExposedViaIngressFor, egressPolicyObjectMetaWhenExposedViaIngressFor)
 	}
@@ -260,9 +274,7 @@ func (r *Reconciler) deleteStalePolicies(networkPolicyList *metav1.PartialObject
 	objectMetaKeysForDesiredPolicies := sets.New(desiredObjectMetaKeys...)
 	var taskFns []flow.TaskFn
 
-	for _, n := range networkPolicyList.Items {
-		networkPolicy := n
-
+	for _, networkPolicy := range networkPolicyList.Items {
 		if !objectMetaKeysForDesiredPolicies.Has(key(networkPolicy.ObjectMeta)) {
 			taskFns = append(taskFns, func(ctx context.Context) error {
 				return kubernetesutils.DeleteObject(ctx, r.TargetClient, &networkPolicy)

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_suite_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_suite_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	resourcemanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/resourcemanager/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/networkpolicy"
@@ -95,6 +96,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 	mgrClient = mgr.GetClient()
+
+	By("Add field indexes")
+	Expect(indexer.AddServiceNamespaceSelectors(ctx, mgr.GetFieldIndexer())).To(Succeed())
 
 	By("Register controller")
 	Expect((&networkpolicy.Reconciler{

--- a/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
+++ b/test/integration/resourcemanager/networkpolicy/networkpolicy_test.go
@@ -17,15 +17,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("NetworkPolicy Controller tests", func() {
 	var (
-		namespace      *corev1.Namespace
-		otherNamespace *corev1.Namespace
-		service        *corev1.Service
+		namespace       *corev1.Namespace
+		otherNamespace  *corev1.Namespace
+		service         *corev1.Service
+		skipPodCreation bool
 
 		serviceSelector         = map[string]string{"foo": "bar"}
 		customPodLabelSelector1 = "custom-selector1"
@@ -56,6 +58,43 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		port6Protocol   = corev1.ProtocolTCP
 		port6TargetPort = intstr.FromInt32(1023)
 		port6Suffix     = fmt.Sprintf("-%s-%s", strings.ToLower(string(port6Protocol)), port6TargetPort.String())
+
+		createPodWithNetPolLabels = func(namespaceName string, labels map[string]string) *corev1.Pod {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "pod-",
+					Namespace:    namespaceName,
+					Labels:       labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "test",
+						Image: "registry.k8s.io/pause:3.7",
+					}},
+				},
+			}
+			ExpectWithOffset(1, testClient.Create(ctx, pod)).To(Succeed())
+			DeferCleanup(func() {
+				ExpectWithOffset(1, testClient.Delete(ctx, pod)).To(Or(Succeed(), BeNotFoundError()))
+			})
+			return pod
+		}
+
+		sameNamespaceLabelsForService = func() map[string]string {
+			labels := map[string]string{
+				"networking.resources.gardener.cloud/to-" + service.Name + port1Suffix: "allowed",
+				"networking.resources.gardener.cloud/to-" + service.Name + port2Suffix: "allowed",
+			}
+			return shortenLabelKeys(labels)
+		}
+
+		crossNamespaceLabelsForService = func() map[string]string {
+			labels := map[string]string{
+				"networking.resources.gardener.cloud/to-" + service.Namespace + "-" + service.Name + port1Suffix: "allowed",
+				"networking.resources.gardener.cloud/to-" + service.Namespace + "-" + service.Name + port2Suffix: "allowed",
+			}
+			return shortenLabelKeys(labels)
+		}
 
 		ensureNetworkPolicies = func(asyncAssertion func(int, any, ...any) AsyncAssertion, should bool) func() {
 			return func() {
@@ -177,6 +216,7 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 
 	BeforeEach(func() {
 		logBuffer.Reset()
+		skipPodCreation = false
 
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -239,6 +279,11 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		By("Create Service")
 		Expect(testClient.Create(ctx, service)).To(Succeed())
 		log.Info("Created Service", "service", client.ObjectKeyFromObject(service))
+
+		if service.Spec.Selector != nil && !skipPodCreation {
+			By("Create Pod with matching netpol labels in service namespace")
+			createPodWithNetPolLabels(service.Namespace, sameNamespaceLabelsForService())
+		}
 
 		DeferCleanup(func() {
 			By("Delete Service")
@@ -336,6 +381,11 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 			service.Spec.Ports = []corev1.ServicePort{service.Spec.Ports[1]}
 			service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{Name: "newport", Port: 1357, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt32(2468)})
 			Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
+
+			By("Create pod with labels for the new port")
+			createPodWithNetPolLabels(service.Namespace, map[string]string{
+				"networking.resources.gardener.cloud/to-" + service.Name + "-udp-2468": "allowed",
+			})
 
 			By("Wait until all policies were reconciled")
 			Eventually(func(g Gomega) []string {
@@ -473,6 +523,10 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/namespace-selectors", `[{"matchLabels":{"other":"namespace"}}]`)
 		})
 
+		JustBeforeEach(func() {
+			createPodWithNetPolLabels(otherNamespace.Name, crossNamespaceLabelsForService())
+		})
+
 		It("should create the expected cross-namespace network policies", func() {
 			ensureNetworkPoliciesGetCreated()
 
@@ -555,6 +609,14 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 			service.Spec.Ports = []corev1.ServicePort{service.Spec.Ports[1]}
 			service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{Name: "newport", Port: 1357, Protocol: corev1.ProtocolUDP, TargetPort: intstr.FromInt32(2468)})
 			Expect(testClient.Patch(ctx, service, patch)).To(Succeed())
+
+			By("Create pods with labels for the new port")
+			createPodWithNetPolLabels(service.Namespace, map[string]string{
+				"networking.resources.gardener.cloud/to-" + service.Name + "-udp-2468": "allowed",
+			})
+			createPodWithNetPolLabels(otherNamespace.Name, map[string]string{
+				"networking.resources.gardener.cloud/to-" + service.Namespace + "-" + service.Name + "-udp-2468": "allowed",
+			})
 
 			By("Wait until cross-namespace policies were reconciled")
 			Eventually(func(g Gomega) []networkingv1.NetworkPolicy {
@@ -687,6 +749,9 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 				}).Should(BeNotFoundError())
 			})
 
+			By("Create Pod with matching netpol labels in new namespace")
+			createPodWithNetPolLabels(newNamespace.Name, crossNamespaceLabelsForService())
+
 			By("Wait until all ingress policies are created")
 			Eventually(func(g Gomega) []string {
 				networkPolicyList := &networkingv1.NetworkPolicyList{}
@@ -713,6 +778,13 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 
 			BeforeEach(func() {
 				metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/pod-label-selector-namespace-alias", alias)
+			})
+
+			JustBeforeEach(func() {
+				createPodWithNetPolLabels(otherNamespace.Name, map[string]string{
+					"networking.resources.gardener.cloud/to-" + alias + "-" + service.Name + port1Suffix: "allowed",
+					"networking.resources.gardener.cloud/to-" + alias + "-" + service.Name + port2Suffix: "allowed",
+				})
 			})
 
 			It("should create the expected cross-namespace network policies", func() {
@@ -753,6 +825,13 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 		BeforeEach(func() {
 			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/from-"+customPodLabelSelector1+"-allowed-ports", `[{"protocol":"`+string(port3Protocol)+`","port":"`+port3TargetPort.String()+`"},{"protocol":"`+string(port4Protocol)+`","port":`+port4TargetPort.String()+`}]`)
 			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/from-"+customPodLabelSelector2+"-allowed-ports", `[{"protocol":"`+string(port5Protocol)+`","port":`+port5TargetPort.String()+`},{"protocol":"`+string(port6Protocol)+`","port":`+port6TargetPort.String()+`}]`)
+		})
+
+		JustBeforeEach(func() {
+			createPodWithNetPolLabels(service.Namespace, map[string]string{
+				"networking.resources.gardener.cloud/to-" + customPodLabelSelector1: "allowed",
+				"networking.resources.gardener.cloud/to-" + customPodLabelSelector2: "allowed",
+			})
 		})
 
 		It("should create the expected network policies", func() {
@@ -1207,4 +1286,72 @@ var _ = Describe("NetworkPolicy Controller tests", func() {
 			ensureExposedViaIngressNetworkPoliciesGetDeleted()
 		})
 	})
+
+	Context("pod-aware policy creation", func() {
+		Context("same-namespace without matching pods", func() {
+			BeforeEach(func() {
+				service.Spec.Selector = serviceSelector
+				skipPodCreation = true
+			})
+
+			It("should not create policies when no matching pods exist", func() {
+				ensureNetworkPoliciesDoNotGetCreated()
+			})
+
+			It("should create policies when a pod with matching labels appears", func() {
+				By("Ensure no policies are created initially")
+				ensureNetworkPoliciesDoNotGetCreated()
+
+				By("Create pod with matching netpol labels")
+				createPodWithNetPolLabels(service.Namespace, sameNamespaceLabelsForService())
+
+				By("Ensure policies are created")
+				ensureNetworkPoliciesGetCreated()
+			})
+		})
+
+		Context("cross-namespace without matching pods", func() {
+			BeforeEach(func() {
+				metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.resources.gardener.cloud/namespace-selectors", `[{"matchLabels":{"other":"namespace"}}]`)
+			})
+
+			It("should not create cross-namespace policies when no matching pods exist in remote namespace", func() {
+				ensureCrossNamespaceNetworkPoliciesDoNotGetCreated()
+			})
+
+			It("should create cross-namespace policies when a pod with matching labels appears in remote namespace", func() {
+				By("Ensure no cross-namespace policies are created initially")
+				ensureCrossNamespaceNetworkPoliciesDoNotGetCreated()
+
+				By("Create pod with matching netpol labels in remote namespace")
+				createPodWithNetPolLabels(otherNamespace.Name, crossNamespaceLabelsForService())
+
+				By("Ensure cross-namespace policies are created")
+				ensureCrossNamespaceNetworkPoliciesGetCreated()
+			})
+
+			It("should delete cross-namespace policies when matching pod disappears from remote namespace", func() {
+				By("Create pod with matching netpol labels in remote namespace")
+				pod := createPodWithNetPolLabels(otherNamespace.Name, crossNamespaceLabelsForService())
+
+				By("Wait until cross-namespace policies are created")
+				ensureCrossNamespaceNetworkPoliciesGetCreated()
+
+				By("Delete pod")
+				Expect(testClient.Delete(ctx, pod)).To(Succeed())
+
+				By("Wait until cross-namespace policies are deleted")
+				ensureCrossNamespaceNetworkPoliciesGetDeleted()
+			})
+		})
+	})
 })
+
+func shortenLabelKeys(labels map[string]string) map[string]string {
+	result := make(map[string]string, len(labels))
+	for k, v := range labels {
+		newKey, _ := gardenerutils.ShortenNetworkPolicyLabelKeyIfTooLong(k)
+		result[newKey] = v
+	}
+	return result
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/area performance
/kind enhancement

**What this PR does / why we need it**:

The `NetworkPolicy` controller creates ingress/egress policies for all namespaces matching a service's namespace selectors — regardless of whether any pod in those namespaces carries the corresponding `networking.resources.gardener.cloud/to-*` labels. Most of these policies are unused and just consume API server and etcd resources.

This PR makes the controller pod-aware: it watches pods with `to-*` labels and only creates policies in namespaces that actually have matching pods. Additionally, two performance optimizations reduce the overhead of the pod-aware reconciliation:
- Cache pod label keys per namespace to avoid repeated informer scans (O(namespaces) instead of O(namespaces × ports)).
- Index services by `namespace-selectors` annotation to scope `getRelevantServiceForNamespace` queries instead of listing all services cluster-wide.

Measurements in a simple local setup: shoot namespace 60% fewer netpols, `istio-system` 69%, `istio-ingress` 79%, `garden` namespace 58%, extension namespace 65%, overall 61%. This scales with the number of shoot namespaces — seeds with many shoots will see even larger reductions.

**Special notes for your reviewer**:

Future optimization (not implemented): skip pod event enqueueing when the pod's `to-*` label keys are already covered by other pods in the same namespace (edge-triggered approach). This would eliminate unnecessary reconciles during pod churn (e.g., rolling updates). Deferred because in-place VPA updates will drastically reduce pod restarts, which is the main contributor today.

**Release note**:
```noteworthy operator
The `gardener-resource-manager`'s `NetworkPolicy` controller now only creates policies in namespaces that have pods with matching `to-*` labels, significantly reducing the number of `NetworkPolicy` objects on seeds.
```