### PR TITLE
[GEP-28] Improve the check if the Pod network is available for a self-hosted Shoot

### DIFF
--- a/pkg/gardenadm/botanist/network.go
+++ b/pkg/gardenadm/botanist/network.go
@@ -10,33 +10,36 @@ import (
 	"net"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	"github.com/gardener/gardener/pkg/controller/networkpolicy"
 	"github.com/gardener/gardener/pkg/controller/networkpolicy/hostnameresolver"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/nodeagent"
 )
 
-// IsPodNetworkAvailable checks if the ManagedResource for CoreDNS is deployed and ready. If yes, pod network must be
-// available. Otherwise, CoreDNS which runs in this network wouldn't be available.
+// IsPodNetworkAvailable checks if the control plane Node has the pod network configured.
+// It checks the NetworkUnavailable condition - when False, the pod network is available.
 func (b *GardenadmBotanist) IsPodNetworkAvailable(ctx context.Context) (bool, error) {
-	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: coredns.ManagedResourceName, Namespace: b.Shoot.ControlPlaneNamespace}}
-	if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
-		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed reading ManagedResource %s: %w", client.ObjectKeyFromObject(managedResource), err)
+	node, err := nodeagent.FetchNodeByHostName(ctx, b.SeedClientSet.Client(), b.HostName)
+	if err != nil {
+		return false, fmt.Errorf("failed fetching node object by hostname %q: %w", b.HostName, err)
 	}
-	return health.CheckManagedResource(managedResource) == nil, nil
+
+	// If no Node exists yet, pod network is not available
+	if node == nil {
+		return false, nil
+	}
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeNetworkUnavailable {
+			return condition.Status == corev1.ConditionFalse, nil
+		}
+	}
+
+	return false, nil
 }
 
 // ApplyNetworkPolicies reconciles all namespaces in the cluster in order to apply the network policies.

--- a/pkg/gardenadm/botanist/network_test.go
+++ b/pkg/gardenadm/botanist/network_test.go
@@ -7,7 +7,6 @@ package botanist_test
 import (
 	"context"
 	"net"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,7 +16,6 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenadm/botanist"
@@ -66,52 +64,74 @@ var _ = Describe("Network", func() {
 	})
 
 	Describe("#IsPodNetworkAvailable", func() {
-		var managedResource *resourcesv1alpha1.ManagedResource
+		var (
+			hostName = "foo"
+
+			node *corev1.Node
+		)
 
 		BeforeEach(func() {
-			managedResource = &resourcesv1alpha1.ManagedResource{
+			node = &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shoot-core-coredns",
-					Namespace: namespaceName,
+					GenerateName: "node-",
+					Labels:       map[string]string{"kubernetes.io/hostname": hostName},
 				},
 			}
+			b.HostName = hostName
 		})
 
-		It("should return false because the ManagedResource does not exist", func() {
+		It("should return false because the Node does not exist", func() {
 			available, err := b.IsPodNetworkAvailable(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(available).To(BeFalse())
 		})
 
-		It("should return false because the ManagedResource is unhealthy", func() {
-			Expect(b.SeedClientSet.Client().Create(ctx, managedResource)).To(Succeed())
+		It("should return an error when it fails fetching node object by hostname", func() {
+			node2 := node.DeepCopy()
+
+			Expect(b.SeedClientSet.Client().Create(ctx, node)).To(Succeed())
+			Expect(b.SeedClientSet.Client().Create(ctx, node2)).To(Succeed())
+
+			available, err := b.IsPodNetworkAvailable(ctx)
+			Expect(err).To(MatchError(ContainSubstring("failed fetching node object by hostname")))
+			Expect(available).To(BeFalse())
+		})
+
+		It("should return false because the Node's NetworkUnavailable condition is true", func() {
+			node.Status.Conditions = []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeNetworkUnavailable,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			Expect(b.SeedClientSet.Client().Create(ctx, node)).To(Succeed())
 
 			available, err := b.IsPodNetworkAvailable(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(available).To(BeFalse())
 		})
 
-		It("should return true because the ManagedResource is healthy", func() {
-			managedResource.Status.ObservedGeneration = managedResource.Generation
-			managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+		It("should return true because the Node's NetworkUnavailable condition is false", func() {
+			node.Status.Conditions = []corev1.NodeCondition{
 				{
-					Type:               "ResourcesHealthy",
-					Status:             "True",
-					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
-					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
-				},
-				{
-					Type:               "ResourcesApplied",
-					Status:             "True",
-					LastUpdateTime:     metav1.NewTime(time.Unix(0, 0)),
-					LastTransitionTime: metav1.NewTime(time.Unix(0, 0)),
+					Type:   corev1.NodeNetworkUnavailable,
+					Status: corev1.ConditionFalse,
 				},
 			}
-			Expect(b.SeedClientSet.Client().Create(ctx, managedResource)).To(Succeed())
+			Expect(b.SeedClientSet.Client().Create(ctx, node)).To(Succeed())
 
 			available, err := b.IsPodNetworkAvailable(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(available).To(BeTrue())
+		})
+
+		It("should return false because the Node's does not have a NetworkUnavailable condition", func() {
+			node.Status.Conditions = []corev1.NodeCondition{}
+			Expect(b.SeedClientSet.Client().Create(ctx, node)).To(Succeed())
+
+			available, err := b.IsPodNetworkAvailable(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(available).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei disaster-recovery
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the check if the Pod network is available in the `gardenadm init` flow. Currenly, the [`IsPodNetworkAvailable` func](https://github.com/gardener/gardener/blob/57a119e43cc30d5350edda6d26dfaba7d6041221/pkg/gardenadm/botanist/network.go#L29-L40) checks if the `shoot-core-coredns` ManagedResource exists, is applied and is healthy. The logic is based on a check if a component (`coredns`) running in the Pod network. The assumption is that if this component (`coredns`) is healthy and running, then the Pod network must be set up already because this component runs in the Pod network.
I also find it problematic that the check for the Pod network availability is coupled with coredns's health. If coredns is down due to another reason, the Pod network can be wrongly calculated as not available.

However, in case of control plane Node restoration this check needs to be adapted. When restoring a control plane Node, the etcd is restored from a backup. The restored backup contains a healthy `shoot-core-coredns` ManagedResource. However, when the Node is lost and has to be restored from the same Machine or a new Machine, the Pod network is not set up. That's why the check if the Pod network is set up needs to be adapted to support control plane restoration.

Instead of checking for the `shoot-core-coredns` ManagedResource, this PR proposes checking the Node's `NetworkUnavailable` condition.

Both calico and cilium as CNI implementations set the `NetworkUnavailable` condition to `False` on startup. Example conditions are:
- `calico`:
   ```yaml
   - lastHeartbeatTime: "2026-04-04T00:55:51Z"
     lastTransitionTime: "2026-04-04T00:55:51Z"
     message: Calico is running on this node
     reason: CalicoIsUp
     status: "False"
     type: NetworkUnavailable
   ```

- `cilium`
   ```yaml
   - lastHeartbeatTime: "2026-04-02T03:08:22Z"
     lastTransitionTime: "2026-04-02T03:08:22Z"
     message: Cilium is running on this node
     reason: CiliumIsUp
     status: "False"
     type: NetworkUnavailable
   ```

This would help us for the disaster recovery scenario as we most likely will need to delete the old Node resource.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardenadm init` flow now determines Pod network availability by checking the Node's `NetworkUnavailable` condition instead of the `shoot-core-coredns` ManagedResource health. This is a prerequisite improvement for the control plane Node restoration feature.
```
