### PR TITLE
`gardenadm`: Fix `--zone` flag help displaying `Shoot` instead of `string` as value type

### DIFF
--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -26,7 +26,7 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
   -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
   -h, --help                 help for init
       --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This is useful for testing purposes to save time.
-  -z, --zone Shoot           Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+  -z, --zone string          Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/gardenadm/gardenadm_join.md
+++ b/docs/cli-reference/gardenadm/gardenadm_join.md
@@ -40,7 +40,7 @@ gardenadm join --bootstrap-token <token> --ca-certificate <ca-cert> --zone zone-
       --control-plane                Create a new control plane instance on this node
   -h, --help                         help for join
   -w, --worker-pool-name string      Name of the worker pool to assign the joining node.
-  -z, --zone Shoot                   Availability zone for the new node. Required if the worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+  -z, --zone string                  Availability zone for the new node. Required if the worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -86,5 +86,5 @@ func (o *Options) Complete() error {
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	o.ManifestOptions.AddFlags(fs)
 	fs.BoolVar(&o.UseBootstrapEtcd, "use-bootstrap-etcd", false, "If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This is useful for testing purposes to save time.")
-	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the `Shoot` has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
+	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 }

--- a/pkg/gardenadm/cmd/join/options.go
+++ b/pkg/gardenadm/cmd/join/options.go
@@ -66,5 +66,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.BootstrapToken, "bootstrap-token", "", "Bootstrap token for joining the cluster (create it with 'gardenadm token' on a control plane node)")
 	fs.StringVarP(&o.WorkerPoolName, "worker-pool-name", "w", "", "Name of the worker pool to assign the joining node.")
 	fs.BoolVar(&o.ControlPlane, "control-plane", false, "Create a new control plane instance on this node")
-	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the worker pool in the `Shoot` has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
+	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/kind bug

**What this PR does / why we need it**:
The `--zone` flag description in `gardenadm init` and `gardenadm join` had backtick-quoted `` `Shoot` `` in the usage string. pflag's [`UnquoteUsage`](https://pkg.go.dev/github.com/spf13/pflag#UnquoteUsage) function (inherited from Go's standard [`flag.UnquoteUsage`](https://pkg.go.dev/flag#UnquoteUsage)) extracts the first backtick-quoted word from the usage string and displays it as the flag's value type. This caused the help output to show `--zone Shoot` instead of `--zone string`.

This PR removes the backticks so pflag falls through to the default type name.

Before:
```
-z, --zone Shoot           Availability zone for the new node. ...
```

After:
```
-z, --zone string          Availability zone for the new node. ...
```

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/14081

**Special notes for your reviewer**:
This is a subtle pflag behavior — backticks in usage strings are not cosmetic. They control the displayed value type in `--help` output.

**Release note**:
```other operator
NONE
```