### PR TITLE
Decouple Shoot-to-collector infrastructure from shootNodeLoggingEnabled flag

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -192,8 +192,9 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 
 		objects = append(objects, istioResources...)
 
-		shootObjects = append(shootObjects, o.getLoggingAgentClusterRole())
-		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, o.getLoggingAgentClusterRole().Name))
+		loggingAgentClusterRole := o.getLoggingAgentClusterRole()
+		shootObjects = append(shootObjects, loggingAgentClusterRole)
+		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, loggingAgentClusterRole.Name))
 	} else {
 		if err := managedresources.DeleteForShoot(ctx, o.client, o.namespace, managedResourceNameTarget); err != nil {
 			return err

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -130,6 +130,33 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		objects                          = []client.Object{}
 	)
 
+	if o.values.ClusterType == component.ClusterTypeShoot {
+
+		if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
+			return err
+		}
+		ingressTLSSecret, err := o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+			Name:                        "logging-tls",
+			CommonName:                  o.values.IngressHost,
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    []string{o.values.IngressHost, o.values.ValiHost},
+			CertType:                    secrets.ServerCert,
+			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
+			SkipPublishingCACertificate: true,
+		}, secretsmanager.SignedByCA(o.values.SecretNameServerCA))
+		if err != nil {
+			return err
+		}
+
+		genericTokenKubeconfigSecret, found := o.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
+		if !found {
+			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
+		}
+		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
+
+		objects = append(objects, o.getIngress(ingressTLSSecret.Name))
+	}
+
 	if o.values.ShootNodeLoggingEnabled {
 		if err := loggingAgentShootAccessSecret.Reconcile(ctx, o.client); err != nil {
 			return err

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -190,6 +190,10 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		if err := managedresources.CreateForShoot(ctx, o.client, o.namespace, managedResourceNameTarget, managedresources.LabelValueGardener, false, resourcesTarget); err != nil {
 			return err
 		}
+	} else {
+		if err := managedresources.DeleteForShoot(ctx, o.client, o.namespace, managedResourceNameTarget); err != nil {
+			return err
+		}
 	}
 
 	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -131,7 +131,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 	)
 
 	if o.values.ClusterType == component.ClusterTypeShoot {
-
 		if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
 			return err
 		}

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -127,7 +127,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		genericTokenKubeconfigSecretName string
 		loggingAgentShootAccessSecret    = o.newLoggingAgentShootAccessSecret()
 		kubeRBACProxyShootAccessSecret   = o.newKubeRBACProxyShootAccessSecret()
-		objects                          = []client.Object{}
+		seedObjects                      = []client.Object{}
 	)
 
 	if o.values.ClusterType == component.ClusterTypeShoot {
@@ -153,7 +153,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
-		objects = append(objects, o.getIngress(ingressTLSSecret.Name))
+		seedObjects = append(seedObjects, o.getIngress(ingressTLSSecret.Name))
 	}
 
 	if o.values.ShootNodeLoggingEnabled {
@@ -193,8 +193,8 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		loggingAgentClusterRole := o.getLoggingAgentClusterRole()
 		loggingAgentClusterRoleBinding := o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, loggingAgentClusterRole.Name)
 
-		resourcesTarget, err := managedresources.
-			NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer).
+		shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+		resourcesTarget, err := shootRegistry.
 			AddAllAndSerialize(
 				kubeRBACProxyClusterRoleBinding,
 				loggingAgentClusterRole,
@@ -219,12 +219,12 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 	}
 
-	objects = append(objects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))
-	objects = append(objects, o.serviceMonitor())
-	objects = append(objects, o.serviceAccount())
+	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))
+	seedObjects = append(seedObjects, o.serviceMonitor())
+	seedObjects = append(seedObjects, o.serviceAccount())
 
-	registry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
-	serializedResources, err := registry.AddAllAndSerialize(objects...)
+	seedRegistry := managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
+	serializedResources, err := seedRegistry.AddAllAndSerialize(seedObjects...)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -42,11 +42,10 @@ import (
 )
 
 const (
-	managedResourceNameTarget           = "logging-target"
-	managedResourceName                 = "opentelemetry-collector"
-	serviceMonitorName                  = "opentelemetry-collector"
-	openTelemetryCollectorName          = "gardener-opentelemetry-collector"
-	kubeRBACProxyClusterRoleBindingName = "gardener.cloud:logging:rbac-proxy"
+	managedResourceNameTarget  = "logging-target"
+	managedResourceName        = "opentelemetry-collector"
+	serviceMonitorName         = "opentelemetry-collector"
+	openTelemetryCollectorName = "gardener-opentelemetry-collector"
 
 	kubeRBACProxyName = "rbac-proxy"
 
@@ -158,7 +157,12 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
-		seedObjects = append(seedObjects, o.getIngress(ingressTLSSecret.Name))
+		istioResources, err := o.getIstioResources(ingressTLSSecret)
+		if err != nil {
+			return fmt.Errorf("failed to get istio resources: %w", err)
+		}
+
+		seedObjects = append(seedObjects, istioResources...)
 		shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
 	}
 
@@ -166,34 +170,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		if err := loggingAgentShootAccessSecret.Reconcile(ctx, o.client); err != nil {
 			return err
 		}
-		if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
-			return err
-		}
-		ingressTLSSecret, err := o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-			Name:                        "logging-tls",
-			CommonName:                  o.values.IngressHost,
-			Organization:                []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:                    []string{o.values.IngressHost, o.values.ValiHost},
-			CertType:                    secrets.ServerCert,
-			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
-			SkipPublishingCACertificate: true,
-		}, secretsmanager.SignedByCA(o.values.SecretNameServerCA))
-		if err != nil {
-			return err
-		}
-
-		genericTokenKubeconfigSecret, found := o.secretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
-		if !found {
-			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
-		}
-		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
-
-		istioResources, err := o.getIstioResources(ingressTLSSecret)
-		if err != nil {
-			return fmt.Errorf("failed to get istio resources: %w", err)
-		}
-
-		objects = append(objects, istioResources...)
 
 		loggingAgentClusterRole := o.getLoggingAgentClusterRole()
 		shootObjects = append(shootObjects, loggingAgentClusterRole)
@@ -234,7 +210,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 func (o *otelCollector) getKubeRBACProxyClusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   kubeRBACProxyClusterRoleBindingName,
+			Name:   "gardener.cloud:logging:rbac-proxy",
 			Labels: map[string]string{v1beta1constants.LabelApp: kubeRBACProxyName},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -133,9 +133,12 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 	)
 
 	if o.values.ClusterType == component.ClusterTypeShoot {
-		if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
-			return err
+		if o.values.WithRBACProxy {
+			if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
+				return err
+			}
 		}
+
 		ingressTLSSecret, err := o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
 			Name:                        "logging-tls",
 			CommonName:                  o.values.IngressHost,

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -194,16 +194,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 
 		shootObjects = append(shootObjects, o.getLoggingAgentClusterRole())
 		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, o.getLoggingAgentClusterRole().Name))
-
-		shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		resourcesTarget, err := shootRegistry.AddAllAndSerialize(shootObjects...)
-		if err != nil {
-			return err
-		}
-
-		if err := managedresources.CreateForShoot(ctx, o.client, o.namespace, managedResourceNameTarget, managedresources.LabelValueGardener, false, resourcesTarget); err != nil {
-			return err
-		}
 	} else {
 		if err := managedresources.DeleteForShoot(ctx, o.client, o.namespace, managedResourceNameTarget); err != nil {
 			return err
@@ -214,13 +204,17 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		); err != nil {
 			return err
 		}
+	}
 
-		if hasClusterRoleBinding(shootObjects, kubeRBACProxyClusterRoleBindingName) {
-			if err := kubernetesutils.DeleteObjects(ctx, o.client,
-				kubeRBACProxyShootAccessSecret.Secret,
-			); err != nil {
-				return err
-			}
+	if len(shootObjects) != 0 {
+		shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+		resourcesTarget, err := shootRegistry.AddAllAndSerialize(shootObjects...)
+		if err != nil {
+			return err
+		}
+
+		if err := managedresources.CreateForShoot(ctx, o.client, o.namespace, managedResourceNameTarget, managedresources.LabelValueGardener, false, resourcesTarget); err != nil {
+			return err
 		}
 	}
 
@@ -235,20 +229,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 	}
 
 	return managedresources.CreateForSeedWithLabels(ctx, o.client, o.namespace, managedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
-}
-
-func hasClusterRoleBinding(objs []client.Object, name string) bool {
-	for _, obj := range objs {
-		crb, ok := obj.(*rbacv1.ClusterRoleBinding)
-		if !ok {
-			continue
-		}
-
-		if crb.Name == name {
-			return true
-		}
-	}
-	return false
 }
 
 func (o *otelCollector) getKubeRBACProxyClusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -136,8 +136,9 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 			if err := kubeRBACProxyShootAccessSecret.Reconcile(ctx, o.client); err != nil {
 				return err
 			}
-		}
 
+			shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
+		}
 		ingressTLSSecret, err := o.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
 			Name:                        "logging-tls",
 			CommonName:                  o.values.IngressHost,
@@ -163,7 +164,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 
 		seedObjects = append(seedObjects, istioResources...)
-		shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
 	}
 
 	if o.values.ShootNodeLoggingEnabled {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -175,9 +175,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		shootObjects = append(shootObjects, loggingAgentClusterRole)
 		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, loggingAgentClusterRole.Name))
 	} else {
-		if err := kubernetesutils.DeleteObjects(ctx, o.client,
-			loggingAgentShootAccessSecret.Secret,
-		); err != nil {
+		if err := kubernetesutils.DeleteObject(ctx, o.client, loggingAgentShootAccessSecret.Secret); err != nil {
 			return err
 		}
 	}

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -196,10 +196,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		shootObjects = append(shootObjects, loggingAgentClusterRole)
 		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, loggingAgentClusterRole.Name))
 	} else {
-		if err := managedresources.DeleteForShoot(ctx, o.client, o.namespace, managedResourceNameTarget); err != nil {
-			return err
-		}
-
 		if err := kubernetesutils.DeleteObjects(ctx, o.client,
 			loggingAgentShootAccessSecret.Secret,
 		); err != nil {

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -188,7 +188,6 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 
 		if err := kubernetesutils.DeleteObjects(ctx, o.client,
 			loggingAgentShootAccessSecret.Secret,
-			kubeRBACProxyShootAccessSecret.Secret,
 		); err != nil {
 			return err
 		}

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -42,10 +42,11 @@ import (
 )
 
 const (
-	managedResourceNameTarget  = "logging-target"
-	managedResourceName        = "opentelemetry-collector"
-	serviceMonitorName         = "opentelemetry-collector"
-	openTelemetryCollectorName = "gardener-opentelemetry-collector"
+	managedResourceNameTarget           = "logging-target"
+	managedResourceName                 = "opentelemetry-collector"
+	serviceMonitorName                  = "opentelemetry-collector"
+	openTelemetryCollectorName          = "gardener-opentelemetry-collector"
+	kubeRBACProxyClusterRoleBindingName = "gardener.cloud:logging:rbac-proxy"
 
 	kubeRBACProxyName = "rbac-proxy"
 
@@ -127,6 +128,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		genericTokenKubeconfigSecretName string
 		loggingAgentShootAccessSecret    = o.newLoggingAgentShootAccessSecret()
 		kubeRBACProxyShootAccessSecret   = o.newKubeRBACProxyShootAccessSecret()
+		shootObjects                     = []client.Object{}
 		seedObjects                      = []client.Object{}
 	)
 
@@ -154,6 +156,7 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
 		seedObjects = append(seedObjects, o.getIngress(ingressTLSSecret.Name))
+		shootObjects = append(shootObjects, o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName))
 	}
 
 	if o.values.ShootNodeLoggingEnabled {
@@ -189,17 +192,11 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 
 		objects = append(objects, istioResources...)
 
-		kubeRBACProxyClusterRoleBinding := o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName)
-		loggingAgentClusterRole := o.getLoggingAgentClusterRole()
-		loggingAgentClusterRoleBinding := o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, loggingAgentClusterRole.Name)
+		shootObjects = append(shootObjects, o.getLoggingAgentClusterRole())
+		shootObjects = append(shootObjects, o.getLoggingAgentClusterRoleBinding(loggingAgentShootAccessSecret.ServiceAccountName, o.getLoggingAgentClusterRole().Name))
 
 		shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		resourcesTarget, err := shootRegistry.
-			AddAllAndSerialize(
-				kubeRBACProxyClusterRoleBinding,
-				loggingAgentClusterRole,
-				loggingAgentClusterRoleBinding,
-			)
+		resourcesTarget, err := shootRegistry.AddAllAndSerialize(shootObjects...)
 		if err != nil {
 			return err
 		}
@@ -217,6 +214,14 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		); err != nil {
 			return err
 		}
+
+		if hasClusterRoleBinding(shootObjects, kubeRBACProxyClusterRoleBindingName) {
+			if err := kubernetesutils.DeleteObjects(ctx, o.client,
+				kubeRBACProxyShootAccessSecret.Secret,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	seedObjects = append(seedObjects, o.openTelemetryCollector(o.namespace, o.values.LokiEndpoint, genericTokenKubeconfigSecretName))
@@ -232,10 +237,24 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 	return managedresources.CreateForSeedWithLabels(ctx, o.client, o.namespace, managedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
 }
 
+func hasClusterRoleBinding(objs []client.Object, name string) bool {
+	for _, obj := range objs {
+		crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+		if !ok {
+			continue
+		}
+
+		if crb.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *otelCollector) getKubeRBACProxyClusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "gardener.cloud:logging:rbac-proxy",
+			Name:   kubeRBACProxyClusterRoleBindingName,
 			Labels: map[string]string{v1beta1constants.LabelApp: kubeRBACProxyName},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -719,11 +719,22 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			values.ShootNodeLoggingEnabled = false
 			component = New(c, namespace, values, fakeSecretManager)
 
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "logging-tls",
+					Namespace: namespace,
+				},
+			}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
+
 			Expect(component.Deploy(ctx)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
-				getIngress(),
+				getGateway(),
+				getVirtualService(),
+				getDestinationRule(),
+				getTLSSecret(tlsSecret),
 				serviceMonitor,
 				serviceAccount,
 			))

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -99,6 +99,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			LokiEndpoint:            lokiEndpoint,
 			Replicas:                1,
 			ShootNodeLoggingEnabled: true,
+			WithRBACProxy:           true,
 			IngressHost:             ingressHost,
 			ValiHost:                valiHost,
 			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
@@ -526,6 +527,16 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			},
 		}
 
+		openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
+		openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume}
+		openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
+			ServicePort: kubeRBACValiServicePort,
+		})
+		openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
+			ServicePort: kubeRBACOTLPServicePort,
+		})
+		metav1.SetMetaDataLabel(&openTelemetryCollector.ObjectMeta, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443", "allowed")
+
 	})
 
 	Describe("#Deploy", func() {
@@ -568,6 +579,10 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Expect(customResourcesManagedResource).To(DeepEqual(expectedMr))
 
 			customResourcesManagedResourceSecret.Name = customResourcesManagedResource.Spec.SecretRefs[0].Name
+			openTelemetryCollector.Spec.AdditionalContainers = nil
+			openTelemetryCollector.Spec.Volumes = nil
+			openTelemetryCollector.Spec.Ports = nil
+			delete(openTelemetryCollector.Labels, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443")
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
 				getGateway(),
@@ -625,15 +640,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Expect(customResourcesManagedResource).To(DeepEqual(expectedMr))
 
 			customResourcesManagedResourceSecret.Name = customResourcesManagedResource.Spec.SecretRefs[0].Name
-			openTelemetryCollector.Spec.AdditionalContainers = []corev1.Container{kubeRBACProxyValiContainer, kubeRBACProxyOTLPContainer}
-			openTelemetryCollector.Spec.Volumes = []corev1.Volume{volume}
-			openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
-				ServicePort: kubeRBACValiServicePort,
-			})
-			openTelemetryCollector.Spec.Ports = append(openTelemetryCollector.Spec.Ports, otelv1beta1.PortsSpec{
-				ServicePort: kubeRBACOTLPServicePort,
-			})
-			metav1.SetMetaDataLabel(&openTelemetryCollector.ObjectMeta, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443", "allowed")
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
 				getGateway(),

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -710,7 +710,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 		})
 
-		It("should still create ingress and secrets when ShootNodeLoggingEnabled is false", func() {
+		It("should create ingress and kubeRBACProxy resources when ShootNodeLoggingEnabled is false", func() {		  
 			values.ShootNodeLoggingEnabled = false
 			component = New(c, namespace, values, fakeSecretManager)
 

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -728,6 +728,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				},
 			}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
 				getGateway(),
@@ -737,8 +738,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				serviceMonitor,
 				serviceAccount,
 			))
-			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(managedResourceTarget).To(consistOf(
 				getKubeRBACProxyClusterRoleBinding(),
 			))

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -580,6 +580,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 			// Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(customResourcesManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(customResourcesManagedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
@@ -675,6 +676,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			managedResourceSecretTarget.Name = managedResourceTarget.Spec.SecretRefs[0].Name
 			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretTarget), managedResourceSecretTarget)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(managedResourceSecretTarget.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(managedResourceSecretTarget.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecretTarget.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
@@ -712,11 +714,13 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			component = New(c, namespace, values, fakeSecretManager)
 
 			Expect(component.Deploy(ctx)).To(Succeed())
-
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
-			customResourcesManagedResourceSecret.Name = customResourcesManagedResource.Spec.SecretRefs[0].Name
-
-			Expect(customResourcesManagedResource).To(consistOf(openTelemetryCollector, getIngress(), serviceMonitor, serviceAccount))
+			Expect(customResourcesManagedResource).To(consistOf(
+				openTelemetryCollector,
+				getIngress(),
+				serviceMonitor,
+				serviceAccount,
+			))
 			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(managedResourceTarget).To(consistOf(

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -719,6 +719,8 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			values.ShootNodeLoggingEnabled = false
 			component = New(c, namespace, values, fakeSecretManager)
 
+			Expect(component.Deploy(ctx)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			tlsSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "logging-tls",
@@ -726,9 +728,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				},
 			}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
-
-			Expect(component.Deploy(ctx)).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
 				getGateway(),

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -709,6 +709,20 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			// Verify that the component created the managed resource
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 		})
+
+		It("should still create ingress and secrets when ShootNodeLoggingEnabled is false", func() {
+			values.ShootNodeLoggingEnabled = false
+			component = New(c, namespace, values, fakeSecretManager)
+
+			Expect(component.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
+			customResourcesManagedResourceSecret.Name = customResourcesManagedResource.Spec.SecretRefs[0].Name
+
+			Expect(customResourcesManagedResource).To(consistOf(openTelemetryCollector, getIngress(), serviceMonitor, serviceAccount))
+			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
+		})
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -722,6 +722,9 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Expect(customResourcesManagedResource).To(consistOf(openTelemetryCollector, getIngress(), serviceMonitor, serviceAccount))
 			Expect(c.Get(ctx, client.ObjectKey{Name: "logging-tls", Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
+			Expect(managedResourceTarget).To(consistOf(
+				getKubeRBACProxyClusterRoleBinding(),
+			))
 		})
 	})
 

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -64,18 +64,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		kubeRBACProxyImage                          = "kube-rbac-proxy:latest"
 		kubeRBACProxyShootAccessSecretName          = "shoot-access-rbac-proxy"
 		opentelemetryCollectorShootAccessSecretName = "shoot-access-opentelemetry-collector"
-		values                                      = Values{
-			Image:                   image,
-			KubeRBACProxyImage:      kubeRBACProxyImage,
-			LokiEndpoint:            lokiEndpoint,
-			Replicas:                1,
-			ShootNodeLoggingEnabled: true,
-			IngressHost:             ingressHost,
-			ValiHost:                valiHost,
-			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
-			PriorityClassName:       "gardener-system-100",
-			ClusterType:             "shoot",
-		}
+		values                                      Values
 
 		c         client.Client
 		component Interface
@@ -104,6 +93,18 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		format.MaxLength = 100000
 		format.TruncateThreshold = 100000
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		values = Values{
+			Image:                   image,
+			KubeRBACProxyImage:      kubeRBACProxyImage,
+			LokiEndpoint:            lokiEndpoint,
+			Replicas:                1,
+			ShootNodeLoggingEnabled: true,
+			IngressHost:             ingressHost,
+			ValiHost:                valiHost,
+			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
+			PriorityClassName:       "gardener-system-100",
+			ClusterType:             "shoot",
+		}
 		fakeSecretManager = fakesecretsmanager.New(c, namespace)
 		component = New(c, namespace, values, fakeSecretManager)
 		consistOf = NewManagedResourceConsistOfObjectsMatcher(c, comptest.CmpOptsForIstio()...)
@@ -681,12 +682,10 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		})
 
 		It("should use custom CA secret name for certificate signing", func() {
-			customValues := values
-			customValues.SecretNameServerCA = "custom-ca-secret"
-			customValues.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
-			customValues.PriorityClassName = "gardener-system-100"
+			values.SecretNameServerCA = "custom-ca-secret"
+			values.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
 
-			component = New(c, namespace, customValues, fakeSecretManager)
+			component = New(c, namespace, values, fakeSecretManager)
 
 			// The main test is that deploy succeeds with a custom CA secret name
 			Expect(component.Deploy(ctx)).To(Succeed())
@@ -696,12 +695,10 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		})
 
 		It("should use seed CA secret when SecretNameServerCA is set to SecretNameCASeed", func() {
-			customValues := values
-			customValues.SecretNameServerCA = v1beta1constants.SecretNameCASeed
-			customValues.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
-			customValues.PriorityClassName = "gardener-system-100"
+			values.SecretNameServerCA = v1beta1constants.SecretNameCASeed
+			values.ShootNodeLoggingEnabled = false // Disable node logging for simpler test
 
-			component = New(c, namespace, customValues, fakeSecretManager)
+			component = New(c, namespace, values, fakeSecretManager)
 
 			// The main test is that deploy succeeds with the seed CA secret
 			Expect(component.Deploy(ctx)).To(Succeed())
@@ -710,7 +707,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 		})
 
-		It("should create ingress and kubeRBACProxy resources when ShootNodeLoggingEnabled is false", func() {		  
+		It("should create ingress and kubeRBACProxy resources when ShootNodeLoggingEnabled is false", func() {
 			values.ShootNodeLoggingEnabled = false
 			component = New(c, namespace, values, fakeSecretManager)
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/area logging
/kind bug

**What this PR does / why we need it**:
Creates kubeRBACProxy+ ingress + kubeconfig secrets for OpenTelemetry setup, even when ShootNodeLogging is disabled.

When feature flag for OTel Collector is set to true and shoot node logging is disabled, the following error occurs on the OTel Collector:
```
failed to create objects for opentelemetry-collector: Deployment.apps "opentelemetry-collector-collector" is invalid: [spec.template.spec.volumes[1].projected.sources[0].secret.name: Required value, spec.template.spec.containers[1].volumeMounts[0].name: Not found: "kubeconfig", spec.template.spec.containers[2].volumeMounts[0].name: Not found: "kubeconfig"]
```

**Release note**:
```bugfix operator
The secret used for the `kube-rbac-proxy` for the `opentelemetry-collector` is now deployed for all shoot clusters, independent of whether node logging is enabled or not. 
```
