### PR TITLE
fix(apiserver-proxy): use dedicated network device for apiserver-proxy

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -981,4 +981,4 @@ images:
       name: apiserver-proxy
     sourceRepository: github.com/gardener/apiserver-proxy
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/apiserver-proxy
-    tag: "v0.20.0"
+    tag: "v0.21.0"

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -323,7 +323,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
 									"--daemon=false",
-									"--interface=lo",
+									fmt.Sprintf("--interface=%s", name),
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -348,7 +348,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									fmt.Sprintf("--ip-address=%s", a.values.advertiseIPAddress),
-									"--interface=lo",
+									fmt.Sprintf("--interface=%s", name),
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -629,7 +629,7 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 					AutomountServiceAccountToken: func(b bool) *bool { return &b }(false),
 					Containers: []corev1.Container{
 						{
-							Args:            []string{"--ip-address=" + advertiseIPAddress, "--interface=lo"},
+							Args:            []string{"--ip-address=" + advertiseIPAddress, "--interface=apiserver-proxy"},
 							Image:           "sidecar-image:some-tag",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "sidecar",
@@ -711,7 +711,7 @@ func getDaemonSet(hash string, advertiseIPAddress string) *appsv1.DaemonSet {
 					HostNetwork: true,
 					InitContainers: []corev1.Container{
 						{
-							Args:            []string{"--ip-address=" + advertiseIPAddress, "--daemon=false", "--interface=lo"},
+							Args:            []string{"--ip-address=" + advertiseIPAddress, "--daemon=false", "--interface=apiserver-proxy"},
 							Image:           "sidecar-image:some-tag",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Name:            "setup",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
- This PR sets a dedicated network interface for apiserver-proxy IP address
- This will prevent Linux from using the IP for routing as a source address.

**Which issue(s) this PR fixes**:
- Now we have a globally scopes IP on the loopback device of all nodes
- Loopback has special handling in Linux in that it may be used as a "shortcut" and bypass routing decisions if it has globally scoped IP addresses bound
- This has the unintended side-effect that Linux will choose the supposedly host-only IP for routing, for example when kubelet calls a pod for a liveness probe
- As a consequence, there is a confusing `240.x.x.x` IP address showing up in logs where we would expect the node IP otherwise (i.e. if the node itself calls something)
- Since this is confusing this PR creates a dedicated network device `kubeapiserver` to avoid the loopback shortcut. This means when kubelet (or other processes on the node) sends packets, they will use the node route table to get a source IP again, instead of the apiserver-proxy `240.x.x.x` IP.

**Special notes for your reviewer**:
Recommended new apiserver-proxy release from [here](https://github.com/gardener/apiserver-proxy/pull/226) to clean up the old IP from loopback during deployment.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Apiserver-Proxy uses a dedicated network interface `apiserver-proxy` for its advertised IP address. Requests from nodes such as kubelet probes will use the proper IP as per the route table again.
```
