### PR TITLE
Increase `SpecTimeout` for in-cluster client pod readiness check

### DIFF
--- a/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
+++ b/test/e2e/gardener/shoot/internal/inclusterclient/inclusterclient.go
@@ -125,7 +125,7 @@ func VerifyInClusterAccessToAPIServer(s *ShootContext) {
 					g.Expect(health.IsPodReady(pod)).To(BeTrue())
 				}).Should(Succeed(), "pod %q should get ready", client.ObjectKeyFromObject(pod))
 			}
-		}, SpecTimeout(time.Minute))
+		}, SpecTimeout(3*time.Minute))
 
 		It("should access the API server via direct path", func(ctx SpecContext) {
 			// this pod connects to the API server directly, i.e., uses the KUBERNETES_SERVICE_HOST env var injected by gardener


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind flake

**What this PR does / why we need it**:
The "should wait for test pods to be ready" spec in the `inclusterclient` e2e test uses `SpecTimeout(time.Minute)`. Observed passing durations regularly reach 20-44s, leaving very little headroom. Under transient CI resource pressure, the timeout is exceeded and `--fail-fast` cascades this into a full suite failure.

Analysis of 10 recent `ha-multi-node` failures shows this timeout was the sole root cause in 5 of them (~50%):
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14370/pull-gardener-e2e-kind-ha-multi-node/2039485120628396032
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14481/pull-gardener-e2e-kind-ha-multi-node/2039380689073213440
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14385/pull-gardener-e2e-kind-ha-multi-node/2039576724785598464
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14385/pull-gardener-e2e-kind-ha-multi-node/2039375652955623424
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind-ha-multi-node/2039521833543274496

In the last one (periodic master), 622 of 1042 specs passed — the cluster was healthy, only this single spec's 60s timeout was too short.

This PR increases the timeout to 3 minutes.

**Which issue(s) this PR fixes**:

**Release note**:
```other developer
NONE
```