### PR TITLE
Update dependency gardener/coredns-config-adapter to v0.5.0

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -535,7 +535,7 @@ images:
   - name: coredns-config-adapter
     sourceRepository: github.com/gardener/coredns-config-adapter
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/coredns-config-adapter
-    tag: "v0.4.0"
+    tag: "v0.5.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update image of coredns-config-adapter to `v0.5.0`.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following dependencies have been updated:
- `gardener/coredns-config-adapter` from `v0.4.0` to `v0.5.0`. [Release Notes](https://redirect.github.com/gardener/coredns-config-adapter/releases/tag/v0.5.0)
```
