### PR TITLE
Ignore nodes not managed by MCM from GNA lease check

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -688,7 +688,7 @@ func (h *Health) CheckClusterNodes(
 		return nil, err
 	}
 
-	if err := CheckNodeAgentLeases(nodeList, leaseList, h.clock); err != nil {
+	if err := CheckNodeAgentLeases(nodesManagedByMCM, leaseList, h.clock); err != nil {
 		c := v1beta1helper.FailedCondition(h.clock, h.shoot.GetInfo().Status.LastOperation, h.conditionThresholds, condition, "NodeAgentUnhealthy", err.Error())
 		return &c, nil
 	}
@@ -708,7 +708,7 @@ func (h *Health) CheckClusterNodes(
 }
 
 // CheckNodeAgentLeases checks if all nodes in the shoot cluster have a corresponding Lease object maintained by gardener-node-agent
-func CheckNodeAgentLeases(nodeList *corev1.NodeList, leaseList *coordinationv1.LeaseList, clock clock.Clock) error {
+func CheckNodeAgentLeases(nodeList []*corev1.Node, leaseList *coordinationv1.LeaseList, clock clock.Clock) error {
 	nodeNameToLease := make(map[string]coordinationv1.Lease, len(leaseList.Items))
 	for _, lease := range leaseList.Items {
 		if strings.HasPrefix(lease.Name, gardenerutils.NodeLeasePrefix) {
@@ -717,7 +717,7 @@ func CheckNodeAgentLeases(nodeList *corev1.NodeList, leaseList *coordinationv1.L
 		}
 	}
 
-	for _, node := range nodeList.Items {
+	for _, node := range nodeList {
 		lease, ok := nodeNameToLease[node.Name]
 		if !ok {
 			return fmt.Errorf("gardener-node-agent is not running on node %q", node.Name)

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -271,15 +271,18 @@ var _ = Describe("health check", func() {
 		})
 
 		DescribeTable("#CheckClusterNodes",
-			func(k8sversion *semver.Version, nodes []corev1.Node, workerPools []gardencorev1beta1.Worker, oscSecretMeta map[string]metav1.ObjectMeta, conditionMatcher types.GomegaMatcher) {
+			func(k8sversion *semver.Version, nodes []corev1.Node, workerPools []gardencorev1beta1.Worker, oscSecretMeta map[string]metav1.ObjectMeta, desiredMachines int32, leases []coordinationv1.Lease, conditionMatcher types.GomegaMatcher) {
 				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
 					*list = corev1.NodeList{Items: nodes}
 					return nil
 				})
 
+				if desiredMachines == 0 {
+					desiredMachines = int32(len(nodes))
+				}
 				Expect(fakeClient.Create(ctx, &machinev1alpha1.MachineDeployment{
 					ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
-					Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(len(nodes))},
+					Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: desiredMachines},
 				})).To(Succeed())
 
 				secretListOptions := []client.ListOption{
@@ -297,6 +300,13 @@ var _ = Describe("health check", func() {
 					return nil
 				})
 
+				if leases != nil {
+					c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&coordinationv1.LeaseList{}), client.InNamespace(metav1.NamespaceSystem)).DoAndReturn(func(_ context.Context, list *coordinationv1.LeaseList, _ ...client.ListOption) error {
+						*list = coordinationv1.LeaseList{Items: leases}
+						return nil
+					})
+				}
+
 				shootObj := &shootpkg.Shoot{
 					ControlPlaneNamespace: controlPlaneNamespace,
 					KubernetesVersion:     k8sversion,
@@ -309,7 +319,15 @@ var _ = Describe("health check", func() {
 					},
 				})
 				seedObj := &seedpkg.Seed{}
-				seedObj.SetInfo(&gardencorev1beta1.Seed{})
+				seedObj.SetInfo(&gardencorev1beta1.Seed{
+					Spec: gardencorev1beta1.SeedSpec{
+						Settings: &gardencorev1beta1.SeedSettings{
+							DependencyWatchdog: &gardencorev1beta1.SeedSettingDependencyWatchdog{
+								Prober: &gardencorev1beta1.SeedSettingDependencyWatchdogProber{Enabled: false},
+							},
+						},
+					},
+				})
 
 				health := NewHealth(
 					logr.Discard(),
@@ -341,6 +359,8 @@ var _ = Describe("health check", func() {
 					},
 				},
 				nil,
+				int32(0),
+				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("missing operating system config secret metadata for worker pool %q", workerPoolName1)))),
 			Entry("missing OSC secret checksum for a worker pool when shoot has not been reconciled yet",
 				kubernetesVersion,
@@ -354,6 +374,8 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
+				nil,
+				int32(0),
 				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("missing operating system config secret metadata for worker pool %q", workerPoolName1)))),
 			Entry("no OSC node checksum for a worker pool",
@@ -369,6 +391,8 @@ var _ = Describe("health check", func() {
 					},
 				},
 				oscSecretMeta,
+				int32(0),
+				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("the last successfully applied operating system config on node %q hasn't been reported yet", nodeName)))),
 			Entry("no OSC node checksum for a worker pool when shoot has not been reconciled yet",
 				kubernetesVersion,
@@ -383,6 +407,8 @@ var _ = Describe("health check", func() {
 					},
 				},
 				oscSecretMeta,
+				int32(0),
+				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("the last successfully applied operating system config on node %q hasn't been reported yet", nodeName)))),
 			Entry("outdated OSC secret checksum for a worker pool",
 				kubernetesVersion,
@@ -403,6 +429,8 @@ var _ = Describe("health check", func() {
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},
 				},
+				int32(0),
+				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("the last successfully applied operating system config on node %q is outdated", nodeName)))),
 			Entry("outdated OSC secret checksum for a worker pool when shoot has not been reconciled yet",
 				kubernetesVersion,
@@ -423,7 +451,60 @@ var _ = Describe("health check", func() {
 						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
 					},
 				},
+				int32(0),
+				nil,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "OperatingSystemConfigOutdated", fmt.Sprintf("the last successfully applied operating system config on node %q is outdated", nodeName)))),
+			Entry("should not report NodeAgentUnhealthy for nodes not managed by MCM",
+				kubernetesVersion,
+				[]corev1.Node{
+					newNode(
+						labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()},
+						map[string]string{nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: cloudConfigSecretChecksum1},
+						kubernetesVersion.Original(),
+					),
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "non-mcm-node",
+							Annotations: map[string]string{
+								"node.machine.sapcloud.io/not-managed-by-mcm": "1",
+							},
+						},
+					},
+				},
+				[]gardencorev1beta1.Worker{{Name: workerPoolName1, Maximum: 10, Minimum: 1}},
+				map[string]metav1.ObjectMeta{
+					workerPoolName1: {
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
+						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
+						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
+					},
+				},
+				int32(1),
+				[]coordinationv1.Lease{{
+					ObjectMeta: metav1.ObjectMeta{Name: "gardener-node-agent-" + nodeName},
+					Spec:       coordinationv1.LeaseSpec{RenewTime: &metav1.MicroTime{Time: time.Now()}, LeaseDurationSeconds: ptr.To[int32](40)},
+				}},
+				BeNil()),
+			Entry("should report NodeAgentUnhealthy for managed node without lease",
+				kubernetesVersion,
+				[]corev1.Node{
+					newNode(
+						labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": kubernetesVersion.Original()},
+						map[string]string{nodeagentconfigv1alpha1.AnnotationKeyChecksumAppliedOperatingSystemConfig: cloudConfigSecretChecksum1},
+						kubernetesVersion.Original(),
+					),
+				},
+				[]gardencorev1beta1.Worker{{Name: workerPoolName1, Maximum: 10, Minimum: 1}},
+				map[string]metav1.ObjectMeta{
+					workerPoolName1: {
+						Name:        operatingsystemconfig.KeyV1(workerPoolName1, kubernetesVersion, nil),
+						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
+						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
+					},
+				},
+				int32(0),
+				[]coordinationv1.Lease{},
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "NodeAgentUnhealthy", fmt.Sprintf("gardener-node-agent is not running on node %q", nodeName)))),
 		)
 	})
 
@@ -994,12 +1075,10 @@ var _ = Describe("health check", func() {
 				},
 			}
 
-			nodeList = corev1.NodeList{
-				Items: []corev1.Node{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "node1",
-						},
+			nodeList = []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
 					},
 				},
 			}
@@ -1012,7 +1091,7 @@ var _ = Describe("health check", func() {
 				},
 			}
 
-			Expect(CheckNodeAgentLeases(&nodeList, &leaseList, fakeClock)).To(expected)
+			Expect(CheckNodeAgentLeases(nodeList, &leaseList, fakeClock)).To(expected)
 		},
 			Entry("should return nil if there is a matching lease for node", validLease, BeNil()),
 			Entry("should return Error that node agent is not running if no matching lease could be found for node", unrelatedLease, MatchError(ContainSubstring("not running"))),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/kind bug

**What this PR does / why we need it**:
This PR ignores nodes not managed by MCM from GNA lease check. For more details check - #14503

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14503

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed `EveryNodeReady` shoot condition incorrectly reporting `NodeAgentUnhealthy` for nodes not managed by MCM.
```
