### PR TITLE
Add `extractVersion` field to `# renovate` comment for `kustomize` in `tools.mk` so that it can be properly managed by `renovate`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -498,18 +498,6 @@
       enabled: false,
     },
     {
-      // TODO(marc1404): Remove when support for Kubernetes v1.27 is dropped.
-      // Restrict updates of ingress-nginx/controller-chroot@v1.11.x for Kubernetes v1.27 to stay below v1.12.0.
-      matchFileNames: [
-        'imagevector/containers.yaml',
-      ],
-      matchPackageNames: [
-        'registry.k8s.io/ingress-nginx/controller-chroot',
-      ],
-      matchCurrentValue: 'v1.11.*',
-      allowedVersions: '<v1.12.0',
-    },
-    {
       // TODO(marc1404): Remove when supported for containerd v1 is dropped or the following issue is resolved: https://github.com/gardener/gardener/issues/12600
       // Disable major updates of go-toml to stay on v1.x.x.
       // Related issue: https://github.com/gardener/gardener/issues/12600

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -68,7 +68,7 @@ HELM_VERSION ?= v3.20.1
 KIND_VERSION ?= v0.31.0
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 KUBECTL_VERSION ?= v1.35.3
-# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/(?<version>.*)$
 KUSTOMIZE_VERSION ?= v5.3.0
 # renovate: datasource=github-releases depName=prometheus/prometheus
 PROMTOOL_VERSION ?= 3.10.0


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
I noticed that `kustomize` versions hadn't been updated in quite some time - latest one is `v5.8.1` whereas the one we use is `v5.3.0` and it seems like renovate didn't open any PRs to bump the version.

The reason for that seems to be that `kustomize` versions are in the form `kustomize/vX.Y.Z` and an `extractVersion` field is necessary so that renovate can pick up the `vX.Y.Z` part and properly compare it to the version specified in `tools.mk`
Note that the [`makefile-versions.json5`](https://github.com/gardener/ci-infra/blob/eb562d235919e8c5a38d876a6b00033f9ec4846b/config/renovate/makefile-versions.json5) renovate config from the `ci-infra` repo can already handle addition of `extractVersion` to the comment.

Additionally, cleaned up a `TODO` in the renovate config tied to dropping support for k8s `1.27`. /cc @marc1404 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
