### PR TITLE
Split `gardenadm` e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ kind-up kind-down gardener-up gardener-dev gardener-debug gardener-down: export 
 test-e2e-local-simple test-e2e-local-migration test-e2e-local-workerless test-e2e-local ci-e2e-kind ci-e2e-kind-upgrade: export KUBECONFIG = $(GARDENER_LOCAL_KUBECONFIG)
 kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-dev gardenlet-kind2-debug gardenlet-kind2-down: export KUBECONFIG = $(GARDENER_LOCAL2_KUBECONFIG)
 kind-multi-node2-up kind-multi-node2-down: export KUBECONFIG = $(GARDENER_LOCAL_MULTI_NODE2_KUBECONFIG)
-kind-single-node-up kind-single-node-down kind-multi-node-up kind-multi-node-down kind-multi-zone-up kind-multi-zone-down operator%up operator-dev operator-debug operator%down operator-seed-dev test-e2e-local-operator ci-e2e-kind-operator garden-up garden-down gardenadm-up gardenadm-down seed-up seed-down test-e2e-local-gardenadm% ci-e2e-kind-gardenadm remote-%: export KUBECONFIG = $(GARDENER_LOCAL_MULTI_ZONE_KUBECONFIG)
+kind-single-node-up kind-single-node-down kind-multi-node-up kind-multi-node-down kind-multi-zone-up kind-multi-zone-down operator%up operator-dev operator-debug operator%down operator-seed-dev test-e2e-local-operator ci-e2e-kind-operator garden-up garden-down gardenadm-up gardenadm-down seed-up seed-down test-e2e-local-gardenadm% ci-e2e-kind-gardenadm% remote-%: export KUBECONFIG = $(GARDENER_LOCAL_MULTI_ZONE_KUBECONFIG)
 garden-up garden-down operator-seed-% test-e2e-local-ha-% ci-e2e-kind-ha-% ci-e2e-kind-ha-%-upgrade test-e2e-local-migration-ha-multi-node seed-% gardenadm-% remote-%: export VIRTUAL_GARDEN_KUBECONFIG = $(REPO_ROOT)/dev-setup/kubeconfigs/virtual-garden/kubeconfig
 test-e2e-local-ha-% test-e2e-local-migration-ha-multi-node ci-e2e-kind-ha-% ci-e2e-kind-ha-%-upgrade: export KUBECONFIG = $(VIRTUAL_GARDEN_KUBECONFIG)
 # CLUSTER_NAME
@@ -475,8 +475,10 @@ ci-e2e-kind-ha-multi-zone: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-ha-multi-zone.sh
 ci-e2e-kind-operator: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-operator.sh
-ci-e2e-kind-gardenadm: $(KIND) $(YQ)
-	./hack/ci-e2e-kind-gardenadm.sh
+ci-e2e-kind-gardenadm-unmanaged-infra: $(KIND) $(YQ)
+	./hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
+ci-e2e-kind-gardenadm-managed-infra: $(KIND) $(YQ)
+	./hack/ci-e2e-kind-gardenadm-managed-infra.sh
 
 ci-e2e-kind-upgrade: $(KIND) $(YQ)
 	SHOOT_FAILURE_TOLERANCE_TYPE= GARDENER_PREVIOUS_RELEASE=$(GARDENER_PREVIOUS_RELEASE) GARDENER_RELEASE_DOWNLOAD_PATH=$(GARDENER_RELEASE_DOWNLOAD_PATH) GARDENER_NEXT_RELEASE=$(GARDENER_NEXT_RELEASE) GARDENER_LOCAL_KUBECONFIG=$(GARDENER_LOCAL_KUBECONFIG) ./hack/ci-e2e-kind-upgrade.sh

--- a/hack/ci-e2e-kind-gardenadm-managed-infra.sh
+++ b/hack/ci-e2e-kind-gardenadm-managed-infra.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+source $(dirname "${0}")/ci-common.sh
+
+clamp_mss_to_pmtu
+
+# export all container logs and events after test execution
+trap "
+  ( export_artifacts_host_services; export_artifacts_infra )
+  ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden )
+  ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig; export cluster_name='virtual-garden'; export_resource_yamls_for seeds shoots )
+  ( make gardenadm-down SCENARIO=managed-infra )
+  ( make kind-single-node-down )
+" EXIT
+
+make kind-single-node-up
+make gardenadm-up SCENARIO=managed-infra
+
+make test-e2e-local-gardenadm-managed-infra

--- a/hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
+++ b/hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
@@ -22,23 +22,8 @@ trap "
   ( make kind-single-node-down )
 " EXIT
 
-# managed-infra tests cannot run when there is a gardener-operator deployment (i.e., unmanaged-infra/connect tests must run
-# separately). Hence, let's run the managed-infra tests first, then clean them up, and then run the unmanaged-infra/connect
-# tests.
-
-# managed infrastructure
-make kind-single-node-up
-make gardenadm-up SCENARIO=managed-infra
-
-make test-e2e-local-gardenadm-managed-infra
-
-make gardenadm-down SCENARIO=managed-infra
-make kind-single-node-down
-
-# unmanaged infrastructure
 make kind-single-node-up
 make gardenadm-up SCENARIO=unmanaged-infra
 make gardenadm-up SCENARIO=connect
 
 make test-e2e-local-gardenadm-unmanaged-infra
-


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind enhancement

**What this PR does / why we need it**:
The `gardenadm` e2e tests currently run sequentially in a single CI job. The managed-infra and unmanaged-infra scenarios each require their own cluster lifecycle (no `gardener-operator` deployment can be present for managed-infra), so they were run back-to-back with a full teardown in between. Splitting them into two independent CI jobs allows parallel execution and prepares for additional scenarios in the future (see #14387).

Context: https://github.com/gardener/gardener/pull/14368#discussion_r2993304499

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```other developer
NONE
```