### PR TITLE
Adjust default test shoot to Kubernetes 1.35

### DIFF
--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -19,9 +19,3 @@ spec:
     alerting:
       emailReceivers:
       - john.doe@example.com
-  addons:
-    nginxIngress:
-      enabled: true
-    kubernetesDashboard:
-      enabled: true
-      authenticationMode: token

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -152,7 +152,7 @@ func CreateShootTestArtifacts(cfg *ShootCreationConfig, projectNamespace string,
 
 	setShootGeneralSettings(shoot, cfg, clearExtensions)
 
-	setKubernetesVersionDependentSetting(shoot)
+	setKubernetesVersionDependentSettings(shoot)
 
 	setShootNetworkingSettings(shoot, cfg, clearDNS)
 
@@ -223,8 +223,8 @@ func setConfiguredShootAnnotations(shoot *gardencorev1beta1.Shoot, cfg *ShootCre
 	return nil
 }
 
-// setShootGeneralSettings sets the Shoot's settings depending on the used Kubernetes version.
-func setKubernetesVersionDependentSetting(shoot *gardencorev1beta1.Shoot) {
+// setKubernetesVersionDependentSettings sets the Shoot's settings depending on the used Kubernetes version.
+func setKubernetesVersionDependentSettings(shoot *gardencorev1beta1.Shoot) {
 	// TODO(timuthy): Drop this handling when support for Kubernetes 1.34 is dropped.
 	if versionutils.ConstraintK8sLess135.CheckVersion(shoot.Spec.Kubernetes.Version) {
 		if shoot.Spec.Addons == nil {

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 // ShootSeedNamespace gets the shoot namespace in the seed
@@ -151,6 +152,8 @@ func CreateShootTestArtifacts(cfg *ShootCreationConfig, projectNamespace string,
 
 	setShootGeneralSettings(shoot, cfg, clearExtensions)
 
+	setKubernetesVersionDependentSetting(shoot)
+
 	setShootNetworkingSettings(shoot, cfg, clearDNS)
 
 	setShootTolerations(shoot)
@@ -218,6 +221,31 @@ func setConfiguredShootAnnotations(shoot *gardencorev1beta1.Shoot, cfg *ShootCre
 		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, k, v)
 	}
 	return nil
+}
+
+// setShootGeneralSettings sets the Shoot's settings depending on the used Kubernetes version.
+func setKubernetesVersionDependentSetting(shoot *gardencorev1beta1.Shoot) {
+	// TODO(timuthy): Drop this handling when support for Kubernetes 1.34 is dropped.
+	if versionutils.ConstraintK8sLess135.CheckVersion(shoot.Spec.Kubernetes.Version) {
+		if shoot.Spec.Addons == nil {
+			shoot.Spec.Addons = &gardencorev1beta1.Addons{}
+		}
+		if shoot.Spec.Addons.NginxIngress == nil {
+			shoot.Spec.Addons.NginxIngress = &gardencorev1beta1.NginxIngress{
+				Addon: gardencorev1beta1.Addon{
+					Enabled: true,
+				},
+			}
+		}
+		if shoot.Spec.Addons.KubernetesDashboard == nil {
+			shoot.Spec.Addons.KubernetesDashboard = &gardencorev1beta1.KubernetesDashboard{
+				Addon: gardencorev1beta1.Addon{
+					Enabled: true,
+				},
+				AuthenticationMode: ptr.To(gardencorev1beta1.KubernetesDashboardAuthModeToken),
+			}
+		}
+	}
 }
 
 // setShootGeneralSettings sets the Shoot's general settings from the given config


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind regression

**What this PR does / why we need it**:
Adjusts the default shoot spec to the requirements of Kubernetes 1.35, where setting `.spec.addons` is not allowed anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Thanks for noticing @hendrikKahl @IndritFejza
/cc @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The default shoot for test machinery tests was adjusted to work with Kubernetes 1.35.
```
