### PR TITLE
resourcemanager: auto delete-and-recreate on immutable field update errors

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -599,15 +599,18 @@ func ignore(meta metav1.Object) bool {
 }
 
 func deleteOnInvalidUpdate(obj *unstructured.Unstructured, err error) bool {
-	isImmutableConfigMapOrSecret := false
-	if obj.GetAPIVersion() == "v1" && sets.New("ConfigMap", "Secret").Has(obj.GetKind()) {
-		cause, ok := apierrors.StatusCause(err, metav1.CauseType(field.ErrorTypeForbidden))
-		if ok && strings.Contains(cause.Message, "field is immutable when `immutable` is set") {
-			isImmutableConfigMapOrSecret = true
+	// The API server returns a 422 Invalid error for immutable-field violations. The cause type
+	// within the status may be either Invalid (e.g. Deployments with immutable spec.selector) or
+	// Forbidden (e.g. immutable Secrets/ConfigMaps). Check both.
+	isImmutable := false
+	for _, causeType := range []metav1.CauseType{metav1.CauseType(field.ErrorTypeInvalid), metav1.CauseType(field.ErrorTypeForbidden)} {
+		cause, ok := apierrors.StatusCause(err, causeType)
+		if ok && strings.Contains(cause.Message, "field is immutable") {
+			isImmutable = true
 		}
 	}
 
-	return keyExistsAndValueTrue(obj.GetAnnotations(), resourcesv1alpha1.DeleteOnInvalidUpdate) || isImmutableConfigMapOrSecret
+	return keyExistsAndValueTrue(obj.GetAnnotations(), resourcesv1alpha1.DeleteOnInvalidUpdate) || isImmutable
 }
 
 func keepObject(meta metav1.Object) bool {

--- a/pkg/resourcemanager/controller/managedresource/reconciler_test.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler_test.go
@@ -7,7 +7,12 @@ package managedresource
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 var _ = Describe("Controller", func() {
@@ -97,6 +102,52 @@ var _ = Describe("Controller", func() {
 
 			Expect(injectLabels(obj, labels)).To(Succeed())
 			Expect(obj).To(Equal(expected))
+		})
+	})
+
+	Describe("#deleteOnInvalidUpdate", func() {
+		var obj *unstructured.Unstructured
+
+		BeforeEach(func() {
+			obj = &unstructured.Unstructured{Object: map[string]any{}}
+		})
+
+		It("should return false for a generic error with no immutable cause", func() {
+			err := apierrors.NewBadRequest("something went wrong")
+			Expect(deleteOnInvalidUpdate(obj, err)).To(BeFalse())
+		})
+
+		It("should return true for an Invalid cause with 'field is immutable'", func() {
+			err := apierrors.NewInvalid(
+				schema.GroupKind{Group: "apps", Kind: "Deployment"},
+				"metrics-server",
+				field.ErrorList{field.Invalid(field.NewPath("spec", "selector"), nil, "field is immutable")},
+			)
+			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
+		})
+
+		It("should return true for a Forbidden cause with 'field is immutable'", func() {
+			err := apierrors.NewInvalid(
+				schema.GroupKind{Group: "", Kind: "Secret"},
+				"test-secret",
+				field.ErrorList{field.Forbidden(field.NewPath("data"), "field is immutable when `immutable` is set")},
+			)
+			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
+		})
+
+		It("should return false for an Invalid cause with an unrelated message", func() {
+			err := apierrors.NewInvalid(
+				schema.GroupKind{Group: "apps", Kind: "Deployment"},
+				"test-deploy",
+				field.ErrorList{field.Invalid(field.NewPath("spec", "replicas"), nil, "must be greater than zero")},
+			)
+			Expect(deleteOnInvalidUpdate(obj, err)).To(BeFalse())
+		})
+
+		It("should return true when the delete-on-invalid-update annotation is set, regardless of error", func() {
+			obj.SetAnnotations(map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"})
+			err := apierrors.NewBadRequest("something went wrong")
+			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
 		})
 	})
 })

--- a/pkg/resourcemanager/controller/managedresource/reconciler_test.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler_test.go
@@ -105,49 +105,48 @@ var _ = Describe("Controller", func() {
 		})
 	})
 
-	Describe("#deleteOnInvalidUpdate", func() {
-		var obj *unstructured.Unstructured
-
-		BeforeEach(func() {
-			obj = &unstructured.Unstructured{Object: map[string]any{}}
-		})
-
-		It("should return false for a generic error with no immutable cause", func() {
-			err := apierrors.NewBadRequest("something went wrong")
-			Expect(deleteOnInvalidUpdate(obj, err)).To(BeFalse())
-		})
-
-		It("should return true for an Invalid cause with 'field is immutable'", func() {
-			err := apierrors.NewInvalid(
+	DescribeTable("#deleteOnInvalidUpdate",
+		func(annotations map[string]string, err error, expected bool) {
+			obj := &unstructured.Unstructured{Object: map[string]any{}}
+			obj.SetAnnotations(annotations)
+			Expect(deleteOnInvalidUpdate(obj, err)).To(Equal(expected))
+		},
+		Entry("should return false for a generic error with no immutable cause",
+			nil,
+			apierrors.NewBadRequest("something went wrong"),
+			false,
+		),
+		Entry("should return true for an Invalid cause with 'field is immutable'",
+			nil,
+			apierrors.NewInvalid(
 				schema.GroupKind{Group: "apps", Kind: "Deployment"},
 				"metrics-server",
 				field.ErrorList{field.Invalid(field.NewPath("spec", "selector"), nil, "field is immutable")},
-			)
-			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
-		})
-
-		It("should return true for a Forbidden cause with 'field is immutable'", func() {
-			err := apierrors.NewInvalid(
+			),
+			true,
+		),
+		Entry("should return true for a Forbidden cause with 'field is immutable')",
+			nil,
+			apierrors.NewInvalid(
 				schema.GroupKind{Group: "", Kind: "Secret"},
 				"test-secret",
 				field.ErrorList{field.Forbidden(field.NewPath("data"), "field is immutable when `immutable` is set")},
-			)
-			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
-		})
-
-		It("should return false for an Invalid cause with an unrelated message", func() {
-			err := apierrors.NewInvalid(
+			),
+			true,
+		),
+		Entry("should return false for an Invalid cause with an unrelated message",
+			nil,
+			apierrors.NewInvalid(
 				schema.GroupKind{Group: "apps", Kind: "Deployment"},
 				"test-deploy",
 				field.ErrorList{field.Invalid(field.NewPath("spec", "replicas"), nil, "must be greater than zero")},
-			)
-			Expect(deleteOnInvalidUpdate(obj, err)).To(BeFalse())
-		})
-
-		It("should return true when the delete-on-invalid-update annotation is set, regardless of error", func() {
-			obj.SetAnnotations(map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"})
-			err := apierrors.NewBadRequest("something went wrong")
-			Expect(deleteOnInvalidUpdate(obj, err)).To(BeTrue())
-		})
-	})
+			),
+			false,
+		),
+		Entry("should return true when the delete-on-invalid-update annotation is set, regardless of error",
+			map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+			apierrors.NewBadRequest("something went wrong"),
+			true,
+		),
+	)
 })


### PR DESCRIPTION
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

When the API server rejects an update with an immutable field error (e.g. a Deployment whose `spec.selector` was changed), the `ManagedResource` controller was stuck in a permanent error loop with no way to recover:

> Deployment.apps "metrics-server" is invalid: spec.selector: Invalid value: ...: field is immutable

This extends `deleteOnInvalidUpdate()` to automatically return `true` for any `Invalid` or `Forbidden` update error whose cause message contains `"field is immutable"`, regardless of resource type. This triggers the existing delete-and-recreate path, so the controller recovers on the next reconcile.

**Which issue(s) this PR fixes**:
Fixes #14392

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
