### PR TITLE
[extensions] Enhancements for webhook library

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"time"
 
 	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
@@ -280,16 +281,28 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			heartbeatCtrlOptions.Completed().Apply(&heartbeat.DefaultAddOptions)
 			prometheusWebhookOptions.Completed().Apply(&prometheuswebhook.DefaultAddOptions)
 
-			reconcileOpts.Completed().Apply(&localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation, &localbackupbucket.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localbastion.DefaultAddOptions.IgnoreOperationAnnotation, &localbastion.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation, &localcontrolplane.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localextensionseedcontroller.DefaultAddOptions.IgnoreOperationAnnotation, &localextensionseedcontroller.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localextensionshootcontroller.DefaultAddOptions.IgnoreOperationAnnotation, &localextensionshootcontroller.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation, &localdnsrecord.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation, &localinfrastructure.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localoperatingsystemconfig.DefaultAddOptions.IgnoreOperationAnnotation, &localoperatingsystemconfig.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(&localworker.DefaultAddOptions.IgnoreOperationAnnotation, &localworker.DefaultAddOptions.ExtensionClasses)
-			reconcileOpts.Completed().Apply(nil, &localhealthcheck.DefaultAddOptions.ExtensionClasses)
+			// Apply extension classes
+			localbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localcontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localextensionseedcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localextensionshootcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localoperatingsystemconfig.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localworker.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+			localhealthcheck.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
+
+			// Apply ignore operation option
+			reconcileOpts.Completed().Apply(&localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localbastion.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localextensionseedcontroller.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localextensionshootcontroller.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localoperatingsystemconfig.DefaultAddOptions.IgnoreOperationAnnotation)
+			reconcileOpts.Completed().Apply(&localworker.DefaultAddOptions.IgnoreOperationAnnotation)
 
 			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 				return fmt.Errorf("could not add healthcheck: %w", err)

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -264,6 +264,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Adding controllers to manager")
+			// Use the Apply functionality to convey parameters to the controller configs.
 			bastionCtrlOpts.Completed().Apply(&localbastion.DefaultAddOptions.Controller)
 			controlPlaneCtrlOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.Controller)
 			dnsRecordCtrlOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions)
@@ -274,35 +275,15 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			operatingSystemConfigCtrlOpts.Completed().Apply(&localoperatingsystemconfig.DefaultAddOptions.Controller)
 			serviceCtrlOpts.Completed().Apply(&localservice.DefaultAddOptions)
 			workerCtrlOpts.Completed().Apply(&localworker.DefaultAddOptions.Controller)
-			localworker.DefaultAddOptions.GardenCluster = gardenCluster
-			localworker.DefaultAddOptions.SelfHostedShootCluster = generalOpts.Completed().SelfHostedShootCluster
 			localBackupBucketOptions.Completed().Apply(&localbackupbucket.DefaultAddOptions)
 			localBackupBucketOptions.Completed().Apply(&localbackupentry.DefaultAddOptions)
 			heartbeatCtrlOptions.Completed().Apply(&heartbeat.DefaultAddOptions)
 			prometheusWebhookOptions.Completed().Apply(&prometheuswebhook.DefaultAddOptions)
 
-			// Apply extension classes
-			localbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localcontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localextensionseedcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localextensionshootcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localoperatingsystemconfig.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localworker.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-			localhealthcheck.DefaultAddOptions.ExtensionClasses = slices.Clone(generalOpts.Completed().ExtensionClasses)
-
-			// Apply ignore operation option
-			reconcileOpts.Completed().Apply(&localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localbastion.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localextensionseedcontroller.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localextensionshootcontroller.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localoperatingsystemconfig.DefaultAddOptions.IgnoreOperationAnnotation)
-			reconcileOpts.Completed().Apply(&localworker.DefaultAddOptions.IgnoreOperationAnnotation)
+			// Apply remaining configs manually.
+			localworker.DefaultAddOptions.GardenCluster = gardenCluster
+			applyGeneralOptions(generalOpts)
+			applyReconcileOptions(reconcileOpts)
 
 			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 				return fmt.Errorf("could not add healthcheck: %w", err)
@@ -341,6 +322,37 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd
+}
+
+func applyReconcileOptions(reconcileOpts *extensionscmdcontroller.ReconcilerOptions) {
+	config := reconcileOpts.Completed()
+
+	localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localbastion.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localextensionseedcontroller.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localextensionshootcontroller.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localoperatingsystemconfig.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localworker.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+}
+
+func applyGeneralOptions(generalOpts *extensionscmdcontroller.GeneralOptions) {
+	config := generalOpts.Completed()
+
+	localworker.DefaultAddOptions.SelfHostedShootCluster = config.SelfHostedShootCluster
+
+	localbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localcontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localextensionseedcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localextensionshootcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localoperatingsystemconfig.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localworker.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localhealthcheck.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 }
 
 // verifyGardenAccess uses the extension's access to the garden cluster to request objects related to the seed it is

--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 )
 
@@ -481,6 +482,8 @@ type GeneralOptions struct {
 	GardenerVersion string
 	// SelfHostedShootCluster indicates whether the extension runs in a self-hosted shoot cluster.
 	SelfHostedShootCluster bool
+	// ExtensionClasses defines the extension classes this controller is responsible for.
+	ExtensionClasses []string
 
 	config *GeneralConfig
 }
@@ -491,6 +494,8 @@ type GeneralConfig struct {
 	GardenerVersion string
 	// SelfHostedShootCluster indicates whether the extension runs in a self-hosted shoot cluster.
 	SelfHostedShootCluster bool
+	// ExtensionClasses defines the extension classes this extension is responsible for.
+	ExtensionClasses []extensionsv1alpha1.ExtensionClass
 }
 
 // Complete implements Complete.
@@ -499,6 +504,10 @@ func (r *GeneralOptions) Complete() error {
 		GardenerVersion:        r.GardenerVersion,
 		SelfHostedShootCluster: r.SelfHostedShootCluster,
 	}
+	for _, class := range r.ExtensionClasses {
+		r.config.ExtensionClasses = append(r.config.ExtensionClasses, extensionsv1alpha1.ExtensionClass(class))
+	}
+
 	return nil
 }
 
@@ -516,5 +525,8 @@ func (r *GeneralOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 	if fs.Lookup(SelfHostedShootClusterFlag) == nil {
 		fs.BoolVar(&r.SelfHostedShootCluster, SelfHostedShootClusterFlag, false, "Does the extension run in a self-hosted shoot cluster?")
+	}
+	if fs.Lookup(ExtensionClassesFlag) == nil {
+		fs.StringSliceVar(&r.ExtensionClasses, ExtensionClassesFlag, r.ExtensionClasses, "Extension classes this extension is responsible for.")
 	}
 }

--- a/extensions/pkg/controller/cmd/reconciler_options.go
+++ b/extensions/pkg/controller/cmd/reconciler_options.go
@@ -6,8 +6,6 @@ package cmd
 
 import (
 	"github.com/spf13/pflag"
-
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 const (
@@ -22,8 +20,6 @@ const (
 type ReconcilerOptions struct {
 	// IgnoreOperationAnnotation defines whether to ignore the operation annotation or not.
 	IgnoreOperationAnnotation bool
-	// ExtensionClasses defines the extension classes this controller is responsible for.
-	ExtensionClasses []string
 
 	config *ReconcilerConfig
 }
@@ -31,17 +27,12 @@ type ReconcilerOptions struct {
 // AddFlags implements Flagger.AddFlags.
 func (c *ReconcilerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.IgnoreOperationAnnotation, IgnoreOperationAnnotationFlag, c.IgnoreOperationAnnotation, "Ignore the operation annotation or not.")
-	fs.StringSliceVar(&c.ExtensionClasses, ExtensionClassesFlag, c.ExtensionClasses, "Extension classes this extension is responsible for.")
 }
 
 // Complete implements Completer.Complete.
 func (c *ReconcilerOptions) Complete() error {
 	c.config = &ReconcilerConfig{
 		IgnoreOperationAnnotation: c.IgnoreOperationAnnotation,
-	}
-
-	for _, class := range c.ExtensionClasses {
-		c.config.ExtensionClasses = append(c.config.ExtensionClasses, extensionsv1alpha1.ExtensionClass(class))
 	}
 
 	return nil
@@ -56,16 +47,11 @@ func (c *ReconcilerOptions) Completed() *ReconcilerConfig {
 type ReconcilerConfig struct {
 	// IgnoreOperationAnnotation defines whether to ignore the operation annotation or not.
 	IgnoreOperationAnnotation bool
-	// ExtensionClasses defines the extension classes this controller is responsible for.
-	ExtensionClasses []extensionsv1alpha1.ExtensionClass
 }
 
 // Apply sets the values of this ReconcilerConfig in the given controller.Options.
-func (c *ReconcilerConfig) Apply(ignore *bool, classes *[]extensionsv1alpha1.ExtensionClass) {
+func (c *ReconcilerConfig) Apply(ignore *bool) {
 	if ignore != nil {
 		*ignore = c.IgnoreOperationAnnotation
-	}
-	if classes != nil {
-		*classes = append(*classes, c.ExtensionClasses...)
 	}
 }

--- a/extensions/pkg/webhook/cloudprovider/cloudprovider.go
+++ b/extensions/pkg/webhook/cloudprovider/cloudprovider.go
@@ -50,7 +50,6 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	webhook := &extensionswebhook.Webhook{
 		Name:              WebhookName,
 		Target:            extensionswebhook.TargetSeed,
-		Provider:          args.Provider,
 		Types:             types,
 		Webhook:           &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
 		Path:              WebhookName,

--- a/extensions/pkg/webhook/controlplane/controlplane.go
+++ b/extensions/pkg/webhook/controlplane/controlplane.go
@@ -70,7 +70,6 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 
 	return &extensionswebhook.Webhook{
 		Name:              getName(args.Kind),
-		Provider:          args.Provider,
 		Types:             args.Types,
 		Target:            extensionswebhook.TargetSeed,
 		Path:              getName(args.Kind),

--- a/extensions/pkg/webhook/controlplane/controlplane_test.go
+++ b/extensions/pkg/webhook/controlplane/controlplane_test.go
@@ -44,7 +44,6 @@ var _ = Describe("ControlPlane", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(webhook).NotTo(BeNil())
 				Expect(webhook.Name).To(Equal(expectedName))
-				Expect(webhook.Provider).To(Equal(provider))
 				Expect(webhook.Target).To(Equal(extensionswebhook.TargetSeed))
 				Expect(webhook.Path).To(Equal(expectedName))
 				Expect(webhook.Types).To(Equal(types))

--- a/extensions/pkg/webhook/network/network.go
+++ b/extensions/pkg/webhook/network/network.go
@@ -53,7 +53,6 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	logger.Info("Creating network webhook", "name", name)
 	return &extensionswebhook.Webhook{
 		Name:              name,
-		Provider:          args.NetworkProvider,
 		Types:             args.Types,
 		Target:            extensionswebhook.TargetSeed,
 		Path:              path,

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -97,7 +97,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:            "mutating",
 					Name:              "webhook1",
-					Provider:          "provider1",
 					Types:             []Type{{Obj: &corev1.ConfigMap{}}, {Obj: &corev1.Secret{}}},
 					Target:            TargetSeed,
 					Path:              "path1",
@@ -105,7 +104,6 @@ var _ = Describe("Registration", func() {
 				},
 				{
 					Name:              "webhook2",
-					Provider:          "provider2",
 					Types:             []Type{{Obj: &corev1.Pod{}}},
 					Target:            TargetSeed,
 					Path:              "path2",
@@ -114,7 +112,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:            "mutating",
 					Name:              "webhook3",
-					Provider:          "provider3",
 					Types:             []Type{{Obj: &corev1.ServiceAccount{}, Subresource: ptr.To("token")}},
 					Target:            TargetShoot,
 					Path:              "path3",
@@ -124,7 +121,6 @@ var _ = Describe("Registration", func() {
 				},
 				{
 					Name:          "webhook4",
-					Provider:      "provider4",
 					Types:         []Type{{Obj: &corev1.Service{}}},
 					Target:        TargetShoot,
 					Path:          "path4",
@@ -136,7 +132,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:            "validating",
 					Name:              "webhook1",
-					Provider:          "provider1",
 					Types:             []Type{{Obj: &corev1.ConfigMap{}}, {Obj: &corev1.Secret{}}},
 					Target:            TargetSeed,
 					Path:              "path1",
@@ -145,7 +140,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:            "validating",
 					Name:              "webhook2",
-					Provider:          "provider2",
 					Types:             []Type{{Obj: &corev1.Pod{}}},
 					Target:            TargetSeed,
 					Path:              "path2",
@@ -154,7 +148,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:            "validating",
 					Name:              "webhook3",
-					Provider:          "provider3",
 					Types:             []Type{{Obj: &corev1.ServiceAccount{}, Subresource: ptr.To("token")}},
 					Target:            TargetShoot,
 					Path:              "path3",
@@ -165,7 +158,6 @@ var _ = Describe("Registration", func() {
 				{
 					Action:        "validating",
 					Name:          "webhook4",
-					Provider:      "provider4",
 					Types:         []Type{{Obj: &corev1.Service{}}},
 					Target:        TargetShoot,
 					Path:          "path4",

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -7,8 +7,10 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,6 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 const (
@@ -155,4 +160,29 @@ func New(mgr manager.Manager, args Args) (*Webhook, error) {
 		Webhook:           &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
 		Types:             objTypes,
 	}, nil
+}
+
+// BuildExtensionTypeNamespaceSelector returns a label selector which matches the 'extensions.gardener.cloud/<extension-type>' label.
+// If the webhook is responsible for the 'garden' or 'seed' extension class, the 'garden' namespace is selected.
+func BuildExtensionTypeNamespaceSelector(extensionType string, extensionClasses []extensionsv1alpha1.ExtensionClass) *metav1.LabelSelector {
+	labelSelector := &metav1.LabelSelector{}
+
+	if slices.Contains(extensionClasses, extensionsv1alpha1.ExtensionClassGarden) ||
+		slices.Contains(extensionClasses, extensionsv1alpha1.ExtensionClassSeed) {
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      corev1.LabelMetadataName,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{v1beta1constants.GardenNamespace},
+		})
+	}
+
+	if len(extensionClasses) == 0 || slices.Contains(extensionClasses, extensionsv1alpha1.ExtensionClassShoot) {
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+			Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"true"},
+		})
+	}
+
+	return labelSelector
 }

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -31,16 +31,32 @@ const (
 
 // Webhook is the specification of a webhook.
 type Webhook struct {
-	Action            string
-	Name              string
-	Path              string
-	Target            string
-	Types             []Type
-	Webhook           *admission.Webhook
+	// Action defines whether this is a mutating or validating webhook (ActionMutating or ActionValidating).
+	Action string
+	// Name is the name of the webhook.
+	Name string
+	// Path is the endpoint webhook path.
+	Path string
+	// Target specifies where the webhook is to be installed (TargetSeed or TargetShoot).
+	// For the garden use case, TargetSeed corresponds to a webhook in the runtime garden, whereas TargetShoot
+	// is a webhook configured in the virtual garden cluster.
+	Target string
+	// Types contains the Kubernetes object types and subresources the webhook acts upon.
+	Types []Type
+	// Webhook is the controller-runtime webhook handler with panic recovery enabled.
+	Webhook *admission.Webhook
+	// NamespaceSelector selects namespaces for which the webhook is active.
+	// If nil, the webhook is active for all namespaces.
 	NamespaceSelector *metav1.LabelSelector
-	ObjectSelector    *metav1.LabelSelector
-	FailurePolicy     *admissionregistrationv1.FailurePolicyType
-	TimeoutSeconds    *int32
+	// ObjectSelector selects objects for which the webhook is active based on labels.
+	// If nil, the webhook is active for all objects matching the type.
+	ObjectSelector *metav1.LabelSelector
+	// FailurePolicy defines how unrecognized errors and timeout errors are handled.
+	// If nil, defaults to the Kubernetes default failure policy.
+	FailurePolicy *admissionregistrationv1.FailurePolicyType
+	// TimeoutSeconds specifies the timeout for the webhook call.
+	// If nil, defaults to the Kubernetes default timeout.
+	TimeoutSeconds *int32
 }
 
 // Validator validates objects.
@@ -63,14 +79,28 @@ type Type struct {
 
 // Args contains Webhook creation arguments.
 type Args struct {
-	Name              string
-	Path              string
-	Target            string
+	// Name is the name of the webhook.
+	Name string
+	// Path is the endpoint webhook path.
+	Path string
+	// Target specifies where the webhook is to be installed (TargetSeed or TargetShoot).
+	// For the garden use case, TargetSeed corresponds to a webhook in the runtime garden, whereas TargetShoot
+	// is a webhook configured in the virtual garden cluster.
+	Target string
+	// NamespaceSelector selects namespaces for which the webhook is active.
+	// If nil, the webhook is active for all namespaces.
 	NamespaceSelector *metav1.LabelSelector
-	ObjectSelector    *metav1.LabelSelector
-	Predicates        []predicate.Predicate
-	Validators        map[Validator][]Type
-	Mutators          map[Mutator][]Type
+	// ObjectSelector selects objects for which the webhook is active based on labels.
+	// If nil, the webhook is active for all objects matching the type.
+	ObjectSelector *metav1.LabelSelector
+	// Predicates are additional filters for objects the webhook should process.
+	Predicates []predicate.Predicate
+	// Validators maps Validator implementations to the object types they validate.
+	// Validators cannot be mixed with Mutators in the same webhook.
+	Validators map[Validator][]Type
+	// Mutators maps Mutator implementations to the object types they mutate.
+	// Mutators cannot be mixed with Validators in the same webhook.
+	Mutators map[Mutator][]Type
 }
 
 // New creates a new Webhook with the given args.

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -33,7 +33,6 @@ const (
 type Webhook struct {
 	Action            string
 	Name              string
-	Provider          string
 	Path              string
 	Target            string
 	Types             []Type
@@ -64,7 +63,6 @@ type Type struct {
 
 // Args contains Webhook creation arguments.
 type Args struct {
-	Provider          string
 	Name              string
 	Path              string
 	Target            string
@@ -80,7 +78,7 @@ func New(mgr manager.Manager, args Args) (*Webhook, error) {
 	var (
 		objTypes []Type
 
-		logger  = log.Log.WithName(args.Name).WithValues("provider", args.Provider)
+		logger  = log.Log.WithName(args.Name)
 		builder = NewBuilder(mgr, logger)
 	)
 
@@ -119,7 +117,6 @@ func New(mgr manager.Manager, args Args) (*Webhook, error) {
 
 	return &Webhook{
 		Name:              args.Name,
-		Provider:          args.Provider,
 		Action:            actionType,
 		NamespaceSelector: args.NamespaceSelector,
 		ObjectSelector:    args.ObjectSelector,

--- a/extensions/pkg/webhook/webhook_test.go
+++ b/extensions/pkg/webhook/webhook_test.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	. "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -68,6 +70,153 @@ var _ = Describe("Webhook", func() {
 
 			Expect(webhook).To(BeNil())
 			Expect(err).To(MatchError("failed to create webhook because a mixture of mutating and validating functions is not permitted"))
+		})
+	})
+
+	Describe("#BuildExtensionTypeNamespaceSelector", func() {
+		const extensionType = "local"
+
+		It("should return a namespace selector for garden extension class", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassGarden,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      corev1.LabelMetadataName,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{v1beta1constants.GardenNamespace},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for seed extension class", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassSeed,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      corev1.LabelMetadataName,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{v1beta1constants.GardenNamespace},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for shoot extension class", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassShoot,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for garden and shoot extension classes", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassGarden,
+				extensionsv1alpha1.ExtensionClassShoot,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      corev1.LabelMetadataName,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{v1beta1constants.GardenNamespace},
+					},
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for seed and shoot extension classes", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassSeed,
+				extensionsv1alpha1.ExtensionClassShoot,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      corev1.LabelMetadataName,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{v1beta1constants.GardenNamespace},
+					},
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for all extension classes", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{
+				extensionsv1alpha1.ExtensionClassGarden,
+				extensionsv1alpha1.ExtensionClassSeed,
+				extensionsv1alpha1.ExtensionClassShoot,
+			})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      corev1.LabelMetadataName,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{v1beta1constants.GardenNamespace},
+					},
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for empty extension classes", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, []extensionsv1alpha1.ExtensionClass{})
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
+		})
+
+		It("should return a namespace selector for nil extension classes", func() {
+			selector := BuildExtensionTypeNamespaceSelector(extensionType, nil)
+
+			Expect(selector).To(Equal(&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1beta1constants.LabelExtensionPrefix + extensionType,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			}))
 		})
 	})
 })

--- a/extensions/pkg/webhook/webhook_test.go
+++ b/extensions/pkg/webhook/webhook_test.go
@@ -31,8 +31,7 @@ var _ = Describe("Webhook", func() {
 
 		It("should successfully return a webhook object", func() {
 			webhook, err := New(mgr, Args{
-				Provider: "test-provider",
-				Name:     "webhook-test",
+				Name: "webhook-test",
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"foo": "bar"},
 				},
@@ -46,7 +45,6 @@ var _ = Describe("Webhook", func() {
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(webhook.Provider).To(Equal("test-provider"))
 			Expect(webhook.Name).To(Equal("webhook-test"))
 			Expect(webhook.NamespaceSelector).To(Equal(&metav1.LabelSelector{
 				MatchLabels: map[string]string{"foo": "bar"},

--- a/pkg/provider-local/admission/mutator/webhook.go
+++ b/pkg/provider-local/admission/mutator/webhook.go
@@ -12,7 +12,6 @@ import (
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/provider-local/local"
 )
 
 const (
@@ -27,9 +26,8 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider: local.Type,
-		Name:     Name,
-		Path:     "/webhooks/mutate",
+		Name: Name,
+		Path: "/webhooks/mutate",
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
 			NewShootMutator(mgr):                  {{Obj: &gardencorev1beta1.Shoot{}}},
 			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},

--- a/pkg/provider-local/admission/validator/webhook.go
+++ b/pkg/provider-local/admission/validator/webhook.go
@@ -30,9 +30,8 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider: local.Type,
-		Name:     Name,
-		Path:     "/webhooks/validate",
+		Name: Name,
+		Path: "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
@@ -51,9 +50,8 @@ func NewSecretsWebhook(mgr manager.Manager) (*extensionswebhook.Webhook, error) 
 	logger.Info("Setting up webhook", "name", SecretsValidatorName)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider: local.Type,
-		Name:     SecretsValidatorName,
-		Path:     "/webhooks/validate/secrets",
+		Name: SecretsValidatorName,
+		Path: "/webhooks/validate/secrets",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewSecretValidator(): {{Obj: &corev1.Secret{}}},
 		},

--- a/pkg/provider-local/webhook/networkpolicy/add.go
+++ b/pkg/provider-local/webhook/networkpolicy/add.go
@@ -50,12 +50,11 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 	logger.Info("Creating webhook", "name", name)
 
 	return &extensionswebhook.Webhook{
-		Name:     name,
-		Provider: provider,
-		Types:    types,
-		Target:   extensionswebhook.TargetSeed,
-		Path:     name,
-		Webhook:  &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
+		Name:    name,
+		Types:   types,
+		Target:  extensionswebhook.TargetSeed,
+		Path:    name,
+		Webhook: &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
 		NamespaceSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: v1beta1constants.LabelSeedProvider, Operator: metav1.LabelSelectorOpIn, Values: []string{provider}},
 		}},

--- a/pkg/provider-local/webhook/node/add.go
+++ b/pkg/provider-local/webhook/node/add.go
@@ -51,7 +51,6 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 
 	return &extensionswebhook.Webhook{
 		Name:           WebhookName,
-		Provider:       provider,
 		Types:          types,
 		Target:         extensionswebhook.TargetShoot,
 		Path:           WebhookName,

--- a/pkg/provider-local/webhook/prometheus/add.go
+++ b/pkg/provider-local/webhook/prometheus/add.go
@@ -59,12 +59,11 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionsw
 	logger.Info("Creating webhook", "name", WebhookName)
 
 	return &extensionswebhook.Webhook{
-		Name:     WebhookName,
-		Provider: provider,
-		Types:    types,
-		Target:   extensionswebhook.TargetSeed,
-		Path:     WebhookName,
-		Webhook:  &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
+		Name:    WebhookName,
+		Types:   types,
+		Target:  extensionswebhook.TargetSeed,
+		Path:    WebhookName,
+		Webhook: &admission.Webhook{Handler: handler, RecoverPanic: ptr.To(true)},
 		ObjectSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: v1beta1constants.LabelApp, Operator: metav1.LabelSelectorOpIn, Values: []string{"prometheus"}},
 			{Key: v1beta1constants.LabelRole, Operator: metav1.LabelSelectorOpIn, Values: []string{v1beta1constants.LabelMonitoring}},

--- a/pkg/provider-local/webhook/rolloutspeedup/add.go
+++ b/pkg/provider-local/webhook/rolloutspeedup/add.go
@@ -55,7 +55,6 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebh
 
 	return &extensionswebhook.Webhook{
 		Name:              name,
-		Provider:          provider,
 		Types:             types,
 		Target:            extensionswebhook.TargetSeed,
 		Path:              name,

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -629,32 +629,29 @@ var _ = Describe("Certificates tests", func() {
 
 func newSeedWebhook(_ manager.Manager) (*extensionswebhook.Webhook, error) {
 	return &extensionswebhook.Webhook{
-		Name:     seedWebhookName,
-		Path:     seedWebhookPath,
-		Provider: extensionType,
-		Types:    []extensionswebhook.Type{{Obj: &corev1.Service{}}},
-		Target:   extensionswebhook.TargetSeed,
+		Name:   seedWebhookName,
+		Path:   seedWebhookPath,
+		Types:  []extensionswebhook.Type{{Obj: &corev1.Service{}}},
+		Target: extensionswebhook.TargetSeed,
 	}, nil
 }
 
 func newShootMutatingWebhook(_ manager.Manager) (*extensionswebhook.Webhook, error) {
 	return &extensionswebhook.Webhook{
-		Name:     shootMutatingWebhookName,
-		Path:     shootMutatingWebhookPath,
-		Provider: extensionType,
-		Types:    []extensionswebhook.Type{{Obj: &corev1.ServiceAccount{}}},
-		Target:   extensionswebhook.TargetShoot,
+		Name:   shootMutatingWebhookName,
+		Path:   shootMutatingWebhookPath,
+		Types:  []extensionswebhook.Type{{Obj: &corev1.ServiceAccount{}}},
+		Target: extensionswebhook.TargetShoot,
 	}, nil
 }
 
 func newShootValidatingWebhook(_ manager.Manager) (*extensionswebhook.Webhook, error) {
 	return &extensionswebhook.Webhook{
-		Action:   "validating",
-		Name:     shootValidatingWebhookName,
-		Path:     shootValidatingWebhookPath,
-		Provider: extensionType,
-		Types:    []extensionswebhook.Type{{Obj: &corev1.ServiceAccount{}}},
-		Target:   extensionswebhook.TargetShoot,
+		Action: "validating",
+		Name:   shootValidatingWebhookName,
+		Path:   shootValidatingWebhookPath,
+		Types:  []extensionswebhook.Type{{Obj: &corev1.ServiceAccount{}}},
+		Target: extensionswebhook.TargetShoot,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Key Changes:

1. Added `BuildExtensionTypeNamespaceSelector` helper - New utility function that creates namespace selectors for extension webhooks based on extension classes.
2. Consolidated extension classes to `GeneralConfig` - moved field to a centralized location that's shared across controllers and webhooks, eliminating duplication
3. Enhanced webhook documentation - Added detailed documentation for webhook struct fields
4. Removed obsolete `Provider` parameter - Cleaned up the generic mutator constructor by removing an unused parameter

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A working example was implemented with the `shoot-oidc-service` - see [here](https://github.com/timuthy/gardener-extension-shoot-oidc-service/commit/873fda35efa793b635af4ff42bdc018d65a6bbf4).
/cc @theoddora @dimityrmirchev

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
A new helper function `BuildExtensionTypeNamespaceSelector` has been introduced. It builds proper namespaces selectors for extension webhooks, based on the extension `type` and `class` attributes.
```
```breaking dependency
The obsolete `Provider` field was removed from the `extensionswebhook.Webhook` struct. The field can be removed without substitution.
```