### PR TITLE
Fix flaky `BackupEntry`/`BackupBucket` integration tests for Secret/Namespace mapper reconciliation

### DIFF
--- a/test/integration/extensions/controller/backupbucket/backupbucket_test.go
+++ b/test/integration/extensions/controller/backupbucket/backupbucket_test.go
@@ -272,10 +272,13 @@ func runTest(c client.Client, ignoreOperationAnnotation bool) {
 		metav1.SetMetaDataAnnotation(&secret.ObjectMeta, "foo", "bar")
 		Expect(c.Update(ctx, secret)).To(Succeed())
 
-		By("Wait until backupbucket is ready")
-		// also wait for lastOperation's update time to be updated to give extension controller some time to observe
-		// secret event and start reconciliation
-		Expect(waitForBackupBucketToBeReady(ctx, c, log, backupBucket, backupBucket.Status.LastOperation.LastUpdateTime)).To(Succeed())
+		By("Wait until backupbucket is reconciled with new time-in annotation")
+		Eventually(func(g Gomega) {
+			backupBucket = &extensionsv1alpha1.BackupBucket{}
+			g.Expect(c.Get(ctx, backupBucketObjectKey, backupBucket)).To(Succeed())
+			g.Expect(backupBucket.Annotations[extensionsintegrationtest.AnnotationKeyTimeOut]).To(Equal(timeIn4))
+		}).WithTimeout(pollTimeout).WithPolling(pollInterval).Should(Succeed())
+		Expect(waitForBackupBucketToBeReady(ctx, c, log, backupBucket)).To(Succeed())
 
 		By("Verify backupbucket readiness (reconciliation should have happened due to secret mapping)")
 		backupBucket = &extensionsv1alpha1.BackupBucket{}
@@ -348,17 +351,12 @@ func patchBackupBucketObject(ctx context.Context, c client.Client, backupBucket 
 	return c.Patch(ctx, backupBucket, patch)
 }
 
-func waitForBackupBucketToBeReady(ctx context.Context, c client.Client, log logr.Logger, backupBucket *extensionsv1alpha1.BackupBucket, minOperationUpdateTime ...metav1.Time) error {
-	healthFuncs := []health.Func{health.CheckExtensionObject}
-	if len(minOperationUpdateTime) > 0 {
-		healthFuncs = append(healthFuncs, health.ExtensionOperationHasBeenUpdatedSince(minOperationUpdateTime[0]))
-	}
-
+func waitForBackupBucketToBeReady(ctx context.Context, c client.Client, log logr.Logger, backupBucket *extensionsv1alpha1.BackupBucket) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		c,
 		log,
-		health.And(healthFuncs...),
+		health.CheckExtensionObject,
 		backupBucket,
 		extensionsv1alpha1.BackupBucketResource,
 		pollInterval,

--- a/test/integration/extensions/controller/backupentry/backupentry_test.go
+++ b/test/integration/extensions/controller/backupentry/backupentry_test.go
@@ -332,14 +332,13 @@ var _ = Describe("BackupEntry", func() {
 					Expect(testClient.Update(ctx, backupEntrySecret)).To(Succeed())
 				})
 
-				It("should verify that BackupEntry becomes ready after modification of Secret", func() {
-					// wait for lastOperation's update time to be updated to give extension controller some time to observe
-					// event and start reconciliation
-					Expect(waitForBackupEntryToBeReady(ctx, testClient, log, backupEntry, backupEntry.Status.LastOperation.LastUpdateTime)).To(Succeed())
-				})
-
 				It("should verify that BackupEntry is reconciled after modification of Secret and has new time-in annotation", func() {
-					Expect(testClient.Get(ctx, backupEntryObjectKey, backupEntry)).To(Succeed())
+					Eventually(func(g Gomega) {
+						g.Expect(testClient.Get(ctx, backupEntryObjectKey, backupEntry)).To(Succeed())
+						g.Expect(backupEntry.Annotations[extensionsintegrationtest.AnnotationKeyTimeOut]).To(Equal(modificationTimeIn))
+					}).WithTimeout(pollTimeout).WithPolling(pollInterval).Should(Succeed())
+
+					Expect(waitForBackupEntryToBeReady(ctx, testClient, log, backupEntry)).To(Succeed())
 					verifyBackupEntry(backupEntry, 1, 1, modificationTimeIn, Equal(gardencorev1beta1.LastOperationTypeReconcile), lastOperationStateMatcher)
 				})
 			})
@@ -369,14 +368,13 @@ var _ = Describe("BackupEntry", func() {
 					Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
 				})
 
-				It("should verify that BackupEntry becomes ready after modification of Namespace", func() {
-					// wait for lastOperation's update time to be updated to give extension controller some time to observe
-					// event and start reconciliation
-					Expect(waitForBackupEntryToBeReady(ctx, testClient, log, backupEntry, backupEntry.Status.LastOperation.LastUpdateTime)).To(Succeed())
-				})
-
 				It("should verify that BackupEntry is reconciled after modification of Namespace and has new time-in annotation", func() {
-					Expect(testClient.Get(ctx, backupEntryObjectKey, backupEntry)).To(Succeed())
+					Eventually(func(g Gomega) {
+						g.Expect(testClient.Get(ctx, backupEntryObjectKey, backupEntry)).To(Succeed())
+						g.Expect(backupEntry.Annotations[extensionsintegrationtest.AnnotationKeyTimeOut]).To(Equal(modificationTimeIn))
+					}).WithTimeout(pollTimeout).WithPolling(pollInterval).Should(Succeed())
+
+					Expect(waitForBackupEntryToBeReady(ctx, testClient, log, backupEntry)).To(Succeed())
 					verifyBackupEntry(backupEntry, 1, 1, modificationTimeIn, Equal(gardencorev1beta1.LastOperationTypeReconcile), lastOperationStateMatcher)
 				})
 			})
@@ -721,17 +719,12 @@ func patchBackupEntryObject(ctx context.Context, c client.Client, backupEntry *e
 	return c.Patch(ctx, backupEntry, patch)
 }
 
-func waitForBackupEntryToBeReady(ctx context.Context, c client.Client, log logr.Logger, backupEntry *extensionsv1alpha1.BackupEntry, minOperationUpdateTime ...metav1.Time) error {
-	healthFuncs := []health.Func{health.CheckExtensionObject}
-	if len(minOperationUpdateTime) > 0 {
-		healthFuncs = append(healthFuncs, health.ExtensionOperationHasBeenUpdatedSince(minOperationUpdateTime[0]))
-	}
-
+func waitForBackupEntryToBeReady(ctx context.Context, c client.Client, log logr.Logger, backupEntry *extensionsv1alpha1.BackupEntry) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		c,
 		log,
-		health.And(healthFuncs...),
+		health.CheckExtensionObject,
 		backupEntry,
 		extensionsv1alpha1.BackupEntryResource,
 		pollInterval,


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind flake

**What this PR does / why we need it**:

`ExtensionOperationHasBeenUpdatedSince` uses `.After()` on `metav1.Time` which is truncated to second precision after JSON round-trip through etcd. If the creation reconciliation and the mapper-triggered reconciliation (from Secret or Namespace update) complete within the same wall-clock second, the health check fails permanently and the test times out after 240s.

This replaces the timestamp-based wait with an annotation-based check that polls for the `time-out` annotation to equal `modificationTimeIn`, which directly verifies the reconciliation ran with the updated data. Applied consistently to `BackupEntry` (Secret + Namespace mapper blocks) and `BackupBucket` (Secret mapper block). Also simplifies `waitForBackupEntryToBeReady` / `waitForBackupBucketToBeReady` by removing the now-unused variadic `minOperationUpdateTime` parameter.

Example failures:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14508/pull-gardener-integration/2041871651699691520
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14519/pull-gardener-integration/2041881986498301952

**Special notes for your reviewer**:

Stress-tested with `stress -p 4`:
- **Baseline (unfixed):** 73 runs, 1 failure (~1.4%) — reproduces the exact flake
- **Fixed:** 244 runs, 0 failures

`ExtensionOperationHasBeenUpdatedSince` now has zero callers outside its own unit test — consider removing it in a follow-up.

**Release note**:
```other developer
NONE
```