### PR TITLE
Add shoot API server availability panel with region labels to Shoot Details dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
@@ -740,7 +740,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Shoot APIServer Availablity",
+      "title": "Shoot APIServer Availability",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
@@ -668,13 +668,123 @@
       }
     },
     {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 25,
+      "panels": [],
+      "repeat": null,
+      "title": "Seed↔Shoot Connectivity",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows APIServer availability for shoots hosted on seed $shoot across regions.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.16",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "shoot:availability * on(name, project) group_left(region, iaas, seed_region, seed_iaas) (garden_shoot_info{seed=\"$shoot\", is_seed=\"false\"} * 0 + 1)",
+          "interval": "",
+          "legendFormat": "{{name}}: {{kind}} ({{iaas}}, {{region}})/({{seed_iaas}}, {{seed_region}})",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot APIServer Availablity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 17
       },
       "id": 12,
       "panels": [
@@ -1075,7 +1185,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 19
       },
       "id": 20,
       "panels": [],
@@ -1103,7 +1213,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 20
       },
       "hiddenSeries": false,
       "id": 22,

--- a/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/garden/shoot-details-dashboard.json
@@ -688,7 +688,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Shows APIServer availability for shoots hosted on seed $shoot across regions.",
+      "description": "Shows APIServer availability for shoots hosted on seed $shoot across regions. \nDisplay: \nShoot Name: (Shoot IaaS, Shoot Region)/(Seed IaaS, Seed Region)",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -730,9 +730,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "shoot:availability * on(name, project) group_left(region, iaas, seed_region, seed_iaas) (garden_shoot_info{seed=\"$shoot\", is_seed=\"false\"} * 0 + 1)",
+          "expr": "min by(name, project) (shoot:availability) * on(name, project) group_left(region, iaas, seed_region, seed_iaas) (garden_shoot_info{seed=\"$shoot\", is_seed=\"false\"} * 0 + 1)",
           "interval": "",
-          "legendFormat": "{{name}}: {{kind}} ({{iaas}}, {{region}})/({{seed_iaas}}, {{seed_region}})",
+          "legendFormat": "{{name}}: ({{iaas}}, {{region}})/({{seed_iaas}}, {{seed_region}})",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Adds a new row to the Plutono Shoot Details dashboard. The section contains one new graph panel — "Shoot APIServer Availability" — that visualises cross-region API server reachability for all shoot clusters hosted on the selected seed.

When a shoot cluster becomes unavailable, the root cause is often ambiguous. When it comes to a network connectivity issue, it makes easier to quickly identify with a visual dashboard showing inter-region connectivity, pointing to the underlying infrastructure connectivity issue. 

The new pannel displays shoot's region/IaaS and the seed's region/IaaS — making it immediately visible whether an availability drop is correlated with a specific cloud provider or region pair.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
