### PR TITLE
Configurable advertised addresses for shoot virtual service endpoints

### DIFF
--- a/docs/development/shoot-advertised-addresses.md
+++ b/docs/development/shoot-advertised-addresses.md
@@ -27,10 +27,10 @@ e.g. observability-related components such as `plutono`, `vali`, `prometheus`,
 etc.
 
 > [!NOTE]
-> As of now, only `Ingress` resources support may be advertised using this label.
+> As of now, only `Ingress` and `VirtualService` resources support to be advertised using this label.
 > In the future, support for `Gateway` resources will be added as well.
 
-In order to advertise such endpoints, their respective `Ingress` resource needs
+In order to advertise such endpoints, their respective `Ingress` or `VirtualService` resource needs
 to be labeled with `endpoint.shoot.gardener.cloud/advertise=true`.
 
 Optionally, an application name can be set using the

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -94,6 +95,12 @@ func (b *Botanist) ToAdvertisedAddresses(ctx context.Context) ([]gardencorev1bet
 	}
 	addresses = append(addresses, ingressItems...)
 
+	virtualServiceItems, err := b.GetVirtualServiceAdvertisedEndpoints(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get virtual service advertised endpoints: %w", err)
+	}
+	addresses = append(addresses, virtualServiceItems...)
+
 	return addresses, nil
 }
 
@@ -135,6 +142,47 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 					Application: application,
 				})
 			}
+		}
+	}
+
+	slices.SortStableFunc(result, func(a, b gardencorev1beta1.ShootAdvertisedAddress) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return result, nil
+}
+
+// GetVirtualServiceAdvertisedEndpoints returns a list of
+// [gardencorev1beta1.ShootAdvertisedAddress] items, which have been derived
+// from any existing [istionetworkingv1beta1.VirtualService] resources labeled with
+// [v1beta1constants.LabelShootEndpointAdvertise].
+func (b *Botanist) GetVirtualServiceAdvertisedEndpoints(ctx context.Context) ([]gardencorev1beta1.ShootAdvertisedAddress, error) {
+	result := make([]gardencorev1beta1.ShootAdvertisedAddress, 0)
+	var virtualServiceList istionetworkingv1beta1.VirtualServiceList
+
+	if err := b.SeedClientSet.Client().List(
+		ctx,
+		&virtualServiceList,
+		client.InNamespace(b.Shoot.ControlPlaneNamespace),
+		client.MatchingLabels(map[string]string{
+			v1beta1constants.LabelShootEndpointAdvertise: "true",
+		}),
+	); err != nil {
+		return nil, fmt.Errorf("failed to list virtual service resources: %w", err)
+	}
+
+	// Only the TLS items are processed, since
+	// [gardencorev1beta1.ShootAdvertisedAddress] is constrained to https://
+	// endpoints only.
+	for _, virtualService := range virtualServiceList.Items {
+		for hostIdx, hostItem := range virtualService.Spec.Hosts {
+			if strings.Contains(hostItem, "*") {
+				continue
+			}
+			result = append(result, gardencorev1beta1.ShootAdvertisedAddress{
+				Name: fmt.Sprintf("virtualservice/%s/%d", virtualService.Name, hostIdx),
+				URL:  fmt.Sprintf("https://%s", hostItem),
+			})
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses.go
@@ -157,8 +157,10 @@ func (b *Botanist) GetIngressAdvertisedEndpoints(ctx context.Context) ([]gardenc
 // from any existing [istionetworkingv1beta1.VirtualService] resources labeled with
 // [v1beta1constants.LabelShootEndpointAdvertise].
 func (b *Botanist) GetVirtualServiceAdvertisedEndpoints(ctx context.Context) ([]gardencorev1beta1.ShootAdvertisedAddress, error) {
-	result := make([]gardencorev1beta1.ShootAdvertisedAddress, 0)
-	var virtualServiceList istionetworkingv1beta1.VirtualServiceList
+	var (
+		result             = make([]gardencorev1beta1.ShootAdvertisedAddress, 0)
+		virtualServiceList istionetworkingv1beta1.VirtualServiceList
+	)
 
 	if err := b.SeedClientSet.Client().List(
 		ctx,
@@ -171,9 +173,6 @@ func (b *Botanist) GetVirtualServiceAdvertisedEndpoints(ctx context.Context) ([]
 		return nil, fmt.Errorf("failed to list virtual service resources: %w", err)
 	}
 
-	// Only the TLS items are processed, since
-	// [gardencorev1beta1.ShootAdvertisedAddress] is constrained to https://
-	// endpoints only.
 	for _, virtualService := range virtualServiceList.Items {
 		for hostIdx, hostItem := range virtualService.Spec.Hosts {
 			if strings.Contains(hostItem, "*") {

--- a/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
+++ b/pkg/gardenlet/operation/botanist/advertisedaddresses_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -352,6 +354,74 @@ var _ = Describe("AdvertisedAddresses", func() {
 					Name:        "ingress/ingress-2/0/0",
 					URL:         "https://bar.example.org",
 					Application: ptr.To("Monitoring"),
+				},
+			}))
+		})
+	})
+
+	Describe("#GetVirtualServiceAdvertisedEndpoints", func() {
+		It("returns nothing with no virtual service resources", func() {
+			items, err := botanist.GetVirtualServiceAdvertisedEndpoints(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(BeEmpty())
+		})
+
+		It("returns nothing when no virtual service is labeled", func() {
+			// Resource does not have the expected labels
+			virtualService := &istionetworkingv1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virtual-service-1",
+					Namespace: shootNamespace.Name,
+				},
+				Spec: istioapinetworkingv1beta1.VirtualService{
+					Hosts: []string{"foo.example.org"},
+				},
+			}
+
+			Expect(botanist.SeedClientSet.Client().Create(ctx, virtualService)).To(Succeed())
+			items, err := botanist.GetVirtualServiceAdvertisedEndpoints(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(BeEmpty())
+		})
+
+		It("returns valid endpoints from virtual service resources", func() {
+			virtualServiceA := &istionetworkingv1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virtual-service-1",
+					Namespace: shootNamespace.Name,
+					Labels: map[string]string{
+						v1beta1constants.LabelShootEndpointAdvertise: "true",
+					},
+				},
+				Spec: istioapinetworkingv1beta1.VirtualService{
+					Hosts: []string{"foo.example.org"},
+				},
+			}
+			virtualServiceB := &istionetworkingv1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virtual-service-2",
+					Namespace: shootNamespace.Name,
+					Labels: map[string]string{
+						v1beta1constants.LabelShootEndpointAdvertise: "true",
+					},
+				},
+				Spec: istioapinetworkingv1beta1.VirtualService{
+					Hosts: []string{"bar.example.org"},
+				},
+			}
+
+			Expect(botanist.SeedClientSet.Client().Create(ctx, virtualServiceA)).To(Succeed())
+			Expect(botanist.SeedClientSet.Client().Create(ctx, virtualServiceB)).To(Succeed())
+			items, err := botanist.GetVirtualServiceAdvertisedEndpoints(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(items).To(HaveExactElements([]gardencorev1beta1.ShootAdvertisedAddress{
+				{
+					Name: "virtualservice/virtual-service-1/0",
+					URL:  "https://foo.example.org",
+				},
+				{
+					Name: "virtualservice/virtual-service-2/0",
+					URL:  "https://bar.example.org",
 				},
 			}))
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Configurable advertised addresses for shoot virtual service endpoints.

Analogous to #13043, this change allows to label `VirtualService` resources to be included in the advertised addresses. This allows an easy migration as part of #13448.

**Which issue(s) this PR fixes**:
Part of #13448

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoot advertised addresses are now configurable by extension components for Shoot VirtualService resources.
```
