### PR TITLE
Improve cleanup of resource in dev setup

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -58,6 +58,10 @@ case "$COMMAND" in
 
     # cleanup the remaining resources required for successful deletion of the garden
     kubectl delete -k "$(dirname "$0")/garden/overlays/$SCENARIO" --ignore-not-found
+
+    # cleanup all PVCs in the garden namespace
+    echo "Cleaning up PVCs in garden namespace..."
+    kubectl delete pvc --all -n garden --ignore-not-found --timeout=120s
     ;;
 
   *)

--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -62,6 +62,12 @@ case "$COMMAND" in
     # cleanup all PVCs in the garden namespace
     echo "Cleaning up PVCs in garden namespace..."
     kubectl delete pvc --all -n garden --ignore-not-found --timeout=120s
+
+    # cleanup virtual garden kubconfig
+    if [[ -f "$VIRTUAL_GARDEN_KUBECONFIG" ]]; then
+      echo "Deleting virtual garden kubeconfig at $VIRTUAL_GARDEN_KUBECONFIG"
+      rm "$VIRTUAL_GARDEN_KUBECONFIG"
+    fi
     ;;
 
   *)

--- a/dev-setup/seed.sh
+++ b/dev-setup/seed.sh
@@ -61,6 +61,7 @@ case "$COMMAND" in
     skaffold --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" delete -m gardenlet
     kubectl  --kubeconfig "$VIRTUAL_GARDEN_KUBECONFIG" delete seed/"$gardenlet_name" --ignore-not-found --wait --timeout 5m
     kubectl  -n garden delete deployment gardenlet --ignore-not-found
+    kubectl  -n garden delete secret gardenlet-kubeconfig --ignore-not-found
 
     if [[ "$SCENARIO" == "remote" ]]; then
       kubectl delete -k "$SCRIPT_DIR/remote/registry/kyverno-policies" --ignore-not-found


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR improves the cleanup of resources in the (remote) dev setup when running `make seed-down` or `make garden-down`.

`make seed-down` now also removes the `gardenlet-kubeconfig`, so running `make seed-up` afterwards succeeds. If the old kubeconfig still exists, gardenlet will use it instead of bootstrapping. This is an issue especially over night or when the virtual garden has been recreated and the old `gardenlet-kubeconfig` is invalid.

`make garden-down` now also removes all PVCs in the `garden` namespace. The ETCD PVCs in particular are causing issues if a new virtual garden is created afterwards, because the ETCD encryption secret has changed and it can no longer access the data in the PVCs. `make garden-down` will also remove the virtual garden kubeconfig, since it has no valid target and can confuse other commands like the deploy-registry script, which will attempt to deploy secrets into an invalid virtual garden.

With these changes it should be possible to run cycles of `make garden-down && make garden-up` or `make seed-down && make seed-up`, which was not possible before without tearing down the entire remote setup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`make seed-down` and `make garden-down` cleanup additional resources
```
