### PR TITLE
Create pull secret in garden namespace of virtual garden for remote setup

### DIFF
--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -126,6 +126,9 @@ kubectl create secret docker-registry -n garden gardener-images --docker-server=
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
+  echo "Creating pull secret in garden namespace of virtual garden"
+  kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
+    kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
   if kubectl --kubeconfig "$virtual_garden_kubeconfig" get namespace seed-remote >/dev/null 2>&1; then
     echo "Creating pull secret in seed-remote namespace of virtual garden"
     kubectl create secret docker-registry -n seed-remote gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \

--- a/dev-setup/seed.sh
+++ b/dev-setup/seed.sh
@@ -46,16 +46,16 @@ case "$COMMAND" in
       --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" \
       --status-check=false --platform="linux/$SYSTEM_ARCH" # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
+    if [[ "$SCENARIO" == "remote" ]]; then
+      "$SCRIPT_DIR"/remote/registry/deploy-registry.sh "$KUBECONFIG" "$registry_domain" "$VIRTUAL_GARDEN_KUBECONFIG"
+      kubectl apply -k "$SCRIPT_DIR/remote/registry/kyverno-policies"
+    fi
+
     skaffold $skaffold_command \
       -m gardenlet \
       --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" \
       --cache-artifacts="$($(dirname "$0")/get-skaffold-cache-artifacts.sh)" \
       --status-check=false --platform="linux/$SYSTEM_ARCH" # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
-
-    if [[ "$SCENARIO" == "remote" ]]; then
-      "$SCRIPT_DIR"/remote/registry/deploy-registry.sh "$KUBECONFIG" "$registry_domain" "$VIRTUAL_GARDEN_KUBECONFIG"
-      kubectl apply -k "$SCRIPT_DIR/remote/registry/kyverno-policies"
-    fi
     ;;
 
   down)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Remote setup was broken by https://github.com/gardener/gardener/pull/14331 because the pull secret in garden namespace of virtual garden was missing.
This PR creates the required pull secret. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Create pull secret in garden namespace of virtual garden for remote setup.
```
