### PR TITLE
Restrict `gardenlet` read permissions in `SeedAuthorizer` via field/label selectors

### DIFF
--- a/pkg/admissioncontroller/webhook/auth/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/authorizer.go
@@ -113,9 +113,6 @@ func WithFieldSelectors(fields map[string]string) configFunc {
 
 // WithLabelSelectors is a config function for setting the label selector keys and values. In case multiple pairs are
 // provided, they are OR-ed, i.e., it is enough for a request to be authorized if one of the selectors matches.
-// TODO(rfranzke): Remove this 'nolint' annotation once the function is used.
-//
-//nolint:unused
 func WithLabelSelectors(labels map[string]string) configFunc {
 	return func(req *authzRequest) {
 		req.listWatchSelector.labels = labels

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer.go
@@ -24,8 +24,10 @@ import (
 	"github.com/gardener/gardener/pkg/admissioncontroller/gardenletidentity"
 	seedidentity "github.com/gardener/gardener/pkg/admissioncontroller/gardenletidentity/seed"
 	authwebhook "github.com/gardener/gardener/pkg/admissioncontroller/webhook/auth"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -124,9 +126,10 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			)
 		case bastionResource:
 			return requestAuthorizer.Check(graph.VertexTypeBastion, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch"),
-				authwebhook.WithAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
+				authwebhook.WithAlwaysAllowedVerbs("create"),
 				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithFieldSelectors(map[string]string{operations.BastionSeedName: seedName}),
 			)
 		case certificateSigningRequestResource:
 			if userType == gardenletidentity.UserTypeExtension {
@@ -158,9 +161,9 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return requestAuthorizer.CheckRead(graph.VertexTypeControllerDeployment, attrs)
 		case controllerInstallationResource:
 			return requestAuthorizer.Check(graph.VertexTypeControllerInstallation, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch"),
-				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
 				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithFieldSelectors(map[string]string{gardencore.SeedRefName: seedName}),
 			)
 		case controllerRegistrationResource:
 			return requestAuthorizer.Check(graph.VertexTypeControllerRegistration, attrs,
@@ -181,15 +184,17 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeLease(requestAuthorizer, userType, attrs)
 		case gardenletResource:
 			return requestAuthorizer.Check(graph.VertexTypeGardenlet, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch"),
-				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch", "create"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
+				authwebhook.WithAlwaysAllowedVerbs("create"),
+				authwebhook.WithAllowedNamespaces(v1beta1constants.GardenNamespace),
 				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithFieldSelectors(map[string]string{metav1.ObjectNameField: seedName}),
 			)
 		case managedSeedResource:
 			return requestAuthorizer.Check(graph.VertexTypeManagedSeed, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch"),
-				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
 				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithLabelSelectors(map[string]string{v1beta1constants.LabelPrefixSeedName + seedName: "true"}),
 			)
 		case namespaceResource:
 			return requestAuthorizer.CheckRead(graph.VertexTypeNamespace, attrs)
@@ -206,9 +211,10 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			)
 		case seedResource:
 			return requestAuthorizer.Check(graph.VertexTypeSeed, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch", "delete"),
-				authwebhook.WithAlwaysAllowedVerbs("create", "get", "list", "watch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch", "delete"),
+				authwebhook.WithAlwaysAllowedVerbs("create"),
 				authwebhook.WithAllowedSubresources("status"),
+				authwebhook.WithLabelSelectors(map[string]string{v1beta1constants.LabelPrefixSeedName + seedName: "true"}),
 			)
 		case serviceAccountResource:
 			if userType == gardenletidentity.UserTypeExtension {
@@ -222,9 +228,9 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeServiceAccount(requestAuthorizer, attrs)
 		case shootResource:
 			return requestAuthorizer.Check(graph.VertexTypeShoot, attrs,
-				authwebhook.WithAllowedVerbs("update", "patch"),
-				authwebhook.WithAlwaysAllowedVerbs("get", "list", "watch"),
+				authwebhook.WithAllowedVerbs("get", "list", "watch", "update", "patch"),
 				authwebhook.WithAllowedSubresources("status", "finalizers"),
+				authwebhook.WithLabelSelectors(map[string]string{v1beta1constants.LabelPrefixSeedName + seedName: "true"}),
 			)
 		case shootStateResource:
 			return requestAuthorizer.Check(graph.VertexTypeShootState, attrs,

--- a/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhook/auth/seed/authorizer_test.go
@@ -18,6 +18,8 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
@@ -34,6 +36,7 @@ import (
 	graphutils "github.com/gardener/gardener/pkg/utils/graph"
 	mockgraph "github.com/gardener/gardener/pkg/utils/graph/mock"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
+	fakeauthorizerwebhook "github.com/gardener/gardener/pkg/webhook/authorizer/fake"
 )
 
 var _ = Describe("Seed", func() {
@@ -57,7 +60,7 @@ var _ = Describe("Seed", func() {
 
 		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		graph = mockgraph.NewMockInterface(ctrl)
-		authorizer = NewAuthorizer(log, graph, nil)
+		authorizer = NewAuthorizer(log, graph, fakeauthorizerwebhook.NewWithSelectorsChecker(true))
 
 		seedName = "seed"
 		gardenletUser = &user.DefaultInfo{
@@ -1228,21 +1231,14 @@ var _ = Describe("Seed", func() {
 					}
 				})
 
-				DescribeTable("should allow with consulting the graph because verb is get, list, watch, create",
-					func(verb string) {
-						attrs.Verb = verb
+				It("should allow without consulting the graph because verb is create", func() {
+					attrs.Verb = "create"
 
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
-
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-					Entry("create", "create"),
-				)
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
 
 				DescribeTable("should not have an opinion because verb is not allowed",
 					func(verb string) {
@@ -1286,10 +1282,41 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ subresource", "patch", "status"),
 					Entry("update w/o subresource", "update", ""),
 					Entry("update w/ subresource", "update", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector("spec.seedName=" + seedName)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 
@@ -1311,21 +1338,6 @@ var _ = Describe("Seed", func() {
 						Verb:            "list",
 					}
 				})
-
-				DescribeTable("should allow without consulting the graph because verb is get, list, or watch",
-					func(verb string) {
-						attrs.Verb = verb
-
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
-
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-				)
 
 				DescribeTable("should have no opinion because verb is not allowed",
 					func(verb string) {
@@ -1370,10 +1382,43 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ subresource", "patch", "status"),
 					Entry("update w/o subresource", "update", ""),
 					Entry("update w/ subresource", "update", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if label selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := labels.Parse("name.seed.gardener.cloud/" + seedName + "=true")
+							Expect(err).NotTo(HaveOccurred())
+							reqs, selectable := selector.Requirements()
+							Expect(selectable).To(BeTrue())
+							attrs.LabelSelectorRequirements = reqs
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 
@@ -1384,7 +1429,7 @@ var _ = Describe("Seed", func() {
 				)
 
 				BeforeEach(func() {
-					name, namespace = "foo", "bar"
+					name, namespace = "foo", "garden"
 					attrs = &auth.AttributesRecord{
 						User:            seedUser,
 						Name:            name,
@@ -1396,21 +1441,23 @@ var _ = Describe("Seed", func() {
 					}
 				})
 
-				DescribeTable("should allow without consulting the graph because verb is get, list, watch, or create",
-					func(verb string) {
-						attrs.Verb = verb
+				It("should have no opinion because namespace is not allowed", func() {
+					attrs.Namespace = "other"
 
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionNoOpinion))
+					Expect(reason).To(ContainSubstring("only the following namespaces are allowed for this resource type: [garden]"))
+				})
 
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-					Entry("create", "create"),
-				)
+				It("should allow without consulting the graph because verb is create", func() {
+					attrs.Verb = "create"
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
 
 				DescribeTable("should have no opinion because verb is not allowed",
 					func(verb string) {
@@ -1454,10 +1501,41 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ subresource", "patch", "status"),
 					Entry("update w/o subresource", "update", ""),
 					Entry("update w/ subresource", "update", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector("metadata.name=" + seedName)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 
@@ -1478,21 +1556,6 @@ var _ = Describe("Seed", func() {
 						Verb:            "list",
 					}
 				})
-
-				DescribeTable("should allow without consulting the graph because verb is get, list, or watch",
-					func(verb string) {
-						attrs.Verb = verb
-
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
-
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-				)
 
 				DescribeTable("should have no opinion because verb is not allowed",
 					func(verb string) {
@@ -1537,10 +1600,41 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ subresource", "patch", "status"),
 					Entry("update w/o subresource", "update", ""),
 					Entry("update w/ subresource", "update", "status"),
+				)
+
+				DescribeTable("should allow list/watch requests if field selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := fields.ParseSelector("spec.seedRef.name=" + seedName)
+							Expect(err).NotTo(HaveOccurred())
+							attrs.FieldSelectorRequirements = selector.Requirements()
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 
@@ -1689,21 +1783,6 @@ var _ = Describe("Seed", func() {
 					}
 				})
 
-				DescribeTable("should allow without consulting the graph because verb is get, list, or watch",
-					func(verb string) {
-						attrs.Verb = verb
-
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
-
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-				)
-
 				DescribeTable("should not have an opinion because verb is not allowed",
 					func(verb string) {
 						attrs.Verb = verb
@@ -1747,12 +1826,46 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ status subresource", "get", "status"),
+					Entry("get w/ finalizers subresource", "get", "finalizers"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ status subresource", "patch", "status"),
 					Entry("patch w/ finalizers subresource", "patch", "finalizers"),
 					Entry("update w/o subresource", "update", ""),
 					Entry("update w/ status subresource", "update", "status"),
 					Entry("update w/ finalizers subresource", "update", "finalizers"),
+				)
+
+				DescribeTable("should allow list/watch requests if label selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := labels.Parse("name.seed.gardener.cloud/" + seedName + "=true")
+							Expect(err).NotTo(HaveOccurred())
+							reqs, selectable := selector.Requirements()
+							Expect(selectable).To(BeTrue())
+							attrs.LabelSelectorRequirements = reqs
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
 				)
 			})
 
@@ -1774,21 +1887,14 @@ var _ = Describe("Seed", func() {
 					}
 				})
 
-				DescribeTable("should allow without consulting the graph because verb is get, list, watch, create",
-					func(verb string) {
-						attrs.Verb = verb
+				It("should allow without consulting the graph because verb is create", func() {
+					attrs.Verb = "create"
 
-						decision, reason, err := authorizer.Authorize(ctx, attrs)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(decision).To(Equal(auth.DecisionAllow))
-						Expect(reason).To(BeEmpty())
-					},
-
-					Entry("get", "get"),
-					Entry("list", "list"),
-					Entry("watch", "watch"),
-					Entry("create", "create"),
-				)
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				})
 
 				It("should allow when verb is delete and resource does not exist", func() {
 					attrs.Verb = "delete"
@@ -1822,6 +1928,8 @@ var _ = Describe("Seed", func() {
 						Expect(reason).To(ContainSubstring("no relationship found"))
 					},
 
+					Entry("get w/o subresource", "get", ""),
+					Entry("get w/ subresource", "get", "status"),
 					Entry("patch w/o subresource", "patch", ""),
 					Entry("patch w/ subresource", "patch", "status"),
 					Entry("update w/o subresource", "update", ""),
@@ -1846,6 +1954,37 @@ var _ = Describe("Seed", func() {
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
 					Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
 				})
+
+				DescribeTable("should allow list/watch requests if label selector is provided",
+					func(verb string, withSelector bool) {
+						attrs.Name = ""
+						attrs.Verb = verb
+
+						if withSelector {
+							selector, err := labels.Parse("name.seed.gardener.cloud/" + seedName + "=true")
+							Expect(err).NotTo(HaveOccurred())
+							reqs, selectable := selector.Requirements()
+							Expect(selectable).To(BeTrue())
+							attrs.LabelSelectorRequirements = reqs
+						}
+
+						decision, reason, err := authorizer.Authorize(ctx, attrs)
+						Expect(err).NotTo(HaveOccurred())
+
+						if withSelector {
+							Expect(decision).To(Equal(auth.DecisionAllow))
+							Expect(reason).To(BeEmpty())
+						} else {
+							Expect(decision).To(Equal(auth.DecisionNoOpinion))
+							Expect(reason).To(ContainSubstring("must specify field or label selector"))
+						}
+					},
+
+					Entry("list w/ needed selector", "list", true),
+					Entry("list w/o needed selector", "list", false),
+					Entry("watch w/ needed selector", "watch", true),
+					Entry("watch w/o needed selector", "watch", false),
+				)
 			})
 
 			Context("when requested for ControllerRegistrations", func() {

--- a/pkg/gardenlet/controller/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/add.go
@@ -44,7 +44,10 @@ func AddToManager(
 ) error {
 	var responsibleForUnmanagedSeed bool
 	if err := gardenCluster.GetAPIReader().Get(ctx, client.ObjectKey{Name: cfg.SeedConfig.Name, Namespace: v1beta1constants.GardenNamespace}, &seedmanagementv1alpha1.ManagedSeed{}); err != nil {
-		if !apierrors.IsNotFound(err) {
+		// Forbidden is treated like NotFound because the SeedAuthorizer only grants access to ManagedSeeds
+		// related to this seed via the resource graph. For unmanaged seeds, no ManagedSeed exists and no graph
+		// edge is present, so the authorizer returns Forbidden.
+		if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) {
 			return fmt.Errorf("failed checking whether gardenlet is responsible for a managed seed: %w", err)
 		}
 		// ManagedSeed was not found, hence gardenlet is responsible for an unmanaged seed.


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind enhancement

**What this PR does / why we need it**:
The `gardenlet` already sets proper field/label selectors when watching resources in the garden cluster. This PR leverages the `AuthorizeWithSelectors` infrastructure (introduced in #12958) to restrict `get`/`list`/`watch` from always-allowed to graph/selector-checked for 6 resources: `ControllerInstallation` (field: `spec.seedRef.name`), `Bastion` (field: `spec.seedName`), `Gardenlet` (field: `metadata.name`, namespace: `garden`), `Seed`, `Shoot`, and `ManagedSeed` (label: `name.seed.gardener.cloud/{seedName}`). This shrinks the blast radius of a compromised gardenlet — it can no longer read resources belonging to other seeds without a matching graph path or selector.

For unmanaged seeds (no `ManagedSeed` object exists), the `SeedAuthorizer` now returns `Forbidden` instead of allowing the `get`. The `gardenlet` treats `Forbidden` the same as `NotFound` when checking `ManagedSeed` existence at startup, since both mean the seed is unmanaged.

**Which issue(s) this PR fixes**:
Fixes #12959

**Release note**:
```noteworthy operator
The `SeedAuthorizer` now enforces field/label selectors for `gardenlet` `list`/`watch` requests on `ControllerInstallation`, `Bastion`, `Gardenlet`, `Seed`, `Shoot`, and `ManagedSeed` resources, restricting each gardenlet to only observe resources belonging to its own seed.
```