### PR TITLE
Also delete pods stuck due to preemption in `DeleteStalePods`

### DIFF
--- a/pkg/utils/kubernetes/health/deployment.go
+++ b/pkg/utils/kubernetes/health/deployment.go
@@ -146,7 +146,7 @@ func DeploymentHasExactNumberOfPods(ctx context.Context, reader client.Reader, d
 
 	var numberOfRelevantPods int32
 	for _, pod := range podList.Items {
-		if !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) {
+		if !IsPodStale(pod.Status.Reason) && !IsPodCompleted(pod.Status.Conditions) && !IsPodDisrupted(pod.Status.Conditions) {
 			numberOfRelevantPods++
 		}
 	}

--- a/pkg/utils/kubernetes/health/deployment_test.go
+++ b/pkg/utils/kubernetes/health/deployment_test.go
@@ -339,5 +339,18 @@ var _ = Describe("Deployment", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ok).To(BeTrue())
 		})
+
+		It("should consider the deployment as updated even though there are still disrupted pods", func() {
+			p1 := pod.DeepCopy()
+			p1.Status.Conditions = []corev1.PodCondition{{Type: "DisruptionTarget", Status: "True", Reason: "TerminationByKubelet"}}
+			Expect(fakeClient.Create(ctx, p1)).To(Succeed())
+
+			p2 := pod.DeepCopy()
+			Expect(fakeClient.Create(ctx, p2)).To(Succeed())
+
+			ok, err := health.DeploymentHasExactNumberOfPods(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
 	})
 })

--- a/pkg/utils/kubernetes/health/pod.go
+++ b/pkg/utils/kubernetes/health/pod.go
@@ -64,7 +64,16 @@ func IsPodStale(reason string) bool {
 	return strings.Contains(reason, "Evicted") ||
 		strings.HasPrefix(reason, "OutOf") ||
 		strings.Contains(reason, "NodeAffinity") ||
-		strings.Contains(reason, "NodeLost")
+		strings.Contains(reason, "NodeLost") ||
+		strings.Contains(reason, "Preempting")
+}
+
+// IsPodDisrupted returns true when the pod has a DisruptionTarget condition set to True, indicating
+// that the pod was disrupted (e.g., preempted by the kubelet or scheduler).
+func IsPodDisrupted(conditions []corev1.PodCondition) bool {
+	return slices.ContainsFunc(conditions, func(condition corev1.PodCondition) bool {
+		return condition.Type == corev1.DisruptionTarget && condition.Status == corev1.ConditionTrue
+	})
 }
 
 // IsPodCompleted returns true when the pod ready condition indicates completeness.

--- a/pkg/utils/kubernetes/health/pod_test.go
+++ b/pkg/utils/kubernetes/health/pod_test.go
@@ -48,7 +48,19 @@ var _ = Describe("Pod", func() {
 		Entry("OutOfDisk", "OutOfDisk", BeTrue()),
 		Entry("NodeAffinity", "NodeAffinity", BeTrue()),
 		Entry("NodeLost", "NodeLost", BeTrue()),
+		Entry("Preempting", "Preempting", BeTrue()),
 		Entry("Foo", "Foo", BeFalse()),
+	)
+
+	DescribeTable("#IsPodDisrupted",
+		func(conditions []corev1.PodCondition, matcher types.GomegaMatcher) {
+			Expect(health.IsPodDisrupted(conditions)).To(matcher)
+		},
+
+		Entry("no conditions", nil, BeFalse()),
+		Entry("no DisruptionTarget condition", []corev1.PodCondition{{Type: "Ready", Status: "True"}}, BeFalse()),
+		Entry("DisruptionTarget condition is False", []corev1.PodCondition{{Type: "DisruptionTarget", Status: "False"}}, BeFalse()),
+		Entry("DisruptionTarget condition is True", []corev1.PodCondition{{Type: "DisruptionTarget", Status: "True"}}, BeTrue()),
 	)
 
 	DescribeTable("#IsPodCompleted",

--- a/pkg/utils/kubernetes/pod.go
+++ b/pkg/utils/kubernetes/pod.go
@@ -203,15 +203,6 @@ func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, pods
 	for _, pod := range pods {
 		logger := log.WithValues("pod", client.ObjectKeyFromObject(&pod))
 
-		if health.IsPodStale(pod.Status.Reason) {
-			logger.V(1).Info("Deleting stale pod", "reason", pod.Status.Reason)
-			if err := c.Delete(ctx, &pod); client.IgnoreNotFound(err) != nil {
-				result = multierror.Append(result, err)
-			}
-
-			continue
-		}
-
 		if shouldObjectBeRemoved(&pod) {
 			logger.V(1).Info("Deleting stuck terminating pod")
 			forceDeleteOptions := []client.DeleteOption{
@@ -219,6 +210,15 @@ func DeleteStalePods(ctx context.Context, log logr.Logger, c client.Client, pods
 				client.GracePeriodSeconds(0),
 			}
 			if err := c.Delete(ctx, &pod, forceDeleteOptions...); client.IgnoreNotFound(err) != nil {
+				result = multierror.Append(result, err)
+			}
+
+			continue
+		}
+
+		if health.IsPodStale(pod.Status.Reason) || health.IsPodDisrupted(pod.Status.Conditions) {
+			logger.V(1).Info("Deleting stale or disrupted pod", "reason", pod.Status.Reason)
+			if err := c.Delete(ctx, &pod); client.IgnoreNotFound(err) != nil {
 				result = multierror.Append(result, err)
 			}
 		}

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -509,18 +509,29 @@ var _ = Describe("Pod Utils", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: "stale", Namespace: "default"},
 					Status:     corev1.PodStatus{Reason: "Evicted"},
 				}
-				pods = []corev1.Pod{*normalPod, *stalePod}
+				preemptedPod = &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "preempted", Namespace: "default"},
+					Status: corev1.PodStatus{
+						Phase: "Succeeded",
+						Conditions: []corev1.PodCondition{
+							{Type: "DisruptionTarget", Status: "True", Reason: "TerminationByKubelet"},
+						},
+					},
+				}
+				pods = []corev1.Pod{*normalPod, *stalePod, *preemptedPod}
 				// There is no good way with the fake client to test the deletion of the pods stuck in termination
 				// We'd have to use a mock client, but we actually want to avoid its usage.
 			)
 
 			Expect(fakeClient.Create(ctx, normalPod)).To(Succeed())
 			Expect(fakeClient.Create(ctx, stalePod)).To(Succeed())
+			Expect(fakeClient.Create(ctx, preemptedPod)).To(Succeed())
 
 			Expect(DeleteStalePods(ctx, logr.Discard(), fakeClient, pods)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(normalPod), &corev1.Pod{})).To(Succeed())
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(stalePod), &corev1.Pod{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(preemptedPod), &corev1.Pod{})).To(BeNotFoundError())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:

Pods preempted by the kubelet or scheduler can get stuck in `Failed` or `Succeeded` phase without being cleaned up by `DeleteStalePods`. This adds detection via the `Preempting` status reason (analogous to `Evicted`) and the `DisruptionTarget` pod condition (for pods that lack a stale status reason). Disrupted pods are also excluded from the relevant pod count in `DeploymentHasExactNumberOfPods`.

**Which issue(s) this PR fixes**:

Fixes #14518

**Release note**:
```bugfix operator
The garbage collection logic now also deletes pods that are stuck due to preemption by the kubelet or scheduler.
```