### PR TITLE
Fix TCP settings (`maxConnectionDuration` and `maxConnections`) for kube-apiserver backend connections

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/ingress_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress_test.go
@@ -172,7 +172,8 @@ var _ = Describe("#Ingress", func() {
 				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
-							MaxConnections: 5000,
+							MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+							MaxConnections:        5000,
 							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 								Time:     &durationpb.Duration{Seconds: 7200},
 								Interval: &durationpb.Duration{Seconds: 75},

--- a/pkg/component/kubernetes/apiserverexposure/ingress_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/ingress_test.go
@@ -173,7 +173,6 @@ var _ = Describe("#Ingress", func() {
 					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
 							MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
-							MaxConnections:        5000,
 							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 								Time:     &durationpb.Duration{Seconds: 7200},
 								Interval: &durationpb.Duration{Seconds: 75},

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -135,7 +135,8 @@ var _ = Describe("#SNI", func() {
 				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
-							MaxConnections: 5000,
+							MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+							MaxConnections:        5000,
 							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 								Time:     &durationpb.Duration{Seconds: 7200},
 								Interval: &durationpb.Duration{Seconds: 75},

--- a/pkg/component/kubernetes/apiserverexposure/sni_test.go
+++ b/pkg/component/kubernetes/apiserverexposure/sni_test.go
@@ -136,7 +136,6 @@ var _ = Describe("#SNI", func() {
 					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
 							MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
-							MaxConnections:        5000,
 							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 								Time:     &durationpb.Duration{Seconds: 7200},
 								Interval: &durationpb.Duration{Seconds: 75},

--- a/pkg/component/networking/nginxingress/nginxingress_test.go
+++ b/pkg/component/networking/nginxingress/nginxingress_test.go
@@ -571,6 +571,7 @@ spec:
   trafficPolicy:
     connectionPool:
       tcp:
+        maxConnectionDuration: 86400s
         maxConnections: 5000
         tcpKeepalive:
           interval: 75s

--- a/pkg/component/networking/nginxingress/nginxingress_test.go
+++ b/pkg/component/networking/nginxingress/nginxingress_test.go
@@ -572,7 +572,6 @@ spec:
     connectionPool:
       tcp:
         maxConnectionDuration: 86400s
-        maxConnections: 5000
         tcpKeepalive:
           interval: 75s
           time: 7200s

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -80,7 +80,6 @@ func destinationRuleWithTrafficPolicy(
 				ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 					Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
 						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
-						MaxConnections:        5000,
 						TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 							Time:     &durationpb.Duration{Seconds: 7200},
 							Interval: &durationpb.Duration{Seconds: 75},

--- a/pkg/utils/istio/destinationrule.go
+++ b/pkg/utils/istio/destinationrule.go
@@ -79,7 +79,8 @@ func destinationRuleWithTrafficPolicy(
 			TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 				ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 					Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
-						MaxConnections: 5000,
+						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+						MaxConnections:        5000,
 						TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
 							Time:     &durationpb.Duration{Seconds: 7200},
 							Interval: &durationpb.Duration{Seconds: 75},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Some TCP settings we set in Istio `DestinationRules` are not ideal especially when L7 load-balancing is enabled.

This PR introduces two changes:
- set `maxConnectionDuration` to `86400s` (1 day)
- remove `maxConnections` setting

**`maxConnectionDuration`:**
The client certificates istio-ingressgateway are using to authenticate at kube-apiservers have a validity of 30 days ([ref](https://github.com/gardener/gardener/blame/da9e531b755d2205d8e7753da84416060b4c23b9/pkg/component/kubernetes/apiserverexposure/sni.go#L510)). 
In rare cases we have seen certificate expired errors in kube-apiserver logs.
```
E0331 00:00:32.140182       1 authentication.go:74] "Unable to authenticate the request" err="[x509: certificate has expired or is not yet valid: current time 2026-03-31T00:00:32Z is after 2026-03-30T21:27:42Z, verifying certificate SN=123, SKID=, AKID=456 failed: x509: certificate has expired or is not yet valid: current time 2026-03-31T00:00:32Z is after 2026-03-30T21:27:42Z]"
```

In this case, clients like kubelet receive 401 unauthorized responses as visible in these istio logs. The issue occurs only in few cases but when this happens it affects all requests between the pods.
```
  |   | 2026-03-31 00:00:32 | [2026-03-31T00:00:32Z] "PUT /apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/shoot--abc--xyz-z1-75e6c-mcq7m?timeout=10s HTTP/2" 401 - via_upstream - "-" 595 72 1 1 "10.64.168.1" "kubelet/v1.32.11 (linux/amd64) kubernetes/2195eae" "98000fa6-b758-4949-89ba-d683d7030aba" "api.xyz.abc.gardener.local" "10.64.252.50:443" outbound\|443\|\|kube-apiserver-mtls.shoot--abc--xyz.svc.cluster.local 10.64.112.219:57714 10.64.112.219:9443 10.64.168.1:26335 api.xyz.abc.gardener.local -
```

The client certificate has been rotated at 2026-03-21. The pods of istio-ingressgateway and kube-apiserver have been running since 2026-03-16, so they have seen the old and the new client certificate.

We also noticed that requests from this istio-ingressgateway to other kube-apiserver pods ran successfully. Requests from other istio-ingressgateway pods to this kube-apiserver were successful too.
Thus, it looks like an issue between those two pods only. 
After we rolled the kube-apiserver pod, things got back to normal.

The issue is very hard to debug, because we can't track single connections between istio-ingressgateway and kube-apiserver pods.
I assume that there was a very long lasting HTTP2 connection between the istio-ingressgateway and kube-apiserver pods. This connection last longer than the validity of the istio client certificate. From this point in time all requests which were running over this connection failed.

Setting `maxConnectionDuration` to one day would prevent such issues, because there is an overlay between the validity of the old and the new client certificate. 
The duration is also high enough that the connections are not terminated too often. Thus, even if my assumption is wrong I don't expect an negative impact on performance.

**`maxConnections`**:
The `maxConnections` setting was meant to protect the kube-apiservers from too many connections.
However, since istio-ingressgateway and kube-apiserver both scale horizontally and independent from which other, the resulting maximum number of connections per kube-apiserver instance looks ambiguous.

In an HA setup istio-ingress has minimum 6 and maximum 48 replicas. Kube-apiserver has a minimum of 3 and a maximum of 6 replicas. 
Let's look at the maximum number of connections per kube-apiserver in two edge scenarios:
- Busy seed (48x istio) with lazy kube-apiserver (3x):  48*5000/3 = 80000 connection per kube-apiserver instance
- Lazy seed (6x istio) with busy kube-apiserver (6x): 6*5000/6 = 5000 connections per kube-apiserver instance

The difference between both numbers is bigger than a magnitude. 
Additionally, it is very hard to find out that the number of backend connections is exhausted since client connections enter an Istio queue in this case and remain there until there is a client timeout.
Thus, we should remove this limit since it does not provide a comprehensible connection limit anyway. 

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
There is now `maxConnectionDuration` of 1 day for connections to kube-apiserver endpoints. Their `maxConnections` limit has been removed.
```
