### PR TITLE
Fix gardenlet panic for shoots without external cluster domain

### DIFF
--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure.go
@@ -167,7 +167,6 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 
 			values := &kubeapiserverexposure.SNIValues{
 				Hosts: []string{
-					v1beta1helper.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
 					v1beta1helper.GetAPIServerDomain(*b.Shoot.InternalClusterDomain),
 				},
 				APIServerProxy: &kubeapiserverexposure.APIServerProxy{
@@ -179,6 +178,10 @@ func (b *Botanist) setAPIServerServiceClusterIPs(clusterIPs []string) {
 				},
 				IstioTLSTermination:   b.ShootUsesIstioTLSTermination(),
 				WildcardConfiguration: wildcardConfiguration,
+			}
+
+			if b.Shoot.ExternalClusterDomain != nil {
+				values.Hosts = append(values.Hosts, v1beta1helper.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain))
 			}
 
 			return values

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -19,10 +19,12 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 )
 
 var _ = Describe("KubeAPIServerExposure", func() {
@@ -65,11 +67,22 @@ var _ = Describe("KubeAPIServerExposure", func() {
 
 		botanist.SeedClientSet = fake.NewClientSetBuilder().WithClient(fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()).Build()
 		Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: botanist.Shoot.ControlPlaneNamespace}})).To(Succeed())
+
+		botanist.SecretsManager = fakesecretsmanager.New(botanist.SeedClientSet.Client(), botanist.Shoot.ControlPlaneNamespace)
 	})
 
 	Describe("#setAPIServerServiceClusterIPs", func() {
 		BeforeEach(func() {
 			botanist.Shoot.InternalClusterDomain = ptr.To("internal.foo.bar")
+
+			By("Create secrets managed outside of this function for which secretsmanager.Get() will be called")
+			for _, name := range []string{
+				v1beta1constants.SecretNameCACluster,
+				v1beta1constants.SecretNameCAClient,
+				apiserver.SecretNameServerCert + "-current",
+			} {
+				Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: botanist.Shoot.ControlPlaneNamespace}})).To(Succeed())
+			}
 
 			Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("KubeAPIServerExposure", func() {
+	var (
+		botanist *Botanist
+	)
+
+	BeforeEach(func() {
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				Config: &gardenletconfigv1alpha1.GardenletConfiguration{
+					SNI: &gardenletconfigv1alpha1.SNI{
+						Ingress: &gardenletconfigv1alpha1.SNIIngress{
+							Namespace:   ptr.To(v1beta1constants.DefaultSNIIngressNamespace),
+							ServiceName: ptr.To(v1beta1constants.DefaultSNIIngressServiceName),
+							Labels: map[string]string{
+								v1beta1constants.LabelApp: v1beta1constants.DefaultIngressGatewayAppLabelValue,
+								"istio":                   "ingressgateway",
+							},
+						},
+					},
+				},
+				Shoot: &shootpkg.Shoot{
+					ControlPlaneNamespace: "shoot--foo--bar",
+					Components: &shootpkg.Components{
+						ControlPlane: &shootpkg.ControlPlane{},
+					},
+				},
+			},
+		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			Spec: gardencorev1beta1.ShootSpec{
+				Networking: &gardencorev1beta1.Networking{
+					IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				},
+			},
+		})
+		botanist.Seed = &seedpkg.Seed{}
+		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
+
+		botanist.SeedClientSet = fake.NewClientSetBuilder().WithClient(fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()).Build()
+		Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: botanist.Shoot.ControlPlaneNamespace}})).To(Succeed())
+	})
+
+	Describe("#setAPIServerServiceClusterIPs", func() {
+		BeforeEach(func() {
+			botanist.Shoot.InternalClusterDomain = ptr.To("internal.foo.bar")
+
+			Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.DeploymentNameKubeAPIServer,
+					Namespace: botanist.Shoot.ControlPlaneNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIPs: []string{"10.0.0.1"},
+				},
+			})).To(Succeed())
+
+			Expect(botanist.SeedClientSet.Client().Create(context.TODO(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta1constants.DefaultSNIIngressServiceName,
+					Namespace: v1beta1constants.DefaultSNIIngressNamespace,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+					},
+				},
+			})).To(Succeed())
+		})
+
+		It("should not panic when ExternalClusterDomain is nil", func() {
+			botanist.Shoot.ExternalClusterDomain = nil
+
+			Expect(botanist.DefaultKubeAPIServerService().Deploy(context.TODO())).To(Succeed())
+
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI).NotTo(BeNil())
+
+			// We call Deploy to trigger the valuesFunc and ensure it doesn't panic.
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(context.TODO())).To(Succeed())
+		})
+
+		It("should not panic when ExternalClusterDomain is not nil", func() {
+			botanist.Shoot.ExternalClusterDomain = ptr.To("external.foo.bar")
+
+			Expect(botanist.DefaultKubeAPIServerService().Deploy(context.TODO())).To(Succeed())
+
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI).NotTo(BeNil())
+
+			// We call Deploy to trigger the valuesFunc and ensure it doesn't panic.
+			Expect(botanist.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(context.TODO())).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR resolves an issue within the gardenlet that prevents shoots without an external cluster domain from being reconciled.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that prevented Gardenlet from reconciling shoots without an external cluster domain.
```
