### PR TITLE
Allow least-nodes expander to be used for CA

### DIFF
--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -130,13 +130,11 @@ var (
 	availableWorkerCRINames = sets.New(
 		string(core.CRINameContainerD),
 	)
-	availableClusterAutoscalerExpanderModesWithK8s130 = sets.New(
+	availableClusterAutoscalerExpanderModes = sets.New(
 		string(core.ClusterAutoscalerExpanderLeastWaste),
 		string(core.ClusterAutoscalerExpanderMostPods),
 		string(core.ClusterAutoscalerExpanderPriority),
 		string(core.ClusterAutoscalerExpanderRandom),
-	)
-	availableClusterAutoscalerExpanderModes = availableClusterAutoscalerExpanderModesWithK8s130.Clone().Insert(
 		string(core.ClusterAutoscalerExpanderLeastNodes),
 	)
 	availableCoreDNSAutoscalingModes = sets.New(
@@ -1492,15 +1490,11 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.ScanInterval, fldPath.Child("scanInterval"))...)
 
-	expanderModes := availableClusterAutoscalerExpanderModes
-	if versionutils.ConstraintK8sLess131.CheckVersion(kubernetesVersion) {
-		expanderModes = availableClusterAutoscalerExpanderModesWithK8s130
-	}
 	if expander := autoScaler.Expander; expander != nil {
 		expanderArray := strings.SplitSeq(string(*expander), ",")
 		for exp := range expanderArray {
-			if !expanderModes.Has(exp) {
-				allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(expanderModes)))
+			if !availableClusterAutoscalerExpanderModes.Has(exp) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(availableClusterAutoscalerExpanderModes)))
 			}
 		}
 	}

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -135,6 +135,13 @@ var (
 		string(core.ClusterAutoscalerExpanderMostPods),
 		string(core.ClusterAutoscalerExpanderPriority),
 		string(core.ClusterAutoscalerExpanderRandom),
+		string(core.ClusterAutoscalerExpanderLeastNodes),
+	)
+	availableClusterAutoscalerExpanderModesWithK8s130 = sets.New(
+		string(core.ClusterAutoscalerExpanderLeastWaste),
+		string(core.ClusterAutoscalerExpanderMostPods),
+		string(core.ClusterAutoscalerExpanderPriority),
+		string(core.ClusterAutoscalerExpanderRandom),
 	)
 	availableCoreDNSAutoscalingModes = sets.New(
 		string(core.CoreDNSAutoscalingModeClusterProportional),
@@ -1489,11 +1496,15 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.ScanInterval, fldPath.Child("scanInterval"))...)
 
+	expanderModes := availableClusterAutoscalerExpanderModes
+	if !versionutils.ConstraintK8sGreaterEqual131.CheckVersion(kubernetesVersion) {
+		expanderModes = availableClusterAutoscalerExpanderModesWithK8s130
+	}
 	if expander := autoScaler.Expander; expander != nil {
 		expanderArray := strings.SplitSeq(string(*expander), ",")
 		for exp := range expanderArray {
-			if !availableClusterAutoscalerExpanderModes.Has(exp) {
-				allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(availableClusterAutoscalerExpanderModes)))
+			if !expanderModes.Has(exp) {
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("expander"), *expander, sets.List(expanderModes)))
 			}
 		}
 	}

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -130,18 +130,14 @@ var (
 	availableWorkerCRINames = sets.New(
 		string(core.CRINameContainerD),
 	)
-	availableClusterAutoscalerExpanderModes = sets.New(
-		string(core.ClusterAutoscalerExpanderLeastWaste),
-		string(core.ClusterAutoscalerExpanderMostPods),
-		string(core.ClusterAutoscalerExpanderPriority),
-		string(core.ClusterAutoscalerExpanderRandom),
-		string(core.ClusterAutoscalerExpanderLeastNodes),
-	)
 	availableClusterAutoscalerExpanderModesWithK8s130 = sets.New(
 		string(core.ClusterAutoscalerExpanderLeastWaste),
 		string(core.ClusterAutoscalerExpanderMostPods),
 		string(core.ClusterAutoscalerExpanderPriority),
 		string(core.ClusterAutoscalerExpanderRandom),
+	)
+	availableClusterAutoscalerExpanderModes = availableClusterAutoscalerExpanderModesWithK8s130.Clone().Insert(
+		string(core.ClusterAutoscalerExpanderLeastNodes),
 	)
 	availableCoreDNSAutoscalingModes = sets.New(
 		string(core.CoreDNSAutoscalingModeClusterProportional),
@@ -1497,7 +1493,7 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.ScanInterval, fldPath.Child("scanInterval"))...)
 
 	expanderModes := availableClusterAutoscalerExpanderModes
-	if !versionutils.ConstraintK8sGreaterEqual131.CheckVersion(kubernetesVersion) {
+	if versionutils.ConstraintK8sLess131.CheckVersion(kubernetesVersion) {
 		expanderModes = availableClusterAutoscalerExpanderModesWithK8s130
 	}
 	if expander := autoScaler.Expander; expander != nil {

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -4079,6 +4079,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 			expanderMostPods                    = core.ClusterAutoscalerExpanderMostPods
 			expanderPriority                    = core.ClusterAutoscalerExpanderPriority
 			expanderRandom                      = core.ClusterAutoscalerExpanderRandom
+			expanderLeastNodes                  = core.ClusterAutoscalerExpanderLeastNodes
 			expanderPriorityAndLeastWaste       = core.ClusterAutoscalerExpanderPriority + "," + core.ClusterAutoscalerExpanderLeastWaste
 			invalidExpander                     = core.ClusterAutoscalerExpanderPriority + ", test-expander"
 			invalidMultipleExpanderString       = core.ClusterAutoscalerExpanderPriority + ", " + core.ClusterAutoscalerExpanderLeastWaste
@@ -4134,6 +4135,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}, version_1_31, BeEmpty()),
 				Entry("valid with expander random", core.ClusterAutoscaler{
 					Expander: &expanderRandom,
+				}, version_1_31, BeEmpty()),
+				Entry("valid with expander least nodes", core.ClusterAutoscaler{
+					Expander: &expanderLeastNodes,
 				}, version_1_31, BeEmpty()),
 				Entry("valid with startup taint", core.ClusterAutoscaler{
 					StartupTaints: taintsUnique,

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -631,6 +631,10 @@ const (
 	// ClusterAutoscalerExpanderRandom should be used when you don't have a particular need
 	// for the node groups to scale differently.
 	ClusterAutoscalerExpanderRandom ExpanderMode = "random"
+	// ClusterAutoscalerExpanderLeastNodes selects the node group that will use the least number of nodes after scale-up.
+	// This is useful when you want to minimize the number of nodes in the cluster and instead opt for fewer larger nodes.
+	// Useful when chained with the most-pods expander before it to ensure that the node group selected can fit the most pods on the fewest nodes.
+	ClusterAutoscalerExpanderLeastNodes ExpanderMode = "least-nodes"
 )
 
 // VerticalPodAutoscaler contains the configuration flags for the Kubernetes vertical pod autoscaler.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -632,7 +632,7 @@ const (
 	// for the node groups to scale differently.
 	ClusterAutoscalerExpanderRandom ExpanderMode = "random"
 	// ClusterAutoscalerExpanderLeastNodes selects the node group that will use the least number of nodes after scale-up.
-	// This is useful when you want to minimize the number of nodes in the cluster and instead opt for fewer larger nodes.
+	// This is useful when you want to minimize the number of nodes in the cluster and opt for fewer larger nodes.
 	// Useful when chained with the most-pods expander before it to ensure that the node group selected can fit the most pods on the fewest nodes.
 	ClusterAutoscalerExpanderLeastNodes ExpanderMode = "least-nodes"
 )

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -797,7 +797,7 @@ const (
 	// for the node groups to scale differently.
 	ClusterAutoscalerExpanderRandom ExpanderMode = "random"
 	// ClusterAutoscalerExpanderLeastNodes selects the node group that will use the least number of nodes after scale-up.
-	// This is useful when you want to minimize the number of nodes in the cluster and instead opt for fewer larger nodes.
+	// This is useful when you want to minimize the number of nodes in the cluster and opt for fewer larger nodes.
 	// Useful when chained with the most-pods expander before it to ensure that the node group selected can fit the most pods on the fewest nodes.
 	ClusterAutoscalerExpanderLeastNodes ExpanderMode = "least-nodes"
 )

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -796,6 +796,10 @@ const (
 	// ClusterAutoscalerExpanderRandom should be used when you don't have a particular need
 	// for the node groups to scale differently.
 	ClusterAutoscalerExpanderRandom ExpanderMode = "random"
+	// ClusterAutoscalerExpanderLeastNodes selects the node group that will use the least number of nodes after scale-up.
+	// This is useful when you want to minimize the number of nodes in the cluster and instead opt for fewer larger nodes.
+	// Useful when chained with the most-pods expander before it to ensure that the node group selected can fit the most pods on the fewest nodes.
+	ClusterAutoscalerExpanderLeastNodes ExpanderMode = "least-nodes"
 )
 
 // VerticalPodAutoscaler contains the configuration flags for the Kubernetes vertical pod autoscaler.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR allows `cluster-autoscaler` to be run with the `least-nodes` [expander](https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders) which has been available to be used since `v1.31`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
cluster-autoscaler now supports a new expander `least-nodes` from v1.31 onwards
```
