### PR TITLE
Replace `Ingress` exposure of Vali with Istio-native exposure

### DIFF
--- a/pkg/component/observability/logging/vali/vali.go
+++ b/pkg/component/observability/logging/vali/vali.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
@@ -40,6 +43,7 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/istio"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -116,12 +120,13 @@ type Values struct {
 	InitLargeDirImage  string
 	IsGardenCluster    bool
 
-	ClusterType             component.ClusterType
-	Replicas                int32
-	PriorityClassName       string
-	IngressHost             string
-	ShootNodeLoggingEnabled bool
-	Storage                 *resource.Quantity
+	ClusterType               component.ClusterType
+	Replicas                  int32
+	PriorityClassName         string
+	IngressHost               string
+	IstioIngressGatewayLabels map[string]string
+	ShootNodeLoggingEnabled   bool
+	Storage                   *resource.Quantity
 }
 
 // Interface is the interface for the Vali deployer.
@@ -208,10 +213,12 @@ func (v *vali) Deploy(ctx context.Context) error {
 		}
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
-		resources = append(resources,
-			v.getIngress(ingressTLSSecret.Name),
-			telegrafConfigMap,
-		)
+		istioResources, err := v.getIstioResources(ingressTLSSecret)
+		if err != nil {
+			return fmt.Errorf("failed to get istio resources: %w", err)
+		}
+
+		resources = append(append(resources, telegrafConfigMap), istioResources...)
 
 		kubeRBACProxyClusterRoleBinding := v.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName)
 		loggingAgentClusterRole := v.getLoggingAgentClusterRole()
@@ -329,60 +336,87 @@ func (v *vali) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 	return vpa
 }
 
-func (v *vali) getIngress(secretName string) *networkingv1.Ingress {
+func (v *vali) getIstioResources(tlsSecret *corev1.Secret) ([]client.Object, error) {
 	var (
-		pathType = networkingv1.PathTypePrefix
-
-		serviceName = valiServiceName
-		endpoint    = valiconstants.PushEndpoint
-		port        = kubeRBACProxyPort
-		annotations = map[string]string{}
+		// Currently, all observability components are exposed via the same istio ingress gateway.
+		// When zonal gateways or exposure classes should be considered, the namespace needs to be dynamic.
+		// See https://github.com/gardener/gardener/issues/11860 for details.
+		ingressNamespace = v1beta1constants.DefaultSNIIngressNamespace
+		gatewayName      = valiName
+		endpoint         = valiconstants.PushEndpoint
+		port             = kubeRBACProxyPort
 	)
 
-	ingress := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        valiName,
-			Namespace:   v.namespace,
-			Annotations: annotations,
-			Labels:      getLabels(),
-		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
-			TLS: []networkingv1.IngressTLS{{
-				SecretName: secretName,
-				Hosts:      []string{v.values.IngressHost},
-			}},
-			Rules: []networkingv1.IngressRule{{
-				Host: v.values.IngressHost,
-				IngressRuleValue: networkingv1.IngressRuleValue{
-					HTTP: &networkingv1.HTTPIngressRuleValue{
-						Paths: []networkingv1.HTTPIngressPath{{
-							Backend: networkingv1.IngressBackend{
-								Service: &networkingv1.IngressServiceBackend{
-									Name: serviceName,
-									Port: networkingv1.ServiceBackendPort{Number: port},
-								},
-							},
-							Path:     endpoint,
-							PathType: &pathType,
-						}},
-					},
-				},
-			}},
-		},
+	if v.values.IsGardenCluster {
+		ingressNamespace = operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DefaultSNIIngressNamespace
+		gatewayName = fmt.Sprintf("%s%s-%s", operatorv1alpha1.VirtualGardenNamePrefix, gatewayName, v1beta1constants.GardenNamespace)
 	}
 
-	return ingress
+	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
+	tlsSecretInIstioNamespace := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-%s", v.namespace, valiName, tlsSecret.Name),
+			Namespace: ingressNamespace,
+			Labels:    getLabels(),
+		},
+		Data: tlsSecret.Data,
+	}
+
+	gateway := &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: v.namespace}}
+	if err := istio.GatewayWithTLSTermination(
+		gateway,
+		getLabels(),
+		v.values.IstioIngressGatewayLabels,
+		[]string{v.values.IngressHost},
+		kubeapiserverconstants.Port,
+		tlsSecretInIstioNamespace.Name,
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create gateway resource: %w", err)
+	}
+
+	destinationHost := kubernetesutils.FQDNForService(valiconstants.ServiceName, v.namespace)
+	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: v.namespace}}
+	if err := istio.VirtualServiceForTLSTermination(
+		virtualService,
+		getLabels(),
+		[]string{v.values.IngressHost},
+		gatewayName,
+		uint32(port),
+		destinationHost,
+		"",
+		"",
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
+	}
+	if len(virtualService.Spec.Http) < 1 {
+		return nil, fmt.Errorf("unexpected number of HTTP routes in virtual service: got %d, want at least 1", len(virtualService.Spec.Http))
+	}
+	virtualService.Spec.Http[0].Match = []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+		Uri: &istioapinetworkingv1beta1.StringMatch{
+			MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{
+				Prefix: endpoint,
+			},
+		},
+	}}
+
+	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: v.namespace}}
+	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, getLabels(), destinationHost)(); err != nil {
+		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
+	}
+
+	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }
 
 func (v *vali) getService() *corev1.Service {
 	var (
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        valiconstants.ServiceName,
-				Namespace:   v.namespace,
-				Labels:      getLabels(),
-				Annotations: map[string]string{},
+				Name:      valiconstants.ServiceName,
+				Namespace: v.namespace,
+				Labels:    getLabels(),
+				Annotations: map[string]string{
+					"networking.istio.io/exportTo": "*",
+				},
 			},
 			Spec: corev1.ServiceSpec{
 				Type:     corev1.ServiceTypeClusterIP,

--- a/pkg/component/observability/logging/vali/vali_test.go
+++ b/pkg/component/observability/logging/vali/vali_test.go
@@ -13,10 +13,13 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	istionetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -88,7 +91,7 @@ var _ = Describe("Vali", func() {
 			var err error
 			c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 			fakeSecretManager = fakesecretsmanager.New(c, namespace)
-			consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
+			consistOf = NewManagedResourceConsistOfObjectsMatcher(c, test.CmpOptsForIstio()...)
 
 			Expect(err).ToNot(HaveOccurred())
 
@@ -157,6 +160,13 @@ var _ = Describe("Vali", func() {
 				Expect(c.Get(ctx, client.ObjectKey{Name: valitailShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 				Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(Succeed())
 
+				tlsSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vali-tls",
+						Namespace: namespace,
+					},
+				}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				expectedMr := &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
@@ -179,7 +189,10 @@ var _ = Describe("Vali", func() {
 					getTelegrafConfigMap(),
 					getValiConfigMap(),
 					getVPA(),
-					getIngress("/vali/api/v1/push", "logging", 8080),
+					getGateway(),
+					getVirtualService(),
+					getDestinationRule(),
+					getTLSSecret(tlsSecret),
 					getService(true, "shoot"),
 					getStatefulSet(true),
 					getServiceMonitor("shoot", true),
@@ -813,7 +826,7 @@ func getService(isRBACProxyEnabled bool, clusterType string) *corev1.Service {
 			Name:        "logging",
 			Namespace:   namespace,
 			Labels:      getLabels(),
-			Annotations: map[string]string{},
+			Annotations: map[string]string{"networking.istio.io/exportTo": "*"},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
@@ -1117,51 +1130,99 @@ func getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 	return vpa
 }
 
-func getIngress(path, serviceName string, port int32) *networkingv1.Ingress {
-	pathType := networkingv1.PathTypePrefix
-	annotations := map[string]string{}
-	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
-		annotations = map[string]string{"nginx.ingress.kubernetes.io/backend-protocol": "GRPC"}
-	}
-	return &networkingv1.Ingress{
+func getGateway() *istionetworkingv1beta1.Gateway {
+	return &istionetworkingv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        valiName,
-			Namespace:   namespace,
-			Annotations: annotations,
-			Labels:      getLabels(),
+			Name:      "vali",
+			Namespace: namespace,
+			Labels:    getLabels(),
 		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: ptr.To("nginx-ingress-gardener"),
-			TLS: []networkingv1.IngressTLS{
-				{
-					SecretName: "vali-tls",
-					Hosts:      []string{valiHost},
+		Spec: istionetworkingv1alpha3.Gateway{
+			Servers: []*istionetworkingv1alpha3.Server{{
+				Port: &istionetworkingv1alpha3.Port{
+					Number:   443,
+					Protocol: "HTTPS",
+					Name:     "tls",
 				},
-			},
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: valiHost,
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: serviceName,
-											Port: networkingv1.ServiceBackendPort{
-												Number: port,
-											},
-										},
-									},
-									Path:     path,
-									PathType: &pathType,
-								},
-							},
-						},
+				Hosts: []string{"vali.foo.bar"},
+				Tls: &istionetworkingv1alpha3.ServerTLSSettings{
+					Mode:           istionetworkingv1alpha3.ServerTLSSettings_SIMPLE,
+					CredentialName: "shoot--foo--bar-vali-vali-tls",
+				},
+			}},
+		},
+	}
+}
+
+func getVirtualService() *istionetworkingv1beta1.VirtualService {
+	return &istionetworkingv1beta1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vali",
+			Namespace: namespace,
+			Labels:    getLabels(),
+		},
+		Spec: istionetworkingv1alpha3.VirtualService{
+			ExportTo: []string{"*"},
+			Gateways: []string{"vali"},
+			Hosts:    []string{"vali.foo.bar"},
+			Http: []*istionetworkingv1alpha3.HTTPRoute{{
+				Match: []*istionetworkingv1alpha3.HTTPMatchRequest{{
+					Uri: &istionetworkingv1alpha3.StringMatch{
+						MatchType: &istionetworkingv1alpha3.StringMatch_Prefix{Prefix: "/vali/api/v1/push"},
+					},
+				}},
+				Route: []*istionetworkingv1alpha3.HTTPRouteDestination{{
+					Destination: &istionetworkingv1alpha3.Destination{
+						Host: "logging.shoot--foo--bar.svc.cluster.local",
+						Port: &istionetworkingv1alpha3.PortSelector{Number: 8080},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+func getDestinationRule() *istionetworkingv1beta1.DestinationRule {
+	return &istionetworkingv1beta1.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vali",
+			Namespace: namespace,
+			Labels:    getLabels(),
+		},
+		Spec: istionetworkingv1alpha3.DestinationRule{
+			ExportTo: []string{"*"},
+			Host:     "logging.shoot--foo--bar.svc.cluster.local",
+			TrafficPolicy: &istionetworkingv1alpha3.TrafficPolicy{
+				LoadBalancer: &istionetworkingv1alpha3.LoadBalancerSettings{
+					LocalityLbSetting: &istionetworkingv1alpha3.LocalityLoadBalancerSetting{
+						FailoverPriority: []string{"topology.kubernetes.io/zone"},
+						Enabled:          wrapperspb.Bool(true),
 					},
 				},
+				ConnectionPool: &istionetworkingv1alpha3.ConnectionPoolSettings{
+					Tcp: &istionetworkingv1alpha3.ConnectionPoolSettings_TCPSettings{
+						TcpKeepalive: &istionetworkingv1alpha3.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+							Time:     &durationpb.Duration{Seconds: 7200},
+							Interval: &durationpb.Duration{Seconds: 75},
+						},
+						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
+					},
+				},
+				OutlierDetection: &istionetworkingv1alpha3.OutlierDetection{},
+				Tls:              &istionetworkingv1alpha3.ClientTLSSettings{},
 			},
 		},
+	}
+}
+
+func getTLSSecret(tlsSecret *corev1.Secret) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shoot--foo--bar-vali-vali-tls",
+			Namespace: "istio-ingress",
+			Labels:    getLabels(),
+		},
+		Data: tlsSecret.Data,
 	}
 }
 

--- a/pkg/component/shared/vali.go
+++ b/pkg/component/shared/vali.go
@@ -26,6 +26,7 @@ func NewVali(
 	storage *resource.Quantity,
 	ingressHost string,
 	isGardenCluster bool,
+	istioIngressGatewayLabels map[string]string,
 ) (
 	vali.Interface,
 	error,
@@ -56,18 +57,19 @@ func NewVali(
 	}
 
 	deployer := vali.New(c, namespace, secretsManager, vali.Values{
-		ValiImage:               valiImage.String(),
-		CuratorImage:            curatorImage.String(),
-		InitLargeDirImage:       tune2fsImage.String(),
-		KubeRBACProxyImage:      kubeRBACProxyImage.String(),
-		TelegrafImage:           telegrafImage.String(),
-		Replicas:                replicas,
-		ShootNodeLoggingEnabled: isShootNodeLoggingEnabled,
-		PriorityClassName:       priorityClassName,
-		Storage:                 storage,
-		ClusterType:             clusterType,
-		IngressHost:             ingressHost,
-		IsGardenCluster:         isGardenCluster,
+		ValiImage:                 valiImage.String(),
+		CuratorImage:              curatorImage.String(),
+		InitLargeDirImage:         tune2fsImage.String(),
+		KubeRBACProxyImage:        kubeRBACProxyImage.String(),
+		TelegrafImage:             telegrafImage.String(),
+		Replicas:                  replicas,
+		ShootNodeLoggingEnabled:   isShootNodeLoggingEnabled,
+		PriorityClassName:         priorityClassName,
+		Storage:                   storage,
+		ClusterType:               clusterType,
+		IngressHost:               ingressHost,
+		IsGardenCluster:           isGardenCluster,
+		IstioIngressGatewayLabels: istioIngressGatewayLabels,
 	})
 
 	return deployer, nil

--- a/pkg/component/test/istiocomponent.go
+++ b/pkg/component/test/istiocomponent.go
@@ -59,3 +59,8 @@ func CmpOptsForVirtualService() cmp.Option {
 		istioapimetav1alpha1.IstioStatus{},
 	)
 }
+
+// CmpOptsForIstio returns a slice of compare options to ignore unexported fields in types related to istio resources
+func CmpOptsForIstio() []cmp.Option {
+	return []cmp.Option{CmpOptsForDestinationRule(), CmpOptsForGateway(), CmpOptsForVirtualService()}
+}

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -256,7 +256,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.vali, err = r.newVali()
+	c.vali, err = r.newVali(c.istioDefaultLabels)
 	if err != nil {
 		return
 	}
@@ -566,7 +566,7 @@ func (r *Reconciler) newSystem(seed *gardencorev1beta1.Seed) (component.DeployWa
 	), nil
 }
 
-func (r *Reconciler) newVali() (component.Deployer, error) {
+func (r *Reconciler) newVali(istioIngressGatewayLabels map[string]string) (component.Deployer, error) {
 	var storage *resource.Quantity
 	if r.Config.Logging != nil && r.Config.Logging.Vali != nil && r.Config.Logging.Vali.Garden != nil {
 		storage = r.Config.Logging.Vali.Garden.Storage
@@ -583,6 +583,7 @@ func (r *Reconciler) newVali() (component.Deployer, error) {
 		storage,
 		"",
 		false,
+		istioIngressGatewayLabels,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -161,7 +161,7 @@ func (b *Botanist) DefaultEventLogger() (component.Deployer, error) {
 
 // DefaultVali returns a deployer for Vali.
 func (b *Botanist) DefaultVali() (vali.Interface, error) {
-	istioLabels := map[string]string{}
+	var istioLabels map[string]string
 	if !b.Shoot.IsSelfHosted() {
 		istioLabels = b.WildcardIstioLabels()
 	}

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -161,6 +161,11 @@ func (b *Botanist) DefaultEventLogger() (component.Deployer, error) {
 
 // DefaultVali returns a deployer for Vali.
 func (b *Botanist) DefaultVali() (vali.Interface, error) {
+	istioLabels := map[string]string{}
+	if !b.Shoot.IsSelfHosted() {
+		istioLabels = b.WildcardIstioLabels()
+	}
+
 	return shared.NewVali(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
@@ -172,6 +177,7 @@ func (b *Botanist) DefaultVali() (vali.Interface, error) {
 		nil,
 		b.ComputeValiHost(),
 		false,
+		istioLabels,
 	)
 }
 

--- a/pkg/gardenlet/operation/botanist/plutono.go
+++ b/pkg/gardenlet/operation/botanist/plutono.go
@@ -17,7 +17,7 @@ import (
 
 // DefaultPlutono returns a deployer for Plutono.
 func (b *Botanist) DefaultPlutono() (plutono.Interface, error) {
-	istioLabels := map[string]string{}
+	var istioLabels map[string]string
 	if !b.Shoot.IsSelfHosted() {
 		istioLabels = b.WildcardIstioLabels()
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -327,7 +327,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.vali, err = r.newVali()
+	c.vali, err = r.newVali(c.istio.GetValues().IngressGateway)
 	if err != nil {
 		return
 	}
@@ -1417,7 +1417,11 @@ func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) 
 	)
 }
 
-func (r *Reconciler) newVali() (component.Deployer, error) {
+func (r *Reconciler) newVali(ingressGatewayValues []istio.IngressGatewayValues) (component.Deployer, error) {
+	if len(ingressGatewayValues) != 1 {
+		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the vali config")
+	}
+
 	deployer, err := sharedcomponent.NewVali(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
@@ -1429,6 +1433,7 @@ func (r *Reconciler) newVali() (component.Deployer, error) {
 		nil,
 		"",
 		true,
+		ingressGatewayValues[0].Labels,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/test/matchers/managedresource.go
+++ b/pkg/utils/test/matchers/managedresource.go
@@ -26,6 +26,7 @@ type managedResourceObjectsMatcher struct {
 	decoder           runtime.Decoder
 	expectedObjects   map[string]client.Object
 	extraObjectsCheck bool
+	compareOptions    []cmp.Option
 
 	extraObjects             []string
 	missingObjects           []string
@@ -98,7 +99,7 @@ func (m *managedResourceObjectsMatcher) Match(actual any) (bool, error) {
 	}
 
 	// Use early returns for the following checks to not overwhelm Gomega output.
-	m.mismatchExpectedToActual = findMismatchObjects(availableObjects, m.expectedObjects)
+	m.mismatchExpectedToActual = findMismatchObjects(availableObjects, m.expectedObjects, m.compareOptions...)
 	if len(m.mismatchExpectedToActual) > 0 {
 		return false, nil
 	}
@@ -118,13 +119,13 @@ func (m *managedResourceObjectsMatcher) Match(actual any) (bool, error) {
 	return true, nil
 }
 
-func findMismatchObjects(availableObjects map[string]client.Object, expectedObjects map[string]client.Object) map[client.Object]*mismatch {
+func findMismatchObjects(availableObjects map[string]client.Object, expectedObjects map[string]client.Object, compareOptions ...cmp.Option) map[client.Object]*mismatch {
 	mismatches := make(map[client.Object]*mismatch)
 
 	for expectedObjKey, expectedObj := range expectedObjects {
 		actualObject, ok := availableObjects[expectedObjKey]
 		if ok {
-			diff := cmp.Diff(actualObject, expectedObj, cmpopts.EquateEmpty())
+			diff := cmp.Diff(actualObject, expectedObj, append(compareOptions, cmpopts.EquateEmpty())...)
 			if diff != "" {
 				mismatches[expectedObj] = &mismatch{diff: diff, obj: actualObject}
 			}

--- a/pkg/utils/test/matchers/managedresource_test.go
+++ b/pkg/utils/test/matchers/managedresource_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -134,7 +135,7 @@ var _ = Describe("ManagedResource Object Matcher", func() {
 		ExpectWithOffset(1, fakeClient.Create(ctx, managedResourceSecret2)).To(Succeed())
 	}
 
-	commonTests := func(matcherFn func(client.Client) func(...client.Object) types.GomegaMatcher) {
+	commonTests := func(matcherFn func(client.Client, ...cmp.Option) func(...client.Object) types.GomegaMatcher) {
 		var matcher func(...client.Object) types.GomegaMatcher
 
 		BeforeEach(func() {

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -7,6 +7,7 @@ package matchers
 import (
 	"context"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
@@ -97,13 +98,15 @@ func ShareSameReferenceAs(expected any) types.GomegaMatcher {
 // NewManagedResourceContainsObjectsMatcher returns a function for a matcher that checks
 // if the given objects are handled by the given managed resource.
 // It is expected that the data keys of referenced secret(s) follow the semantics of `managedresources.Registry`.
-func NewManagedResourceContainsObjectsMatcher(c client.Client) func(...client.Object) types.GomegaMatcher {
+// It allows to pass additional options to the underlying comparison, e.g. to ignore certain fields.
+func NewManagedResourceContainsObjectsMatcher(c client.Client, compareOptions ...cmp.Option) func(...client.Object) types.GomegaMatcher {
 	return func(objs ...client.Object) types.GomegaMatcher {
 		return &managedResourceObjectsMatcher{
 			ctx:             context.Background(),
 			client:          c,
 			decoder:         serializer.NewCodecFactory(c.Scheme()).UniversalDeserializer(),
 			expectedObjects: expectedObjects(objs, c.Scheme()),
+			compareOptions:  compareOptions,
 		}
 	}
 }
@@ -112,7 +115,8 @@ func NewManagedResourceContainsObjectsMatcher(c client.Client) func(...client.Ob
 // if the exact list of given objects are handled by the given managed resource.
 // Any extra objects found through the ManagedResource let the matcher fail.
 // It is expected that the data keys of referenced secret(s) follow the semantics of `managedresources.Registry`.
-func NewManagedResourceConsistOfObjectsMatcher(c client.Client) func(...client.Object) types.GomegaMatcher {
+// It allows to pass additional options to the underlying comparison, e.g. to ignore certain fields.
+func NewManagedResourceConsistOfObjectsMatcher(c client.Client, compareOptions ...cmp.Option) func(...client.Object) types.GomegaMatcher {
 	return func(objs ...client.Object) types.GomegaMatcher {
 		return &managedResourceObjectsMatcher{
 			ctx:               context.Background(),
@@ -120,6 +124,7 @@ func NewManagedResourceConsistOfObjectsMatcher(c client.Client) func(...client.O
 			decoder:           serializer.NewCodecFactory(c.Scheme()).UniversalDeserializer(),
 			expectedObjects:   expectedObjects(objs, c.Scheme()),
 			extraObjectsCheck: true,
+			compareOptions:    compareOptions,
 		}
 	}
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:

As `nginx-ingress` is retired, we need to change the exposure of `vali`, which is currently exposed via `nginx-ingress`. Istio ingress gateway is already deployed everywhere `vali` is running. Hence, it is a simple choice to switch to it.

Istio allows exposure via a multitude of APIs, among them `Ingress`, istio-native `Gateway`, and Gateway API. The `Ingress` support in istio was never really on par. Hence, we will not use it. Gateway API does not cover all use cases we need. Therefore, we use the same istio-native APIs, which we already use for `kube-apiserver` exposure. This unifies our ingress traffic architecture and simplifies it eventually when `nginx-ingress` is no longer used.

This change is the adaption of `vali` to istio-native exposure.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/13448

**Special notes for your reviewer**:

The change is analogous to https://github.com/gardener/gardener/pull/14142.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Vali is now exposed directly via istio instead of nginx-ingress
```

/cc @rfranzke @axel7born @DockToFuture @domdom82 