### PR TITLE
Update `kindest/node` image to `v1.35.1`

### DIFF
--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -25,6 +25,12 @@ The minimum version of a garden cluster that can be used to run Gardener is **`1
 
 The minimum version of a seed cluster that can be connected to Gardener is **`1.31.x`** up to **`1.35.x`**.
 
+> [!WARNING]
+> Kubernetes `v1.35.x` with `x` in `0..3` has a [regression](https://github.com/kubernetes/kubernetes/issues/137409) where the `MaxUnavailableStatefulSet` feature gate (enabled by default in `v1.35`) can cause StatefulSet rolling updates to deadlock when readiness probes fail.
+> This affects seed clusters and can prevent components like `vpn-seed-server` from being updated.
+> If you run a seed cluster with `v1.35.0` to `v1.35.3`, disable the feature gate in `kube-controller-manager` (`--feature-gates=MaxUnavailableStatefulSet=false`).
+> This is fixed in `v1.35.4` and beyond.
+
 ## Shoot Clusters
 
 Gardener itself is capable of spinning up clusters with Kubernetes versions **`1.31`** up to **`1.35`**.

--- a/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
+++ b/example/gardener-local/kind/cluster/templates/_kubeadm_config_patches.tpl
@@ -34,6 +34,11 @@
 {{- else }}
       hostPath: /etc/gardener-local/kube-apiserver/authz-config-without-seedauthorizer.yaml
 {{- end }}
+  controllerManager:
+    extraArgs:
+      # TODO(LucaBernstein): Remove once kind uses a Kubernetes version that includes the fix for
+      # https://github.com/kubernetes/kubernetes/issues/137409 (MaxUnavailableStatefulSet deadlock).
+      feature-gates: "MaxUnavailableStatefulSet=false"
 - |
   apiVersion: kubelet.config.k8s.io/v1beta1
   kind: KubeletConfiguration

--- a/example/gardener-local/kind/cluster/values.yaml
+++ b/example/gardener-local/kind/cluster/values.yaml
@@ -1,4 +1,4 @@
-image: kindest/node:v1.34.2@sha256:745f8ed46d8e99517774768227fd1a0af34a6bf395aef9c7ed98fbce0e263918
+image: kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
 
 gardener:
   apiserverRelay:

--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -3,6 +3,13 @@ FROM kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f828
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends wget apparmor apparmor-utils jq openssh-server sudo logrotate
 
+# TODO(LucaBernstein): kindest/node:v1.35.1 ships containerd v2.2.1 which has a broken `ctr images mount` command
+# (https://github.com/containerd/containerd/issues/12549, fixed in v2.2.2). Override with v2.2.2 until a new
+# kindest/node image is available that includes the fix.
+RUN arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
+    wget -qO- "https://github.com/containerd/containerd/releases/download/v2.2.2/containerd-2.2.2-linux-${arch}.tar.gz" | \
+    tar -xz -C /usr/local/bin --strip-components=1 bin/containerd bin/ctr
+
 # remove kind's kubelet unit
 RUN rm -f /etc/systemd/system/kubelet.service && \
     rm -rf /etc/systemd/system/kubelet.service.d/

--- a/pkg/provider-local/node/Dockerfile
+++ b/pkg/provider-local/node/Dockerfile
@@ -1,5 +1,4 @@
-# TODO(rfranzke): Update to v1.35 once https://github.com/gardener/gardener/pull/13651 is resolved.
-FROM kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+FROM kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends wget apparmor apparmor-utils jq openssh-server sudo logrotate


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `kindest/node` image used in the local setup and provider-local node Dockerfile from `v1.34.2` to `v1.35.1`.

Supersedes #13651.

**Version changes:**

| Component | Before | After |
|---|---|---|
| Kubernetes | v1.34.2 | v1.35.1 |
| containerd | v2.2.0 | v2.2.1 |
| runc | v1.3.3 | v1.3.4 |

The containerd v2.2.1 bump is a patch release (bug fixes only, no config format changes). The existing `VersionGreaterThanEqual22` gate already covers the containerd 2.2.x config path correctly.

All Kubernetes 1.35 support work (feature gates, admission plugins, API groups, controller list, deprecations) was already done in #13845.

 **Special notes for your reviewer**:

 **Release note**:

```other dependency
Update kindest/node image to v1.35.1 (Kubernetes v1.35.1, containerd v2.2.1).
```