### PR TITLE
Use `Info` logging for admission denials instead of `Error`.

### DIFF
--- a/extensions/pkg/webhook/handler.go
+++ b/extensions/pkg/webhook/handler.go
@@ -173,7 +173,7 @@ func (h *handler) handle(ctx context.Context, req admission.Request, action hand
 	switch {
 	case action.mutator != nil:
 		if err = action.mutator.Mutate(ctx, newObj, oldObj); err != nil {
-			h.logger.Error(fmt.Errorf("could not process: %w", err), "Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
+			h.logger.Info("Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName(), "error", fmt.Errorf("could not process: %w", err))
 			return admission.Denied(err.Error())
 		}
 
@@ -193,7 +193,7 @@ func (h *handler) handle(ctx context.Context, req admission.Request, action hand
 
 	case action.validator != nil:
 		if err = action.validator.Validate(ctx, newObj, oldObj); err != nil {
-			h.logger.Error(fmt.Errorf("could not process: %w", err), "Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
+			h.logger.Info("Admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName(), "error", fmt.Errorf("could not process: %w", err))
 			return admission.Denied(err.Error())
 		}
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:

Admission denials are expected behaviour, not code errors. Using `logger.Error()` caused zap to automatically append a full stack trace to every denial log entry, adding noise without actionable information.

This change switches to `logger.Info()` for both mutator and validator denial paths, keeping the same structured fields (kind, namespace, name, error) while eliminating the spurious stack traces.


For example:
```
2026-04-10T09:52:33.864Z	ERROR	shoot-validator.handler	Admission denied	{"provider": "shoot-traefik", "kind": "Shoot", "namespace": "garden", "name": "d068290l-v4b", "error": "could not process: traefik extension can only be enabled for shoots with purpose 'evaluation'. Current purpose: production. Traefik acts as a replacement for the nginx ingress controller and is only supported for evaluation clusters"}
github.com/gardener/gardener/extensions/pkg/webhook.(*handler).handle
	/go/pkg/mod/github.com/gardener/gardener@v1.138.0/extensions/pkg/webhook/handler.go:196
github.com/gardener/gardener/extensions/pkg/webhook.(*handler).Handle
	/go/pkg/mod/github.com/gardener/gardener@v1.138.0/extensions/pkg/webhook/handler.go:137
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/webhook/admission/webhook.go:181
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/webhook/admission/http.go:119
sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/promhttp/instrument_server.go:60
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2286
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/promhttp/instrument_server.go:147
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2286
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
	/go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/promhttp/instrument_server.go:109
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2286
net/http.(*ServeMux).ServeHTTP
	/usr/local/go/src/net/http/server.go:2828
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:3311
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:2073
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `Info` logging for admission denials instead of `Error` so that the full stack trace to every denial log entry does not get logged
```
