### PR TITLE
Remove `backup` and `extensions` configuration from `gardenlet` in `remote` setup

### DIFF
--- a/dev-setup/gardenlet/components/remote/kustomization.yaml
+++ b/dev-setup/gardenlet/components/remote/kustomization.yaml
@@ -10,6 +10,10 @@ patches:
         path: /spec/kubeconfigSecretRef
         value:
           name: seed-remote
+      - op: remove
+        path: /spec/config/seedConfig/spec/backup
+      - op: remove
+        path: /spec/config/seedConfig/spec/extensions
     target:
       group: seedmanagement.gardener.cloud
       kind: Gardenlet

--- a/dev-setup/gardenlet/overlays/remote/gardenlet.yaml.tmpl
+++ b/dev-setup/gardenlet/overlays/remote/gardenlet.yaml.tmpl
@@ -12,8 +12,6 @@ spec:
   config:
     seedConfig:
       spec:
-        # Specify all fields when defining 'backup' so that they correctly overwrite the corresponding fields in example/gardener-local/gardenlet/values.yaml
-        backup: ~
         provider:
           # This field will be automatically set by `make remote-up` when using a Gardener shoot.
           region: ""
@@ -57,8 +55,6 @@ spec:
             domain: ""
             # Enter the zone of the default domain of your seed
             zone: ""
-        # Specify extensions if you want to use any
-        extensions: ~
         ingress:
           controller:
             kind: nginx


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`/spec/config/seedConfig/spec/backup` and `/spec/config/seedConfig/spec/extensions` inherit configurations from gardenlet of the local setup.
Before the users had to remove those fields that the setup works correctly, but we could also remove it via the remote component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @hebelsan 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
