### PR TITLE
Fix flaky `extension-required-runtime` integration test

### DIFF
--- a/pkg/operator/controller/extension/required/runtime/add.go
+++ b/pkg/operator/controller/extension/required/runtime/add.go
@@ -6,8 +6,6 @@ package runtime
 
 import (
 	"context"
-	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -27,14 +25,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	apiextensions "github.com/gardener/gardener/pkg/api/extensions"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	"github.com/gardener/gardener/pkg/extensions"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/gardener/operator"
 )
 
 // ControllerName is the name of this controller.
@@ -112,32 +107,20 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	return nil
 }
 
-// MapGardenToExtensions returns a mapping function that maps a given garden resource to all related extensions.
+// MapGardenToExtensions returns a mapping function that maps a given garden resource to all extensions.
+// All extensions are enqueued (not just the currently required ones) so that extensions transitioning from
+// required to not-required are also reconciled and have their conditions updated.
 func (r *Reconciler) MapGardenToExtensions(log logr.Logger) handler.MapFunc {
-	return func(ctx context.Context, obj client.Object) []reconcile.Request {
-		garden, ok := obj.(*operatorv1alpha1.Garden)
-		if !ok {
-			log.Error(fmt.Errorf("expected Garden but got %#v", obj), "Unable to convert to Garden")
-			return nil
-		}
-
+	return func(ctx context.Context, _ client.Object) []reconcile.Request {
 		extensionList := &operatorv1alpha1.ExtensionList{}
 		if err := r.Client.List(ctx, extensionList); err != nil {
 			log.Error(err, "Failed to list extensions")
 			return nil
 		}
 
-		var (
-			requests           []reconcile.Request
-			requiredExtensions = operator.ComputeRequiredExtensionsForGarden(garden, extensionList)
-		)
-
+		var requests []reconcile.Request
 		for _, extension := range extensionList.Items {
-			if slices.ContainsFunc(extension.Spec.Resources, func(resource gardencorev1beta1.ControllerResource) bool {
-				return requiredExtensions.Has(gardenerutils.ExtensionsID(resource.Kind, resource.Type))
-			}) {
-				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
-			}
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: extension.Name, Namespace: extension.Namespace}})
 		}
 
 		return requests

--- a/pkg/operator/controller/extension/required/runtime/add_test.go
+++ b/pkg/operator/controller/extension/required/runtime/add_test.go
@@ -48,7 +48,6 @@ var _ = Describe("Add", func() {
 		Describe("#MapGardenToExtensions", func() {
 			var (
 				fakeClient client.Client
-				garden     *operatorv1alpha1.Garden
 				mapperFunc handler.MapFunc
 			)
 
@@ -56,41 +55,18 @@ var _ = Describe("Add", func() {
 				fakeClient = fake.NewClientBuilder().WithScheme(operatorclient.RuntimeScheme).Build()
 				reconciler.Client = fakeClient
 
-				garden = &operatorv1alpha1.Garden{
-					Spec: operatorv1alpha1.GardenSpec{
-						DNS: &operatorv1alpha1.DNSManagement{
-							Providers: []operatorv1alpha1.DNSProvider{
-								{Type: "local-dns"},
-							},
-						},
-						Extensions: []operatorv1alpha1.GardenExtension{
-							{Type: "local-extension-1"},
-							{Type: "local-extension-2"},
-						},
-						VirtualCluster: operatorv1alpha1.VirtualCluster{
-							ETCD: &operatorv1alpha1.ETCD{
-								Main: &operatorv1alpha1.ETCDMain{
-									Backup: &operatorv1alpha1.Backup{
-										Provider: "local-infrastructure",
-									},
-								},
-							},
-						},
-					},
-				}
-
 				mapperFunc = reconciler.MapGardenToExtensions(log)
 			})
 
 			Context("without extensions", func() {
 				It("should not return any requests", func() {
-					Expect(mapperFunc(ctx, garden)).To(BeEmpty())
+					Expect(mapperFunc(ctx, nil)).To(BeEmpty())
 				})
 			})
 
 			Context("with extensions", func() {
 				var (
-					infraExtension, dnsExtension *operatorv1alpha1.Extension
+					infraExtension, dnsExtension, genericExtension *operatorv1alpha1.Extension
 				)
 
 				BeforeEach(func() {
@@ -116,14 +92,27 @@ var _ = Describe("Add", func() {
 						},
 					}
 
+					genericExtension = &operatorv1alpha1.Extension{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "local-generic",
+						},
+						Spec: operatorv1alpha1.ExtensionSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{Kind: "Extension", Type: "local-extension"},
+							},
+						},
+					}
+
 					Expect(fakeClient.Create(ctx, infraExtension)).To(Succeed())
 					Expect(fakeClient.Create(ctx, dnsExtension)).To(Succeed())
+					Expect(fakeClient.Create(ctx, genericExtension)).To(Succeed())
 				})
 
-				It("should return the expected extensions", func() {
-					Expect(mapperFunc(ctx, garden)).To(ConsistOf(
+				It("should return all extensions", func() {
+					Expect(mapperFunc(ctx, nil)).To(ConsistOf(
 						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: infraExtension.Name}}),
 						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: dnsExtension.Name}}),
+						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: genericExtension.Name}}),
 					))
 				})
 			})

--- a/test/integration/operator/extension/required/runtime/runtime_suite_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_suite_test.go
@@ -53,6 +53,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	testRunID       string
 	testNamespace   *corev1.Namespace
@@ -134,6 +135,7 @@ var _ = BeforeSuite(func() {
 	})
 
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("Register controller")
 	DeferCleanup(test.WithVar(&requiredruntime.RequeueExtensionKindNotCalculated, 10*time.Millisecond))

--- a/test/integration/operator/extension/required/runtime/runtime_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_test.go
@@ -290,6 +290,10 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 			Expect(testClient.Delete(ctx, backupBucket)).To(Succeed())
 		})
 
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(backupBucket), backupBucket)
+		}).Should(Succeed())
+
 		Expect(testClient.Delete(ctx, garden)).To(Succeed())
 
 		Eventually(func(g Gomega) []gardencorev1beta1.Condition {


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind flake

**What this PR does / why we need it**:
The `extension-required-runtime` integration test creates a `BackupBucket` and immediately deletes the `Garden`, but the controller's cached client may not have seen the `BackupBucket` yet. This causes the reconciler to incorrectly report the provider extension as not-required, flaking the test. Fix by waiting for the `BackupBucket` to be visible in the manager cache (via `mgrClient.Get()`) before deleting the garden.

Additionally, `MapGardenToExtensions` is simplified to enqueue all extensions unconditionally — the reconciler already computes the correct required state, so filtering in the mapper was unnecessary.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Example CI failures: [#14508](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14508/pull-gardener-integration/2041871651699691520), [#14519](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14519/pull-gardener-integration/2041881986498301952).

**Release note**:
```other developer
NONE
```