### PR TITLE
docs: Fix the GEP reference in the apiserver-proxy docs from GEP-11 to GEP-8

### DIFF
--- a/docs/usage/advanced/control-plane-endpoints-and-ports.md
+++ b/docs/usage/advanced/control-plane-endpoints-and-ports.md
@@ -32,7 +32,7 @@ The connections are forwarded via the [HaProxy Proxy Protocol](https://www.envoy
 The Istio ingress-gateway forwards the connection to the respective shoot API Server by it's cluster IP address.
 As TLS termination happens at the API Server, the traffic is end-to-end encrypted the same way as with SNI.
 
-Details can be found in [GEP-0011](https://github.com/gardener/enhancements/tree/main/geps/0011-apiserver-network-proxy).
+Details can be found in [GEP-0008](https://github.com/gardener/enhancements/tree/main/geps/0008-shoot-apiserver-via-sni).
 
 ## Reversed VPN Tunnel
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
The section https://gardener.cloud/docs/gardener/advanced/control-plane-endpoints-and-ports/#kube-apiserver-via-apiserver-proxy
mentions GEP-11 for more details. That GEP is not related to that particular piece of documentation. The documetation is about shoot -> seed requests and the apiserver-proxy -> Istio gateway SNI functionality we use. The GEP is about the kubeapiserver-network-proxy upstream component, which we previously used (something related to KonnectivityTunnel?), but is not used anymore. A more appropriate reference is GEP-8, describing the Istio SNI LB we use (which also mentions examples of a proxy in the shoot to communicate to the API-server, which is the exact same usecase).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
NONE
```
