### PR TITLE
Do not copy pull/CA bundle secrets to seed namespaces and cleanup already copied secrets

### DIFF
--- a/pkg/controllermanager/controller/seed/secrets/add.go
+++ b/pkg/controllermanager/controller/seed/secrets/add.go
@@ -61,7 +61,10 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 
 var (
 	gardenRoleReq      = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
-	gardenRoleSelector = labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq)
+	gardenRoleSelector = labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq, gardenerutils.NoPullOrCABundleSecretsReq)
+	// TODO(shafeeqes): Remove this after gardener v1.145
+	// This selector is used to cleanup already copied secrets with role oci-ca-bundle or oci-pull-secret, which are not needed anymore because now gardenlet can read them from garden namespace directly.
+	deprecatedGardenRoleSelector = labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq)
 )
 
 // GardenSecretPredicate returns true for all events when the respective secret is in the garden namespace and has a

--- a/pkg/controllermanager/controller/seed/secrets/add_test.go
+++ b/pkg/controllermanager/controller/seed/secrets/add_test.go
@@ -71,6 +71,16 @@ var _ = Describe("Add", func() {
 				Expect(f(secret)).To(BeFalse())
 			})
 
+			It("should return false because object has helm-pull-secret role", func() {
+				secret.Labels["gardener.cloud/role"] = "helm-pull-secret"
+				Expect(f(secret)).To(BeFalse())
+			})
+
+			It("should return false because object has oci-ca-bundle role", func() {
+				secret.Labels["gardener.cloud/role"] = "oci-ca-bundle"
+				Expect(f(secret)).To(BeFalse())
+			})
+
 			It("should return true because object matches all conditions", func() {
 				Expect(f(secret)).To(BeTrue())
 			})

--- a/pkg/controllermanager/controller/seed/secrets/reconciler.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler.go
@@ -94,8 +94,9 @@ func (r *Reconciler) cleanupStaleSecrets(ctx context.Context, existingSecrets []
 	var fns []flow.TaskFn
 	exclude := sets.New(existingSecrets...)
 
+	// TODO(shafeeqes): Use gardenRoleSelector after gardener v1.145
 	secretList := &corev1.SecretList{}
-	if err := r.Client.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: gardenRoleSelector}); err != nil {
+	if err := r.Client.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: deprecatedGardenRoleSelector}); err != nil {
 		return err
 	}
 

--- a/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
@@ -119,11 +119,11 @@ var _ = Describe("Reconciler", func() {
 				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
 
 				// Garden secret to sync
-				gardenSecret := createSecret("garden-secret", v1beta1constants.GardenNamespace, []byte("data"), "foo")
+				gardenSecret := createSecret("garden-secret", v1beta1constants.GardenNamespace, "key", []byte("data"), "foo")
 				Expect(fakeClient.Create(ctx, gardenSecret)).To(Succeed())
 
 				// Stale secret in seed namespace that should be deleted
-				staleSecret := createSecret("stale-secret", namespaceName, []byte("old"), "foo")
+				staleSecret := createSecret("stale-secret", namespaceName, "key", []byte("old"), "foo")
 				Expect(fakeClient.Create(ctx, staleSecret)).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
@@ -154,6 +154,63 @@ var _ = Describe("Reconciler", func() {
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespaceName}, updatedNs)).To(Succeed())
 				Expect(updatedNs.Labels).To(HaveKeyWithValue(v1beta1constants.GardenRole, v1beta1constants.GardenRoleSeed))
 			})
+
+			It("should not sync secrets with helm-pull-secret or oci-ca-bundle role", func() {
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namespaceName,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))},
+						Labels:          map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed},
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+
+				// Pull secret in garden namespace — should NOT be synced
+				pullSecret := createSecret("my-pull-secret", v1beta1constants.GardenNamespace, ".dockerconfigjson", []byte("pull"), v1beta1constants.GardenRoleHelmPullSecret)
+				Expect(fakeClient.Create(ctx, pullSecret)).To(Succeed())
+
+				// CA bundle secret in garden namespace — should NOT be synced
+				caBundleSecret := createSecret("my-ca-bundle", v1beta1constants.GardenNamespace, "bundle.crt", []byte("ca"), v1beta1constants.GardenRoleOCICABundle)
+				Expect(fakeClient.Create(ctx, caBundleSecret)).To(Succeed())
+
+				// Regular garden secret — should be synced
+				regularSecret := createSecret("regular-secret", v1beta1constants.GardenNamespace, "key", []byte("data"), "foo")
+				Expect(fakeClient.Create(ctx, regularSecret)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: regularSecret.Name}, &corev1.Secret{})).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: pullSecret.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: caBundleSecret.Name}, &corev1.Secret{})).To(BeNotFoundError())
+			})
+
+			It("should delete stale helm-pull-secret and oci-ca-bundle secrets from seed namespace", func() {
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namespaceName,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))},
+						Labels:          map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed},
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+
+				// Old pull secret and CA bundle secret already copied to seed namespace — should be cleaned up
+				stalePullSecret := createSecret("old-pull-secret", namespaceName, ".dockerconfigjson", []byte("pull"), v1beta1constants.GardenRoleHelmPullSecret)
+				staleCaBundleSecret := createSecret("old-ca-bundle", namespaceName, "bundle.crt", []byte("ca"), v1beta1constants.GardenRoleOCICABundle)
+				Expect(fakeClient.Create(ctx, stalePullSecret)).To(Succeed())
+				Expect(fakeClient.Create(ctx, staleCaBundleSecret)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				// Verify stale pull secret and CA bundle secret were deleted
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: stalePullSecret.Name}, &corev1.Secret{})).To(BeNotFoundError())
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: staleCaBundleSecret.Name}, &corev1.Secret{})).To(BeNotFoundError())
+			})
 		})
 
 		Context("when seed is new", func() {
@@ -163,10 +220,10 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should create namespace and sync secrets if namespace does not exist", func() {
-				gardenSecret1 := createSecret("my-secret-1", v1beta1constants.GardenNamespace, []byte("data"), "foo")
+				gardenSecret1 := createSecret("my-secret-1", v1beta1constants.GardenNamespace, "key", []byte("data"), "foo")
 				Expect(fakeClient.Create(ctx, gardenSecret1)).To(Succeed())
 
-				gardenSecret2 := createSecret("my-secret-2", v1beta1constants.GardenNamespace, []byte("data"), "bar")
+				gardenSecret2 := createSecret("my-secret-2", v1beta1constants.GardenNamespace, "key", []byte("data"), "bar")
 				Expect(fakeClient.Create(ctx, gardenSecret2)).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
@@ -190,7 +247,7 @@ var _ = Describe("Reconciler", func() {
 	})
 })
 
-func createSecret(name, namespace string, data []byte, role string) *corev1.Secret {
+func createSecret(name, namespace string, key string, data []byte, role string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -200,7 +257,7 @@ func createSecret(name, namespace string, data []byte, role string) *corev1.Secr
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"key": data,
+			key: data,
 		},
 	}
 }

--- a/pkg/utils/gardener/secrets.go
+++ b/pkg/utils/gardener/secrets.go
@@ -30,6 +30,8 @@ import (
 var (
 	// NoControlPlaneSecretsReq is a label selector requirement to select non-control plane secrets.
 	NoControlPlaneSecretsReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.NotIn, v1beta1constants.ControlPlaneSecretRoles...)
+	// NoPullOrCABundleSecretsReq is a label selector requirement to select secrets which are not pull secrets or OCI CA bundle secrets.
+	NoPullOrCABundleSecretsReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.NotIn, v1beta1constants.GardenRoleHelmPullSecret, v1beta1constants.GardenRoleOCICABundle)
 	// UncontrolledSecretSelector is a selector for objects which are managed by operators/users and not created by
 	// Gardener controllers.
 	UncontrolledSecretSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(NoControlPlaneSecretsReq)}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind cleanup

**What this PR does / why we need it**:
After #14418 `gardenlet` can directly read referred secrets in controllerdeployment in the `garden` namespace, there is no need to duplicate it per seed namespace.
We need to wait till the above PR is merged is released, otherwise the secret could get cleaned up before `gardenlet` is updated with the change where it directly access the garden secret.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~/hold until `v1.142` release branch is created.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The secrets reconciler in the `gardener-controller-manager` no longer copies secrets with labels `gardener.cloud/role:{helm-pull-secret, oci-ca-bundle}` from garden namespace to the seed namespaces in the virtual cluster. Gardenlet can already access this secret if the secret is referred in a `ControllerDeployment` and the seed has a `ControllerInstallation` referring this deployment.
```
