### PR TITLE
chore: Promote `UseUnifiedHTTPProxyPort` feature gate to `Beta`

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,7 +28,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CloudProfileCapabilities       | `false` | `Alpha` | `1.117` |         |
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
-| UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` |         |
+| UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` | `1.139` |
+| UseUnifiedHTTPProxyPort        | `true`  | `Beta`  | `1.140` |         |
 | VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |
 | VPAInPlaceUpdates              | `true`  | `Beta`  | `1.138` |         |
 | VictoriaLogsBackend            | `false` | `Alpha` | `1.137` |         |

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -39,7 +39,6 @@ config:
     DefaultSeccompProfile: true
     NewWorkerPoolHash: true
     IstioTLSTermination: true
-    UseUnifiedHTTPProxyPort: true
     VictoriaLogsBackend: true
     VPNBondingModeRoundRobin: true
     PrometheusHealthChecks: true

--- a/example/operator/10-componentconfig.yaml
+++ b/example/operator/10-componentconfig.yaml
@@ -29,7 +29,6 @@ debugging:
   enableContentionProfiling: false
 featureGates:
   DefaultSeccompProfile: true
-  UseUnifiedHTTPProxyPort: true
 controllers:
   garden:
     concurrentSyncs: 1

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -272,7 +272,7 @@ var _ = Describe("APIServerProxy", func() {
 
 		Context("IPv4", func() {
 			It("should deploy the managed resource successfully", func() {
-				testFunc("cb9301ef")
+				testFunc("00d55bbf") // hash of envoy config with V4_ONLY DNS + port 8443 (default: UseUnifiedHTTPProxyPort=true)
 			})
 		})
 
@@ -283,7 +283,7 @@ var _ = Describe("APIServerProxy", func() {
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				testFunc("5a33f6dd")
+				testFunc("25408ef2") // hash of envoy config with V6_ONLY DNS + port 8443 (default: UseUnifiedHTTPProxyPort=true)
 			})
 		})
 
@@ -294,7 +294,7 @@ var _ = Describe("APIServerProxy", func() {
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				testFunc("9e555b69")
+				testFunc("3b9cdaf4") // hash of envoy config with IstioTLSTermination + port 8443 (default: UseUnifiedHTTPProxyPort=true)
 			})
 		})
 	})
@@ -560,7 +560,7 @@ static_resources:
             address:
               socket_address:
                 address: api.internal.local.
-                port_value: 8132
+                port_value: 8443
     upstream_connection_options:
       tcp_keepalive:
         keepalive_time: 7200

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -80,6 +80,7 @@ const (
 	// UseUnifiedHTTPProxyPort enables the API server proxy and shoot VPN client to connect to the unified port using the new X-Gardener-Destination header.
 	// owner: @hown3d
 	// alpha: v1.130.0
+	// beta: v1.140.0
 	UseUnifiedHTTPProxyPort featuregate.Feature = "UseUnifiedHTTPProxyPort"
 
 	// VPAInPlaceUpdates enables the usage of in-place Pod resource updates in the Vertical Pod Autoscaler resources
@@ -139,7 +140,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DoNotCopyBackupCredentials:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	OpenTelemetryCollector:         {Default: true, PreRelease: featuregate.Beta},
 	VictoriaLogsBackend:            {Default: false, PreRelease: featuregate.Alpha},
-	UseUnifiedHTTPProxyPort:        {Default: false, PreRelease: featuregate.Alpha},
+	UseUnifiedHTTPProxyPort:        {Default: true, PreRelease: featuregate.Beta},
 	VPAInPlaceUpdates:              {Default: true, PreRelease: featuregate.Beta},
 	CustomDNSServerInNodeLocalDNS:  {Default: true, PreRelease: featuregate.Beta},
 	VPNBondingModeRoundRobin:       {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenlet/operation/botanist/vpnshoot_test.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot_test.go
@@ -132,11 +132,6 @@ var _ = Describe("VPNShoot", func() {
 		It("should set the network ranges and deploy", func() {
 			vpnShoot.EXPECT().Deploy(ctx)
 			Expect(botanist.DeployVPNShoot(ctx)).To(Succeed())
-
-			Expect(botanist.GardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
-			Expect(shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort),
-			))
 		})
 
 		It("should report a constraint if feature gate UseUnifiedHTTPProxyPort is enabled and remove it if disabled", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Promotes the `UseUnifiedHTTPProxyPort` feature gate to `Beta` (`Alpha` since `v1.130.0`).

Part of [GEP-30](https://github.com/gardener/enhancements/tree/main/geps/0030-apiserver-proxy): Rework API Server Proxy to Drop Proxy Protocol, see ☂️ umbrella issue https://github.com/gardener/gardener/issues/11214

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

The `UseUnifiedHTTPProxyPort` was explicitly enabled in the local setup and we recently (successfully) rolled it out on all our stages at STACKIT, including Prod.

It should be noted that operators using the [`gardener-extension-acl`](https://github.com/stackitcloud/gardener-extension-acl) should ensure that at least version `v1.15.0` is rolled out everywhere (+ reconciliation of shoots) before the upgrade (see release note).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `UseUnifiedHTTPProxyPort` feature gate has been promoted to Beta and is enabled by default. If using the [Gardener ACL Extension](https://github.com/stackitcloud/gardener-extension-acl) you need make sure that at least version `v1.15.0` is installed and all `Shoots` are reconciled before the upgrade.
```
