### PR TITLE
Move the deletion of the Observability tasks as late as possible in the reconciliation loop

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -636,7 +636,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilKubeAPIServerDeleted),
 		})
 
-		syncPoint = flow.NewTaskIDs(
+		syncPointControlPlaneDown = flow.NewTaskIDs(
 			waitUntilKubeAPIServerDeleted,
 			waitUntilControlPlaneDeleted,
 			waitUntilExtensionResourcesAfterKubeAPIServerDeleted,
@@ -649,30 +649,30 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		deleteAlertmanager = g.Add(flow.Task{
 			Name:         "Deleting Shoot Alertmanager",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Alertmanager.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncPointControlPlaneDown),
 		})
 		deletePrometheus = g.Add(flow.Task{
 			Name:         "Deleting Shoot Prometheus",
 			Fn:           flow.TaskFn(botanist.DestroyPrometheus).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncPointControlPlaneDown),
 		})
 		deleteBlackboxExporter = g.Add(flow.Task{
 			Name:         "Destroying control plane blackbox-exporter",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.BlackboxExporter.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncPointControlPlaneDown),
 		})
 		deletePlutono = g.Add(flow.Task{
 			Name:         "Deleting Plutono in Seed",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Plutono.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncPointControlPlaneDown),
 		})
 		destroySeedLogging = g.Add(flow.Task{
 			Name:         "Deleting logging stack in Seed",
 			Fn:           flow.TaskFn(botanist.DestroySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncPointControlPlaneDown),
 		})
 
-		syncObservabilityPoint = flow.NewTaskIDs(
+		syncPointObservabilityDown = flow.NewTaskIDs(
 			deleteAlertmanager,
 			deletePrometheus,
 			deleteBlackboxExporter,
@@ -684,27 +684,27 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Name:         "Destroying internal domain DNS record",
 			Fn:           botanist.DestroyInternalDNSRecord,
 			SkipIf:       !nonTerminatingNamespace,
-			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
+			Dependencies: flow.NewTaskIDs(syncPointObservabilityDown),
 		})
 		destroyReferencedResources = g.Add(flow.Task{
 			Name:         "Deleting referenced resources",
 			Fn:           flow.TaskFn(botanist.DestroyReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
+			Dependencies: flow.NewTaskIDs(syncPointObservabilityDown),
 		})
 		destroyEtcd = g.Add(flow.Task{
 			Name:         "Destroying main and events etcd",
 			Fn:           flow.TaskFn(botanist.DestroyEtcd).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
+			Dependencies: flow.NewTaskIDs(syncPointObservabilityDown),
 		})
 		waitUntilEtcdDeleted = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd have been destroyed",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsDeleted).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncObservabilityPoint, destroyEtcd),
+			Dependencies: flow.NewTaskIDs(syncPointObservabilityDown, destroyEtcd),
 		})
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
 			Fn:           flow.TaskFn(botanist.DeleteSeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncObservabilityPoint, destroyInternalDomainDNSRecord, destroyReferencedResources, waitUntilEtcdDeleted),
+			Dependencies: flow.NewTaskIDs(syncPointObservabilityDown, destroyInternalDomainDNSRecord, destroyReferencedResources, waitUntilEtcdDeleted),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace in Seed has been deleted",

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -353,21 +353,6 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager),
 		})
-		deleteAlertmanager = g.Add(flow.Task{
-			Name:         "Deleting Shoot Alertmanager",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Alertmanager.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
-		deletePrometheus = g.Add(flow.Task{
-			Name:         "Deleting Shoot Prometheus",
-			Fn:           flow.TaskFn(botanist.DestroyPrometheus).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
-		deleteBlackboxExporter = g.Add(flow.Task{
-			Name:         "Destroying control plane blackbox-exporter",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.BlackboxExporter.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
-		})
 		deleteClusterAutoscaler = g.Add(flow.Task{
 			Name: "Deleting cluster autoscaler",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -650,23 +635,8 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       !nonTerminatingNamespace,
 			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilKubeAPIServerDeleted),
 		})
-		deletePlutono = g.Add(flow.Task{
-			Name:         "Deleting Plutono in Seed",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Plutono.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(waitUntilInfrastructureDeleted),
-		})
-		destroySeedLogging = g.Add(flow.Task{
-			Name:         "Deleting logging stack in Seed",
-			Fn:           flow.TaskFn(botanist.DestroySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(waitUntilInfrastructureDeleted),
-		})
 
 		syncPoint = flow.NewTaskIDs(
-			deleteAlertmanager,
-			deletePrometheus,
-			deleteBlackboxExporter,
-			deletePlutono,
-			destroySeedLogging,
 			waitUntilKubeAPIServerDeleted,
 			waitUntilControlPlaneDeleted,
 			waitUntilExtensionResourcesAfterKubeAPIServerDeleted,
@@ -676,31 +646,65 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			waitUntilInfrastructureDeleted,
 		)
 
+		deleteAlertmanager = g.Add(flow.Task{
+			Name:         "Deleting Shoot Alertmanager",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Alertmanager.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+		deletePrometheus = g.Add(flow.Task{
+			Name:         "Deleting Shoot Prometheus",
+			Fn:           flow.TaskFn(botanist.DestroyPrometheus).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+		deleteBlackboxExporter = g.Add(flow.Task{
+			Name:         "Destroying control plane blackbox-exporter",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.BlackboxExporter.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+		deletePlutono = g.Add(flow.Task{
+			Name:         "Deleting Plutono in Seed",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.Plutono.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+		destroySeedLogging = g.Add(flow.Task{
+			Name:         "Deleting logging stack in Seed",
+			Fn:           flow.TaskFn(botanist.DestroySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
+
+		syncObservabilityPoint = flow.NewTaskIDs(
+			deleteAlertmanager,
+			deletePrometheus,
+			deleteBlackboxExporter,
+			deletePlutono,
+			destroySeedLogging,
+		)
+
 		destroyInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record",
 			Fn:           botanist.DestroyInternalDNSRecord,
 			SkipIf:       !nonTerminatingNamespace,
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
 		})
 		destroyReferencedResources = g.Add(flow.Task{
 			Name:         "Deleting referenced resources",
 			Fn:           flow.TaskFn(botanist.DestroyReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
 		})
 		destroyEtcd = g.Add(flow.Task{
 			Name:         "Destroying main and events etcd",
 			Fn:           flow.TaskFn(botanist.DestroyEtcd).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint),
+			Dependencies: flow.NewTaskIDs(syncObservabilityPoint),
 		})
 		waitUntilEtcdDeleted = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd have been destroyed",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsDeleted).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint, destroyEtcd),
+			Dependencies: flow.NewTaskIDs(syncObservabilityPoint, destroyEtcd),
 		})
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
 			Fn:           flow.TaskFn(botanist.DeleteSeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(syncPoint, destroyInternalDomainDNSRecord, destroyReferencedResources, waitUntilEtcdDeleted),
+			Dependencies: flow.NewTaskIDs(syncObservabilityPoint, destroyInternalDomainDNSRecord, destroyReferencedResources, waitUntilEtcdDeleted),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace in Seed has been deleted",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this issue?**

/area monitoring
/kind bug

**What this PR does / why we need it**:
Refine the reconciliation logic so that all Observability-related components are removed as late as possible. This ensures that if any issues arise during the deletion of other components, Observability is still available to capture and report those problems.

**Which issue(s) this PR fixes**:
Fixes #12352 

**Release note**:
```bugfix operator
The observability setup is deleted as late as possible so that, in case an error occurs during the deletion of any components, there is still enough information available to investigate the issue.
```