### PR TITLE
Fix flaky `KubeAPIServer` unit tests

### DIFF
--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -34,6 +34,8 @@ import (
 	apiserverv1alpha1 "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 	apiserverv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -136,7 +138,7 @@ var _ = Describe("KubeAPIServer", func() {
 	)
 
 	BeforeEach(func() {
-		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
 		sm = fakesecretsmanager.New(c, namespace)
 		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
 
@@ -4815,7 +4817,7 @@ kind: AuthenticationConfiguration
 		})
 
 		It("should successfully wait for the deployment to be updated", func() {
-			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
 			fakeKubernetesInterface := fakekubernetes.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 			kapi = New(fakeKubernetesInterface, namespace, nil, Values{
 				Values: apiserver.Values{
@@ -4826,7 +4828,7 @@ kind: AuthenticationConfiguration
 			deploy := deployment.DeepCopy()
 
 			defer test.WithVars(&IntervalWaitForDeployment, time.Millisecond)()
-			defer test.WithVars(&TimeoutWaitForDeployment, 100*time.Millisecond)()
+			defer test.WithVars(&TimeoutWaitForDeployment, 500*time.Millisecond)()
 
 			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())
@@ -4860,13 +4862,13 @@ kind: AuthenticationConfiguration
 
 	Describe("#WaitCleanup", func() {
 		It("should successfully wait for the deployment to be deleted", func() {
-			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
 			fakeKubernetesInterface := fakekubernetes.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 			kapi = New(fakeKubernetesInterface, namespace, nil, Values{})
 			deploy := deployment.DeepCopy()
 
 			defer test.WithVars(&IntervalWaitForDeployment, time.Millisecond)()
-			defer test.WithVars(&TimeoutWaitForDeployment, 100*time.Millisecond)()
+			defer test.WithVars(&TimeoutWaitForDeployment, 500*time.Millisecond)()
 
 			Expect(fakeClient.Create(ctx, deploy)).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(deploy), deploy)).To(Succeed())

--- a/pkg/component/kubernetes/apiserver/apiserver_test.go
+++ b/pkg/component/kubernetes/apiserver/apiserver_test.go
@@ -74,6 +74,16 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.Clock, testclock.NewFakeClock(time.Time{})))
 })
 
+// newSeedFakeClientBuilder returns a fake client builder using the simpler client-go ObjectTracker instead of the
+// default FieldManagedObjectTracker. SeedScheme registers types from ~20 scheme builders (hundreds of GVKs), and the
+// field-managed tracker's REST mapper and structured-merge-diff machinery causes significant overhead, leading to flaky
+// test timeouts under CPU contention.
+func newSeedFakeClientBuilder() *fakeclient.ClientBuilder {
+	return fakeclient.NewClientBuilder().
+		WithScheme(kubernetes.SeedScheme).
+		WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder()))
+}
+
 var _ = Describe("KubeAPIServer", func() {
 	var (
 		ctx = context.Background()
@@ -138,7 +148,7 @@ var _ = Describe("KubeAPIServer", func() {
 	)
 
 	BeforeEach(func() {
-		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
+		c = newSeedFakeClientBuilder().Build()
 		sm = fakesecretsmanager.New(c, namespace)
 		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
 
@@ -4817,7 +4827,7 @@ kind: AuthenticationConfiguration
 		})
 
 		It("should successfully wait for the deployment to be updated", func() {
-			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
+			fakeClient := newSeedFakeClientBuilder().Build()
 			fakeKubernetesInterface := fakekubernetes.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 			kapi = New(fakeKubernetesInterface, namespace, nil, Values{
 				Values: apiserver.Values{
@@ -4862,7 +4872,7 @@ kind: AuthenticationConfiguration
 
 	Describe("#WaitCleanup", func() {
 		It("should successfully wait for the deployment to be deleted", func() {
-			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).WithObjectTracker(testing.NewObjectTracker(kubernetes.SeedScheme, scheme.Codecs.UniversalDecoder())).Build()
+			fakeClient := newSeedFakeClientBuilder().Build()
 			fakeKubernetesInterface := fakekubernetes.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 			kapi = New(fakeKubernetesInterface, namespace, nil, Values{})
 			deploy := deployment.DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind flake

**What this PR does / why we need it**:

The `KubeAPIServer` unit test suite (`pkg/component/kubernetes/apiserver`) intermittently times out at 120s on CI. This has been observed in multiple independent Prow runs:

- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14369/pull-gardener-unit/2039036149422362624
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14465/pull-gardener-unit/2039253682960207872
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14369/pull-gardener-unit/2038682241801916416

**Root cause — fake client object tracker:**

Since controller-runtime v0.22, `fakeclient.NewClientBuilder().Build()` defaults to `NewFieldManagedObjectTracker`, which performs server-side-apply-style field ownership tracking on every `Create`/`Update`. This requires building a REST mapper from the scheme (iterating every registered GVK) and serializing field paths via structured-merge-diff.

`SeedScheme` registers types from ~20 scheme builders (core Kubernetes, extensions, VPA, etcd-druid, MCM, istio, fluent-bit, prometheus-operator, Victoria Metrics, OpenTelemetry, etc.) — hundreds of GVKs. The goroutine dumps from the three Prow runs show the test suite hanging at different points inside this machinery:

- `TestOnlyStaticRESTMapper` → `KnownTypes()` → `maps.(*Iter).Next()`
- `UnsafeGuessKindToResource` → `strings.ToLower()`
- `fieldpath.(*Set).ToJSON` → `serializePathElementToWriter`

The fix is to use `WithObjectTracker(testing.NewObjectTracker(...))` — the simpler client-go tracker that skips field ownership tracking entirely. This is an established pattern: **12 other test files** in the codebase already use it specifically with `SeedScheme` (e.g., `cleaner_test.go`, `health_test.go`, `migration_test.go`). No test files using the smaller `GardenScheme` or `ShootScheme` need this workaround.

**Root cause — timing race in `Wait`/`WaitCleanup`:**

Two tests use `time.AfterFunc(10*time.Millisecond, ...)` to update/delete a deployment, with `TimeoutWaitForDeployment` set to `100*time.Millisecond`. Under CPU contention (e.g., CI nodes running many parallel jobs), the timer callback doesn't fire within 100ms and the test times out. Increasing `TimeoutWaitForDeployment` to `500*time.Millisecond` gives sufficient margin — the test still completes in ~10ms in the common case.

**Stress test results:**

Before the fix: ~2-4% failure rate with `stress -p 32`.
After the fix: **3,958 runs over 10 minutes, 0 failures** with `stress -p 32`.

**Release note**:
```bugfix developer
NONE
```