### PR TITLE
Clean up leftover vars from `test-e2e-local.sh`

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -34,13 +34,4 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   fi
 fi
 
-local_address="172.18.255.1"
-if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
-  local_address="::1"
-fi
-local_address_operator="172.18.255.3"
-if [[ "${IPFAMILY:-}" == "ipv6" ]]; then
-  local_address_operator="::3"
-fi
-
 GO111MODULE=on ginkgo run --timeout=125m $ginkgo_flags --v --show-node-events "$@"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
While comparing [v1.37.4..v1.138.0](https://github.com/gardener/gardener/compare/v1.137.4..v1.138.0) I noticed few stale variables in the `test-e2e-local.sh` can could be also cleaned up after https://github.com/gardener/gardener/pull/14062.
These variables were previously used for the `/etc/hosts` file modifications.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14062

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
