### PR TITLE
Remove `sast` and `sast-report` checks from `verify` and `verify-extended` make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,10 @@ check-apidiff:
 	@REPO_ROOT=$(REPO_ROOT) ./hack/check-apidiff.sh
 
 .PHONY: verify
-verify: check format test test-integration sast
+verify: check format test test-integration
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test-cov test-cov-clean test-integration sast-report
+verify-extended: check-generate check format test-cov test-cov-clean test-integration
 
 #####################################################################
 # Rules for local environment                                       #


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR removes `sast` and `sast-report` from `verify` and `verify-extended` make targets.

In prow we don't use the `verify` target, but call each target individually ([ref](https://github.com/gardener/ci-infra/blob/9cb2093da4087f8948a4322d47216d262cb5e5a7/config/jobs/gardener/gardener-unit-tests.yaml#L24-L28)).
When releasing there is a dedicated [`sast-lint` job](https://github.com/gardener/gardener/blob/488bb7975d10de6361cf83623423235a386dca60/.github/workflows/build.yaml#L58-L73). Thus, effectively the sast check is running twice when we cut a release. 

With this change the release workflow will be ~6 minutes faster. It also improves speeds up running tests in local dev environments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `sast` and `sast-report` checks have been removed from `verify` and `verify-extended` make targets. Please call them explicitly when required.
```
