### PR TITLE
Add custom unmarshaling logic to restore backwards compatibility for `tokenExpirationDuration`

### DIFF
--- a/pkg/apis/config/gardenlet/v1alpha1/json.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/json.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// UnmarshalJSON implements custom JSON unmarshaling for TokenRequestorWorkloadIdentityControllerConfiguration.
+// It handles backward compatibility for the TokenExpirationDuration field which was changed from time.Duration
+// (serialized as nanoseconds integer) to metav1.Duration (serialized as string like "6h").
+// TODO(oliver-goetz): Remove this custom unmarshaling logic once Gardener v1.142 has been released.
+func (c *TokenRequestorWorkloadIdentityControllerConfiguration) UnmarshalJSON(data []byte) error {
+	// Define a type alias to avoid infinite recursion when calling json.Unmarshal.
+	type alias TokenRequestorWorkloadIdentityControllerConfiguration
+
+	// First, try to unmarshal with the new format (metav1.Duration as string).
+	aux := &alias{}
+	if err := json.Unmarshal(data, aux); err == nil {
+		*c = TokenRequestorWorkloadIdentityControllerConfiguration(*aux)
+		return nil
+	}
+
+	// If that fails, try the old format with TokenExpirationDuration as a number (nanoseconds).
+	type oldFormat struct {
+		ConcurrentSyncs         *int   `json:"concurrentSyncs,omitempty"`
+		TokenExpirationDuration *int64 `json:"tokenExpirationDuration,omitempty"`
+	}
+
+	old := &oldFormat{}
+	if err := json.Unmarshal(data, old); err != nil {
+		return err
+	}
+
+	c.ConcurrentSyncs = old.ConcurrentSyncs
+	if old.TokenExpirationDuration != nil {
+		c.TokenExpirationDuration = &metav1.Duration{Duration: time.Duration(*old.TokenExpirationDuration)}
+	}
+
+	return nil
+}

--- a/pkg/apis/config/gardenlet/v1alpha1/json_test.go
+++ b/pkg/apis/config/gardenlet/v1alpha1/json_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+)
+
+var _ = Describe("JSON", func() {
+	Describe("TokenRequestorWorkloadIdentityControllerConfiguration", func() {
+		DescribeTable("UnmarshalJSON",
+			func(input string, expected TokenRequestorWorkloadIdentityControllerConfiguration) {
+				var cfg TokenRequestorWorkloadIdentityControllerConfiguration
+				Expect(json.Unmarshal([]byte(input), &cfg)).To(Succeed())
+				Expect(cfg).To(Equal(expected))
+			},
+			Entry("new format with string duration",
+				`{"concurrentSyncs":10,"tokenExpirationDuration":"6h"}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{
+					ConcurrentSyncs:         ptr.To(10),
+					TokenExpirationDuration: &metav1.Duration{Duration: 6 * time.Hour},
+				},
+			),
+			Entry("old format with numeric duration (nanoseconds)",
+				`{"concurrentSyncs":10,"tokenExpirationDuration":21600000000000}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{
+					ConcurrentSyncs:         ptr.To(10),
+					TokenExpirationDuration: &metav1.Duration{Duration: 6 * time.Hour},
+				},
+			),
+			Entry("empty object",
+				`{}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{},
+			),
+			Entry("only concurrentSyncs",
+				`{"concurrentSyncs":5}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{
+					ConcurrentSyncs: ptr.To(5),
+				},
+			),
+			Entry("only new format duration",
+				`{"tokenExpirationDuration":"30m"}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{
+					TokenExpirationDuration: &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			),
+			Entry("only old format duration",
+				`{"tokenExpirationDuration":1800000000000}`,
+				TokenRequestorWorkloadIdentityControllerConfiguration{
+					TokenExpirationDuration: &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			),
+		)
+	})
+})

--- a/pkg/apis/seedmanagement/encoding/encoding_test.go
+++ b/pkg/apis/seedmanagement/encoding/encoding_test.go
@@ -7,11 +7,13 @@ package encoding_test
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
@@ -59,6 +61,53 @@ var _ = Describe("Encoding", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(config))
+		})
+
+		// TODO(oliver-goetz): Remove this test when Gardener v1.142 has been released.
+		It("should decode config with numeric tokenExpirationDuration format (migration from time.Duration)", func() {
+			// This simulates a ConfigMap created before PR #14333 which changed TokenExpirationDuration
+			// from time.Duration (serialized as nanoseconds) to metav1.Duration (serialized as string).
+			// 6 hours in nanoseconds = 6 * 60 * 60 * 1e9 = 21600000000000
+			configBytes := []byte(`{
+				"apiVersion": "gardenlet.config.gardener.cloud/v1alpha1",
+				"kind": "GardenletConfiguration",
+				"controllers": {
+					"tokenRequestorWorkloadIdentity": {
+						"concurrentSyncs": 5,
+						"tokenExpirationDuration": 21600000000000
+					}
+				}
+			}`)
+
+			result, err := DecodeGardenletConfigurationFromBytes(configBytes, false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Controllers).NotTo(BeNil())
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity).NotTo(BeNil())
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(Equal(ptr.To(5)))
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(Equal(&metav1.Duration{Duration: 6 * time.Hour}))
+		})
+
+		// TODO(oliver-goetz): Remove this test when Gardener v1.142 has been released.
+		It("should decode config with string tokenExpirationDuration format", func() {
+			configBytes := []byte(`{
+				"apiVersion": "gardenlet.config.gardener.cloud/v1alpha1",
+				"kind": "GardenletConfiguration",
+				"controllers": {
+					"tokenRequestorWorkloadIdentity": {
+						"concurrentSyncs": 5,
+						"tokenExpirationDuration": "6h"
+					}
+				}
+			}`)
+
+			result, err := DecodeGardenletConfigurationFromBytes(configBytes, false)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Controllers).NotTo(BeNil())
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity).NotTo(BeNil())
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity.ConcurrentSyncs).To(Equal(ptr.To(5)))
+			Expect(result.Controllers.TokenRequestorWorkloadIdentity.TokenExpirationDuration).To(Equal(&metav1.Duration{Duration: 6 * time.Hour}))
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR restores backwards compatibility for the new format of `tokenExpirationDuration` introduced in PR #14333.

Without this PR the reconciliation of managed seeds created in a previous version of Gardener fails [at this place](https://github.com/gardener/gardener/blob/ea07d014bdaed19f84aaed479e192199db08b606/pkg/controller/gardenletdeployer/actuator.go#L459-L462), because the existing gardenlet-configmap with old numeric format cannot be unmarshaled.

```
{"level":"error","ts":"2026-03-25T15:42:11.062Z","msg":"Reconciler error","controller":"managedseed","namespace":"garden","name":"managedseed","reconcileID":"3e4749c6-f79e-4a7b-ac81-c1c7f653da1e","error":"could not reconcile ManagedSeed garden/managedseed creation or update: failed to decode gardenlet configuration in ConfigMap garden/gardenlet-configmap-053496f2: json: cannot unmarshal number into Go struct field TokenRequestorWorkloadIdentityControllerConfiguration.controllers.tokenRequestorWorkloadIdentity.tokenExpirationDuration of type string","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:495\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313"}
```

It does not help to set a new value for `tokenExpirationDuration` explicitly because the error happens while reading the existing config.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev 

With friendly support from Claude 😄 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
