### PR TITLE
Fix `Makefile` target name for `gardenadm` unmanaged-infra-external-gardener e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ ci-e2e-kind-operator: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-operator.sh
 ci-e2e-kind-gardenadm-unmanaged-infra: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-gardenadm-unmanaged-infra.sh
-ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh: $(KIND) $(YQ)
+ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener.sh
 ci-e2e-kind-gardenadm-managed-infra: $(KIND) $(YQ)
 	./hack/ci-e2e-kind-gardenadm-managed-infra.sh


### PR DESCRIPTION
## Summary
- The `Makefile` target `ci-e2e-kind-gardenadm-unmanaged-infra-external-gardener` was accidentally named with a `.sh` suffix, causing GNU Make to fall back to its built-in implicit rule (`%: %.sh` → `cat`) instead of running the intended recipe.

## Related
- Prow job failure: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14220/pull-gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener/2043581174634254336