### PR TITLE
fix: label pull secrets in remote setup to be propagated automatically

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -35,6 +35,11 @@ case "$COMMAND" in
     fi
     # Export kubeconfig for the virtual garden cluster
     RUNTIME_CLUSTER_KUBECONFIG="$KUBECONFIG" GARDEN_NAME="$garden_name" "$(dirname "$0")"/../hack/usage/generate-admin-kubeconfig-local.sh virtual-garden > "$VIRTUAL_GARDEN_KUBECONFIG"
+    # Rerun registry script to deploy pull secret into virtual garden
+    if [[ "$SCENARIO" == "remote" ]]; then
+      registry_domain=$(cat "$(dirname "$0")/remote/registry/registrydomain")
+      "$(dirname "$0")"/remote/registry/deploy-registry.sh "$KUBECONFIG" "$registry_domain" "$VIRTUAL_GARDEN_KUBECONFIG"
+    fi
     ;;
 
   down)

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -133,7 +133,6 @@ kubectl --kubeconfig "$kubeconfig" create configmap -n registry registry-domain 
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
   echo "Creating pull secret in garden namespace of virtual garden"
   kubectl --kubeconfig "$virtual_garden_kubeconfig" create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
-    yq '.metadata.labels["gardener.cloud/role"] = "helm-pull-secret"' | \
     kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
 fi
 

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -124,6 +124,8 @@ kubectl create namespace garden --dry-run=client -o yaml |
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
+# With this label the secret will be propagated automatically for extensions by the gardener-operator
+kubectl label --kubeconfig "$kubeconfig" -n garden secret gardener-images "gardener.cloud/role=helm-pull-secret"
 
 echo "Creating registry domain ConfigMap"
 kubectl create configmap -n registry registry-domain --from-literal=domain="$registry" --dry-run=client -o yaml | \
@@ -133,11 +135,8 @@ if [[ -n "$virtual_garden_kubeconfig" ]]; then
   echo "Creating pull secret in garden namespace of virtual garden"
   kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
     kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
-  if kubectl --kubeconfig "$virtual_garden_kubeconfig" get namespace seed-remote >/dev/null 2>&1; then
-    echo "Creating pull secret in seed-remote namespace of virtual garden"
-    kubectl create secret docker-registry -n seed-remote gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
-      kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
-  fi
+  # With this label the secret will be propagated automatically to all seed namespaces by the gardener-controller-manager
+  kubectl label --kubeconfig "$virtual_garden_kubeconfig" -n garden secret gardener-images "gardener.cloud/role=helm-pull-secret"
 fi
 
 echo "Deploying container registry $registry"

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -120,19 +120,19 @@ stringData:
 EOF
 
 echo "Creating pull secret in garden namespace"
-kubectl create namespace garden --dry-run=client -o yaml |
+kubectl --kubeconfig "$kubeconfig" create namespace garden --dry-run=client -o yaml |
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
-kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
+kubectl --kubeconfig "$kubeconfig" create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
   yq '.metadata.labels["gardener.cloud/role"] = "helm-pull-secret"' | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 
 echo "Creating registry domain ConfigMap"
-kubectl create configmap -n registry registry-domain --from-literal=domain="$registry" --dry-run=client -o yaml | \
+kubectl --kubeconfig "$kubeconfig" create configmap -n registry registry-domain --from-literal=domain="$registry" --dry-run=client -o yaml | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
   echo "Creating pull secret in garden namespace of virtual garden"
-  kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
+  kubectl --kubeconfig "$virtual_garden_kubeconfig" create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
     yq '.metadata.labels["gardener.cloud/role"] = "helm-pull-secret"' | \
     kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
 fi

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -123,7 +123,7 @@ echo "Creating pull secret in garden namespace"
 kubectl create namespace garden --dry-run=client -o yaml |
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
-  kubectl label --dry-run=client -o yaml -f - "gardener.cloud/role=helm-pull-secret" | \
+  yq '.metadata.labels["gardener.cloud/role"] = "helm-pull-secret"' | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 
 echo "Creating registry domain ConfigMap"
@@ -133,7 +133,7 @@ kubectl create configmap -n registry registry-domain --from-literal=domain="$reg
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
   echo "Creating pull secret in garden namespace of virtual garden"
   kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
-    kubectl label --dry-run=client -o yaml -f - "gardener.cloud/role=helm-pull-secret" | \
+    yq '.metadata.labels["gardener.cloud/role"] = "helm-pull-secret"' | \
     kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
 fi
 

--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -123,9 +123,8 @@ echo "Creating pull secret in garden namespace"
 kubectl create namespace garden --dry-run=client -o yaml |
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
 kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
+  kubectl label --dry-run=client -o yaml -f - "gardener.cloud/role=helm-pull-secret" | \
   kubectl --kubeconfig "$kubeconfig" --server-side=true apply  -f -
-# With this label the secret will be propagated automatically for extensions by the gardener-operator
-kubectl label --kubeconfig "$kubeconfig" -n garden secret gardener-images "gardener.cloud/role=helm-pull-secret"
 
 echo "Creating registry domain ConfigMap"
 kubectl create configmap -n registry registry-domain --from-literal=domain="$registry" --dry-run=client -o yaml | \
@@ -134,9 +133,8 @@ kubectl create configmap -n registry registry-domain --from-literal=domain="$reg
 if [[ -n "$virtual_garden_kubeconfig" ]]; then
   echo "Creating pull secret in garden namespace of virtual garden"
   kubectl create secret docker-registry -n garden gardener-images --docker-server="$registry" --docker-username=gardener --docker-password="$password" --docker-email=gardener@localhost --dry-run=client -o yaml | \
+    kubectl label --dry-run=client -o yaml -f - "gardener.cloud/role=helm-pull-secret" | \
     kubectl --kubeconfig "$virtual_garden_kubeconfig" --server-side=true apply  -f -
-  # With this label the secret will be propagated automatically to all seed namespaces by the gardener-controller-manager
-  kubectl label --kubeconfig "$virtual_garden_kubeconfig" -n garden secret gardener-images "gardener.cloud/role=helm-pull-secret"
 fi
 
 echo "Deploying container registry $registry"

--- a/dev-setup/seed.sh
+++ b/dev-setup/seed.sh
@@ -46,6 +46,7 @@ case "$COMMAND" in
       --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" \
       --status-check=false --platform="linux/$SYSTEM_ARCH" # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
+    # Rerun registry script to deploy pull secret into virtual garden
     if [[ "$SCENARIO" == "remote" ]]; then
       "$SCRIPT_DIR"/remote/registry/deploy-registry.sh "$KUBECONFIG" "$registry_domain" "$VIRTUAL_GARDEN_KUBECONFIG"
       kubectl apply -k "$SCRIPT_DIR/remote/registry/kyverno-policies"

--- a/dev-setup/seed.sh
+++ b/dev-setup/seed.sh
@@ -46,17 +46,15 @@ case "$COMMAND" in
       --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" \
       --status-check=false --platform="linux/$SYSTEM_ARCH" # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
 
-    # Rerun registry script to deploy pull secret into virtual garden
-    if [[ "$SCENARIO" == "remote" ]]; then
-      "$SCRIPT_DIR"/remote/registry/deploy-registry.sh "$KUBECONFIG" "$registry_domain" "$VIRTUAL_GARDEN_KUBECONFIG"
-      kubectl apply -k "$SCRIPT_DIR/remote/registry/kyverno-policies"
-    fi
-
     skaffold $skaffold_command \
       -m gardenlet \
       --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" \
       --cache-artifacts="$($(dirname "$0")/get-skaffold-cache-artifacts.sh)" \
       --status-check=false --platform="linux/$SYSTEM_ARCH" # deployments don't exist in virtual-garden, see https://skaffold.dev/docs/status-check/; nodes don't exist in virtual-garden, ensure skaffold use the host architecture instead of amd64, see https://skaffold.dev/docs/workflows/handling-platforms/
+
+    if [[ "$SCENARIO" == "remote" ]]; then
+      kubectl apply -k "$SCRIPT_DIR/remote/registry/kyverno-policies"
+    fi
     ;;
 
   down)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

This PR adds a `gardener.cloud/role=helm-pull-secret` label to the `gardener-images` `Secret` in the remote setup. With this label gardener-operator and gardener-controller-manager will automatically propagate the secret to all necessary namespaces in the virtual garden. In particular this is required for extension Helm charts to be pulled from the remote registry in the seed cluster. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Pull secrets in the remote setup are labeled correctly to be automatically propagated
```
