### PR TITLE
Expose CA flag `emit-per-nodegroup-metrics`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2189,6 +2189,18 @@ integer
 <p>NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset (default: 3h).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>emitPerNodeGroupMetrics</code></br>
+<em>
+boolean
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EmitPerNodeGroupMetrics emits additional per node group metrics</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2191,7 +2191,7 @@ integer
 </tr>
 <tr>
 <td>
-<code>EmitPerNodeGroupMetrics</code></br>
+<code>emitPerNodeGroupMetrics</code></br>
 <em>
 boolean
 </em>

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2191,14 +2191,14 @@ integer
 </tr>
 <tr>
 <td>
-<code>emitPerNodeGroupMetrics</code></br>
+<code>EmitPerNodeGroupMetrics</code></br>
 <em>
 boolean
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>EmitPerNodeGroupMetrics emits additional per node group metrics</p>
+<p>EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).</p>
 </td>
 </tr>
 

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -348,6 +348,7 @@ spec:
   #   maxScaleDownParallelism: 10
   #   maxDrainParallelism: 1
   #   ignoreDaemonsetsUtilization: false
+  #   emitPerNodeGroupMetrics: false
   #   verbosity: 2
   # verticalPodAutoscaler:
   #   enabled: true

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -608,7 +608,7 @@ type ClusterAutoscaler struct {
 	MaxDrainParallelism *int32
 	// IgnoreDaemonsetsUtilization allows CA to ignore DaemonSet pods when calculating resource utilization for scaling down.
 	IgnoreDaemonsetsUtilization *bool
-	// EmitPerNodeGroupMetrics emits additional per node group metrics
+	// EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
 	EmitPerNodeGroupMetrics *bool
 	// Verbosity allows CA to modify its log level.
 	Verbosity *int32

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -608,6 +608,8 @@ type ClusterAutoscaler struct {
 	MaxDrainParallelism *int32
 	// IgnoreDaemonsetsUtilization allows CA to ignore DaemonSet pods when calculating resource utilization for scaling down.
 	IgnoreDaemonsetsUtilization *bool
+	// EmitPerNodeGroupMetrics emits additional per node group metrics
+	EmitPerNodeGroupMetrics *bool
 	// Verbosity allows CA to modify its log level.
 	Verbosity *int32
 }

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -399,6 +399,9 @@ func SetDefaults_ClusterAutoscaler(obj *ClusterAutoscaler) {
 	if obj.IgnoreDaemonsetsUtilization == nil {
 		obj.IgnoreDaemonsetsUtilization = ptr.To(false)
 	}
+	if obj.EmitPerNodeGroupMetrics == nil {
+		obj.EmitPerNodeGroupMetrics = ptr.To(false)
+	}
 	if obj.Verbosity == nil {
 		obj.Verbosity = ptr.To[int32](2)
 	}

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -1063,6 +1063,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Expander).To(PointTo(Equal(expanderLeastWaste)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxGracefulTerminationSeconds).To(PointTo(Equal(int32(600))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.IgnoreDaemonsetsUtilization).To(PointTo(Equal(false)))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.EmitPerNodeGroupMetrics).To(PointTo(Equal(false)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Verbosity).To(PointTo(Equal(int32(2))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NewPodScaleUpDelay).To(PointTo(Equal(metav1.Duration{Duration: 0})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxScaleDownParallelism).To(PointTo(Equal(int32(10))))
@@ -1084,6 +1085,7 @@ var _ = Describe("Shoot defaulting", func() {
 				MaxNodeProvisionTime:            &metav1.Duration{Duration: 6 * time.Hour},
 				MaxGracefulTerminationSeconds:   ptr.To(int32(60 * 60 * 24)),
 				IgnoreDaemonsetsUtilization:     ptr.To(true),
+				EmitPerNodeGroupMetrics:         ptr.To(true),
 				Verbosity:                       ptr.To[int32](4),
 				NewPodScaleUpDelay:              &metav1.Duration{Duration: 1},
 				MaxEmptyBulkDelete:              ptr.To[int32](20),
@@ -1106,6 +1108,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Expander).To(PointTo(Equal(ClusterAutoscalerExpanderRandom)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxGracefulTerminationSeconds).To(PointTo(Equal(int32(60 * 60 * 24))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.IgnoreDaemonsetsUtilization).To(PointTo(Equal(true)))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.EmitPerNodeGroupMetrics).To(PointTo(Equal(true)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Verbosity).To(PointTo(Equal(int32(4))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NewPodScaleUpDelay).To(PointTo(Equal(metav1.Duration{Duration: 1})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxEmptyBulkDelete).To(PointTo(Equal(int32(20))))
@@ -1128,6 +1131,7 @@ var _ = Describe("Shoot defaulting", func() {
 				MaxNodeProvisionTime:            &metav1.Duration{Duration: 6 * time.Hour},
 				MaxGracefulTerminationSeconds:   ptr.To(int32(60 * 60 * 24)),
 				IgnoreDaemonsetsUtilization:     ptr.To(true),
+				EmitPerNodeGroupMetrics:         ptr.To(true),
 				Verbosity:                       ptr.To[int32](4),
 				NewPodScaleUpDelay:              &metav1.Duration{Duration: 1},
 				MaxEmptyBulkDelete:              ptr.To[int32](17),
@@ -1149,6 +1153,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Expander).To(PointTo(Equal(ClusterAutoscalerExpanderRandom)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxGracefulTerminationSeconds).To(PointTo(Equal(int32(60 * 60 * 24))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.IgnoreDaemonsetsUtilization).To(PointTo(Equal(true)))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.EmitPerNodeGroupMetrics).To(PointTo(Equal(true)))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.Verbosity).To(PointTo(Equal(int32(4))))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NewPodScaleUpDelay).To(PointTo(Equal(metav1.Duration{Duration: 1})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxEmptyBulkDelete).To(PointTo(Equal(int32(17))))

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -2215,6 +2215,18 @@ func (m *ClusterAutoscaler) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.EmitPerNodeGroupMetrics != nil {
+		i--
+		if *m.EmitPerNodeGroupMetrics {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb0
+	}
 	if m.NodeGroupBackoffResetTimeout != nil {
 		{
 			size, err := m.NodeGroupBackoffResetTimeout.MarshalToSizedBuffer(dAtA[:i])
@@ -14285,6 +14297,9 @@ func (m *ClusterAutoscaler) Size() (n int) {
 		l = m.NodeGroupBackoffResetTimeout.Size()
 		n += 2 + l + sovGenerated(uint64(l))
 	}
+	if m.EmitPerNodeGroupMetrics != nil {
+		n += 3
+	}
 	return n
 }
 
@@ -18937,6 +18952,7 @@ func (this *ClusterAutoscaler) String() string {
 		`InitialNodeGroupBackoffDuration:` + strings.Replace(fmt.Sprintf("%v", this.InitialNodeGroupBackoffDuration), "Duration", "v11.Duration", 1) + `,`,
 		`MaxNodeGroupBackoffDuration:` + strings.Replace(fmt.Sprintf("%v", this.MaxNodeGroupBackoffDuration), "Duration", "v11.Duration", 1) + `,`,
 		`NodeGroupBackoffResetTimeout:` + strings.Replace(fmt.Sprintf("%v", this.NodeGroupBackoffResetTimeout), "Duration", "v11.Duration", 1) + `,`,
+		`EmitPerNodeGroupMetrics:` + valueToStringGenerated(this.EmitPerNodeGroupMetrics) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -27423,6 +27439,27 @@ func (m *ClusterAutoscaler) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 22:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EmitPerNodeGroupMetrics", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			b := bool(v != 0)
+			m.EmitPerNodeGroupMetrics = &b
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -604,6 +604,10 @@ message ClusterAutoscaler {
   // NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset (default: 3h).
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeGroupBackoffResetTimeout = 21;
+
+  // EmitPerNodeGroupMetrics emits additional per node group metrics
+  // +optional
+  optional bool emitPerNodeGroupMetrics = 22;
 }
 
 // ClusterAutoscalerOptions contains the cluster autoscaler configurations for a worker pool.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -605,7 +605,7 @@ message ClusterAutoscaler {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration nodeGroupBackoffResetTimeout = 21;
 
-  // EmitPerNodeGroupMetrics emits additional per node group metrics
+  // EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
   // +optional
   optional bool emitPerNodeGroupMetrics = 22;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -775,6 +775,9 @@ type ClusterAutoscaler struct {
 	// NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset (default: 3h).
 	// +optional
 	NodeGroupBackoffResetTimeout *metav1.Duration `json:"nodeGroupBackoffResetTimeout,omitempty" protobuf:"bytes,21,opt,name=nodeGroupBackoffResetTimeout"`
+	// EmitPerNodeGroupMetrics emits additional per node group metrics
+	// +optional
+	EmitPerNodeGroupMetrics *bool `json:"emitPerNodeGroupMetrics,omitempty" protobuf:"bytes,22,opt,name=emitPerNodeGroupMetrics"`
 }
 
 // ExpanderMode is type used for Expander values

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -775,9 +775,9 @@ type ClusterAutoscaler struct {
 	// NodeGroupBackoffResetTimeout is the time after last failed scale-up when the backoff duration is reset (default: 3h).
 	// +optional
 	NodeGroupBackoffResetTimeout *metav1.Duration `json:"nodeGroupBackoffResetTimeout,omitempty" protobuf:"bytes,21,opt,name=nodeGroupBackoffResetTimeout"`
-	// EmitPerNodeGroupMetrics emits additional per node group metrics
+	// EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
 	// +optional
-	EmitPerNodeGroupMetrics *bool `json:"emitPerNodeGroupMetrics,omitempty" protobuf:"bytes,22,opt,name=emitPerNodeGroupMetrics"`
+	EmitPerNodeGroupMetrics *bool `json:"emitPerNodeGroupMetrics,omitempty" protobuf:"varint,22,opt,name=emitPerNodeGroupMetrics"`
 }
 
 // ExpanderMode is type used for Expander values

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3071,6 +3071,7 @@ func autoConvert_v1beta1_ClusterAutoscaler_To_core_ClusterAutoscaler(in *Cluster
 	out.InitialNodeGroupBackoffDuration = (*metav1.Duration)(unsafe.Pointer(in.InitialNodeGroupBackoffDuration))
 	out.MaxNodeGroupBackoffDuration = (*metav1.Duration)(unsafe.Pointer(in.MaxNodeGroupBackoffDuration))
 	out.NodeGroupBackoffResetTimeout = (*metav1.Duration)(unsafe.Pointer(in.NodeGroupBackoffResetTimeout))
+	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
 	return nil
 }
 
@@ -3100,6 +3101,7 @@ func autoConvert_core_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *core.Cl
 	out.MaxScaleDownParallelism = (*int32)(unsafe.Pointer(in.MaxScaleDownParallelism))
 	out.MaxDrainParallelism = (*int32)(unsafe.Pointer(in.MaxDrainParallelism))
 	out.IgnoreDaemonsetsUtilization = (*bool)(unsafe.Pointer(in.IgnoreDaemonsetsUtilization))
+	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
 	out.Verbosity = (*int32)(unsafe.Pointer(in.Verbosity))
 	return nil
 }

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1099,6 +1099,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.EmitPerNodeGroupMetrics != nil {
+		in, out := &in.EmitPerNodeGroupMetrics, &out.EmitPerNodeGroupMetrics
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1094,6 +1094,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EmitPerNodeGroupMetrics != nil {
+		in, out := &in.EmitPerNodeGroupMetrics, &out.EmitPerNodeGroupMetrics
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Verbosity != nil {
 		in, out := &in.Verbosity, &out.Verbosity
 		*out = new(int32)

--- a/pkg/apiserver/openapi/api_violations.report
+++ b/pkg/apiserver/openapi/api_violations.report
@@ -106,6 +106,7 @@ API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seed
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1,ManagedSeedSetStatus,Conditions
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1,ManagedSeedStatus,Conditions
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/settings/v1alpha1,KubeAPIServerOpenIDConnect,SigningAlgs
+API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,ClusterAutoscaler,EmitPerNodeGroupMetrics
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,DataVolume,VolumeSize
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,KubeControllerManagerConfig,HorizontalPodAutoscalerConfig
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,KubeletConfig,PodPIDsLimit

--- a/pkg/apiserver/openapi/api_violations.report
+++ b/pkg/apiserver/openapi/api_violations.report
@@ -106,7 +106,6 @@ API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seed
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1,ManagedSeedSetStatus,Conditions
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1,ManagedSeedStatus,Conditions
 API rule violation: list_type_missing,github.com/gardener/gardener/pkg/apis/settings/v1alpha1,KubeAPIServerOpenIDConnect,SigningAlgs
-API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,ClusterAutoscaler,EmitPerNodeGroupMetrics
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,DataVolume,VolumeSize
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,KubeControllerManagerConfig,HorizontalPodAutoscalerConfig
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/core/v1beta1,KubeletConfig,PodPIDsLimit

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2625,6 +2625,13 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},
+					"emitPerNodeGroupMetrics": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EmitPerNodeGroupMetrics emits additional per node group metrics",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2625,9 +2625,9 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},
-					"emitPerNodeGroupMetrics": {
+					"EmitPerNodeGroupMetrics": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EmitPerNodeGroupMetrics emits additional per node group metrics",
+							Description: "EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2625,7 +2625,7 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},
-					"EmitPerNodeGroupMetrics": {
+					"emitPerNodeGroupMetrics": {
 						SchemaProps: spec.SchemaProps{
 							Description: "EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).",
 							Type:        []string{"boolean"},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -348,6 +348,11 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 					"cluster_autoscaler_unneeded_nodes_count",
 					"cluster_autoscaler_old_unregistered_nodes_removed_count",
 					"cluster_autoscaler_skipped_scale_events_count",
+					"cluster_autoscaler_node_group_backoff_status",
+					"cluster_autoscaler_node_group_healthiness",
+					"cluster_autoscaler_node_group_target_count",
+					"cluster_autoscaler_node_group_max_count",
+					"cluster_autoscaler_node_group_min_count",
 				),
 			}},
 		}
@@ -500,6 +505,7 @@ func (c *clusterAutoscaler) computeCommand(workersHavePriorityConfigured bool) [
 		fmt.Sprintf("--max-drain-parallelism=%d", *c.config.MaxDrainParallelism),
 		fmt.Sprintf("--new-pod-scale-up-delay=%s", c.config.NewPodScaleUpDelay.Duration),
 		fmt.Sprintf("--max-nodes-total=%d", c.maxNodesTotal),
+		fmt.Sprintf("--emit-per-nodegroup-metrics=%t", *c.config.EmitPerNodeGroupMetrics),
 	)
 
 	for _, taint := range c.config.StartupTaints {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -133,6 +133,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 		configScaleDownUtilizationThreshold         = ptr.To(float64(1.2345))
 		configScanInterval                          = &metav1.Duration{Duration: time.Second}
 		configIgnoreDaemonsetsUtilization           = true
+		configEmitPerNodeGroupMetrics               = true
 		configVerbosity                       int32 = 4
 		configMaxEmptyBulkDelete                    = ptr.To[int32](20)
 		configMaxScaleDownParallelism               = ptr.To[int32](20)
@@ -156,6 +157,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			StatusTaints:                    configTaints,
 			IgnoreTaints:                    configTaints,
 			IgnoreDaemonsetsUtilization:     &configIgnoreDaemonsetsUtilization,
+			EmitPerNodeGroupMetrics:         &configEmitPerNodeGroupMetrics,
 			Verbosity:                       &configVerbosity,
 			MaxEmptyBulkDelete:              configMaxEmptyBulkDelete,
 			MaxScaleDownParallelism:         configMaxScaleDownParallelism,
@@ -326,6 +328,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					"--max-drain-parallelism=1",
 					"--new-pod-scale-up-delay=0s",
 					"--max-nodes-total=0",
+					"--emit-per-nodegroup-metrics=false",
 				)
 			} else {
 				commandConfigFlags = append(commandConfigFlags,
@@ -347,6 +350,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					fmt.Sprintf("--max-drain-parallelism=%d", *configMaxDrainParallelism),
 					fmt.Sprintf("--new-pod-scale-up-delay=%s", configNewPodScaleUpDelay.Duration),
 					"--max-nodes-total=0",
+					fmt.Sprintf("--emit-per-nodegroup-metrics=%t", configEmitPerNodeGroupMetrics),
 					fmt.Sprintf("--startup-taint=%s", configTaints[0]),
 					fmt.Sprintf("--startup-taint=%s", configTaints[1]),
 					fmt.Sprintf("--status-taint=%s", configTaints[0]),
@@ -504,7 +508,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
 						SourceLabels: []monitoringv1.LabelName{"__name__"},
 						Action:       "keep",
-						Regex:        `^(process_max_fds|process_open_fds|cluster_autoscaler_cluster_safe_to_autoscale|cluster_autoscaler_nodes_count|cluster_autoscaler_unschedulable_pods_count|cluster_autoscaler_node_groups_count|cluster_autoscaler_max_nodes_count|cluster_autoscaler_cluster_cpu_current_cores|cluster_autoscaler_cpu_limits_cores|cluster_autoscaler_cluster_memory_current_bytes|cluster_autoscaler_memory_limits_bytes|cluster_autoscaler_last_activity|cluster_autoscaler_function_duration_seconds|cluster_autoscaler_errors_total|cluster_autoscaler_scaled_up_nodes_total|cluster_autoscaler_scaled_down_nodes_total|cluster_autoscaler_scaled_up_gpu_nodes_total|cluster_autoscaler_scaled_down_gpu_nodes_total|cluster_autoscaler_failed_scale_ups_total|cluster_autoscaler_evicted_pods_total|cluster_autoscaler_unneeded_nodes_count|cluster_autoscaler_old_unregistered_nodes_removed_count|cluster_autoscaler_skipped_scale_events_count)$`,
+						Regex:        `^(process_max_fds|process_open_fds|cluster_autoscaler_cluster_safe_to_autoscale|cluster_autoscaler_nodes_count|cluster_autoscaler_unschedulable_pods_count|cluster_autoscaler_node_groups_count|cluster_autoscaler_max_nodes_count|cluster_autoscaler_cluster_cpu_current_cores|cluster_autoscaler_cpu_limits_cores|cluster_autoscaler_cluster_memory_current_bytes|cluster_autoscaler_memory_limits_bytes|cluster_autoscaler_last_activity|cluster_autoscaler_function_duration_seconds|cluster_autoscaler_errors_total|cluster_autoscaler_scaled_up_nodes_total|cluster_autoscaler_scaled_down_nodes_total|cluster_autoscaler_scaled_up_gpu_nodes_total|cluster_autoscaler_scaled_down_gpu_nodes_total|cluster_autoscaler_failed_scale_ups_total|cluster_autoscaler_evicted_pods_total|cluster_autoscaler_unneeded_nodes_count|cluster_autoscaler_old_unregistered_nodes_removed_count|cluster_autoscaler_skipped_scale_events_count|cluster_autoscaler_node_group_backoff_status|cluster_autoscaler_node_group_healthiness|cluster_autoscaler_node_group_target_count|cluster_autoscaler_node_group_max_count|cluster_autoscaler_node_group_min_count)$`,
 					}},
 				}},
 			},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement api-change

**What this PR does / why we need it**:
This PR updated the shoot API to add a new field: `.spec.kubernetes.clusterAutoscaler.emitPerNodeGroupMetrics`

This field is to be passed on to cluster-autoscaler as a configurable flag and is meant to help users by emitting additional per nodegroup metrics

**Which issue(s) this PR fixes**:
Fixes #13956

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Additional per nodegroup metrics can be exposed by `cluster-autoscaler` via the field `.spec.kubernetes.clusterAutoscaler.emitPerNodeGroupMetrics` in the `Shoot` API .
```
