### PR TITLE
Always Add Image Pull Secrets for Remote Registry

### DIFF
--- a/dev-setup/remote/kyverno-policies/gardener-image-pull-policy.yaml
+++ b/dev-setup/remote/kyverno-policies/gardener-image-pull-policy.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
       Locally built Gardener images are pushed to a container registry on the seed.
-      This registry requires an imagePullSecret, which cannot to gardener components by gardener itself.   
+      This registry requires an imagePullSecret, which cannot be added to gardener components by gardener itself.
 spec:
   failurePolicy: Ignore
   rules:
@@ -18,10 +18,15 @@ spec:
       - resources:
           kinds:
           - Pod
+    context:
+      - name: registrydomain
+        configMap:
+          name: registry-domain
+          namespace: registry
     mutate:
       patchStrategicMerge:
         spec:
           containers:
-          - <(image): "*/local-skaffold*"
+          - <(image): "{{ registrydomain.data.domain }}/*"
           imagePullSecrets:
           - name: gardener-images

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -125,6 +125,10 @@ kubectl create namespace garden --dry-run=client -o yaml |
 kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 
+echo "Creating registry domain ConfigMap"
+kubectl create configmap -n registry registry-domain --from-literal=domain="$registry" --dry-run=client -o yaml | \
+  kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
+
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
   if kubectl --kubeconfig "$virtual_garden_kubeconfig" get namespace seed-remote >/dev/null 2>&1; then
     echo "Creating pull secret in seed-remote namespace of virtual garden"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

As extension developer it is valuable to be able to test the extension in the remote setup. To do so, we push the extension to the registry running in the remote cluster. Since the extension images are built without Skaffold the image name does not include `local-skaffold`. This PR changes the Kyverno policy to add `imagePullSecrets` for all images pulled from the remote registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
In the remote setup Kyverno now always adds imagePullSecret for images in the remote registry.
```
