### PR TITLE
[release-v1.139] Use the correct kubeconfig for runtime cluster

### DIFF
--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -18,7 +18,7 @@ if [[ -n "$IPFAMILY" ]] && [[ "$IPFAMILY" == "ipv6" ]]; then
   # export all container logs and events after test execution
   trap "
     ( export_artifacts_host_services; export_artifacts_infra )
-    ( export KUBECONFIG=$PWD/example/gardener-local/kind/multi-zone/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden extop)
+    ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig; export_artifacts 'gardener-operator-local'; export_resource_yamls_for garden extop)
     ( export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig; export cluster_name='virtual-garden'; export_resource_yamls_for gardenlet seeds shoots; export_events_for_shoots)
     ( make kind-single-node-down )
   " EXIT


### PR DESCRIPTION
/area testing
/kind bug

Cherry pick of https://github.com/gardener/gardener/pull/14368/changes/a9a9ca1eceeb924b162b5ec417b8c231ec286e06 on release-v1.139.

https://github.com/gardener/gardener/pull/14368/changes/a9a9ca1eceeb924b162b5ec417b8c231ec286e06: Use the correct kubeconfig for runtime cluster

With https://github.com/gardener/gardener/pull/13994, the runtime kubeconfig path is changed from `./example/gardener-local/kind/multi-zone/kubeconfig` to `./dev-setup/kubeconfigs/runtime/kubeconfig`.

**Release Notes:**
```other operator
NONE
```