### PR TITLE
Replace mock clients with fake clients in `pkg/controllermanager` and `pkg/utils` tests (Part 1)

### DIFF
--- a/pkg/controllermanager/controller/bastion/reconciler_test.go
+++ b/pkg/controllermanager/controller/bastion/reconciler_test.go
@@ -10,26 +10,24 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/bastion"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Controller", func() {
 	var (
-		mockCtrl   *gomock.Controller
-		mockClient *mockclient.MockClient
+		fakeClient client.Client
 		reconciler reconcile.Reconciler
 
 		namespace   = "garden-dev"
@@ -41,10 +39,9 @@ var _ = Describe("Controller", func() {
 	)
 
 	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = mockclient.NewMockClient(mockCtrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		reconciler = &Reconciler{
-			Client: mockClient,
+			Client: fakeClient,
 			Config: controllermanagerconfigv1alpha1.BastionControllerConfiguration{
 				MaxLifetime: &metav1.Duration{Duration: maxLifetime},
 			},
@@ -52,14 +49,8 @@ var _ = Describe("Controller", func() {
 		}
 	})
 
-	AfterEach(func() {
-		mockCtrl.Finish()
-	})
-
 	Describe("Reconciler", func() {
 		It("should return nil because object not found", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
@@ -69,15 +60,11 @@ var _ = Describe("Controller", func() {
 			created := time.Now().Add(-maxLifetime / 2)
 			requeueAfter := time.Until(created.Add(maxLifetime))
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &seedName)
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &seedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
-				return nil
-			})
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result.RequeueAfter).To(BeNumerically("~", requeueAfter, 1*time.Second))
@@ -89,15 +76,11 @@ var _ = Describe("Controller", func() {
 			remaining := 30 * time.Second
 			expires := now.Add(remaining)
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &seedName)
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &seedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &now, &expires)
-				return nil
-			})
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &now, &expires)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result.RequeueAfter).To(BeNumerically("~", remaining, 1*time.Second))
@@ -105,19 +88,15 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should requeue soon-to-reach-max-lifetime Bastions", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &seedName)
-				return nil
-			})
+			now := time.Now()
+			created := now.Add(-maxLifetime).Add(10 * time.Minute) // reaches end-of-life in 10 minutes
+			expires := now.Add(30 * time.Minute)                   // expires in 30 minutes
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				now := time.Now()
-				created := now.Add(-maxLifetime).Add(10 * time.Minute) // reaches end-of-life in 10 minutes
-				expires := now.Add(30 * time.Minute)                   // expires in 30 minutes
+			shoot := newShoot(namespace, shootName, &seedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
-				return nil
-			})
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result.RequeueAfter).To(BeNumerically("~", 10*time.Minute, 1*time.Second))
@@ -125,128 +104,97 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should delete Bastions with missing shoots", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime / 2)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime / 2)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 
 		It("should delete Bastions with shoots in deletion", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				shoot := newShoot(namespace, shootName, &seedName)
-				now := metav1.Now()
-				shoot.DeletionTimestamp = &now
-				*obj = shoot
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &seedName)
+			shoot.Finalizers = []string{"test-finalizer"}
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime / 2)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime / 2)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 
 		It("should delete expired Bastions", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &seedName)
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &seedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime / 2)
-				expires := time.Now().Add(-5 * time.Second)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime / 2)
+			expires := time.Now().Add(-5 * time.Second)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 
 		It("should delete Bastions that have reached their TTL", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &seedName)
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &seedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime * 2)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime * 2)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, nil)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 
 		It("should delete Bastions with outdated seed information", func() {
 			newSeedName := "new-seed-after-migration"
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, &newSeedName)
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, &newSeedName)
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime / 2)
-				expires := time.Now().Add(1 * time.Minute)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime / 2)
+			expires := time.Now().Add(1 * time.Minute)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 
 		It("should delete Bastions with outdated seed information 2", func() {
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: shootName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot, _ ...client.GetOption) error {
-				*obj = newShoot(namespace, shootName, nil) // shoot was removed from original seed and since then hasn't found a new seed
-				return nil
-			})
+			shoot := newShoot(namespace, shootName, nil) // shoot was removed from original seed and since then hasn't found a new seed
+			Expect(fakeClient.Create(ctx, &shoot)).To(Succeed())
 
-			mockClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: bastionName}, gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *operationsv1alpha1.Bastion, _ ...client.GetOption) error {
-				created := time.Now().Add(-maxLifetime / 2)
-				expires := time.Now().Add(1 * time.Minute)
-
-				*obj = newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
-				return nil
-			})
-
-			mockClient.EXPECT().Delete(gomock.Any(), gomock.AssignableToTypeOf(&operationsv1alpha1.Bastion{}))
+			created := time.Now().Add(-maxLifetime / 2)
+			expires := time.Now().Add(1 * time.Minute)
+			bastion := newBastion(namespace, bastionName, shootName, &seedName, &created, &expires)
+			Expect(fakeClient.Create(ctx, &bastion)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: bastionName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: bastionName}, &operationsv1alpha1.Bastion{})).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/controllermanager/controller/certificatesigningrequest/reconciler_test.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/reconciler_test.go
@@ -12,11 +12,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -25,37 +23,32 @@ import (
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/certificatesigningrequest"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/bootstraptoken"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Reconciler", func() {
 	var (
 		ctx                    = context.TODO()
-		ctrl                   *gomock.Controller
-		c                      *mockclient.MockClient
+		c                      client.Client
 		fakeCertificatesClient certificatesclientv1.CertificateSigningRequestInterface
 
-		sar                *authorizationv1.SubjectAccessReview
 		csr                *certificatesv1.CertificateSigningRequest
 		reconciler         reconcile.Reconciler
 		privateKey         *rsa.PrivateKey
 		certificateSubject *pkix.Name
-
-		errNotFound = &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-
-		fakeClient := fakeclientset.NewSimpleClientset()
-		fakeCertificatesClient = fakeClient.CertificatesV1().CertificateSigningRequests()
+		fakeClientset := fakeclientset.NewSimpleClientset()
+		fakeCertificatesClient = fakeClientset.CertificatesV1().CertificateSigningRequests()
 
 		privateKey, _ = secretsutils.FakeGenerateKey(rand.Reader, 4096)
 		csr = &certificatesv1.CertificateSigningRequest{
@@ -73,23 +66,11 @@ var _ = Describe("Reconciler", func() {
 			},
 		}
 
-		sar = &authorizationv1.SubjectAccessReview{
-			Status: authorizationv1.SubjectAccessReviewStatus{
-				Allowed: false,
-				Denied:  false,
-			},
-		}
-
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), &certificatesv1.CertificateSigningRequest{}).Return(errNotFound)
-
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 		Expect(result).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
@@ -97,12 +78,8 @@ var _ = Describe("Reconciler", func() {
 
 	Context("when csr is in final state", func() {
 		It("should ignore it because certificate is present in the status field", func() {
-			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-					csr.Status.Certificate = []byte("test-certificate")
-					csr.DeepCopyInto(obj)
-					return nil
-				}).AnyTimes()
+			csr.Status.Certificate = []byte("test-certificate")
+			Expect(c.Create(ctx, csr.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -110,14 +87,10 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should ignore it because csr is Approved", func() {
-			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-					csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
-						Type: certificatesv1.CertificateApproved,
-					})
-					csr.DeepCopyInto(obj)
-					return nil
-				}).AnyTimes()
+			csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+				Type: certificatesv1.CertificateApproved,
+			})
+			Expect(c.Create(ctx, csr.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -134,11 +107,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			csr.Spec.Request = csrData
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-					csr.DeepCopyInto(obj)
-					return nil
-				}).AnyTimes()
+			Expect(c.Create(ctx, csr.DeepCopy())).To(Succeed())
 		})
 
 		It("should ignore the csr because csr does not match the requirements for a client certificate for a seed", func() {
@@ -158,31 +127,33 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			csr.Spec.Request = csrData
 
-			c.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{})).DoAndReturn(func(_ context.Context, obj *authorizationv1.SubjectAccessReview, _ ...client.CreateOption) error {
-				// For the simplicity of test, we are assuming SubjectAccessReview will be allowed if user is admin and not allowed for other users.
-				if obj.Spec.User == "admin" {
-					sar.Status = authorizationv1.SubjectAccessReviewStatus{
-						Allowed: true,
-					}
-				} else {
-					sar.Status = authorizationv1.SubjectAccessReviewStatus{
-						Allowed: false,
-					}
-				}
-				sar.DeepCopyInto(obj)
-				return nil
-			})
+			// Build client with SAR interceptor that allows admin
+			c = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if sar, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+							if sar.Spec.User == "admin" {
+								sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+							} else {
+								sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: false}
+							}
+							return nil
+						}
+						return cl.Create(ctx, obj, opts...)
+					},
+				}).
+				Build()
 
 			reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 		})
 
-		It("should result an error when user does not has authorization for seedclient subresource (sar.Status.Allowed is false)", func() {
-			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-					csr.Spec.Username = "foo"
-					csr.DeepCopyInto(obj)
-					return nil
-				}).AnyTimes()
+		It("should result an error when user does not have authorization for seedclient subresource (sar.Status.Allowed is false)", func() {
+			csrObj := csr.DeepCopy()
+			csrObj.Spec.Username = "foo"
+
+			Expect(c.Create(ctx, csrObj)).To(Succeed())
+
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).To(MatchError(ContainSubstring("recognized CSR but SubjectAccessReview was not allowed")))
@@ -191,12 +162,11 @@ var _ = Describe("Reconciler", func() {
 		It("should approve the csr when user has authorization for seedclient subresource (sar.Status.Allowed is true)", func() {
 			_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-					csr.Spec.Username = "admin"
-					csr.DeepCopyInto(obj)
-					return nil
-				}).AnyTimes()
+
+			csrObj := csr.DeepCopy()
+			csrObj.Spec.Username = "admin"
+
+			Expect(c.Create(ctx, csrObj)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -221,37 +191,42 @@ var _ = Describe("Reconciler", func() {
 			csrData, err := certutil.MakeCSR(privateKey, certificateSubject, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			csr.Spec.Request = csrData
-
-			c.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&authorizationv1.SubjectAccessReview{})).DoAndReturn(func(_ context.Context, obj *authorizationv1.SubjectAccessReview, _ ...client.CreateOption) error {
-				// For the simplicity of test, we are assuming SubjectAccessReview will be allowed if user is the bootstrap user and not allowed for other users.
-				if obj.Spec.User == bootstrapUsername {
-					sar.Status = authorizationv1.SubjectAccessReviewStatus{
-						Allowed: true,
-					}
-				} else {
-					sar.Status = authorizationv1.SubjectAccessReviewStatus{
-						Allowed: false,
-					}
-				}
-				sar.DeepCopyInto(obj)
-				return nil
-			}).AnyTimes()
-
-			reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 		})
+
+		buildClientWithSAR := func(bootstrapUser string) client.Client {
+			cl := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if sar, ok := obj.(*authorizationv1.SubjectAccessReview); ok {
+							if sar.Spec.User == bootstrapUser {
+								sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+							} else {
+								sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: false}
+							}
+							return nil
+						}
+						return cl.Create(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			return cl
+		}
 
 		When("CSR is not requested via bootstrap token", func() {
 			It("should result an error when username does not have bootstrap token prefix", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = "regular-user"
-						csr.Spec.Groups = []string{"system:authenticated"}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = "regular-user"
+				csrObj.Spec.Groups = []string{"system:authenticated"}
+
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -268,13 +243,14 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{"system:authenticated"}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{"system:authenticated"}
+
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -293,15 +269,15 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenName}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
+				// No bootstrap token secret created
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -330,19 +306,15 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(bootstrapTokenSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						bootstrapTokenSecret.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+				Expect(c.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -369,19 +341,15 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(bootstrapTokenSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						bootstrapTokenSecret.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+				Expect(c.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -418,20 +386,16 @@ var _ = Describe("Reconciler", func() {
 					},
 				}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.Spec.Request = wrongCSRData
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
+				csrObj.Spec.Request = wrongCSRData
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(bootstrapTokenSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						bootstrapTokenSecret.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+				Expect(c.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -460,19 +424,15 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = "unauthorized-user"
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = "unauthorized-user"
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(bootstrapTokenSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						bootstrapTokenSecret.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+				Expect(c.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -501,19 +461,15 @@ var _ = Describe("Reconciler", func() {
 				_, err := fakeCertificatesClient.Create(ctx, csr, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(csr), gomock.AssignableToTypeOf(&certificatesv1.CertificateSigningRequest{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *certificatesv1.CertificateSigningRequest, _ ...client.GetOption) error {
-						csr.Spec.Username = bootstrapUsername
-						csr.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
-						csr.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				csrObj := csr.DeepCopy()
+				csrObj.Spec.Username = bootstrapUsername
+				csrObj.Spec.Groups = []string{bootstraptokenapi.BootstrapDefaultGroup}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(bootstrapTokenSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-						bootstrapTokenSecret.DeepCopyInto(obj)
-						return nil
-					}).AnyTimes()
+				c = buildClientWithSAR(bootstrapUsername)
+				Expect(c.Create(ctx, csrObj)).To(Succeed())
+				Expect(c.Create(ctx, bootstrapTokenSecret)).To(Succeed())
+
+				reconciler = &Reconciler{Client: c, CertificatesClient: fakeCertificatesClient}
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: csr.Name}})
 				Expect(result).To(Equal(reconcile.Result{}))

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -7,31 +7,31 @@ package cloudprofile_test
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
+	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/cloudprofile"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Reconciler", func() {
 	const finalizerName = "gardener"
 
 	var (
-		ctx  = context.TODO()
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
+		ctx        = context.TODO()
+		fakeClient client.Client
 
 		cloudProfileName string
 		fakeErr          error
@@ -40,34 +40,41 @@ var _ = Describe("Reconciler", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-
 		cloudProfileName = "test-cloudprofile"
 		fakeErr = errors.New("fake err")
-		reconciler = &Reconciler{Client: c, Recorder: &events.FakeRecorder{}}
+
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithIndex(
+				&gardencorev1beta1.NamespacedCloudProfile{},
+				core.NamespacedCloudProfileParentRefName,
+				indexer.NamespacedCloudProfileParentRefNameIndexerFunc,
+			).
+			Build()
+		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 		cloudProfile = &gardencorev1beta1.CloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            cloudProfileName,
-				ResourceVersion: "42",
+				Name: cloudProfileName,
 			},
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return err because object reading failed", func() {
-		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fakeErr
+				},
+			}).
+			Build()
+		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -76,51 +83,52 @@ var _ = Describe("Reconciler", func() {
 
 	Context("when deletion timestamp not set", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				*obj = *cloudProfile
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
 		})
 
 		It("should ensure the finalizer (error)", func() {
-			errToReturn := apierrors.NewNotFound(schema.GroupResource{}, cloudProfileName)
+			patchCalls := 0
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						patchCalls++
+						return fakeErr
+					},
+				}).
+				Build()
+			reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-				Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-				return errToReturn
-			})
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
-			Expect(err).To(MatchError(err))
+			Expect(err).To(HaveOccurred())
+			Expect(patchCalls).To(Equal(1))
 		})
 
 		It("should ensure the finalizer (no error)", func() {
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-				Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-				return nil
-			})
-
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, cloudProfile)).To(Succeed())
+			Expect(cloudProfile.Finalizers).To(ContainElement(finalizerName))
 		})
 	})
 
 	Context("when deletion timestamp set", func() {
 		BeforeEach(func() {
-			now := metav1.Now()
-			cloudProfile.DeletionTimestamp = &now
 			cloudProfile.Finalizers = []string{finalizerName}
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Delete(ctx, cloudProfile.DeepCopy())).To(Succeed())
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				*obj = *cloudProfile
-				return nil
-			})
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, cloudProfile)).To(Succeed())
 		})
 
 		It("should do nothing because finalizer is not present", func() {
 			cloudProfile.Finalizers = nil
+			Expect(fakeClient.Patch(ctx, cloudProfile, client.MergeFrom(cloudProfile))).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -128,21 +136,13 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should return an error because Shoot referencing CloudProfile exists", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfileList{}), gomock.Eq(client.MatchingFields{"spec.parent.name": cloudProfileName})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.NamespacedCloudProfileList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.NamespacedCloudProfileList{}).DeepCopyInto(obj)
-				return nil
-			})
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: "test-namespace"},
-						Spec: gardencorev1beta1.ShootSpec{
-							CloudProfileName: &cloudProfileName,
-						},
-					},
-				}}).DeepCopyInto(obj)
-				return nil
-			})
+			shoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: "test-namespace"},
+				Spec: gardencorev1beta1.ShootSpec{
+					CloudProfileName: &cloudProfileName,
+				},
+			}
+			Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -150,20 +150,16 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should return an error because NamespacedCloudProfile referencing CloudProfile exists", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfileList{}), gomock.Eq(client.MatchingFields{"spec.parent.name": cloudProfileName})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.NamespacedCloudProfileList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.NamespacedCloudProfileList{Items: []gardencorev1beta1.NamespacedCloudProfile{
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-namespacedprofile", Namespace: "test-namespace"},
-						Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
-							Parent: gardencorev1beta1.CloudProfileReference{
-								Kind: "CloudProfile",
-								Name: cloudProfileName,
-							},
-						},
+			ncpProfile := &gardencorev1beta1.NamespacedCloudProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-namespacedprofile", Namespace: "test-namespace"},
+				Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
+					Parent: gardencorev1beta1.CloudProfileReference{
+						Kind: "CloudProfile",
+						Name: cloudProfileName,
 					},
-				}}).DeepCopyInto(obj)
-				return nil
-			})
+				},
+			}
+			Expect(fakeClient.Create(ctx, ncpProfile)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -171,19 +167,26 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should remove the finalizer (error)", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfileList{}), gomock.Eq(client.MatchingFields{"spec.parent.name": cloudProfileName})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.NamespacedCloudProfileList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.NamespacedCloudProfileList{}).DeepCopyInto(obj)
-				return nil
-			})
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
-				return nil
-			})
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithIndex(
+					&gardencorev1beta1.NamespacedCloudProfile{},
+					core.NamespacedCloudProfileParentRefName,
+					indexer.NamespacedCloudProfileParentRefNameIndexerFunc,
+				).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
+			reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-				Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-				return fakeErr
-			})
+			cp := cloudProfile.DeepCopy()
+			cp.ResourceVersion = ""
+			cp.Finalizers = []string{finalizerName}
+			Expect(fakeClient.Create(ctx, cp)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, cp.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
@@ -191,23 +194,11 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should remove the finalizer (no error)", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfileList{}), gomock.Eq(client.MatchingFields{"spec.parent.name": cloudProfileName})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.NamespacedCloudProfileList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.NamespacedCloudProfileList{}).DeepCopyInto(obj)
-				return nil
-			})
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-				Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-				return nil
-			})
-
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, &gardencorev1beta1.CloudProfile{})).To(BeNotFoundError())
 		})
 	})
 })

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/reconciler_test.go
@@ -11,21 +11,22 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/goleak"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Reconciler", func() {
@@ -789,29 +790,17 @@ var _ = Describe("Reconciler", func() {
 
 	Context("deployment and deletion", func() {
 		var (
-			ctrl      *gomock.Controller
-			k8sClient *mockclient.MockClient
+			k8sClient client.Client
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			k8sClient = mockclient.NewMockClient(ctrl)
+			k8sClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 
-			k8sClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: controllerDeployment.Name}, gomock.AssignableToTypeOf(&gardencorev1.ControllerDeployment{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *gardencorev1.ControllerDeployment, _ ...client.GetOption) error {
-					*obj = *controllerDeployment
-					return nil
-				},
-			).AnyTimes()
-
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
+			Expect(k8sClient.Create(ctx, controllerDeployment.DeepCopy())).To(Succeed())
 		})
 
 		Describe("#deployNeededInstallations", func() {
-			It("should return an error when cannot get controller installation", func() {
+			It("should return an error when it cannot get controller installation", func() {
 				var (
 					wantedControllerRegistrations  = sets.New(controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
@@ -822,7 +811,16 @@ var _ = Describe("Reconciler", func() {
 					fakeErr = errors.New("err")
 				)
 
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{})).Return(fakeErr)
+				k8sClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+							if _, ok := obj.(*gardencorev1beta1.ControllerInstallation); ok && key.Name == controllerInstallation2.Name {
+								return fakeErr
+							}
+							return c.Get(ctx, key, obj, opts...)
+						},
+					}).Build()
+				Expect(k8sClient.Create(ctx, controllerDeployment.DeepCopy())).To(Succeed())
 
 				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
@@ -856,41 +854,51 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				installation2 := controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					SeedSpecHash:             "9cebb557b37cc60b",
-				}
-
-				installation3 := controllerInstallation3.DeepCopy()
-				installation3.Labels = map[string]string{
-					RegistrationSpecHash: "61ca93a1782c5fa3",
-					SeedSpecHash:         "9cebb557b37cc60b",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation3.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation3, gomock.Any())
-
-				k8sClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
+				Expect(k8sClient.Create(ctx, controllerInstallation3.DeepCopy())).To(Succeed())
 
 				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				ciList := &gardencorev1beta1.ControllerInstallationList{}
+				Expect(k8sClient.List(ctx, ciList)).To(Succeed())
+				Expect(ciList.Items).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(controllerInstallation2.Name),
+							"Labels": And(
+								HaveKeyWithValue(ControllerDeploymentHash, "deb30f197b882cd1"),
+								HaveKeyWithValue(RegistrationSpecHash, "61ca93a1782c5fa3"),
+								HaveKeyWithValue(SeedSpecHash, "9cebb557b37cc60b"),
+							),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(controllerInstallation3.Name),
+							"Labels": And(
+								Not(HaveKey(ControllerDeploymentHash)),
+								HaveKeyWithValue(RegistrationSpecHash, "61ca93a1782c5fa3"),
+								HaveKeyWithValue(SeedSpecHash, "9cebb557b37cc60b"),
+							),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": HavePrefix(controllerRegistration4.Name),
+							"Labels": And(
+								Not(HaveKey(ControllerDeploymentHash)),
+								HaveKeyWithValue(RegistrationSpecHash, "9c7dbe8f62b60dfb"), // spellchecker:disable-line
+								HaveKeyWithValue(SeedSpecHash, "9cebb557b37cc60b"),
+							),
+						}),
+					}),
+				))
 			})
 
 			It("should correctly deploy needed controller installations for shoots", func() {
 				var (
-					setShootRef = func(controllerInstallation *gardencorev1beta1.ControllerInstallation, shoot *gardencorev1beta1.Shoot) *gardencorev1beta1.ControllerInstallation {
-						obj := controllerInstallation.DeepCopy()
-						obj.Spec.SeedRef = nil
-						obj.Spec.ShootRef = &corev1.ObjectReference{Name: shoot.Name, Namespace: shoot.Namespace, ResourceVersion: shoot.ResourceVersion}
-						return obj
-					}
-
 					wantedControllerRegistrations  = sets.New(controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
@@ -900,28 +908,45 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				installation2 := setShootRef(controllerInstallation2, shoot3)
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					ShootSpecHash:            "a1fbf32b9ada7b98",
-				}
-
-				installation3 := setShootRef(controllerInstallation3, shoot3)
-				installation3.Labels = map[string]string{
-					RegistrationSpecHash: "61ca93a1782c5fa3",
-					ShootSpecHash:        "a1fbf32b9ada7b98",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation3.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation3, gomock.Any())
-
-				k8sClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
+				Expect(k8sClient.Create(ctx, controllerInstallation3.DeepCopy())).To(Succeed())
 
 				Expect(deployNeededInstallations(ctx, log, k8sClient, shoot3, ShootKind, nil, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)).To(Succeed())
+
+				ciList := &gardencorev1beta1.ControllerInstallationList{}
+				Expect(k8sClient.List(ctx, ciList)).To(Succeed())
+				Expect(ciList.Items).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(controllerInstallation2.Name),
+							"Labels": And(
+								HaveKeyWithValue(ControllerDeploymentHash, "deb30f197b882cd1"),
+								HaveKeyWithValue(RegistrationSpecHash, "61ca93a1782c5fa3"),
+								HaveKeyWithValue(ShootSpecHash, "a1fbf32b9ada7b98"),
+							),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": Equal(controllerInstallation3.Name),
+							"Labels": And(
+								Not(HaveKey(ControllerDeploymentHash)),
+								HaveKeyWithValue(RegistrationSpecHash, "61ca93a1782c5fa3"),
+								HaveKeyWithValue(ShootSpecHash, "a1fbf32b9ada7b98"),
+							),
+						}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"ObjectMeta": MatchFields(IgnoreExtras, Fields{
+							"Name": HavePrefix(controllerRegistration4.Name),
+							"Labels": And(
+								Not(HaveKey(ControllerDeploymentHash)),
+								HaveKeyWithValue(RegistrationSpecHash, "9c7dbe8f62b60dfb"), // spellchecker:disable-line
+								HaveKeyWithValue(ShootSpecHash, "a1fbf32b9ada7b98"),
+							),
+						}),
+					}),
+				))
 			})
 
 			It("should not skip the controller registration that is after one in deletion", func() {
@@ -939,19 +964,19 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				installation2 := controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					SeedSpecHash:             "9cebb557b37cc60b",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
 
 				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				patchedInstallation2 := &gardencorev1beta1.ControllerInstallation{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation2)).To(Succeed())
+				Expect(patchedInstallation2.Labels).To(And(
+					HaveKeyWithValue(ControllerDeploymentHash, "deb30f197b882cd1"),
+					HaveKeyWithValue(RegistrationSpecHash, "61ca93a1782c5fa3"),
+					HaveKeyWithValue(SeedSpecHash, "9cebb557b37cc60b"),
+				))
 			})
 
 			It("should not create or update controller installation for controller registration in deletion", func() {
@@ -993,22 +1018,15 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				installation2 := controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					SeedSpecHash:             "9cebb557b37cc60b",
-				}
-				installation2.Annotations = map[string]string{
-					v1beta1constants.AnnotationPodSecurityEnforce: "baseline",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
 
 				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				patchedInstallation2 := &gardencorev1beta1.ControllerInstallation{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation2)).To(Succeed())
+				Expect(patchedInstallation2.Annotations).To(HaveKeyWithValue(v1beta1constants.AnnotationPodSecurityEnforce, "baseline"))
 			})
 
 			It("should deploy controller installation without security.gardener.cloud/pod-security-enforce annotation when removed from controller registration", func() {
@@ -1028,38 +1046,26 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				installation2 := controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					SeedSpecHash:             "9cebb557b37cc60b",
-				}
-				installation2.Annotations = map[string]string{
-					v1beta1constants.AnnotationPodSecurityEnforce: "baseline",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
 
 				err := deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
 
+				patchedInstallation2 := &gardencorev1beta1.ControllerInstallation{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation2)).To(Succeed())
+				Expect(patchedInstallation2.Annotations).To(HaveKeyWithValue(v1beta1constants.AnnotationPodSecurityEnforce, "baseline"))
+
+				// Now remove the annotation from registration and re-deploy
 				delete(registration2.Annotations, v1beta1constants.AnnotationPodSecurityEnforce)
 				registrations[registration2.Name] = controllerRegistration{obj: registration2, deployAlways: false}
-				installation2 = controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					ControllerDeploymentHash: "deb30f197b882cd1",
-					RegistrationSpecHash:     "61ca93a1782c5fa3",
-					SeedSpecHash:             "9cebb557b37cc60b",
-				}
-
-				k8sClient.EXPECT().Get(ctx, client.ObjectKey{Name: controllerInstallation2.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err = deployNeededInstallations(ctx, log, k8sClient, seed, SeedKind, nil, wantedControllerRegistrations, registrations, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation2)).To(Succeed())
+				Expect(patchedInstallation2.Annotations).NotTo(HaveKey(v1beta1constants.AnnotationPodSecurityEnforce))
 			})
 		})
 
@@ -1073,7 +1079,12 @@ var _ = Describe("Reconciler", func() {
 					fakeErr = errors.New("err")
 				)
 
-				k8sClient.EXPECT().Delete(ctx, controllerInstallation1).Return(fakeErr)
+				k8sClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+							return fakeErr
+						},
+					}).Build()
 
 				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
@@ -1090,12 +1101,18 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				k8sClient.EXPECT().Delete(ctx, controllerInstallation1)
-				k8sClient.EXPECT().Delete(ctx, controllerInstallation3)
+				Expect(k8sClient.Create(ctx, controllerInstallation1.DeepCopy())).To(Succeed())
+				Expect(k8sClient.Create(ctx, controllerInstallation2.DeepCopy())).To(Succeed())
+				Expect(k8sClient.Create(ctx, controllerInstallation3.DeepCopy())).To(Succeed())
 
 				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				// Verify ci1 and ci3 are deleted, ci2 remains
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation1), &gardencorev1beta1.ControllerInstallation{})).To(BeNotFoundError())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), &gardencorev1beta1.ControllerInstallation{})).To(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation3), &gardencorev1beta1.ControllerInstallation{})).To(BeNotFoundError())
 			})
 
 			It("should remove the seed ownership label instead of deleting when the ControllerInstallation has the seed-ref-name label", func() {
@@ -1109,13 +1126,16 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
-				expectedInstallation := installation.DeepCopy()
-				delete(expectedInstallation.Labels, SeedRefName)
-				k8sClient.EXPECT().Patch(ctx, expectedInstallation, gomock.Any())
+				Expect(k8sClient.Create(ctx, installation.DeepCopy())).To(Succeed())
 
 				err := deleteUnneededInstallations(ctx, log, k8sClient, SeedKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				// Verify the installation still exists but without the SeedRefName label
+				patchedInstallation := &gardencorev1beta1.ControllerInstallation{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation)).To(Succeed())
+				Expect(patchedInstallation.Labels).NotTo(HaveKey(SeedRefName))
 			})
 
 			It("should skip seed-owned ControllerInstallations when the shoot reconciler calls", func() {
@@ -1129,9 +1149,16 @@ var _ = Describe("Reconciler", func() {
 					}
 				)
 
+				Expect(k8sClient.Create(ctx, installation.DeepCopy())).To(Succeed())
+
 				err := deleteUnneededInstallations(ctx, log, k8sClient, ShootKind, wantedControllerRegistrationNames, registrationNameToInstallation)
 
 				Expect(err).NotTo(HaveOccurred())
+
+				// Verify the installation still exists with the SeedRefName label (not touched)
+				patchedInstallation := &gardencorev1beta1.ControllerInstallation{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation2), patchedInstallation)).To(Succeed())
+				Expect(patchedInstallation.Labels).To(HaveKey(SeedRefName))
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/managedseedset/actuator_test.go
+++ b/pkg/controllermanager/controller/managedseedset/actuator_test.go
@@ -16,16 +16,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	mockmanagedseedset "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset/mock"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockevents "github.com/gardener/gardener/third_party/mock/client-go/tools/events"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 const (
@@ -39,7 +40,7 @@ var _ = Describe("Actuator", func() {
 	var (
 		ctrl *gomock.Controller
 
-		gc       *mockclient.MockClient
+		gc       client.Client
 		rg       *mockmanagedseedset.MockReplicaGetter
 		rf       *mockmanagedseedset.MockReplicaFactory
 		r0       *mockmanagedseedset.MockReplica
@@ -60,7 +61,7 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		gc = mockclient.NewMockClient(ctrl)
+		gc = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		rg = mockmanagedseedset.NewMockReplicaGetter(ctrl)
 		rf = mockmanagedseedset.NewMockReplicaFactory(ctrl)
 		r0 = mockmanagedseedset.NewMockReplica(ctrl)

--- a/pkg/controllermanager/controller/managedseedset/reconciler_test.go
+++ b/pkg/controllermanager/controller/managedseedset/reconciler_test.go
@@ -13,14 +13,16 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	mockmanagedseedset "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset/mock"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 const (
@@ -31,9 +33,8 @@ var _ = Describe("reconciler", func() {
 	var (
 		ctrl *gomock.Controller
 
-		actuator *mockmanagedseedset.MockActuator
-		c        *mockclient.MockClient
-		sw       *mockclient.MockStatusWriter
+		actuator   *mockmanagedseedset.MockActuator
+		fakeClient client.Client
 
 		cfg controllermanagerconfigv1alpha1.ManagedSeedSetControllerConfiguration
 
@@ -50,16 +51,13 @@ var _ = Describe("reconciler", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		actuator = mockmanagedseedset.NewMockActuator(ctrl)
-		c = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockStatusWriter(ctrl)
-
-		c.EXPECT().Status().Return(sw).AnyTimes()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithStatusSubresource(&seedmanagementv1alpha1.ManagedSeedSet{}).Build()
 
 		cfg = controllermanagerconfigv1alpha1.ManagedSeedSetControllerConfiguration{
 			SyncPeriod: metav1.Duration{Duration: syncPeriod},
 		}
 
-		reconciler = &Reconciler{Client: c, Actuator: actuator, Config: cfg}
+		reconciler = &Reconciler{Client: fakeClient, Actuator: actuator, Config: cfg}
 
 		ctx = context.TODO()
 		request = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}
@@ -80,63 +78,34 @@ var _ = Describe("reconciler", func() {
 		ctrl.Finish()
 	})
 
-	var (
-		expectGetManagedSeedSet = func() {
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, mss *seedmanagementv1alpha1.ManagedSeedSet, _ ...client.GetOption) error {
-					*mss = *managedSeedSet
-					return nil
-				},
-			)
-		}
-		expectPatchManagedSeedSet = func(expect func(*seedmanagementv1alpha1.ManagedSeedSet)) {
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, mss *seedmanagementv1alpha1.ManagedSeedSet, _ client.Patch, _ ...client.PatchOption) error {
-					expect(mss)
-					*managedSeedSet = *mss
-					return nil
-				},
-			)
-		}
-		expectPatchManagedSeedSetStatus = func(expect func(*seedmanagementv1alpha1.ManagedSeedSet)) {
-			sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedSet{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, mss *seedmanagementv1alpha1.ManagedSeedSet, _ client.Patch, _ ...client.PatchOption) error {
-					expect(mss)
-					*managedSeedSet = *mss
-					return nil
-				},
-			)
-		}
-	)
-
 	Describe("#Reconcile", func() {
 		Context("reconcile", func() {
 			It("should add the finalizer, if not present", func() {
-				expectGetManagedSeedSet()
-				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(mss.Finalizers).To(Equal([]string{gardencorev1beta1.GardenerName}))
-				})
-				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
-				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(&mss.Status).To(Equal(status))
-				})
+				Expect(fakeClient.Create(ctx, managedSeedSet.DeepCopy())).To(Succeed())
+
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), gomock.Any()).Return(status, false, nil)
 
 				result, err := reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: syncPeriod}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), managedSeedSet)).To(Succeed())
+				Expect(managedSeedSet.Finalizers).To(Equal([]string{gardencorev1beta1.GardenerName}))
+				Expect(managedSeedSet.Status.ObservedGeneration).To(Equal(int64(1)))
 			})
 
 			It("should reconcile the ManagedSeedSet creation or update, and update the status", func() {
-				expectGetManagedSeedSet()
 				managedSeedSet.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
-				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(&mss.Status).To(Equal(status))
-				})
+				Expect(fakeClient.Create(ctx, managedSeedSet.DeepCopy())).To(Succeed())
+
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), gomock.Any()).Return(status, false, nil)
 
 				result, err := reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: syncPeriod}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), managedSeedSet)).To(Succeed())
+				Expect(managedSeedSet.Status.ObservedGeneration).To(Equal(int64(1)))
 			})
 		})
 
@@ -148,27 +117,36 @@ var _ = Describe("reconciler", func() {
 			})
 
 			It("should reconcile the ManagedSeedSet deletion and update the status", func() {
-				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, false, nil)
-				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(&mss.Status).To(Equal(status))
-				})
+				Expect(fakeClient.Create(ctx, managedSeedSet)).To(Succeed())
+				Expect(fakeClient.Delete(ctx, managedSeedSet)).To(Succeed())
+
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), gomock.Any()).Return(status, false, nil)
+
+				// Verify object still exists
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), &seedmanagementv1alpha1.ManagedSeedSet{})).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: syncPeriod}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), managedSeedSet)).To(Succeed())
+				Expect(managedSeedSet.Status.ObservedGeneration).To(Equal(int64(1)))
 			})
 
 			It("should reconcile the ManagedSeedSet deletion, remove the finalizer, and not update the status", func() {
-				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), managedSeedSet).Return(status, true, nil)
-				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(mss.Finalizers).To(BeEmpty())
-				})
+				Expect(fakeClient.Create(ctx, managedSeedSet)).To(Succeed())
+				Expect(fakeClient.Delete(ctx, managedSeedSet)).To(Succeed())
+
+				// Verify object still exists
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), &seedmanagementv1alpha1.ManagedSeedSet{})).To(Succeed())
+
+				actuator.EXPECT().Reconcile(gomock.Any(), gomock.Any(), gomock.Any()).Return(status, true, nil)
 
 				result, err := reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedSeedSet), &seedmanagementv1alpha1.ManagedSeedSet{})).To(BeNotFoundError())
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/managedseedset/replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/replica_test.go
@@ -6,23 +6,25 @@ package managedseedset_test
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 const (
@@ -32,9 +34,8 @@ const (
 
 var _ = Describe("Replica", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		ctx  context.Context
+		fakeClient client.Client
+		ctx        context.Context
 
 		managedSeedSet *seedmanagementv1alpha1.ManagedSeedSet
 
@@ -42,8 +43,7 @@ var _ = Describe("Replica", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 		ctx = context.TODO()
 
 		managedSeedSet = &seedmanagementv1alpha1.ManagedSeedSet{
@@ -90,10 +90,6 @@ var _ = Describe("Replica", func() {
 				},
 			},
 		}
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	var (
@@ -301,134 +297,90 @@ var _ = Describe("Replica", func() {
 
 	Describe("#CreateShoot", func() {
 		It("should create the shoot", func() {
-			c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
-				func(_ context.Context, s *gardencorev1beta1.Shoot, _ ...client.CreateOption) error {
-					Expect(s).To(Equal(&gardencorev1beta1.Shoot{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      replicaName,
-							Namespace: namespace,
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-							OwnerReferences: []metav1.OwnerReference{
-								*metav1.NewControllerRef(managedSeedSet, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeedSet")),
-							},
-						},
-						Spec: gardencorev1beta1.ShootSpec{
-							DNS: &gardencorev1beta1.DNS{
-								Domain: ptr.To(replicaName + ".example.com"),
-							},
-						},
-					}))
-					return nil
-				},
-			)
-
 			replica := NewReplica(managedSeedSet, nil, nil, nil, false)
-			err := replica.CreateShoot(ctx, c, ordinal)
+			err := replica.CreateShoot(ctx, fakeClient, ordinal)
 			Expect(err).ToNot(HaveOccurred())
+
+			createdShoot := &gardencorev1beta1.Shoot{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: replicaName}, createdShoot)).To(Succeed())
+			Expect(createdShoot.Name).To(Equal(replicaName))
+			Expect(createdShoot.Namespace).To(Equal(namespace))
+			Expect(createdShoot.Labels).To(Equal(map[string]string{"foo": "bar"}))
+			Expect(createdShoot.OwnerReferences).To(Equal([]metav1.OwnerReference{
+				*metav1.NewControllerRef(managedSeedSet, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeedSet")),
+			}))
+			Expect(createdShoot.Spec.DNS).ToNot(BeNil())
+			Expect(createdShoot.Spec.DNS.Domain).To(Equal(ptr.To(replicaName + ".example.com")))
 		})
 	})
 
 	Describe("#CreateManagedSeed", func() {
 		It("should create the managed seed", func() {
-			shoot := shoot(nil, "", "", "", false)
-			c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-				func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.CreateOption) error {
-					Expect(ms).To(Equal(&seedmanagementv1alpha1.ManagedSeed{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      replicaName,
-							Namespace: namespace,
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-							OwnerReferences: []metav1.OwnerReference{
-								*metav1.NewControllerRef(managedSeedSet, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeedSet")),
-							},
-						},
-						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-							Shoot: &seedmanagementv1alpha1.Shoot{
-								Name: replicaName,
-							},
-							Gardenlet: seedmanagementv1alpha1.GardenletConfig{
-								Config: runtime.RawExtension{
-									Object: &gardenletconfigv1alpha1.GardenletConfiguration{
-										SeedConfig: &gardenletconfigv1alpha1.SeedConfig{
-											SeedTemplate: gardencorev1beta1.SeedTemplate{
-												Spec: gardencorev1beta1.SeedSpec{
-													Ingress: &gardencorev1beta1.Ingress{
-														Domain: "ingress." + replicaName + ".example.com",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}))
-					return nil
-				},
-			)
-
-			replica := NewReplica(managedSeedSet, shoot, nil, nil, false)
-			err := replica.CreateManagedSeed(ctx, c)
+			s := shoot(nil, "", "", "", false)
+			replica := NewReplica(managedSeedSet, s, nil, nil, false)
+			err := replica.CreateManagedSeed(ctx, fakeClient)
 			Expect(err).ToNot(HaveOccurred())
+
+			createdMS := &seedmanagementv1alpha1.ManagedSeed{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: replicaName}, createdMS)).To(Succeed())
+			Expect(createdMS.Name).To(Equal(replicaName))
+			Expect(createdMS.Namespace).To(Equal(namespace))
+			Expect(createdMS.Labels).To(Equal(map[string]string{"foo": "bar"}))
+			Expect(createdMS.OwnerReferences).To(Equal([]metav1.OwnerReference{
+				*metav1.NewControllerRef(managedSeedSet, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeedSet")),
+			}))
+			Expect(createdMS.Spec.Shoot).ToNot(BeNil())
+			Expect(createdMS.Spec.Shoot.Name).To(Equal(replicaName))
+			Expect(createdMS.Spec.Gardenlet.Config.Raw).NotTo(BeNil())
+			gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
+			Expect(json.Unmarshal(createdMS.Spec.Gardenlet.Config.Raw, gardenletConfig)).To(Succeed())
+			Expect(gardenletConfig.SeedConfig).ToNot(BeNil())
+			Expect(gardenletConfig.SeedConfig.SeedTemplate.Spec.Ingress).ToNot(BeNil())
+			Expect(gardenletConfig.SeedConfig.SeedTemplate.Spec.Ingress.Domain).To(Equal("ingress." + replicaName + ".example.com"))
 		})
 	})
 
 	Describe("#DeleteShoot", func() {
 		It("should clean the retries, confirm the deletion, and delete the shoot", func() {
-			shoot := shoot(nil, "", "", "", false)
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, s *gardencorev1beta1.Shoot, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(s.Annotations).To(HaveKeyWithValue(v1beta1constants.ConfirmationDeletion, "true"))
-					*shoot = *s
-					return nil
-				},
-			)
-			c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
-				func(_ context.Context, s *gardencorev1beta1.Shoot, _ ...client.DeleteOption) error {
-					Expect(s).To(Equal(shoot))
-					return nil
-				},
-			)
+			s := shoot(nil, "", "", "", false)
+			s.ResourceVersion = ""
+			Expect(fakeClient.Create(ctx, s)).To(Succeed())
 
-			replica := NewReplica(managedSeedSet, shoot, nil, nil, false)
-			err := replica.DeleteShoot(ctx, c)
+			replica := NewReplica(managedSeedSet, s, nil, nil, false)
+			err := replica.DeleteShoot(ctx, fakeClient)
 			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: replicaName}, &gardencorev1beta1.Shoot{})).To(BeNotFoundError())
 		})
 	})
 
 	Describe("#DeleteManagedSeed", func() {
 		It("should delete the managed seed", func() {
-			managedSeed := managedSeed(nil, false, false)
-			c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-				func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.DeleteOption) error {
-					Expect(ms).To(Equal(managedSeed))
-					return nil
-				},
-			)
+			ms := managedSeed(nil, false, false)
+			ms.ResourceVersion = ""
+			Expect(fakeClient.Create(ctx, ms)).To(Succeed())
 
-			replica := NewReplica(managedSeedSet, nil, managedSeed, nil, false)
-			err := replica.DeleteManagedSeed(ctx, c)
+			replica := NewReplica(managedSeedSet, nil, ms, nil, false)
+			err := replica.DeleteManagedSeed(ctx, fakeClient)
 			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: replicaName}, &seedmanagementv1alpha1.ManagedSeed{})).To(BeNotFoundError())
 		})
 	})
 
 	Describe("#RetryShoot", func() {
 		It("should managedSeedSet the operation to retry and the retries to 1", func() {
-			shoot := shoot(nil, "", "", "", false)
-			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, s *gardencorev1beta1.Shoot, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(s.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
-					return nil
-				},
-			)
+			s := shoot(nil, "", "", "", false)
+			s.ResourceVersion = ""
+			Expect(fakeClient.Create(ctx, s)).To(Succeed())
 
-			replica := NewReplica(managedSeedSet, shoot, nil, nil, false)
-			err := replica.RetryShoot(ctx, c)
+			replica := NewReplica(managedSeedSet, s, nil, nil, false)
+			err := replica.RetryShoot(ctx, fakeClient)
 			Expect(err).ToNot(HaveOccurred())
+
+			patchedShoot := &gardencorev1beta1.Shoot{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: replicaName}, patchedShoot)).To(Succeed())
+			Expect(patchedShoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
 		})
 	})
 })

--- a/pkg/controllermanager/controller/managedseedset/replicagetter_test.go
+++ b/pkg/controllermanager/controller/managedseedset/replicagetter_test.go
@@ -9,24 +9,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("ReplicaGetter", func() {
 	var (
-		ctrl *gomock.Controller
-
-		c *mockclient.MockClient
-		r *mockclient.MockReader
+		c client.Client
 
 		replicaGetter ReplicaGetter
 
@@ -39,14 +35,19 @@ var _ = Describe("ReplicaGetter", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-
-		c = mockclient.NewMockClient(ctrl)
-		r = mockclient.NewMockReader(ctrl)
-
-		replicaGetter = NewReplicaGetter(c, r, ReplicaFactoryFunc(NewReplica))
-
 		ctx = context.TODO()
+
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).
+			WithIndex(&gardencorev1beta1.Shoot{}, gardencore.ShootSeedName, func(obj client.Object) []string {
+				shoot, ok := obj.(*gardencorev1beta1.Shoot)
+				if !ok {
+					return nil
+				}
+				if shoot.Spec.SeedName != nil {
+					return []string{*shoot.Spec.SeedName}
+				}
+				return nil
+			}).Build()
 
 		managedSeedSet = &seedmanagementv1alpha1.ManagedSeedSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -66,18 +67,21 @@ var _ = Describe("ReplicaGetter", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name + "-0",
 					Namespace: namespace,
+					Labels:    map[string]string{"name": name},
 				},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name + "-1",
 					Namespace: namespace,
+					Labels:    map[string]string{"name": name},
 				},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name + "-2",
 					Namespace: namespace,
+					Labels:    map[string]string{"name": name},
 				},
 			},
 		}
@@ -86,84 +90,69 @@ var _ = Describe("ReplicaGetter", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name + "-0",
 					Namespace: namespace,
+					Labels:    map[string]string{"name": name},
 				},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name + "-1",
 					Namespace: namespace,
+					Labels:    map[string]string{"name": name},
 				},
 			},
 		}
 		seeds = []gardencorev1beta1.Seed{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name + "-0",
+					Name:   name + "-0",
+					Labels: map[string]string{"name": name},
 				},
 			},
 		}
-
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#GetReplicas", func() {
 		It("should return all existing replicas", func() {
-			selector, err := metav1.LabelSelectorAsSelector(&managedSeedSet.Spec.Selector)
-			Expect(err).ToNot(HaveOccurred())
+			scheduledShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seeds[0].Name,
+				},
+			}
 
-			c.EXPECT().Scheme().Return(kubernetes.GardenScheme)
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(managedSeedSet.Namespace), client.MatchingLabelsSelector{Selector: selector}).DoAndReturn(
-				func(_ context.Context, shootList *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-					shootList.Items = shoots
-					return nil
-				},
-			)
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{}), client.InNamespace(managedSeedSet.Namespace), client.MatchingLabelsSelector{Selector: selector}).DoAndReturn(
-				func(_ context.Context, msList *seedmanagementv1alpha1.ManagedSeedList, _ ...client.ListOption) error {
-					msList.Items = managedSeeds
-					return nil
-				},
-			)
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{}), client.MatchingLabelsSelector{Selector: selector}).DoAndReturn(
-				func(_ context.Context, seedList *gardencorev1beta1.SeedList, _ ...client.ListOption) error {
-					seedList.Items = seeds
-					return nil
-				},
-			)
-			r.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(managedSeedSet.Namespace), client.MatchingLabelsSelector{Selector: selector}).DoAndReturn(
-				func(_ context.Context, pomList *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-					var items []metav1.PartialObjectMetadata
-					for _, shoot := range shoots {
-						items = append(items, metav1.PartialObjectMetadata{ObjectMeta: shoot.ObjectMeta})
-					}
-					pomList.Items = items
-					return nil
-				},
-			)
-			r.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.MatchingFields{gardencore.ShootSeedName: seeds[0].Name}, client.Limit(1)).DoAndReturn(
-				func(_ context.Context, shootList *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-					shootList.Items = []gardencorev1beta1.Shoot{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "foo",
-								Namespace: "bar",
-							},
-						},
-					}
-					return nil
-				},
-			)
+			Expect(c.Create(ctx, scheduledShoot.DeepCopy())).To(Succeed())
+
+			for _, s := range shoots {
+				Expect(c.Create(ctx, s.DeepCopy())).To(Succeed())
+			}
+			for _, ms := range managedSeeds {
+				Expect(c.Create(ctx, ms.DeepCopy())).To(Succeed())
+			}
+			for _, sd := range seeds {
+				Expect(c.Create(ctx, sd.DeepCopy())).To(Succeed())
+			}
+
+			replicaGetter = NewReplicaGetter(c, c, ReplicaFactoryFunc(NewReplica))
 
 			result, err := replicaGetter.GetReplicas(ctx, managedSeedSet)
+
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal([]Replica{
-				NewReplica(managedSeedSet, &shoots[0], &managedSeeds[0], &seeds[0], true),
-				NewReplica(managedSeedSet, &shoots[1], &managedSeeds[1], nil, false),
-				NewReplica(managedSeedSet, &shoots[2], nil, nil, false),
-			}))
+			Expect(result).To(HaveLen(3))
+
+			// Verify structure: first shoot has managed seed and seed (with scheduled shoots)
+			Expect(result[0].GetName()).To(Equal(name + "-0"))
+			Expect(result[0].IsDeletable()).To(BeFalse()) // has scheduled shoots
+
+			// Second shoot has managed seed but no seed
+			Expect(result[1].GetName()).To(Equal(name + "-1"))
+			Expect(result[1].GetStatus()).To(Equal(StatusManagedSeedPreparing))
+
+			// Third shoot has neither managed seed nor seed
+			Expect(result[2].GetName()).To(Equal(name + "-2"))
+			Expect(result[2].GetStatus()).To(Equal(StatusShootReconciling))
 		})
 	})
 })

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -7,24 +7,21 @@ package namespacedcloudprofile_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/gardener/pkg/api/indexer"
@@ -33,7 +30,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	namespacedcloudprofilecontroller "github.com/gardener/gardener/pkg/controllermanager/controller/namespacedcloudprofile"
 	"github.com/gardener/gardener/pkg/provider-local/apis/local/v1alpha1"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("NamespacedCloudProfile Reconciler", func() {
@@ -41,9 +38,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 
 	var (
 		ctx        context.Context
-		ctrl       *gomock.Controller
-		c          *mockclient.MockClient
-		sw         *mockclient.MockStatusWriter
+		fakeClient client.Client
 		reconciler reconcile.Reconciler
 
 		fakeErr error
@@ -61,12 +56,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockStatusWriter(ctrl)
-
 		fakeErr = errors.New("fake err")
-		reconciler = &namespacedcloudprofilecontroller.Reconciler{Client: c, Recorder: &events.FakeRecorder{}}
 
 		namespaceName = "test-namespace"
 		cloudProfileName = "test-cloudprofile"
@@ -79,9 +69,8 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 		}
 		namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            namespacedCloudProfileName,
-				Namespace:       namespaceName,
-				ResourceVersion: "42",
+				Name:      namespacedCloudProfileName,
+				Namespace: namespaceName,
 			},
 			Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
 				Parent: gardencorev1beta1.CloudProfileReference{
@@ -91,23 +80,36 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			},
 		}
 
-		newExpiryDate = metav1.Now()
-	})
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithStatusSubresource(&gardencorev1beta1.NamespacedCloudProfile{}).
+			WithIndex(
+				&gardencorev1beta1.NamespacedCloudProfile{},
+				core.NamespacedCloudProfileParentRefName,
+				indexer.NamespacedCloudProfileParentRefNameIndexerFunc,
+			).
+			Build()
+		reconciler = &namespacedcloudprofilecontroller.Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
-	AfterEach(func() {
-		ctrl.Finish()
+		newExpiryDate = metav1.NewTime(time.Now().Truncate(time.Second))
 	})
 
 	It("should return nil because object not found", func() {
-		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 		Expect(result).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return err because object reading failed", func() {
-		c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).Return(fakeErr)
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fakeErr
+				},
+			}).
+			Build()
+		reconciler = &namespacedcloudprofilecontroller.Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
 		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 		Expect(result).To(Equal(reconcile.Result{}))
@@ -118,29 +120,18 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 		It("should apply the CloudProfile providerConfig to the NamespacedCloudProfile status on spec change", func() {
 			cloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"key":"value"}`)}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"providerConfig":{"key":"value"}}}}`))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			// Verify status was updated
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.ProviderConfig).ToNot(BeNil())
+			Expect(updated.Status.CloudProfileSpec.ProviderConfig.Raw).To(Equal([]byte(`{"key":"value"}`)))
 		})
 
 		It("should ignore an existing NamespacedCloudProfile status providerConfig on spec change", func() {
@@ -148,29 +139,18 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"key2":"value2"}`)}
 			namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"key":"value","key2":"value2"}`)}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"providerConfig":{"key2":null}}}}`))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			// Verify status was updated - the parent providerConfig should be set in the status
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.ProviderConfig).ToNot(BeNil())
+			Expect(updated.Status.CloudProfileSpec.ProviderConfig.Raw).To(Equal([]byte(`{"key":"value"}`)))
 		})
 
 		It("should sync the architecture capabilities", func() {
@@ -190,33 +170,22 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				{Name: "architecture", Values: []string{"amd64", "arm64"}},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(And(
-						ContainSubstring(`"machineCapabilities":[{"name":"architecture","values":["amd64","arm64"]}]`), // global capabilities
-						ContainSubstring(`"versions":[{"architectures":["arm64"]`),                                     // original value
-						ContainSubstring(`"capabilityFlavors":[{"architecture":["arm64"]}]`),                           // synced value
-					))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineCapabilities).To(Equal([]gardencorev1beta1.CapabilityDefinition{
+				{Name: "architecture", Values: []string{"amd64", "arm64"}},
+			}))
+			Expect(updated.Status.CloudProfileSpec.MachineImages).To(HaveLen(1))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Versions[0].Architectures).To(ConsistOf("arm64"))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Versions[0].CapabilityFlavors).To(HaveLen(1))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Versions[0].CapabilityFlavors[0].Capabilities).To(HaveKeyWithValue("architecture", gardencorev1beta1.CapabilityValues{"arm64"}))
 		})
 	})
 
@@ -237,29 +206,16 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]}}}}`))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{{Version: "1.0.0"}}))
 		})
 
 		It("should merge Kubernetes versions correctly", func() {
@@ -267,94 +223,74 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				{Version: "1.0.0", ExpirationDate: &newExpiryDate},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"expirationDate":"%s","version":"1.0.0"}]}}}}`, newExpiryDate.UTC().Format(time.RFC3339))))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Version":        Equal("1.0.0"),
+					"ExpirationDate": Equal(&newExpiryDate),
+				}),
+			))
 		})
 
 		It("should set observedGeneration correctly", func() {
 			namespacedCloudProfile.Generation = 7
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"kubernetes":{"versions":[{"version":"1.0.0"}]}},"observedGeneration":7}}`))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			// The fake client doesn't track generation, so we check observedGeneration equals what the reconciler sets.
+			// The reconciler reads the object's generation and sets observedGeneration to it.
+			Expect(updated.Status.ObservedGeneration).To(Equal(updated.Generation))
 		})
 
 		Context("when deletion timestamp set", func() {
 			BeforeEach(func() {
-				now := metav1.Now()
-				namespacedCloudProfile.DeletionTimestamp = &now
 				namespacedCloudProfile.Finalizers = []string{finalizerName}
 
-				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-					*obj = *namespacedCloudProfile
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+				Expect(fakeClient.Delete(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, namespacedCloudProfile)).To(Succeed())
 			})
 
 			It("should do nothing because finalizer is not present", func() {
-				namespacedCloudProfile.Finalizers = nil
+				updated := namespacedCloudProfile.DeepCopy()
+				updated.Finalizers = []string{"some-other-finalizer"}
+				Expect(fakeClient.Patch(ctx, updated, client.MergeFrom(namespacedCloudProfile))).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, namespacedCloudProfile)).To(Succeed())
+				Expect(namespacedCloudProfile.Finalizers).To(Equal([]string{"some-other-finalizer"}))
 			})
 
 			It("should return an error because Shoot referencing NamespacedCloudProfile exists", func() {
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-					(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: "test-namespace"},
-							Spec: gardencorev1beta1.ShootSpec{
-								CloudProfile: &gardencorev1beta1.CloudProfileReference{
-									Kind: "NamespacedCloudProfile",
-									Name: namespacedCloudProfileName,
-								},
-							},
+				shoot := &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: namespaceName},
+					Spec: gardencorev1beta1.ShootSpec{
+						CloudProfile: &gardencorev1beta1.CloudProfileReference{
+							Kind: "NamespacedCloudProfile",
+							Name: namespacedCloudProfileName,
 						},
-					}}).DeepCopyInto(obj)
-					return nil
-				})
+					},
+				}
+				Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -362,15 +298,22 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			})
 
 			It("should remove the finalizer (error)", func() {
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-					(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
-					return nil
-				})
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithStatusSubresource(&gardencorev1beta1.NamespacedCloudProfile{}).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
+				reconciler = &namespacedcloudprofilecontroller.Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
-				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-					return fakeErr
-				})
+				ncp := namespacedCloudProfile.DeepCopy()
+				ncp.Finalizers = []string{finalizerName}
+				ncp.ResourceVersion = ""
+				Expect(fakeClient.Create(ctx, ncp)).To(Succeed())
+				Expect(fakeClient.Delete(ctx, ncp.DeepCopy())).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
@@ -378,63 +321,47 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			})
 
 			It("should remove the finalizer (no error)", func() {
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-					(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
-					return nil
-				})
-
-				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-					return nil
-				})
-
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, &gardencorev1beta1.NamespacedCloudProfile{})).To(BeNotFoundError())
 			})
 		})
 
 		Context("when deletion timestamp not set", func() {
-			BeforeEach(func() {
-				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-					namespacedCloudProfile.DeepCopyInto(obj)
-					return nil
-				})
-			})
-
 			It("should ensure the finalizer (error)", func() {
-				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, namespaceName+"/"+namespacedCloudProfileName)
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithStatusSubresource(&gardencorev1beta1.NamespacedCloudProfile{}).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
+				reconciler = &namespacedcloudprofilecontroller.Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
-				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-					return errToReturn
-				})
+				Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
-				Expect(err).To(MatchError(err))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("should ensure the finalizer (no error)", func() {
-				c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-					return nil
-				})
-
 				cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{}
-				c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-					cloudProfile.DeepCopyInto(obj)
-					return nil
-				})
 
-				gomock.InOrder(
-					c.EXPECT().Status().Return(sw),
-					sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()),
-				)
+				Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+				Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(err).NotTo(HaveOccurred())
+
+				updated := &gardencorev1beta1.NamespacedCloudProfile{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+				Expect(updated.Finalizers).To(ContainElement(finalizerName))
 			})
 		})
 	})
@@ -469,41 +396,40 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					machineImageParent := `{"name":"test-image","updateStrategy":"major","versions":[{"architectures":["amd64"],"cri":[{"name":"containerd"}],"kubeletVersionConstraint":"==1.30.0","version":"1.0.0"}]}`
-					machineImageNamespacedCloudProfile := `{"name":"test-image-namespaced","updateStrategy":"major","versions":[{"architectures":["arm64"],"cri":[{"name":"containerd"}],"kubeletVersionConstraint":"==1.30.0","version":"1.1.2"}]}`
-					Expect(patch.Data(o)).To(And(
-						// The order is (currently) indeterministic.
-						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[`),
-						ContainSubstring(machineImageParent),
-						ContainSubstring(machineImageNamespacedCloudProfile),
-						ContainSubstring(`]}}}`),
-					))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineImages).To(HaveLen(2))
+			Expect(updated.Status.CloudProfileSpec.MachineImages).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("test-image"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion":         Equal(gardencorev1beta1.ExpirableVersion{Version: "1.0.0", ExpirationDate: nil, Classification: nil, Lifecycle: nil}),
+						"CRI":                      Equal([]gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}),
+						"Architectures":            ConsistOf("amd64"),
+						"KubeletVersionConstraint": Equal(ptr.To("==1.30.0")),
+					})),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Name": Equal("test-image-namespaced"),
+					"Versions": ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"ExpirableVersion":         Equal(gardencorev1beta1.ExpirableVersion{Version: "1.1.2", ExpirationDate: nil, Classification: nil, Lifecycle: nil}),
+						"CRI":                      Equal([]gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}),
+						"Architectures":            ConsistOf("arm64"),
+						"KubeletVersionConstraint": Equal(ptr.To("==1.30.0")),
+					})),
+				}),
+			))
 		})
 
 		It("should merge MachineImages correctly", func() {
-			newExpiryDate := metav1.Now()
+			newExpiryDate := metav1.NewTime(time.Now().Truncate(time.Second))
 			namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 				{
 					Name: "test-image",
@@ -516,37 +442,23 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					versionOverride := fmt.Sprintf(`{"architectures":["amd64"],"cri":[{"name":"containerd"}],"expirationDate":"%s","kubeletVersionConstraint":"==1.30.0","version":"1.0.0"}`, newExpiryDate.UTC().Format(time.RFC3339))
-					versionAdded := `{"architectures":["amd64"],"version":"1.1.2"}`
-					Expect(patch.Data(o)).To(And(
-						// The order is (currently) indeterministic.
-						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[{"name":"test-image","updateStrategy":"major","versions":[`),
-						ContainSubstring(versionOverride),
-						ContainSubstring(versionAdded),
-						ContainSubstring(`]}]}}}`),
-					))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineImages).To(HaveLen(1))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Name).To(Equal("test-image"))
+			versions := updated.Status.CloudProfileSpec.MachineImages[0].Versions
+			Expect(versions).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
+				"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{Version: "1.0.0", ExpirationDate: &newExpiryDate, Classification: nil, Lifecycle: nil}),
+			}), MatchFields(IgnoreExtras, Fields{
+				"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{Version: "1.1.2", ExpirationDate: nil, Classification: nil, Lifecycle: nil}),
+			})))
 		})
 
 		It("should merge MachineImages with overridden updateStrategy correctly", func() {
@@ -557,33 +469,23 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(And(
-						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineImages":[{"name":"test-image","updateStrategy":"minor","versions":[`),
-						ContainSubstring(`{"architectures":["amd64"],"cri":[{"name":"containerd"}],"kubeletVersionConstraint":"==1.30.0","version":"1.0.0"}`),
-						ContainSubstring(`]}]}}}`),
-					))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineImages).To(HaveLen(1))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].UpdateStrategy).To(Equal(ptr.To(gardencorev1beta1.UpdateStrategyMinor)))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Versions).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
+				"ExpirableVersion":         Equal(gardencorev1beta1.ExpirableVersion{Version: "1.0.0", ExpirationDate: nil, Classification: nil, Lifecycle: nil}),
+				"CRI":                      Equal([]gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}),
+				"Architectures":            ConsistOf("amd64"),
+				"KubeletVersionConstraint": Equal(ptr.To("==1.30.0")),
+			})))
 		})
 	})
 
@@ -613,29 +515,23 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(`{"status":{"cloudProfileSpec":{"machineTypes":[{"architecture":"amd64","cpu":"1","gpu":"5","memory":"3Gi","name":"test-type-namespaced"}]}}}`))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineTypes).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
+				"Name":         Equal("test-type-namespaced"),
+				"CPU":          Equal(resource.MustParse("1")),
+				"GPU":          Equal(resource.MustParse("5")),
+				"Memory":       Equal(resource.MustParse("3Gi")),
+				"Architecture": Equal(ptr.To("amd64")),
+			})))
+
 		})
 
 		It("should successfully add types specified in CloudProfile and NamespacedCloudProfile", func() {
@@ -648,34 +544,31 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				},
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.NamespacedCloudProfile, _ ...client.GetOption) error {
-				namespacedCloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			c.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any())
-
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: cloudProfileName}, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile, _ ...client.GetOption) error {
-				cloudProfile.DeepCopyInto(obj)
-				return nil
-			})
-
-			gomock.InOrder(
-				c.EXPECT().Status().Return(sw),
-				sw.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.NamespacedCloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
-					// Order of machine type array in patch is not guaranteed
-					Expect(patch.Data(o)).To(And(
-						ContainSubstring(`{"status":{"cloudProfileSpec":{"machineTypes":[`),
-						ContainSubstring(`{"architecture":"amd64","cpu":"1","gpu":"5","memory":"3Gi","name":"test-type-namespaced"}`),
-						ContainSubstring(`{"architecture":"amd64","cpu":"2","gpu":"7","memory":"10Gi","name":"test-type"}`),
-					))
-					return nil
-				}),
-			)
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.MachineTypes).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Name":         Equal("test-type"),
+					"CPU":          Equal(resource.MustParse("2")),
+					"GPU":          Equal(resource.MustParse("7")),
+					"Memory":       Equal(resource.MustParse("10Gi")),
+					"Architecture": Equal(ptr.To("amd64")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Name":         Equal("test-type-namespaced"),
+					"CPU":          Equal(resource.MustParse("1")),
+					"GPU":          Equal(resource.MustParse("5")),
+					"Memory":       Equal(resource.MustParse("3Gi")),
+					"Architecture": Equal(ptr.To("amd64")),
+				}),
+			))
 		})
 	})
 

--- a/pkg/controllermanager/controller/project/activity/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/activity/reconciler_test.go
@@ -7,21 +7,21 @@ package activity_test
 import (
 	"context"
 	"errors"
-	"reflect"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/project/activity"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Project Activity", func() {
@@ -36,17 +36,11 @@ var _ = Describe("Project Activity", func() {
 
 		fakeClock *testclock.FakeClock
 
-		ctrl                   *gomock.Controller
-		k8sGardenRuntimeClient *mockclient.MockClient
-		mockStatusWriter       *mockclient.MockStatusWriter
-		ctx                    context.Context
+		fakeClient client.Client
+		ctx        context.Context
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
-		mockStatusWriter = mockclient.NewMockStatusWriter(ctrl)
-
 		ctx = context.TODO()
 
 		projectName = "name"
@@ -65,54 +59,51 @@ var _ = Describe("Project Activity", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("Reconciler", func() {
 		BeforeEach(func() {
 			fakeClock = testclock.NewFakeClock(time.Now())
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithStatusSubresource(&gardencorev1beta1.Project{}).
+				Build()
 			reconciler = &Reconciler{
-				Client: k8sGardenRuntimeClient,
+				Client: fakeClient,
 				Clock:  fakeClock,
 			}
 
-			k8sGardenRuntimeClient.EXPECT().Get(
-				gomock.Any(),
-				gomock.Any(),
-				gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}),
-			).DoAndReturn(func(_ context.Context, namespacedName client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
-				if reflect.DeepEqual(namespacedName.Namespace, namespaceName) {
-					project.DeepCopyInto(obj)
-					return nil
-				}
-				return errors.New("error retrieving object from store")
-			})
-
-			k8sGardenRuntimeClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
-
-			mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, prj *gardencorev1beta1.Project, _ client.Patch, _ ...client.PatchOption) error {
-					*project = *prj
-					return nil
-				},
-			).AnyTimes()
+			Expect(fakeClient.Create(ctx, project)).To(Succeed())
 		})
 
 		Context("#Reconcile", func() {
 			It("should update the lastActivityTimestamp to now", func() {
-				request = reconcile.Request{NamespacedName: types.NamespacedName{Name: project.Name, Namespace: namespaceName}}
+				request = reconcile.Request{NamespacedName: types.NamespacedName{Name: project.Name}}
 				_, err := reconciler.Reconcile(ctx, request)
 				Expect(err).ToNot(HaveOccurred())
 
-				now := &metav1.Time{Time: fakeClock.Now()}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: projectName}, project)).To(Succeed())
+				// JSON serialization of metav1.Time truncates to second precision, so compare with truncated time
+				now := &metav1.Time{Time: fakeClock.Now().Truncate(time.Second)}
 				Expect(project.Status.LastActivityTimestamp).To(Equal(now))
 			})
 
 			It("should fail reconcile because the project can't be retrieved", func() {
+				fakeErr := errors.New("error retrieving object from store")
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
+				reconciler = &Reconciler{
+					Client: fakeClient,
+					Clock:  fakeClock,
+				}
+
 				request = reconcile.Request{NamespacedName: types.NamespacedName{Name: project.Name, Namespace: namespaceName + "other"}}
 				_, err := reconciler.Reconcile(ctx, request)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fakeErr))
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/project/project/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/project/reconciler_test.go
@@ -9,35 +9,28 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 var _ = Describe("Default Resource Quota", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		ctx  = context.TODO()
+		fakeClient client.Client
+		ctx        = context.TODO()
 
 		namespace   = "namespace"
 		projectName = "name"
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 	})
 
 	Describe("#quotaConfigurationForProject", func() {
@@ -201,19 +194,16 @@ var _ = Describe("Default Resource Quota", func() {
 				Config: resourceQuota,
 			}
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
-				Return(apierrors.NewNotFound(corev1.Resource("resourcequota"), "resourcequota"))
+			Expect(createOrUpdateResourceQuota(ctx, fakeClient, namespace, ownerRef, config)).To(Succeed())
 
-			expectedResourceQuota := resourceQuota.DeepCopy()
-			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
-			expectedResourceQuota.Labels = map[string]string{"bar": "baz"}
-			expectedResourceQuota.Annotations = map[string]string{"foo": "bar"}
-			expectedResourceQuota.SetName(ResourceQuotaName)
-			expectedResourceQuota.SetNamespace(namespace)
-
-			c.EXPECT().Create(gomock.Any(), expectedResourceQuota).Return(nil)
-
-			Expect(createOrUpdateResourceQuota(ctx, c, namespace, ownerRef, config)).To(Succeed())
+			// Verify the ResourceQuota was created
+			created := &corev1.ResourceQuota{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, created)).To(Succeed())
+			Expect(created.OwnerReferences).To(ConsistOf(*ownerRef))
+			Expect(created.Labels).To(Equal(map[string]string{"bar": "baz"}))
+			Expect(created.Annotations).To(Equal(map[string]string{"foo": "bar"}))
+			Expect(created.Spec.Hard[shoots]).To(Equal(quantity))
+			Expect(created.Spec.Hard[secrets]).To(Equal(quantity))
 		})
 
 		It("should update a existing ResourceQuota", func() {
@@ -234,22 +224,20 @@ var _ = Describe("Default Resource Quota", func() {
 					},
 				},
 			}
+			Expect(fakeClient.Create(ctx, existingResourceQuota)).To(Succeed())
 
-			c.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, gomock.AssignableToTypeOf(&corev1.ResourceQuota{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, resourceQuota *corev1.ResourceQuota, _ ...client.GetOption) error {
-					*resourceQuota = *existingResourceQuota
-					return nil
-				})
+			Expect(createOrUpdateResourceQuota(ctx, fakeClient, namespace, ownerRef, config)).To(Succeed())
 
-			expectedResourceQuota := existingResourceQuota.DeepCopy()
-			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{existingOwnerRef, *ownerRef})
-			expectedResourceQuota.Labels = map[string]string{"bar": "baz"}
-			expectedResourceQuota.Annotations = map[string]string{"foo": "bar"}
-			expectedResourceQuota.Spec.Hard[secrets] = quantity
-
-			c.EXPECT().Patch(gomock.Any(), expectedResourceQuota, gomock.Any()).Return(nil)
-
-			Expect(createOrUpdateResourceQuota(ctx, c, namespace, ownerRef, config)).To(Succeed())
+			// Verify the ResourceQuota was updated
+			updated := &corev1.ResourceQuota{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ResourceQuotaName}, updated)).To(Succeed())
+			Expect(updated.OwnerReferences).To(ConsistOf(existingOwnerRef, *ownerRef))
+			Expect(updated.Labels).To(Equal(map[string]string{"bar": "baz"}))
+			Expect(updated.Annotations).To(Equal(map[string]string{"foo": "bar"}))
+			// The existing quota value for shoots should be preserved (not overwritten)
+			Expect(updated.Spec.Hard[shoots]).To(Equal(resource.MustParse("50")))
+			// The new quota for secrets should be added
+			Expect(updated.Spec.Hard[secrets]).To(Equal(quantity))
 		})
 	})
 })

--- a/pkg/controllermanager/controller/project/stale/reconciler_test.go
+++ b/pkg/controllermanager/controller/project/stale/reconciler_test.go
@@ -10,13 +10,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
@@ -27,7 +27,7 @@ import (
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/project/stale"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Reconciler", func() {
@@ -35,8 +35,7 @@ var _ = Describe("Reconciler", func() {
 		ctx       = context.TODO()
 		fakeClock *testing.FakeClock
 
-		k8sGardenRuntimeClient *mockclient.MockClient
-		mockStatusWriter       *mockclient.MockStatusWriter
+		fakeClient client.Client
 
 		projectName            = "foo"
 		namespaceName          = "garden-foo"
@@ -52,60 +51,40 @@ var _ = Describe("Reconciler", func() {
 		staleExpirationTimeDays = 15
 		staleSyncPeriod         = metav1.Duration{Duration: time.Second}
 
-		partialShootMetaList            = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "core.gardener.cloud/v1beta1", Kind: "ShootList"}}
-		partialBackupEntryMetaList      = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "core.gardener.cloud/v1beta1", Kind: "BackupEntryList"}}
-		partialQuotaMetaList            = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "core.gardener.cloud/v1beta1", Kind: "QuotaList"}}
-		partialSecretMetaList           = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "SecretList"}}
-		partialInternalSecretMetaList   = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "core.gardener.cloud/v1beta1", Kind: "InternalSecretList"}}
-		partialWorkloadIdentityMetaList = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "security.gardener.cloud/v1alpha1", Kind: "WorkloadIdentityList"}}
-
-		project               *gardencorev1beta1.Project
-		namespace             *corev1.Namespace
-		partialObjectMetadata *metav1.PartialObjectMetadata
-		shoot                 *gardencorev1beta1.Shoot
-		quotaMeta             *metav1.PartialObjectMetadata
-		secretMeta            *metav1.PartialObjectMetadata
-		internalSecretMeta    *metav1.PartialObjectMetadata
-		workloadIdentityMeta  *metav1.PartialObjectMetadata
-		secretBinding         *gardencorev1beta1.SecretBinding
-		credentialsBinding    *securityv1alpha1.CredentialsBinding
-		cfg                   controllermanagerconfigv1alpha1.ProjectControllerConfiguration
-		request               reconcile.Request
+		project            *gardencorev1beta1.Project
+		namespace          *corev1.Namespace
+		shoot              *gardencorev1beta1.Shoot
+		secretBinding      *gardencorev1beta1.SecretBinding
+		credentialsBinding *securityv1alpha1.CredentialsBinding
+		cfg                controllermanagerconfigv1alpha1.ProjectControllerConfiguration
+		request            reconcile.Request
 
 		reconciler reconcile.Reconciler
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
-		mockStatusWriter = mockclient.NewMockStatusWriter(ctrl)
 		fakeClock = testing.NewFakeClock(time.Now())
+
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithStatusSubresource(&gardencorev1beta1.Project{}).
+			Build()
 
 		project = &gardencorev1beta1.Project{
 			ObjectMeta: metav1.ObjectMeta{Name: projectName},
 			Spec:       gardencorev1beta1.ProjectSpec{Namespace: &namespaceName},
 		}
+
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
 		}
-		partialObjectMetadata = &metav1.PartialObjectMetadata{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName},
-		}
+
+		Expect(fakeClient.Create(ctx, project)).To(Succeed())
+		Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
+
 		shoot = &gardencorev1beta1.Shoot{
-			ObjectMeta: partialObjectMetadata.ObjectMeta,
+			ObjectMeta: metav1.ObjectMeta{Name: "shoot1", Namespace: namespaceName},
 			Spec:       gardencorev1beta1.ShootSpec{SecretBindingName: ptr.To(secretBindingName)},
-		}
-		quotaMeta = &metav1.PartialObjectMetadata{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: quotaName},
-		}
-		secretMeta = &metav1.PartialObjectMetadata{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: secretName},
-		}
-		internalSecretMeta = &metav1.PartialObjectMetadata{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: internalSecretName},
-		}
-		workloadIdentityMeta = &metav1.PartialObjectMetadata{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: workloadIdentityName},
 		}
 		secretBinding = &gardencorev1beta1.SecretBinding{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespaceName, Name: secretBindingName},
@@ -125,18 +104,51 @@ var _ = Describe("Reconciler", func() {
 		}
 		request = reconcile.Request{NamespacedName: types.NamespacedName{Name: project.Name}}
 
-		reconciler = &Reconciler{
-			Client: k8sGardenRuntimeClient,
-			Config: cfg,
-			Clock:  fakeClock,
-		}
-
-		k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: project.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
-			*obj = *project
-			return nil
-		})
-		k8sGardenRuntimeClient.EXPECT().Scheme().Return(kubernetes.GardenScheme).AnyTimes()
+		reconciler = &Reconciler{Client: fakeClient, Config: cfg, Clock: fakeClock}
 	})
+
+	// secretObj creates a corev1.Secret with the specified labels for the fake client.
+	secretObj := func(ns, name string, labels map[string]string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+		}
+	}
+
+	// internalSecretObj creates a gardencorev1beta1.InternalSecret.
+	internalSecretObj := func(ns, name string, labels map[string]string) *gardencorev1beta1.InternalSecret {
+		return &gardencorev1beta1.InternalSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+		}
+	}
+
+	// workloadIdentityObj creates a securityv1alpha1.WorkloadIdentity.
+	workloadIdentityObj := func(ns, name string, labels map[string]string) *securityv1alpha1.WorkloadIdentity {
+		return &securityv1alpha1.WorkloadIdentity{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+				Labels:    labels,
+			},
+		}
+	}
+
+	// quotaObj creates a gardencorev1beta1.Quota.
+	quotaObj := func(ns, name string) *gardencorev1beta1.Quota {
+		return &gardencorev1beta1.Quota{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      name,
+			},
+		}
+	}
 
 	Describe("#Reconcile", func() {
 		Context("early exit", func() {
@@ -148,44 +160,45 @@ var _ = Describe("Reconciler", func() {
 			})
 		})
 
-		BeforeEach(func() {
-			k8sGardenRuntimeClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
-				*obj = *namespace
-				return nil
-			}).AnyTimes()
-		})
-
 		It("should mark the project as 'not stale' because the namespace has the skip-stale-check annotation", func() {
 			fakeClock.SetTime(time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC))
-
 			namespace.Annotations = map[string]string{v1beta1constants.ProjectSkipStaleCheck: "true"}
 
-			expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+			Expect(fakeClient.Update(ctx, namespace)).To(Succeed())
 
 			_, result := reconciler.Reconcile(ctx, request)
 			Expect(result).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+			Expect(project.Status.StaleSinceTimestamp).To(BeNil())
+			Expect(project.Status.StaleAutoDeleteTimestamp).To(BeNil())
 		})
 
 		It("should mark the project as 'not stale' because it is younger than the configured MinimumLifetimeDays", func() {
-			fakeClock.SetTime(time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC))
-
+			fakeClock.SetTime(time.Date(1, 1, minimumLifetimeDays+1, 0, 0, 0, 0, time.UTC))
 			project.CreationTimestamp = metav1.Time{Time: time.Date(1, 1, minimumLifetimeDays-1, 0, 0, 0, 0, time.UTC)}
-
-			expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+			Expect(fakeClient.Update(ctx, project)).To(Succeed())
 
 			_, result := reconciler.Reconcile(ctx, request)
 			Expect(result).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+			Expect(project.Status.StaleSinceTimestamp).To(BeNil())
+			Expect(project.Status.StaleAutoDeleteTimestamp).To(BeNil())
 		})
 
 		It("should mark the project as 'not stale' because the last activity was before the MinimumLifetimeDays", func() {
 			fakeClock.SetTime(time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC))
-
 			project.Status.LastActivityTimestamp = &metav1.Time{Time: time.Date(1, 1, minimumLifetimeDays-1, 0, 0, 0, 0, time.UTC)}
 
-			expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+			Expect(fakeClient.Status().Update(ctx, project)).To(Succeed())
 
 			_, result := reconciler.Reconcile(ctx, request)
 			Expect(result).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+			Expect(project.Status.StaleSinceTimestamp).To(BeNil())
+			Expect(project.Status.StaleAutoDeleteTimestamp).To(BeNil())
 		})
 
 		Context("project older than the configured MinimumLifetimeDays", func() {
@@ -196,527 +209,379 @@ var _ = Describe("Reconciler", func() {
 
 			Describe("project should be marked as not stale", func() {
 				It("has shoots", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*partialObjectMetadata}}).DeepCopyInto(list)
-						return nil
-					})
+					shootInNs := &gardencorev1beta1.Shoot{
+						ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: namespaceName},
+					}
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, shootInNs)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has backupentries", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*partialObjectMetadata}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					backupEntry := &gardencorev1beta1.BackupEntry{
+						ObjectMeta: metav1.ObjectMeta{Name: "be1", Namespace: namespaceName},
+						Spec:       gardencorev1beta1.BackupEntrySpec{BucketName: "bucket1"},
+					}
+					Expect(fakeClient.Create(ctx, backupEntry)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has secrets referenced by secret binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelSecretBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secretBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, shoot.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has secrets referenced by credentials binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					shootWithCB := shoot.DeepCopy()
+					shootWithCB.Spec.SecretBindingName = nil
+					shootWithCB.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootWithCB)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has secrets referenced by secret binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
-					secretBinding.Namespace = otherNamespace
-					shoot.Namespace = otherNamespace
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelSecretBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					sbInOther := secretBinding.DeepCopy()
+					sbInOther.Namespace = otherNamespace
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, sbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has secrets referenced by credentials binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
-					credentialsBinding.Namespace = otherNamespace
-					shoot.Namespace = otherNamespace
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					cbInOther := credentialsBinding.DeepCopy()
+					cbInOther.Namespace = otherNamespace
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
+					shootInOther.Spec.SecretBindingName = nil
+					shootInOther.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has quotas referenced by secret binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					quota := quotaObj(namespaceName, quotaName)
+					Expect(fakeClient.Create(ctx, quota)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secretBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, shoot.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has quotas referenced by credentials binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					quota := quotaObj(namespaceName, quotaName)
+					shootWithCB := shoot.DeepCopy()
+					shootWithCB.Spec.SecretBindingName = nil
+					shootWithCB.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
+					Expect(fakeClient.Create(ctx, quota)).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootWithCB)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has quotas referenced by secret binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
-					secretBinding.Namespace = otherNamespace
-					shoot.Namespace = otherNamespace
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					quota := quotaObj(namespaceName, quotaName)
+					sbInOther := secretBinding.DeepCopy()
+					sbInOther.Namespace = otherNamespace
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, quota)).To(Succeed())
+					Expect(fakeClient.Create(ctx, sbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has quotas referenced by credentials binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
-					credentialsBinding.Namespace = otherNamespace
-					shoot.Namespace = otherNamespace
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					quota := quotaObj(namespaceName, quotaName)
+					cbInOther := credentialsBinding.DeepCopy()
+					cbInOther.Namespace = otherNamespace
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
+					shootInOther.Spec.SecretBindingName = nil
+					shootInOther.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, quota)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has internal secrets referenced by credentials binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*internalSecretMeta}}).DeepCopyInto(list)
-						return nil
+					internalSecret := internalSecretObj(namespaceName, internalSecretName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						credentialsBinding.CredentialsRef = corev1.ObjectReference{Kind: "InternalSecret", APIVersion: "core.gardener.cloud/v1beta1", Namespace: namespaceName, Name: internalSecretName}
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					cbWithInternalSecret := credentialsBinding.DeepCopy()
+					cbWithInternalSecret.CredentialsRef = corev1.ObjectReference{Kind: "InternalSecret", APIVersion: "core.gardener.cloud/v1beta1", Namespace: namespaceName, Name: internalSecretName}
+					shootWithCB := shoot.DeepCopy()
+					shootWithCB.Spec.SecretBindingName = nil
+					shootWithCB.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, internalSecret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbWithInternalSecret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootWithCB)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has internal secrets referenced by credentials binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*internalSecretMeta}}).DeepCopyInto(list)
-						return nil
+					internalSecret := internalSecretObj(namespaceName, internalSecretName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						credentialsBinding.Namespace = otherNamespace
-						credentialsBinding.CredentialsRef = corev1.ObjectReference{Kind: "InternalSecret", APIVersion: "core.gardener.cloud/v1beta1", Namespace: namespaceName, Name: internalSecretName}
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Namespace = otherNamespace
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					cbInOther := credentialsBinding.DeepCopy()
+					cbInOther.Namespace = otherNamespace
+					cbInOther.CredentialsRef = corev1.ObjectReference{Kind: "InternalSecret", APIVersion: "core.gardener.cloud/v1beta1", Namespace: namespaceName, Name: internalSecretName}
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
+					shootInOther.Spec.SecretBindingName = nil
+					shootInOther.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, internalSecret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has workload identities referenced by credentials binding that are used by shoots in the same namespace", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*workloadIdentityMeta}}).DeepCopyInto(list)
-						return nil
+					wi := workloadIdentityObj(namespaceName, workloadIdentityName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						credentialsBinding.CredentialsRef = corev1.ObjectReference{Kind: "WorkloadIdentity", APIVersion: "security.gardener.cloud/v1alpha1", Namespace: namespaceName, Name: workloadIdentityName}
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					cbWithWI := credentialsBinding.DeepCopy()
+					cbWithWI.CredentialsRef = corev1.ObjectReference{Kind: "WorkloadIdentity", APIVersion: "security.gardener.cloud/v1alpha1", Namespace: namespaceName, Name: workloadIdentityName}
+					shootWithCB := shoot.DeepCopy()
+					shootWithCB.Spec.SecretBindingName = nil
+					shootWithCB.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, wi)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbWithWI)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootWithCB)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 
 				It("has workload identities referenced by credentials binding that are used by shoots in another namespace", func() {
 					otherNamespace := namespaceName + "other"
+					otherNs := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: otherNamespace}}
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*workloadIdentityMeta}}).DeepCopyInto(list)
-						return nil
+					wi := workloadIdentityObj(namespaceName, workloadIdentityName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						credentialsBinding.Namespace = otherNamespace
-						credentialsBinding.CredentialsRef = corev1.ObjectReference{Kind: "WorkloadIdentity", APIVersion: "security.gardener.cloud/v1alpha1", Namespace: namespaceName, Name: workloadIdentityName}
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(otherNamespace)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						shoot.Namespace = otherNamespace
-						shoot.Spec.SecretBindingName = nil
-						shoot.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
+					cbInOther := credentialsBinding.DeepCopy()
+					cbInOther.Namespace = otherNamespace
+					cbInOther.CredentialsRef = corev1.ObjectReference{Kind: "WorkloadIdentity", APIVersion: "security.gardener.cloud/v1alpha1", Namespace: namespaceName, Name: workloadIdentityName}
+					shootInOther := shoot.DeepCopy()
+					shootInOther.Namespace = otherNamespace
+					shootInOther.Spec.SecretBindingName = nil
+					shootInOther.Spec.CredentialsBindingName = ptr.To(credentialsBindingName)
 
-					expectNonStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project)
+					Expect(fakeClient.Create(ctx, otherNs)).To(Succeed())
+					Expect(fakeClient.Create(ctx, wi)).To(Succeed())
+					Expect(fakeClient.Create(ctx, cbInOther)).To(Succeed())
+					Expect(fakeClient.Create(ctx, shootInOther)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).To(BeNil())
 				})
 			})
 
 			Describe("project should be marked as stale", func() {
 				It("has secrets that are unused", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelSecretBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
+					// SecretBinding references the secret, but no shoot uses this secretBinding
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secretBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleSinceTimestamp.UTC()).To(Equal(fakeClock.Now().UTC()))
 				})
 
 				It("has secrets that are unused (secret binding & credentials binding are nil for shoot)", func() {
-					shoot.Spec.SecretBindingName = nil
-					shoot.Spec.CredentialsBindingName = nil
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
+					secret := secretObj(namespaceName, secretName, map[string]string{
+						v1beta1constants.LabelSecretBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*secretMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{*shoot}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
+					//  SecretBinding and CredentialsBinding reference the secret, but no shoots use them
+					Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secretBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleSinceTimestamp.UTC()).To(Equal(fakeClock.Now().UTC()))
 				})
 
 				It("has quotas that are unused", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*quotaMeta}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBindingList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SecretBindingList, _ ...client.ListOption) error {
-						(&gardencorev1beta1.SecretBindingList{Items: []gardencorev1beta1.SecretBinding{*secretBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{}), client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
+					quota := quotaObj(namespaceName, quotaName)
+					// SecretBinding and CredentialsBinding reference the quota, but no shoots use them
+					Expect(fakeClient.Create(ctx, quota)).To(Succeed())
+					Expect(fakeClient.Create(ctx, secretBinding.DeepCopy())).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleSinceTimestamp.UTC()).To(Equal(fakeClock.Now().UTC()))
 				})
 
 				It("has workload identities that are unused", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-						(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{*workloadIdentityMeta}}).DeepCopyInto(list)
-						return nil
+					wi := workloadIdentityObj(namespaceName, workloadIdentityName, map[string]string{
+						v1beta1constants.LabelCredentialsBindingReference: "true",
 					})
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&securityv1alpha1.CredentialsBindingList{})).DoAndReturn(func(_ context.Context, list *securityv1alpha1.CredentialsBindingList, _ ...client.ListOption) error {
-						(&securityv1alpha1.CredentialsBindingList{Items: []securityv1alpha1.CredentialsBinding{*credentialsBinding}}).DeepCopyInto(list)
-						return nil
-					})
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
+					// CredentialsBinding references the workload identity, but no shoot uses it
+					Expect(fakeClient.Create(ctx, wi)).To(Succeed())
+					Expect(fakeClient.Create(ctx, credentialsBinding.DeepCopy())).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleSinceTimestamp.UTC()).To(Equal(fakeClock.Now().UTC()))
 				})
 
 				It("it is not used", func() {
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, nil, nil, fakeClock)
-
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleSinceTimestamp.UTC()).To(Equal(fakeClock.Now().UTC()))
 				})
 
 				It("should not set the auto delete timestamp because stale grace period is not exceeded", func() {
 					staleSinceTimestamp := metav1.Time{Time: fakeClock.Now().Add(-24*time.Hour*time.Duration(staleGracePeriodDays) + time.Hour)}
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, nil, fakeClock)
+					// Set the stale status on the project
+					p := &gardencorev1beta1.Project{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), p)).To(Succeed())
+					p.Status.StaleSinceTimestamp = &staleSinceTimestamp
+					Expect(fakeClient.Status().Update(ctx, p)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleAutoDeleteTimestamp).To(BeNil())
 				})
 
 				It("should set the auto delete timestamp because stale grace period is exceeded", func() {
@@ -726,18 +591,18 @@ var _ = Describe("Reconciler", func() {
 					)
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, &staleAutoDeleteTimestamp, fakeClock)
+					p := &gardencorev1beta1.Project{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), p)).To(Succeed())
+					p.Status.StaleSinceTimestamp = &staleSinceTimestamp
+					Expect(fakeClient.Status().Update(ctx, p)).To(Succeed())
 
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(Succeed())
+					Expect(project.Status.StaleSinceTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleAutoDeleteTimestamp).ToNot(BeNil())
+					Expect(project.Status.StaleAutoDeleteTimestamp.UTC()).To(Equal(staleAutoDeleteTimestamp.UTC()))
 				})
 
 				It("should delete the project if the auto delete timestamp is exceeded", func() {
@@ -749,56 +614,22 @@ var _ = Describe("Reconciler", func() {
 					project.Status.StaleSinceTimestamp = &staleSinceTimestamp
 					project.Status.StaleAutoDeleteTimestamp = &staleAutoDeleteTimestamp
 
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialShootMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialBackupEntryMetaList, client.InNamespace(namespaceName), client.Limit(1))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialInternalSecretMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialWorkloadIdentityMetaList, client.InNamespace(namespaceName))
-					k8sGardenRuntimeClient.EXPECT().List(gomock.Any(), partialQuotaMetaList, client.InNamespace(namespaceName))
-
-					expectStaleMarking(k8sGardenRuntimeClient, mockStatusWriter, project, &staleSinceTimestamp, &staleAutoDeleteTimestamp, fakeClock)
+					p := &gardencorev1beta1.Project{}
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), p)).To(Succeed())
+					p.Status.StaleSinceTimestamp = &staleSinceTimestamp
+					p.Status.StaleAutoDeleteTimestamp = &staleAutoDeleteTimestamp
+					Expect(fakeClient.Status().Update(ctx, p)).To(Succeed())
 
 					defer test.WithVar(&gardenerutils.TimeNow, func() time.Time {
 						return time.Date(1, 1, minimumLifetimeDays+1, 1, 0, 0, 0, time.UTC)
 					})()
 
-					projectCopy := project.DeepCopy()
-					projectCopy.Annotations = map[string]string{
-						v1beta1constants.ConfirmationDeletion: "true",
-						v1beta1constants.GardenerTimestamp:    gardenerutils.TimeNow().UTC().Format(time.RFC3339Nano),
-					}
-					k8sGardenRuntimeClient.EXPECT().Patch(gomock.Any(), projectCopy, gomock.Any())
-					k8sGardenRuntimeClient.EXPECT().Delete(gomock.Any(), projectCopy)
-
 					_, result := reconciler.Reconcile(ctx, request)
 					Expect(result).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(project), project)).To(BeNotFoundError())
 				})
 			})
 		})
 	})
 })
-
-func expectNonStaleMarking(k8sGardenRuntimeClient *mockclient.MockClient, mockStatusWriter *mockclient.MockStatusWriter, project *gardencorev1beta1.Project) {
-	k8sGardenRuntimeClient.EXPECT().Status().Return(mockStatusWriter)
-
-	projectPatched := project.DeepCopy()
-	projectPatched.Status.StaleSinceTimestamp = nil
-	projectPatched.Status.StaleAutoDeleteTimestamp = nil
-
-	test.EXPECTStatusPatch(gomock.Any(), mockStatusWriter, projectPatched, project, types.MergePatchType)
-}
-
-func expectStaleMarking(k8sGardenRuntimeClient *mockclient.MockClient, mockStatusWriter *mockclient.MockStatusWriter, project *gardencorev1beta1.Project, staleSinceTimestamp, staleAutoDeleteTimestamp *metav1.Time, fakeClock *testing.FakeClock) {
-	k8sGardenRuntimeClient.EXPECT().Status().Return(mockStatusWriter)
-
-	projectPatched := project.DeepCopy()
-	if staleSinceTimestamp == nil {
-		projectPatched.Status.StaleSinceTimestamp = &metav1.Time{Time: fakeClock.Now()}
-	} else {
-		projectPatched.Status.StaleSinceTimestamp = staleSinceTimestamp
-	}
-	projectPatched.Status.StaleAutoDeleteTimestamp = staleAutoDeleteTimestamp
-
-	test.EXPECTStatusPatch(gomock.Any(), mockStatusWriter, projectPatched, project, types.MergePatchType)
-}

--- a/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
+++ b/pkg/controllermanager/controller/seed/secrets/reconciler_test.go
@@ -10,260 +10,197 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed/secrets"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
-	mockcorev1 "github.com/gardener/gardener/third_party/mock/client-go/core/v1"
-	mockclientgo "github.com/gardener/gardener/third_party/mock/client-go/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Reconciler", func() {
 	var (
-		ctrl *gomock.Controller
+		ctx = context.Background()
 
-		gardenRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
-		labelSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq)}
+		reconciler *Reconciler
+
+		fakeClient    client.Client
+		seed          *gardencorev1beta1.Seed
+		namespaceName string
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		seed = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "seed",
+				UID:  "abcdef",
+			},
+		}
+		namespaceName = gardenerutils.ComputeGardenNamespace(seed.Name)
 	})
 
 	Describe("#Reconcile", func() {
-		var (
-			cl          *mockclient.MockClient
-			k           *mockclientgo.MockInterface
-			corev1If    *mockcorev1.MockCoreV1Interface
-			namespaceIf *mockcorev1.MockNamespaceInterface
-			secretIf    *mockcorev1.MockSecretInterface
+		It("should not return an error if seed cannot be found", func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+			reconciler = &Reconciler{Client: fakeClient, GardenNamespace: v1beta1constants.GardenNamespace}
 
-			control reconcile.Reconciler
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
 
-			seed      *gardencorev1beta1.Seed
-			namespace *corev1.Namespace
-		)
-
-		BeforeEach(func() {
-			cl = mockclient.NewMockClient(ctrl)
-			seed = &gardencorev1beta1.Seed{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "seed",
-					UID:  "abcdef",
+		It("should return an error if getting the seed fails", func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					if _, ok := obj.(*gardencorev1beta1.Seed); ok {
+						return errors.New("fake")
+					}
+					return nil
 				},
-			}
-			namespace = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: gardenerutils.ComputeGardenNamespace(seed.Name),
-					OwnerReferences: []metav1.OwnerReference{
-						*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed")),
-					},
-					Labels: map[string]string{"gardener.cloud/role": "seed"},
-				},
-			}
-		})
+			}).Build()
+			reconciler = &Reconciler{Client: fakeClient, GardenNamespace: v1beta1constants.GardenNamespace}
 
-		JustBeforeEach(func() {
-			control = &Reconciler{
-				Client:          cl,
-				GardenNamespace: "garden",
-			}
-		})
-
-		It("should fail if get namespace fails", func() {
-			cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(errors.New("fake"))
-
-			_, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-			Expect(err).To(MatchError(ContainSubstring("fake")))
-		})
-
-		It("should fail if get namespace fails", func() {
-			cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
-				*obj = *seed
-				return nil
-			})
-
-			cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespace.Name}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(errors.New("fake"))
-
-			_, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
 			Expect(err).To(MatchError(ContainSubstring("fake")))
 		})
 
 		Context("when seed exists", func() {
-			var (
-				addedSecret, oldSecret, deletedSecret *corev1.Secret
-			)
-
 			BeforeEach(func() {
-				cl = mockclient.NewMockClient(ctrl)
-				k = mockclientgo.NewMockInterface(ctrl)
-				corev1If = mockcorev1.NewMockCoreV1Interface(ctrl)
-				namespaceIf = mockcorev1.NewMockNamespaceInterface(ctrl)
-				secretIf = mockcorev1.NewMockSecretInterface(ctrl)
-
-				k.EXPECT().CoreV1().Return(corev1If).AnyTimes()
-				corev1If.EXPECT().Secrets(gomock.Any()).Return(secretIf).AnyTimes()
-				corev1If.EXPECT().Namespaces().Return(namespaceIf).AnyTimes()
-
-				oldSecret = createSecret("existing", namespace.Name, "old", []byte("data"))
-				addedSecret = createSecret("new", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
-				deletedSecret = createSecret("stale", namespace.Name, "foo", []byte("bar"))
-
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
-					*obj = *seed
-					return nil
-				})
+				fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(seed).Build()
+				reconciler = &Reconciler{Client: fakeClient, GardenNamespace: v1beta1constants.GardenNamespace}
 			})
 
 			It("should fail if namespace exists and has no ownerReference", func() {
-				namespace.SetOwnerReferences(nil)
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(seed.Name)}, gomock.AssignableToTypeOf(&corev1.Namespace{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, ns *corev1.Namespace, _ ...client.GetOption) error {
-						namespace.DeepCopyInto(ns)
-						return nil
-					})
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespaceName,
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
 
-				_, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
 				Expect(err).To(MatchError(ContainSubstring("not controlled by")))
 			})
 
 			It("should fail if namespace exists and is not controlled by seed", func() {
-				owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "boss", UID: "12345"}}
-				namespace.SetOwnerReferences([]metav1.OwnerReference{*metav1.NewControllerRef(owner, corev1.SchemeGroupVersion.WithKind("ConfigMap"))})
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(seed.Name)}, gomock.AssignableToTypeOf(&corev1.Namespace{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, ns *corev1.Namespace, _ ...client.GetOption) error {
-						namespace.DeepCopyInto(ns)
-						return nil
-					})
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespaceName,
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(
+								&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "boss", UID: "12345"}},
+								corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+							),
+						},
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
 
-				_, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
 				Expect(err).To(MatchError(ContainSubstring("not controlled by")))
 			})
 
-			It("should sync secrets if namespace exists and is controlled by seed", func() {
-				cl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), labelSelector).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					(&corev1.SecretList{Items: []corev1.Secret{*oldSecret, *addedSecret}}).DeepCopyInto(list)
-					return nil
-				})
+			It("should sync secrets and clean up stale secrets in seed namespace", func() {
+				// Create the seed namespace controlled by the seed
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namespaceName,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))},
+						Labels:          map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed},
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
 
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: gardenerutils.ComputeGardenNamespace(seed.Name)}, gomock.AssignableToTypeOf(&corev1.Namespace{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, ns *corev1.Namespace, _ ...client.GetOption) error {
-						namespace.DeepCopyInto(ns)
-						return nil
-					})
+				// Garden secret to sync
+				gardenSecret := createSecret("garden-secret", v1beta1constants.GardenNamespace, []byte("data"), "foo")
+				Expect(fakeClient.Create(ctx, gardenSecret)).To(Succeed())
 
-				// expect update for existing secret
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace.Name, Name: oldSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{}))
-				cl.EXPECT().Patch(gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any())
+				// Stale secret in seed namespace that should be deleted
+				staleSecret := createSecret("stale-secret", namespaceName, []byte("old"), "foo")
+				Expect(fakeClient.Create(ctx, staleSecret)).To(Succeed())
 
-				// expect create for non existing secret
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace.Name, Name: addedSecret.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				cl.EXPECT().Create(gomock.Any(), copySecretWithNamespace(addedSecret, namespace.Name))
-
-				// expect deletion for deleted secret in Garden namespace
-				cl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespace.Name), labelSelector).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					(&corev1.SecretList{Items: []corev1.Secret{*deletedSecret}}).DeepCopyInto(list)
-					return nil
-				})
-				cl.EXPECT().Delete(gomock.Any(), deletedSecret)
-
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
+
+				syncedSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: gardenSecret.Name}, syncedSecret)).To(Succeed())
+				Expect(syncedSecret.Data).To(Equal(gardenSecret.Data))
+
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: namespaceName, Name: staleSecret.Name}, &corev1.Secret{})).To(BeNotFoundError())
+			})
+
+			It("should add garden role label to namespace if missing", func() {
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            namespaceName,
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))},
+					},
+				}
+				Expect(fakeClient.Create(ctx, ns)).To(Succeed())
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				updatedNs := &corev1.Namespace{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespaceName}, updatedNs)).To(Succeed())
+				Expect(updatedNs.Labels).To(HaveKeyWithValue(v1beta1constants.GardenRole, v1beta1constants.GardenRoleSeed))
 			})
 		})
 
 		Context("when seed is new", func() {
-			It("should fail if namespace exists but not in the cache", func() {
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
-					*obj = *seed
-					return nil
-				})
-
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespace.Name}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				cl.EXPECT().Create(gomock.Any(), namespace).Return(errors.New("fake"))
-
-				_, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(MatchError(ContainSubstring("fake")))
+			BeforeEach(func() {
+				fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(seed).Build()
+				reconciler = &Reconciler{Client: fakeClient, GardenNamespace: v1beta1constants.GardenNamespace}
 			})
 
-			It("should create namespace and sync secrets if namespace does not exists", func() {
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed, _ ...client.GetOption) error {
-					*obj = *seed
-					return nil
-				})
+			It("should create namespace and sync secrets if namespace does not exist", func() {
+				gardenSecret1 := createSecret("my-secret-1", v1beta1constants.GardenNamespace, []byte("data"), "foo")
+				Expect(fakeClient.Create(ctx, gardenSecret1)).To(Succeed())
 
-				var (
-					secret1 = createSecret("1", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
-					secret2 = createSecret("2", v1beta1constants.GardenNamespace, "foo", []byte("bar"))
-				)
+				gardenSecret2 := createSecret("my-secret-2", v1beta1constants.GardenNamespace, []byte("data"), "bar")
+				Expect(fakeClient.Create(ctx, gardenSecret2)).To(Succeed())
 
-				cl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), labelSelector).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					(&corev1.SecretList{Items: []corev1.Secret{*secret1, *secret2}}).DeepCopyInto(list)
-					return nil
-				})
-
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: namespace.Name}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				cl.EXPECT().Create(gomock.Any(), namespace)
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace.Name, Name: secret1.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				cl.EXPECT().Create(gomock.Any(), copySecretWithNamespace(secret1, namespace.Name))
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: namespace.Name, Name: secret2.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				cl.EXPECT().Create(gomock.Any(), copySecretWithNamespace(secret2, namespace.Name))
-
-				cl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(namespace.Name), labelSelector).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					(&corev1.SecretList{}).DeepCopyInto(list)
-					return nil
-				})
-
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
-			})
 
-			It("should not create and copy assets if seed cannot be found", func() {
-				cl.EXPECT().Get(gomock.Any(), client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				// Verify namespace was created
+				ns := &corev1.Namespace{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespaceName}, ns)).To(Succeed())
+				Expect(ns.Labels).To(HaveKeyWithValue(v1beta1constants.GardenRole, v1beta1constants.GardenRoleSeed))
+				Expect(metav1.IsControlledBy(ns, seed)).To(BeTrue())
 
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
-				Expect(result).To(Equal(reconcile.Result{}))
+				// Verify secret was synced to seed namespace
+				secretList := &corev1.SecretList{}
+				Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespaceName))).To(Succeed())
+				Expect(secretList.Items).To(HaveLen(2))
+				Expect(secretList.Items[0].Data).To(Equal(gardenSecret1.Data))
+				Expect(secretList.Items[1].Data).To(Equal(gardenSecret2.Data))
 			})
 		})
 	})
 })
 
-func copySecretWithNamespace(secret *corev1.Secret, namespace string) *corev1.Secret {
-	s := secret.DeepCopy()
-	s.SetNamespace(namespace)
-	return s
-}
-
-func createSecret(name, namespace, key string, data []byte) *corev1.Secret {
+func createSecret(name, namespace string, data []byte, role string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				v1beta1constants.GardenRole: "role",
+				v1beta1constants.GardenRole: role,
 			},
 			Name:      name,
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			key: data,
+			"key": data,
 		},
 	}
 }

--- a/pkg/utils/gardener/gardenlet/gardenlet_test.go
+++ b/pkg/utils/gardener/gardenlet/gardenlet_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,53 +18,57 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	. "github.com/gardener/gardener/pkg/utils/gardener/gardenlet"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Gardenlet", func() {
 	Describe("#ClusterIsGarden", func() {
 		var (
 			ctx        context.Context
-			mockReader *mockclient.MockReader
-			ctrl       *gomock.Controller
+			fakeClient client.Client
 		)
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			ctrl = gomock.NewController(GinkgoT())
-			mockReader = mockclient.NewMockReader(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(operatorclient.RuntimeScheme).
+				Build()
 		})
 
 		It("should return that seed is a garden cluster", func() {
-			mockReader.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.Limit(1)).DoAndReturn(
-				func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-					list.Items = []metav1.PartialObjectMetadata{{}}
-					return nil
-				})
-			Expect(ClusterIsGarden(ctx, mockReader)).To(BeTrue())
+			garden := &operatorv1alpha1.Garden{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "garden",
+				},
+			}
+			Expect(fakeClient.Create(ctx, garden)).To(Succeed())
+
+			Expect(ClusterIsGarden(ctx, fakeClient)).To(BeTrue())
 		})
 
 		It("should return that seed is a not a garden cluster because no garden object found", func() {
-			mockReader.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.Limit(1))
-			Expect(ClusterIsGarden(ctx, mockReader)).To(BeFalse())
+			Expect(ClusterIsGarden(ctx, fakeClient)).To(BeFalse())
 		})
 
 		It("should return that seed is a not a garden cluster because of a no match error", func() {
-			mockReader.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}), client.Limit(1)).DoAndReturn(
-				func(_ context.Context, _ *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-					return &meta.NoResourceMatchError{}
-				})
-			Expect(ClusterIsGarden(ctx, mockReader)).To(BeFalse())
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(operatorclient.RuntimeScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return &meta.NoResourceMatchError{}
+					},
+				}).
+				Build()
+
+			Expect(ClusterIsGarden(ctx, fakeClient)).To(BeFalse())
 		})
 	})
 
@@ -76,7 +79,7 @@ var _ = Describe("Gardenlet", func() {
 		)
 
 		BeforeEach(func() {
-			fakeClient = fake.NewClientBuilder().Build()
+			fakeClient = fakeclient.NewClientBuilder().Build()
 		})
 
 		It("should return that the seed is a self-hosted shoot", func() {
@@ -182,7 +185,7 @@ var _ = Describe("Gardenlet", func() {
 		)
 
 		BeforeEach(func() {
-			fakeClient = fake.NewClientBuilder().Build()
+			fakeClient = fakeclient.NewClientBuilder().Build()
 
 			bootstrapTokenSecretName = "bootstrap-token-123456"
 			expectedShootNamespace = "garden-my-project"

--- a/pkg/utils/gardener/project_test.go
+++ b/pkg/utils/gardener/project_test.go
@@ -10,35 +10,40 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/gardener/gardener/pkg/api/indexer"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Project", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
+		fakeClient client.Client
 
 		ctx     = context.TODO()
 		fakeErr = errors.New("fake err")
 
 		namespaceName = "foo"
-		namespace     = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: namespaceName,
-			},
-		}
 
 		projectName = "bar"
-		project     = &gardencorev1beta1.Project{
+		project     *gardencorev1beta1.Project
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().
+			WithScheme(kubernetes.GardenScheme).
+			WithIndex(&gardencorev1beta1.Project{}, gardencore.ProjectNamespace, indexer.ProjectNamespaceIndexerFunc).
+			Build()
+
+		project = &gardencorev1beta1.Project{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: projectName,
 			},
@@ -46,99 +51,113 @@ var _ = Describe("Project", func() {
 				Namespace: &namespaceName,
 			},
 		}
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#ProjectForNamespaceFromReader", func() {
 		It("should return an error because the listing failed", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{}), client.MatchingFields{gardencore.ProjectNamespace: namespaceName}).Return(fakeErr)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			projectResult, err := ProjectForNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, err := ProjectForNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).To(MatchError(fakeErr))
 			Expect(projectResult).To(BeNil())
 		})
 
 		It("should return an error because the listing yielded no results", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{}), client.MatchingFields{gardencore.ProjectNamespace: namespaceName})
-
-			projectResult, err := ProjectForNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, err := ProjectForNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).To(BeNotFoundError())
 			Expect(projectResult).To(BeNil())
 		})
 
 		It("should return the project", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{}), client.MatchingFields{gardencore.ProjectNamespace: namespaceName}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
-				(&gardencorev1beta1.ProjectList{Items: []gardencorev1beta1.Project{*project}}).DeepCopyInto(list)
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, project)).To(Succeed())
 
-			projectResult, err := ProjectForNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, err := ProjectForNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(projectResult).To(Equal(project))
+			Expect(projectResult.Name).To(Equal(projectName))
+			Expect(projectResult.Spec.Namespace).To(Equal(&namespaceName))
 		})
 	})
 
 	Describe("#ProjectAndNamespaceFromReader", func() {
 		It("should return an error because getting the namespace failed", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(fakeErr)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).To(MatchError(fakeErr))
 			Expect(namespaceResult).To(BeNil())
 			Expect(projectResult).To(BeNil())
 		})
 
 		It("should return the namespace but no project because labels missing", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
-				namespace.DeepCopyInto(obj)
-				return nil
-			})
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+				},
+			}
+			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
 
-			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(namespaceResult).To(Equal(namespace))
+			Expect(namespaceResult.Name).To(Equal(namespaceName))
 			Expect(projectResult).To(BeNil())
 		})
 
 		It("should return an error because getting the project failed", func() {
-			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   namespaceName,
+					Labels: map[string]string{"project.gardener.cloud/name": projectName},
+				},
+			}
+			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
-				namespace.DeepCopyInto(obj)
-				return nil
-			})
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(fakeErr)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithObjects(namespace).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*gardencorev1beta1.Project); ok {
+							return fakeErr
+						}
+						return cl.Get(ctx, key, obj, opts...)
+					},
+				}).
+				Build()
 
-			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).To(MatchError(fakeErr))
-			Expect(namespaceResult).To(Equal(namespace))
+			Expect(namespaceResult.Name).To(Equal(namespaceName))
 			Expect(projectResult).To(BeNil())
 		})
 
 		It("should return both namespace and project", func() {
-			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   namespaceName,
+					Labels: map[string]string{"project.gardener.cloud/name": projectName},
+				},
+			}
+			Expect(fakeClient.Create(ctx, namespace)).To(Succeed())
+			Expect(fakeClient.Create(ctx, project)).To(Succeed())
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: namespaceName}, gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace, _ ...client.GetOption) error {
-				namespace.DeepCopyInto(obj)
-				return nil
-			})
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: projectName}, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Project, _ ...client.GetOption) error {
-				project.DeepCopyInto(obj)
-				return nil
-			})
-
-			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, fakeClient, namespaceName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(namespaceResult).To(Equal(namespace))
-			Expect(projectResult).To(Equal(project))
+			Expect(namespaceResult.Name).To(Equal(namespaceName))
+			Expect(projectResult.Name).To(Equal(projectName))
 		})
 	})
 })

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -21,18 +21,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	fakekubernetes "k8s.io/client-go/kubernetes/fake"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 	mockutilclient "github.com/gardener/gardener/pkg/utils/kubernetes/client/mock"
-	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 func TestClient(t *testing.T) {
@@ -42,21 +42,9 @@ func TestClient(t *testing.T) {
 
 var _ = Describe("Cleaner", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		ctx  context.Context
-
-		cm1Key client.ObjectKey
-		cm2Key client.ObjectKey
-		nsKey  client.ObjectKey
-
-		cm1    corev1.ConfigMap
-		cm2    corev1.ConfigMap
-		cmList corev1.ConfigMapList
-		ns     corev1.Namespace
-
-		cm2WithFinalizer corev1.ConfigMap
-		nsWithFinalizer  corev1.Namespace
+		ctrl       *gomock.Controller
+		ctx        context.Context
+		fakeClient client.Client
 
 		fakeClock *testclock.FakeClock
 		now       time.Time
@@ -64,22 +52,8 @@ var _ = Describe("Cleaner", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
 		ctx = context.Background()
-
-		cm1Key = client.ObjectKey{Namespace: "n", Name: "foo"}
-		cm2Key = client.ObjectKey{Namespace: "n", Name: "bar"}
-		nsKey = client.ObjectKey{Name: "baz"}
-
-		cm1 = corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
-		cm2 = corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar"}}
-		cmList = corev1.ConfigMapList{Items: []corev1.ConfigMap{cm1, cm2}}
-		ns = corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "baz"}}
-
-		cm2.DeepCopyInto(&cm2WithFinalizer)
-		cm2WithFinalizer.Finalizers = []string{"finalize.me"}
-		ns.DeepCopyInto(&nsWithFinalizer)
-		nsWithFinalizer.Spec.Finalizers = []corev1.FinalizerName{"kubernetes"}
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
 		now = time.Unix(60, 0)
 		fakeClock = testclock.NewFakeClock(now)
@@ -91,310 +65,328 @@ var _ = Describe("Cleaner", func() {
 	Context("Cleaner", func() {
 		Describe("#Clean", func() {
 			It("should delete the target object", func() {
-				var (
-					ctx     = context.TODO()
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, cm1Key, &cm1),
-					c.EXPECT().Delete(ctx, &cm1),
-				)
+				cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+				Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, &cm1)).To(Succeed())
+				Expect(cleaner.Clean(ctx, fakeClient, cm1)).To(Succeed())
+
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm1), &corev1.ConfigMap{})).To(BeNotFoundError())
 			})
 
 			It("should succeed if not found error occurs for target object", func() {
-				var (
-					ctx     = context.TODO()
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				c.EXPECT().Get(ctx, cm1Key, &cm1).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-				Expect(cleaner.Clean(ctx, c, &cm1)).To(Succeed())
+				cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+				Expect(cleaner.Clean(ctx, fakeClient, cm1)).To(Succeed())
 			})
 
 			It("should succeed if no match error occurs for target object", func() {
-				var (
-					ctx     = context.TODO()
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				c.EXPECT().Get(ctx, cm1Key, &cm1).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+							return &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}}
+						},
+					}).Build()
 
-				Expect(cleaner.Clean(ctx, c, &cm1)).To(Succeed())
+				cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+				Expect(cleaner.Clean(ctx, c, cm1)).To(Succeed())
 			})
 
 			It("should delete all objects matching the selector", func() {
-				var (
-					ctx     = context.TODO()
-					list    = &corev1.ConfigMapList{}
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				listCall := c.EXPECT().List(ctx, list).SetArg(1, cmList)
-				c.EXPECT().Delete(ctx, &cm1).After(listCall)
-				c.EXPECT().Delete(ctx, &cm2).After(listCall)
+				cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+				cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar"}}
+				Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
+				Expect(fakeClient.Create(ctx, cm2)).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, list)).To(Succeed())
+				Expect(cleaner.Clean(ctx, fakeClient, &corev1.ConfigMapList{})).To(Succeed())
+
+				list := &corev1.ConfigMapList{}
+				Expect(fakeClient.List(ctx, list)).To(Succeed())
+				Expect(list.Items).To(BeEmpty())
 			})
 
 			It("should succeed if not found error occurs for list type", func() {
-				var (
-					ctx     = context.TODO()
-					list    = &corev1.ConfigMapList{}
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				c.EXPECT().List(ctx, list).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return apierrors.NewNotFound(schema.GroupResource{}, "")
+						},
+					}).Build()
 
-				Expect(cleaner.Clean(ctx, c, list)).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &corev1.ConfigMapList{})).To(Succeed())
 			})
 
 			It("should succeed if no match error occurs for list type", func() {
-				var (
-					ctx     = context.TODO()
-					list    = &corev1.ConfigMapList{}
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				c.EXPECT().List(ctx, list).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}}
+						},
+					}).Build()
 
-				Expect(cleaner.Clean(ctx, c, list)).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &corev1.ConfigMapList{})).To(Succeed())
 			})
 
 			It("should finalize the object if its deletion timestamp is over the finalize grace period", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					now               = time.Unix(60, 0)
-					cleaner           = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", Finalizers: []string{"finalize.me"}},
+				}
+				Expect(fakeClient.Create(ctx, cm)).To(Succeed())
+				Expect(fakeClient.Delete(ctx, cm)).To(Succeed())
 
-				fakeClock.SetTime(now)
+				result := &corev1.ConfigMap{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm), result)).To(Succeed())
+				fakeClock.SetTime(result.DeletionTimestamp.Add(21 * time.Second))
 
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, cm2Key, &cm2).SetArg(2, cm2WithFinalizer),
-					test.EXPECTPatch(ctx, c, &cm2, &cm2WithFinalizer, types.MergePatchType),
-				)
+				Expect(cleaner.Clean(ctx, fakeClient, result, FinalizeGracePeriodSeconds(20))).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm), &corev1.ConfigMap{})).To(BeNotFoundError())
 			})
 
 			It("should finalize the namespace if its deletion timestamp is over the finalize grace period", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					now               = time.Unix(60, 0)
-					sw                = mockclient.NewMockSubResourceClient(ctrl)
-					finalizer         = NewNamespaceFinalizer()
-					cleaner           = NewCleaner(fakeClock, finalizer)
-				)
+				finalizer := NewNamespaceFinalizer()
+				cleaner := NewCleaner(fakeClock, finalizer)
 
-				nsWithFinalizer.DeletionTimestamp = &deletionTimestamp
-				ns.DeletionTimestamp = &deletionTimestamp
+				subResourceUpdateCalled := false
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						SubResourceUpdate: func(_ context.Context, _ client.Client, subResourceName string, obj client.Object, _ ...client.SubResourceUpdateOption) error {
+							subResourceUpdateCalled = true
+							Expect(subResourceName).To(Equal("finalize"))
+							ns, ok := obj.(*corev1.Namespace)
+							Expect(ok).To(BeTrue())
+							Expect(ns.Finalizers).To(BeEmpty())
+							Expect(ns.Spec.Finalizers).To(BeEmpty())
+							return nil
+						},
+					}).Build()
 
 				fakeClock.SetTime(now)
+				ns := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "baz", Finalizers: []string{"some-finalizer"}},
+					Spec:       corev1.NamespaceSpec{Finalizers: []corev1.FinalizerName{"kubernetes"}},
+				}
+				Expect(c.Create(ctx, ns)).To(Succeed())
+				Expect(c.Delete(ctx, ns)).To(Succeed())
 
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, nsKey, &nsWithFinalizer),
-					c.EXPECT().SubResource("finalize").Return(sw),
-					sw.EXPECT().Update(ctx, &ns).Return(nil),
-				)
+				result := &corev1.Namespace{}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(ns), result)).To(Succeed())
+				fakeClock.SetTime(result.DeletionTimestamp.Add(21 * time.Second))
 
-				Expect(cleaner.Clean(ctx, c, &nsWithFinalizer, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, result, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(subResourceUpdateCalled).To(BeTrue())
 			})
 
 			It("should not delete the object if its deletion timestamp is not over the finalize grace period", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					now               = time.Unix(50, 0)
-					cleaner           = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", Finalizers: []string{"finalize.me"}},
+				}
+				Expect(fakeClient.Create(ctx, cm)).To(Succeed())
+				Expect(fakeClient.Delete(ctx, cm)).To(Succeed())
 
 				fakeClock.SetTime(now)
+				result := &corev1.ConfigMap{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm), result)).To(Succeed())
 
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, cm2Key, &cm2).SetArg(2, cm2WithFinalizer),
-				)
+				Expect(cleaner.Clean(ctx, fakeClient, result, FinalizeGracePeriodSeconds(20))).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm), result)).To(Succeed())
+				Expect(result.Finalizers).To(ConsistOf("finalize.me"))
 			})
 
 			It("should not delete the object if its deletion timestamp is over the finalize grace period and no finalizer is left", func() {
 				var (
-					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
 					now               = time.Unix(50, 0)
 					cleaner           = NewCleaner(fakeClock, NewFinalizer())
 				)
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", DeletionTimestamp: &deletionTimestamp}}
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+							if key.Name == "bar" && key.Namespace == "n" {
+								cm2.DeepCopyInto(obj.(*corev1.ConfigMap))
+								return nil
+							}
+							return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+						},
+					}).Build()
 
 				fakeClock.SetTime(now)
 
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, cm2Key, &cm2),
-				)
-
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(10))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, cm2, FinalizeGracePeriodSeconds(10))).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(cm2), &corev1.ConfigMap{})).To(Succeed())
 			})
 
 			It("should finalize the list if the object's deletion timestamps are over the finalize grace period", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					list              = &corev1.ConfigMapList{}
-					cleaner           = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cmTemplate := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", Finalizers: []string{"finalize.me"}},
+				}
+				for i := range 3 {
+					cm1 := cmTemplate.DeepCopy()
+					cm1.Name = fmt.Sprintf("bar-%d", i)
+					Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
+					Expect(fakeClient.Delete(ctx, cm1)).To(Succeed())
+				}
 
-				fakeClock.SetTime(now)
+				result := &corev1.ConfigMap{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: "n", Name: "bar-2"}, result)).To(Succeed())
+				fakeClock.SetTime(result.DeletionTimestamp.Add(21 * time.Second))
 
-				gomock.InOrder(
-					c.EXPECT().List(ctx, list).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2WithFinalizer}}),
-					test.EXPECTPatch(ctx, c, &cm2, &cm2WithFinalizer, types.MergePatchType),
-				)
+				Expect(cleaner.Clean(ctx, fakeClient, &corev1.ConfigMapList{}, FinalizeGracePeriodSeconds(20))).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				cmList := &corev1.ConfigMapList{}
+				Expect(fakeClient.List(ctx, cmList)).To(Succeed())
+				Expect(cmList.Items).To(BeEmpty())
 			})
 
 			It("should ignore not found errors when finalizing objects", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					list              = &corev1.ConfigMapList{}
-					cleaner           = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				patchCalled := false
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+							patchCalled = true
+							return apierrors.NewNotFound(schema.GroupResource{}, "")
+						},
+					}).Build()
 
 				fakeClock.SetTime(now)
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", Finalizers: []string{"finalize.me"}},
+				}
+				Expect(c.Create(ctx, cm)).To(Succeed())
+				Expect(c.Delete(ctx, cm)).To(Succeed())
 
-				gomock.InOrder(
-					c.EXPECT().List(ctx, list).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2WithFinalizer}}),
-					test.EXPECTPatch(ctx, c, &cm2, &cm2WithFinalizer, types.MergePatchType).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-				)
+				result := &corev1.ConfigMap{}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(cm), result)).To(Succeed())
+				fakeClock.SetTime(result.DeletionTimestamp.Add(21 * time.Second))
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &corev1.ConfigMapList{}, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				Expect(patchCalled).To(BeTrue())
 			})
 
 			It("should not delete the list if the object's deletion timestamp is not over the finalize grace period", func() {
-				var (
-					ctx               = context.TODO()
-					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-					now               = time.Unix(50, 0)
-					list              = &corev1.ConfigMapList{}
-					cleaner           = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cmTemplate := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar", Finalizers: []string{"finalize.me"}},
+				}
+
+				for i := range 3 {
+					cm1 := cmTemplate.DeepCopy()
+					cm1.Name = fmt.Sprintf("bar-%d", i)
+					Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
+					Expect(fakeClient.Delete(ctx, cm1)).To(Succeed())
+				}
 
 				fakeClock.SetTime(now)
 
-				gomock.InOrder(
-					c.EXPECT().List(ctx, list).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2WithFinalizer}}),
-				)
+				Expect(cleaner.Clean(ctx, fakeClient, &corev1.ConfigMapList{}, FinalizeGracePeriodSeconds(20))).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
+				cmList := &corev1.ConfigMapList{}
+				Expect(fakeClient.List(ctx, cmList)).To(Succeed())
+				Expect(cmList.Items).To(HaveLen(3))
+				for i := range 3 {
+					Expect(cmList.Items[i].Finalizers).To(ConsistOf("finalize.me"))
+				}
 			})
 
 			It("should not delete the list if the object's deletion timestamp is over the finalize grace period and no finalizers are left", func() {
 				var (
-					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
 					now               = time.Unix(50, 0)
-					list              = &corev1.ConfigMapList{}
 					cleaner           = NewCleaner(fakeClock, NewFinalizer())
 				)
 
-				cm2WithFinalizer.DeletionTimestamp = &deletionTimestamp
-				cm2.DeletionTimestamp = &deletionTimestamp
+				cm1 := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar-1", DeletionTimestamp: &deletionTimestamp}}
+				cm2 := corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar-2", DeletionTimestamp: &deletionTimestamp}}
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+							cmList, ok := list.(*corev1.ConfigMapList)
+							if ok {
+								cmList.Items = []corev1.ConfigMap{cm1, cm2}
+							}
+							return nil
+						},
+					}).Build()
 
 				fakeClock.SetTime(now)
 
-				gomock.InOrder(
-					c.EXPECT().List(ctx, list).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2}}),
-				)
+				Expect(cleaner.Clean(ctx, c, &corev1.ConfigMapList{}, FinalizeGracePeriodSeconds(10))).To(Succeed())
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(10))).To(Succeed())
+				cmList := &corev1.ConfigMapList{}
+				Expect(c.List(ctx, cmList)).To(Succeed())
+				Expect(cmList.Items).To(HaveLen(2))
 			})
 
 			It("should ensure that no error occurs because resource is not present in the cluster", func() {
-				var (
-					ctx     = context.TODO()
-					list    = &corev1.ConfigMapList{}
-					cleaner = NewCleaner(fakeClock, NewFinalizer())
-				)
+				cleaner := NewCleaner(fakeClock, NewFinalizer())
 
-				c.EXPECT().List(ctx, list).DoAndReturn(func(_ context.Context, _ *corev1.ConfigMapList, _ ...client.ListOption) error {
-					return &meta.NoResourceMatchError{}
-				})
+				c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+							return &meta.NoResourceMatchError{}
+						},
+					}).Build()
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(10))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &corev1.ConfigMapList{}, FinalizeGracePeriodSeconds(10))).To(Succeed())
 			})
 		})
 	})
 
 	Describe("VolumeSnapshotCleaner", func() {
 		var (
-			cl       client.Client
-			cleaner  Cleaner
-			labels   map[string]string
-			cleanOps []CleanOption
+			fakeClient client.Client
+			cleaner    Cleaner
+			labels     map[string]string
+			cleanOps   []CleanOption
 
-			deletionTimestamp                metav1.Time
 			cleanupContent, remainingContent map[string]*volumesnapshotv1.VolumeSnapshotContent
 		)
 
 		BeforeEach(func() {
 			var (
-				deletionTimestampLater = metav1.NewTime(deletionTimestamp.Add(-1 * time.Second))
-				finalizers             = []string{"foo/bar"}
+				finalizers = []string{"foo/bar"}
 			)
 
-			deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
-
-			cleaner = NewVolumeSnapshotContentCleaner(fakeClock)
 			labels = map[string]string{"action": "cleanup"}
-			cleanOps = []CleanOption{
-				ListWith{
-					client.MatchingLabels(labels),
-				},
-				DeleteWith{
-					client.GracePeriodSeconds(29),
-				},
-			}
+
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
 
 			cleanupContent = map[string]*volumesnapshotv1.VolumeSnapshotContent{
 				"content1": {
 					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &deletionTimestamp,
-						Finalizers:        finalizers,
-						Name:              "content1",
-						Namespace:         "default",
-						Labels:            labels,
+						Finalizers: finalizers,
+						Name:       "content1",
+						Namespace:  "default",
+						Labels:     labels,
 					},
 				},
 				"content2": {
 					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &deletionTimestamp,
-						Finalizers:        finalizers,
-						Name:              "content2",
-						Namespace:         "default",
+						Finalizers: finalizers,
+						Name:       "content2",
+						Namespace:  "default",
 						Annotations: map[string]string{
 							"snapshot.storage.kubernetes.io/volumesnapshot-being-deleted": "yes",
 							"snapshot.storage.kubernetes.io/volumesnapshot-being-created": "yes",
@@ -404,10 +396,9 @@ var _ = Describe("Cleaner", func() {
 				},
 				"content3": {
 					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &deletionTimestamp,
-						Finalizers:        finalizers,
-						Name:              "content3",
-						Namespace:         "default",
+						Finalizers: finalizers,
+						Name:       "content3",
+						Namespace:  "default",
 						Annotations: map[string]string{
 							"snapshot.storage.kubernetes.io/volumesnapshot-being-created": "yes",
 						},
@@ -431,42 +422,65 @@ var _ = Describe("Cleaner", func() {
 				// Object w/o matching label.
 				"content5": {
 					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &deletionTimestamp,
-						Finalizers:        finalizers,
-						Name:              "content5",
-						Namespace:         "default",
+						Finalizers: finalizers,
+						Name:       "content5",
+						Namespace:  "default",
 					},
 				},
-				// Object w/ deletionTimestamp before grace period passed.
+				// Object w/ deletionTimestamp before grace period passed (created 1s later, so shorter time since deletion).
 				"content6": {
 					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &deletionTimestampLater,
-						Finalizers:        finalizers,
-						Name:              "content6",
-						Namespace:         "default",
+						Finalizers: finalizers,
+						Name:       "content6",
+						Namespace:  "default",
 					},
 				},
 			}
 
-			fakeClientBuilder := fakeclient.NewClientBuilder()
+			// Create objects that should be cleaned up (with deletion timestamps)
 			for _, content := range cleanupContent {
-				obj := content
-				fakeClientBuilder.WithObjects(obj)
+				Expect(fakeClient.Create(ctx, content.DeepCopy())).To(Succeed())
 			}
 
+			// Delete cleanup content objects so they get deletion timestamps
+			for name := range cleanupContent {
+				Expect(fakeClient.Delete(ctx, &volumesnapshotv1.VolumeSnapshotContent{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name}})).To(Succeed())
+			}
+
+			// Create remaining objects
 			for _, content := range remainingContent {
-				obj := content
-				fakeClientBuilder.WithObjects(obj)
+				Expect(fakeClient.Create(ctx, content.DeepCopy())).To(Succeed())
 			}
 
-			cl = fakeClientBuilder.WithScheme(kubernetes.ShootScheme).Build()
+			// Delete content5 and content6 so they get deletion timestamps too
+			for _, name := range []string{"content5", "content6"} {
+				Expect(fakeClient.Delete(ctx, &volumesnapshotv1.VolumeSnapshotContent{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name}})).To(Succeed())
+			}
+
+			// Read back an actual deletion timestamp from one of the cleanup objects to determine "now"
+			vsc := &volumesnapshotv1.VolumeSnapshotContent{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "content6"}, vsc)).To(Succeed())
+			deletionTimestamp := vsc.DeletionTimestamp
+
+			// Set fakeClock to well past the grace period (29s) for the cleanup objects
+			fakeClock.SetTime(deletionTimestamp.Add(30 * time.Second))
+
+			cleaner = NewVolumeSnapshotContentCleaner(fakeClock)
+			cleanOps = []CleanOption{
+				ListWith{
+					client.MatchingLabels(labels),
+				},
+				DeleteWith{
+					client.GracePeriodSeconds(29),
+				},
+			}
 		})
 
 		It("should maintain the right annotations for all contents in the list to be cleaned up", func() {
-			Expect(cleaner.Clean(ctx, cl, &volumesnapshotv1.VolumeSnapshotContentList{}, cleanOps...)).To(Succeed())
+			Expect(cleaner.Clean(ctx, fakeClient, &volumesnapshotv1.VolumeSnapshotContentList{}, cleanOps...)).To(Succeed())
 
 			contents := &volumesnapshotv1.VolumeSnapshotContentList{}
-			Expect(cl.List(ctx, contents)).To(Succeed())
+			Expect(fakeClient.List(ctx, contents)).To(Succeed())
 
 			for _, content := range contents.Items {
 				if _, ok := cleanupContent[content.Name]; ok {
@@ -481,12 +495,14 @@ var _ = Describe("Cleaner", func() {
 		})
 
 		It("should maintain the right annotations for the content to be cleaned up", func() {
-			cleanupContent := cleanupContent["content1"]
+			// Get the object as stored in the fake client (with deletion timestamp set by Delete)
+			storedContent := &volumesnapshotv1.VolumeSnapshotContent{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "content1"}, storedContent)).To(Succeed())
 
-			Expect(cleaner.Clean(ctx, cl, cleanupContent, cleanOps...)).To(Succeed())
+			Expect(cleaner.Clean(ctx, fakeClient, storedContent, cleanOps...)).To(Succeed())
 
 			content := &volumesnapshotv1.VolumeSnapshotContent{}
-			Expect(cl.Get(ctx, client.ObjectKeyFromObject(cleanupContent), content)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(storedContent), content)).To(Succeed())
 
 			Expect(content.Annotations).To(HaveKeyWithValue("snapshot.storage.kubernetes.io/volumesnapshot-being-deleted", "yes"))
 			Expect(content.Annotations).NotTo(HaveKeyWithValue("snapshot.storage.kubernetes.io/volumesnapshot-being-created", "yes"))
@@ -494,103 +510,108 @@ var _ = Describe("Cleaner", func() {
 	})
 
 	Describe("#EnsureGone", func() {
+		var fakeClient client.Client
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		})
+
 		It("should ensure that the object is gone when not found error occurs", func() {
-			ctx := context.TODO()
-
-			c.EXPECT().Get(ctx, cm1Key, &cm1).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, cm1)).To(Succeed())
 		})
 
 		It("should ensure that the object is gone when no match error occurs", func() {
-			ctx := context.TODO()
+			c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}}
+					},
+				}).Build()
 
-			c.EXPECT().Get(ctx, cm1Key, &cm1).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			Expect(EnsureGone(ctx, logr.Discard(), c, cm1)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone", func() {
-			var (
-				ctx  = context.TODO()
-				list = corev1.ConfigMapList{}
-			)
-
-			c.EXPECT().List(ctx, &list)
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
+			list := corev1.ConfigMapList{}
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, &list)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone when not found error occurs", func() {
-			var (
-				ctx  = context.TODO()
-				list = corev1.ConfigMapList{}
-			)
+			c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return apierrors.NewNotFound(schema.GroupResource{}, "")
+					},
+				}).Build()
 
-			c.EXPECT().List(ctx, &list).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
+			list := corev1.ConfigMapList{}
 			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
 		})
 
 		It("should ensure that the list is gone when no match error occurs", func() {
-			var (
-				ctx  = context.TODO()
-				list = corev1.ConfigMapList{}
-			)
+			c := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}}
+					},
+				}).Build()
 
-			c.EXPECT().List(ctx, &list).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
-
+			list := corev1.ConfigMapList{}
 			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Succeed())
 		})
 
 		It("should error that the object is still present", func() {
-			ctx := context.TODO()
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
 
-			c.EXPECT().Get(ctx, cm1Key, &cm1)
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1)).To(Equal(NewObjectsRemaining(&cm1)))
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, cm1)).To(Equal(NewObjectsRemaining(cm1)))
 		})
 
 		It("should ensure that the object is ignored", func() {
-			ctx := context.TODO()
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
 
-			c.EXPECT().Get(ctx, cm1Key, &cm1)
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &cm1, &CleanOptions{
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, cm1, &CleanOptions{
 				IgnoreLeftovers: []IgnoreLeftoverFunc{
 					func(_ logr.Logger, _ client.Object) bool {
 						return true
 					},
 				},
 			})).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(cm1), &corev1.ConfigMap{})).To(Succeed())
 		})
 
 		It("should error that the list is non-empty", func() {
-			var (
-				ctx  = context.TODO()
-				list = corev1.ConfigMapList{}
-			)
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar"}}
+			Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, cm2)).To(Succeed())
 
-			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &list)).To(Equal(NewObjectsRemaining(&cmList)))
+			list := corev1.ConfigMapList{}
+			err := EnsureGone(ctx, logr.Discard(), fakeClient, &list)
+			Expect(err).To(HaveOccurred())
+			Expect(AreObjectsRemaining(err)).To(BeTrue())
 		})
 
 		It("should ensure objects in list are ignored", func() {
-			var (
-				ctx  = context.TODO()
-				list = corev1.ConfigMapList{}
-			)
+			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
+			cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "bar"}}
+			Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, cm2)).To(Succeed())
 
-			c.EXPECT().List(ctx, &list).SetArg(1, cmList)
-
-			Expect(EnsureGone(ctx, logr.Discard(), c, &list, &CleanOptions{
+			list := corev1.ConfigMapList{}
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, &list, &CleanOptions{
 				IgnoreLeftovers: []IgnoreLeftoverFunc{
 					func(_ logr.Logger, _ client.Object) bool {
 						return true
 					},
 				},
 			})).To(Succeed())
+
+			Expect(fakeClient.List(ctx, &list)).To(Succeed())
+			Expect(list.Items).To(HaveLen(2))
 		})
 	})
 
@@ -608,14 +629,14 @@ var _ = Describe("Cleaner", func() {
 
 		Describe("CleanAndEnsureGone", func() {
 			It("should clean and ensure that the object is gone", func() {
-				ctx := context.TODO()
+				cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
 
 				gomock.InOrder(
-					cleaner.EXPECT().Clean(ctx, c, &cm1),
-					ensurer.EXPECT().EnsureGone(ctx, logr.Discard(), c, &cm1),
+					cleaner.EXPECT().Clean(ctx, fakeClient, cm1),
+					ensurer.EXPECT().EnsureGone(ctx, logr.Discard(), fakeClient, cm1),
 				)
 
-				Expect(o.CleanAndEnsureGone(ctx, logr.Discard(), c, &cm1)).To(Succeed())
+				Expect(o.CleanAndEnsureGone(ctx, logr.Discard(), fakeClient, cm1)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/utils/kubernetes/deployment_test.go
+++ b/pkg/utils/kubernetes/deployment_test.go
@@ -10,31 +10,27 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Deployments", func() {
 	var (
-		ctrl      *gomock.Controller
-		c         *mockclient.MockClient
-		namespace = "test"
-		name      = "dummy-app"
+		ctx        = context.TODO()
+		fakeClient client.Client
+		namespace  = "test"
+		name       = "dummy-app"
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 	})
 
 	DescribeTable("#ValidDeploymentContainerImageVersion",
@@ -63,37 +59,30 @@ var _ = Describe("Deployments", func() {
 
 	Describe("#HasDeploymentRolloutCompleted", func() {
 		It("Rollout is complete", func() {
+			var (
+				replicas   int32 = 5
+				generation int64 = 10
+			)
 
-			c.EXPECT().
-				Get(
-					gomock.Any(),
-					gomock.AssignableToTypeOf(client.ObjectKey{}),
-					gomock.AssignableToTypeOf(&appsv1.Deployment{}),
-				).
-				DoAndReturn(func(
-					_ context.Context,
-					_ client.ObjectKey,
-					deployment *appsv1.Deployment,
-					_ ...client.GetOption,
-				) error {
-					var (
-						replicas   int32 = 5
-						generation int64 = 10
-					)
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       name,
+					Namespace:  namespace,
+					Generation: generation,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: generation,
+					Replicas:           replicas,
+					UpdatedReplicas:    replicas,
+					AvailableReplicas:  replicas,
+				},
+			}
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
-					deployment.Generation = generation
-					deployment.Spec.Replicas = &replicas
-					deployment.Status = appsv1.DeploymentStatus{
-						ObservedGeneration: generation,
-						Replicas:           replicas,
-						UpdatedReplicas:    replicas,
-						AvailableReplicas:  replicas,
-					}
-
-					return nil
-				})
-
-			_, actualError := kubernetes.HasDeploymentRolloutCompleted(context.TODO(), c, namespace, name)
+			_, actualError := kubernetes.HasDeploymentRolloutCompleted(ctx, fakeClient, namespace, name)
 			Expect(actualError).NotTo(HaveOccurred())
 		})
 
@@ -107,31 +96,25 @@ var _ = Describe("Deployments", func() {
 			_, expectedError := retry.MinorError(fmt.Errorf("%q not observed at latest generation (%d/%d)",
 				name, observedGeneration, generation))
 
-			c.EXPECT().
-				Get(
-					gomock.Any(),
-					gomock.AssignableToTypeOf(client.ObjectKey{}),
-					gomock.AssignableToTypeOf(&appsv1.Deployment{}),
-				).
-				DoAndReturn(func(
-					_ context.Context,
-					_ client.ObjectKey,
-					deployment *appsv1.Deployment,
-					_ ...client.GetOption,
-				) error {
-					deployment.Generation = generation
-					deployment.Spec.Replicas = &replicas
-					deployment.Status = appsv1.DeploymentStatus{
-						ObservedGeneration: observedGeneration,
-						Replicas:           replicas - 1,
-						UpdatedReplicas:    replicas - 1,
-						AvailableReplicas:  replicas - 1,
-					}
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       name,
+					Namespace:  namespace,
+					Generation: generation,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: observedGeneration,
+					Replicas:           replicas - 1,
+					UpdatedReplicas:    replicas - 1,
+					AvailableReplicas:  replicas - 1,
+				},
+			}
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
-					return nil
-				})
-
-			_, actualError := kubernetes.HasDeploymentRolloutCompleted(context.TODO(), c, namespace, name)
+			_, actualError := kubernetes.HasDeploymentRolloutCompleted(ctx, fakeClient, namespace, name)
 			Expect(actualError).To(Equal(expectedError))
 		})
 
@@ -146,31 +129,25 @@ var _ = Describe("Deployments", func() {
 			_, expectedError := retry.MinorError(fmt.Errorf("deployment %q currently has Updated/Available: %d/%d replicas. Desired: %d",
 				name, updatedReplicas, availableReplicas, replicas))
 
-			c.EXPECT().
-				Get(
-					gomock.Any(),
-					gomock.AssignableToTypeOf(client.ObjectKey{}),
-					gomock.AssignableToTypeOf(&appsv1.Deployment{}),
-				).
-				DoAndReturn(func(
-					_ context.Context,
-					_ client.ObjectKey,
-					deployment *appsv1.Deployment,
-					_ ...client.GetOption,
-				) error {
-					deployment.Generation = generation
-					deployment.Spec.Replicas = &replicas
-					deployment.Status = appsv1.DeploymentStatus{
-						ObservedGeneration: generation,
-						Replicas:           replicas - 1,
-						UpdatedReplicas:    updatedReplicas,
-						AvailableReplicas:  availableReplicas,
-					}
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       name,
+					Namespace:  namespace,
+					Generation: generation,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: generation,
+					Replicas:           replicas - 1,
+					UpdatedReplicas:    updatedReplicas,
+					AvailableReplicas:  availableReplicas,
+				},
+			}
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
-					return nil
-				})
-
-			_, actualError := kubernetes.HasDeploymentRolloutCompleted(context.TODO(), c, namespace, name)
+			_, actualError := kubernetes.HasDeploymentRolloutCompleted(ctx, fakeClient, namespace, name)
 			Expect(actualError).To(Equal(expectedError))
 		})
 
@@ -185,31 +162,25 @@ var _ = Describe("Deployments", func() {
 			_, expectedError := retry.MinorError(fmt.Errorf("deployment %q currently has Updated/Available: %d/%d replicas. Desired: %d",
 				name, updatedReplicas, availableReplicas, replicas))
 
-			c.EXPECT().
-				Get(
-					gomock.Any(),
-					gomock.AssignableToTypeOf(client.ObjectKey{}),
-					gomock.AssignableToTypeOf(&appsv1.Deployment{}),
-				).
-				DoAndReturn(func(
-					_ context.Context,
-					_ client.ObjectKey,
-					deployment *appsv1.Deployment,
-					_ ...client.GetOption,
-				) error {
-					deployment.Generation = generation
-					deployment.Spec.Replicas = &replicas
-					deployment.Status = appsv1.DeploymentStatus{
-						ObservedGeneration: generation,
-						Replicas:           replicas - 1,
-						UpdatedReplicas:    updatedReplicas,
-						AvailableReplicas:  availableReplicas,
-					}
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       name,
+					Namespace:  namespace,
+					Generation: generation,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: generation,
+					Replicas:           replicas - 1,
+					UpdatedReplicas:    updatedReplicas,
+					AvailableReplicas:  availableReplicas,
+				},
+			}
+			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
-					return nil
-				})
-
-			_, actualError := kubernetes.HasDeploymentRolloutCompleted(context.TODO(), c, namespace, name)
+			_, actualError := kubernetes.HasDeploymentRolloutCompleted(ctx, fakeClient, namespace, name)
 			Expect(actualError).To(Equal(expectedError))
 		})
 	})

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -36,6 +36,8 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -43,7 +45,6 @@ import (
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
 	mockcorev1 "github.com/gardener/gardener/third_party/mock/client-go/core/v1"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("kubernetes", func() {
@@ -54,7 +55,9 @@ var _ = Describe("kubernetes", func() {
 
 	var (
 		ctrl *gomock.Controller
-		c    *mockclient.MockClient
+
+		fakeClient client.Client
+		scheme     *runtime.Scheme
 
 		ctx     = context.TODO()
 		fakeErr = fmt.Errorf("fake error")
@@ -62,7 +65,12 @@ var _ = Describe("kubernetes", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+		Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 	})
 
 	AfterEach(func() {
@@ -137,7 +145,6 @@ var _ = Describe("kubernetes", func() {
 		var (
 			namespace = "bar"
 			name      = "foo"
-			key       = client.ObjectKey{Namespace: namespace, Name: name}
 			configMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
@@ -147,35 +154,49 @@ var _ = Describe("kubernetes", func() {
 		)
 
 		It("should wait until the resource is deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Get(ctx, key, configMap),
-				c.EXPECT().Get(ctx, key, configMap),
-				c.EXPECT().Get(ctx, key, configMap).Return(apierrors.NewNotFound(schema.GroupResource{}, name)),
-			)
+			Expect(fakeClient.Create(ctx, configMap.DeepCopy())).To(Succeed())
+			// Delete after two iterations: use interceptor to return the object twice, then not-found
+			callCount := 0
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					callCount++
+					if callCount <= 2 {
+						return cl.Get(ctx, key, obj, opts...)
+					}
+					return apierrors.NewNotFound(schema.GroupResource{}, name)
+				},
+			}).WithObjects(configMap.DeepCopy()).Build()
 
-			Expect(WaitUntilResourceDeleted(ctx, c, configMap, time.Microsecond)).To(Succeed())
+			Expect(WaitUntilResourceDeleted(ctx, c, configMap.DeepCopy(), time.Microsecond)).To(Succeed())
 		})
 
 		It("should timeout", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			gomock.InOrder(
-				c.EXPECT().Get(ctx, key, configMap),
-				c.EXPECT().Get(ctx, key, configMap).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
-					cancel()
-					return nil
-				}),
-			)
+			callCount := 0
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					callCount++
+					if callCount >= 2 {
+						cancel()
+					}
+					return cl.Get(ctx, key, obj, opts...)
+				},
+			}).WithObjects(configMap.DeepCopy()).Build()
 
-			Expect(WaitUntilResourceDeleted(ctx, c, configMap, time.Microsecond)).To(HaveOccurred())
+			Expect(WaitUntilResourceDeleted(ctx, c, configMap.DeepCopy(), time.Microsecond)).To(HaveOccurred())
 		})
 
 		It("return an unexpected error", func() {
 			expectedErr := fmt.Errorf("unexpected")
-			c.EXPECT().Get(ctx, key, configMap).Return(expectedErr)
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return expectedErr
+				},
+			}).Build()
 
-			err := WaitUntilResourceDeleted(ctx, c, configMap, time.Microsecond)
+			err := WaitUntilResourceDeleted(ctx, c, configMap.DeepCopy(), time.Microsecond)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(BeIdenticalTo(expectedErr))
 		})
@@ -197,27 +218,32 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should wait until the resources are deleted w/ empty list", func() {
-			c.EXPECT().List(ctx, configMapList).Return(nil)
-
-			Expect(WaitUntilResourcesDeleted(ctx, c, configMapList, time.Microsecond)).To(Succeed())
+			Expect(WaitUntilResourcesDeleted(ctx, fakeClient, configMapList, time.Microsecond)).To(Succeed())
 		})
 
 		It("should timeout w/ remaining elements", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			c.EXPECT().List(ctx, configMapList).DoAndReturn(func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
-				cancel()
-				configMapList.Items = append(configMapList.Items, configMap)
-				return nil
-			})
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+					cancel()
+					cmList := list.(*corev1.ConfigMapList)
+					cmList.Items = append(cmList.Items, configMap)
+					return nil
+				},
+			}).Build()
 
 			Expect(WaitUntilResourcesDeleted(ctx, c, configMapList, time.Microsecond)).To(HaveOccurred())
 		})
 
 		It("return an unexpected error", func() {
 			expectedErr := fmt.Errorf("unexpected")
-			c.EXPECT().List(ctx, configMapList).Return(expectedErr)
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return expectedErr
+				},
+			}).Build()
 
 			Expect(WaitUntilResourcesDeleted(ctx, c, configMapList, time.Microsecond)).To(BeIdenticalTo(expectedErr))
 		})
@@ -233,19 +259,26 @@ var _ = Describe("kubernetes", func() {
 
 	Describe("#GetLoadBalancerIngress", func() {
 		var (
-			key     = client.ObjectKey{Namespace: namespace, Name: name}
+			service *corev1.Service
+		)
+
+		BeforeEach(func() {
 			service = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
 				},
 			}
-		)
+		})
 
 		It("should return an unexpected client error", func() {
 			expectedErr := fmt.Errorf("unexpected")
 
-			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&corev1.Service{})).Return(expectedErr)
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return expectedErr
+				},
+			}).Build()
 
 			_, err := GetLoadBalancerIngress(ctx, c, service)
 
@@ -254,54 +287,43 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should return an error because no ingresses found", func() {
-			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&corev1.Service{}))
+			Expect(fakeClient.Create(ctx, service.DeepCopy())).To(Succeed())
 
-			_, err := GetLoadBalancerIngress(ctx, c, service)
+			_, err := GetLoadBalancerIngress(ctx, fakeClient, service)
 
 			Expect(err).To(MatchError("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created"))
 		})
 
 		It("should return an ip address", func() {
-			var (
-				ctx        = context.TODO()
-				expectedIP = "1.2.3.4"
-			)
+			expectedIP := "1.2.3.4"
+			svc := service.DeepCopy()
+			svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: expectedIP}}
+			Expect(fakeClient.Create(ctx, svc)).To(Succeed())
 
-			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, service *corev1.Service, _ ...client.GetOption) error {
-				service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: expectedIP}}
-				return nil
-			})
-
-			ingress, err := GetLoadBalancerIngress(ctx, c, service)
+			ingress, err := GetLoadBalancerIngress(ctx, fakeClient, service)
 
 			Expect(ingress).To(Equal(expectedIP))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return an hostname address", func() {
-			var (
-				ctx              = context.TODO()
-				expectedHostname = "cluster.local"
-			)
+		It("should return a hostname address", func() {
+			expectedHostname := "cluster.local"
+			svc := service.DeepCopy()
+			svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{Hostname: expectedHostname}}
+			Expect(fakeClient.Create(ctx, svc)).To(Succeed())
 
-			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, service *corev1.Service, _ ...client.GetOption) error {
-				service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{Hostname: expectedHostname}}
-				return nil
-			})
-
-			ingress, err := GetLoadBalancerIngress(ctx, c, service)
+			ingress, err := GetLoadBalancerIngress(ctx, fakeClient, service)
 
 			Expect(ingress).To(Equal(expectedHostname))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return an error if neither ip nor hostname were set", func() {
-			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, service *corev1.Service, _ ...client.GetOption) error {
-				service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{}}
-				return nil
-			})
+			svc := service.DeepCopy()
+			svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{}}
+			Expect(fakeClient.Create(ctx, svc)).To(Succeed())
 
-			_, err := GetLoadBalancerIngress(ctx, c, service)
+			_, err := GetLoadBalancerIngress(ctx, fakeClient, service)
 
 			Expect(err).To(MatchError("`.status.loadBalancer.ingress[]` has an element which does neither contain `.ip` nor `.hostname`"))
 		})
@@ -309,41 +331,49 @@ var _ = Describe("kubernetes", func() {
 
 	Describe("#LookupObject", func() {
 		var (
-			key       = client.ObjectKey{Namespace: namespace, Name: name}
+			key       client.ObjectKey
+			configMap *corev1.ConfigMap
+		)
+
+		BeforeEach(func() {
+			key = client.ObjectKey{Namespace: namespace, Name: name}
 			configMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,
 					Name:      name,
 				},
 			}
-
-			apiReader *mockclient.MockClient
-		)
-
-		BeforeEach(func() {
-			apiReader = mockclient.NewMockClient(ctrl)
 		})
 
 		It("should retrieve the obj when cached client can retrieve it", func() {
-			c.EXPECT().Get(ctx, key, configMap)
+			Expect(fakeClient.Create(ctx, configMap.DeepCopy())).To(Succeed())
 
-			err := LookupObject(context.TODO(), c, apiReader, key, configMap)
+			err := LookupObject(context.TODO(), fakeClient, fakeClient, key, configMap)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return error when cached client fails with error other than NotFound error", func() {
 			expectedErr := fmt.Errorf("unexpected")
-			c.EXPECT().Get(ctx, key, configMap).Return(expectedErr)
+			cachedClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return expectedErr
+				},
+			}).Build()
 
-			err := LookupObject(context.TODO(), c, apiReader, key, configMap)
+			err := LookupObject(context.TODO(), cachedClient, fakeClient, key, configMap)
 			Expect(err).To(BeIdenticalTo(expectedErr))
 		})
 
 		It("should retrieve the obj using the apiReader when cached client fails with NotFound error", func() {
-			c.EXPECT().Get(ctx, key, configMap).Return(apierrors.NewNotFound(schema.GroupResource{}, name))
-			apiReader.EXPECT().Get(ctx, key, configMap)
+			// cached client returns not-found, apiReader succeeds (has the object)
+			cachedClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return apierrors.NewNotFound(schema.GroupResource{}, name)
+				},
+			}).Build()
+			Expect(fakeClient.Create(ctx, configMap.DeepCopy())).To(Succeed())
 
-			err := LookupObject(context.TODO(), c, apiReader, key, configMap)
+			err := LookupObject(context.TODO(), cachedClient, fakeClient, key, configMap)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -404,18 +434,11 @@ var _ = Describe("kubernetes", func() {
 	Describe("#WaitUntilLoadBalancerIsReady", func() {
 		var (
 			k8sShootClient kubernetes.Interface
-			key            = client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "load-balancer"}
 			logger         = logr.Discard()
-			scheme         *runtime.Scheme
 		)
 
 		BeforeEach(func() {
-			scheme = runtime.NewScheme()
-			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-			c.EXPECT().Scheme().Return(scheme).AnyTimes()
-			k8sShootClient = fakekubernetes.NewClientSetBuilder().
-				WithClient(c).
-				Build()
+			k8sShootClient = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
 		})
 
 		It("should return nil when the Service has .status.loadBalancer.ingress[]", func() {
@@ -436,14 +459,7 @@ var _ = Describe("kubernetes", func() {
 					},
 				}
 			)
-
-			gomock.InOrder(
-				c.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Service, _ ...client.GetOption) error {
-						*obj = *svc
-						return nil
-					}),
-			)
+			Expect(fakeClient.Create(ctx, svc)).To(Succeed())
 
 			actual, err := WaitUntilLoadBalancerIsReady(ctx, logger, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second)
 			Expect(err).NotTo(HaveOccurred())
@@ -461,9 +477,9 @@ var _ = Describe("kubernetes", func() {
 						Name:      "load-balancer",
 						Namespace: metav1.NamespaceSystem,
 					},
-					Status: corev1.ServiceStatus{},
 				}
-				event = corev1.Event{
+				event = &corev1.Event{
+					ObjectMeta:     *svc.ObjectMeta.DeepCopy(),
 					Source:         corev1.EventSource{Component: "service-controller"},
 					Message:        "Error syncing load balancer: an error occurred",
 					FirstTimestamp: metav1.NewTime(time.Date(2020, time.January, 15, 0, 0, 0, 0, time.UTC)),
@@ -473,20 +489,19 @@ var _ = Describe("kubernetes", func() {
 				}
 			)
 
-			gomock.InOrder(
-				c.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, obj *corev1.Service, _ ...client.GetOption) error {
-						*obj = *svc
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if el, ok := list.(*corev1.EventList); ok {
+						el.Items = append(el.Items, *event)
 						return nil
-					}),
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-					func(_ context.Context, list *corev1.EventList, _ ...client.ListOption) error {
-						list.Items = append(list.Items, event)
-						return nil
-					}),
-			)
+					}
+					return c.List(ctx, list, opts...)
+				},
+			}).Build()
 
-			actual, err := WaitUntilLoadBalancerIsReady(ctx, logger, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second)
+			Expect(fakeClient.Create(ctx, svc)).To(Succeed())
+
+			actual, err := WaitUntilLoadBalancerIsReady(ctx, logger, fakeClient, metav1.NamespaceSystem, "load-balancer", 1*time.Second)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("-> Events:\n* service-controller reported"))
 			Expect(err.Error()).To(ContainSubstring("Error syncing load balancer: an error occurred"))
@@ -496,15 +511,11 @@ var _ = Describe("kubernetes", func() {
 
 	Describe("#FetchEventMessages", func() {
 		var (
-			reader     *mockclient.MockReader
 			events     []corev1.Event
 			serviceObj *corev1.Service
-			scheme     *runtime.Scheme
 		)
 
 		BeforeEach(func() {
-			reader = mockclient.NewMockReader(ctrl)
-
 			events = []corev1.Event{
 				{
 					Source:         corev1.EventSource{Component: "service-controller"},
@@ -544,14 +555,15 @@ var _ = Describe("kubernetes", func() {
 
 			It("should return an event message with only the latest event", func() {
 				var listOpts []client.ListOption
-				gomock.InOrder(
-					reader.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-						func(_ context.Context, list *corev1.EventList, listOptions ...client.ListOption) error {
-							list.Items = append(list.Items, events...)
-							listOpts = listOptions
-							return nil
-						}),
-				)
+				reader := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if el, ok := list.(*corev1.EventList); ok {
+							el.Items = append(el.Items, events...)
+							listOpts = opts
+						}
+						return nil
+					},
+				}).Build()
 
 				msg, err := FetchEventMessages(ctx, scheme, reader, serviceObj, corev1.EventTypeWarning, 1)
 
@@ -569,14 +581,15 @@ var _ = Describe("kubernetes", func() {
 
 			It("should return an event message with all events", func() {
 				var listOpts []client.ListOption
-				gomock.InOrder(
-					reader.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-						func(_ context.Context, list *corev1.EventList, listOptions ...client.ListOption) error {
-							list.Items = append(list.Items, events...)
-							listOpts = listOptions
-							return nil
-						}),
-				)
+				reader := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if el, ok := list.(*corev1.EventList); ok {
+							el.Items = append(el.Items, events...)
+							listOpts = opts
+						}
+						return nil
+					},
+				}).Build()
 
 				msg, err := FetchEventMessages(ctx, scheme, reader, serviceObj, corev1.EventTypeWarning, len(events))
 
@@ -595,13 +608,12 @@ var _ = Describe("kubernetes", func() {
 
 			It("should not return a message because no events exist", func() {
 				var listOpts []client.ListOption
-				gomock.InOrder(
-					reader.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-						func(_ context.Context, _ *corev1.EventList, listOptions ...client.ListOption) error {
-							listOpts = listOptions
-							return nil
-						}),
-				)
+				reader := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, opts ...client.ListOption) error {
+						listOpts = opts
+						return nil
+					},
+				}).Build()
 
 				msg, err := FetchEventMessages(ctx, scheme, reader, serviceObj, corev1.EventTypeWarning, len(events))
 
@@ -618,13 +630,12 @@ var _ = Describe("kubernetes", func() {
 
 			It("should not return a message because an error occurred", func() {
 				var listOpts []client.ListOption
-				gomock.InOrder(
-					reader.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-						func(_ context.Context, _ *corev1.EventList, listOptions ...client.ListOption) error {
-							listOpts = listOptions
-							return errors.New("foo")
-						}),
-				)
+				reader := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, opts ...client.ListOption) error {
+						listOpts = opts
+						return errors.New("foo")
+					},
+				}).Build()
 
 				msg, err := FetchEventMessages(ctx, scheme, reader, serviceObj, corev1.EventTypeWarning, len(events))
 
@@ -647,7 +658,7 @@ var _ = Describe("kubernetes", func() {
 			})
 
 			It("should not return a message because type kind is not in scheme", func() {
-				msg, err := FetchEventMessages(ctx, scheme, reader, &corev1.Service{}, corev1.EventTypeWarning, len(events))
+				msg, err := FetchEventMessages(ctx, scheme, fakeclient.NewClientBuilder().WithScheme(scheme).Build(), &corev1.Service{}, corev1.EventTypeWarning, len(events))
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to identify GVK for object"))
@@ -695,7 +706,11 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should return an error because the List() call failed", func() {
-			c.EXPECT().List(ctx, podList).Return(fakeErr)
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return fakeErr
+				},
+			}).Build()
 
 			obj, err := NewestObject(ctx, c, podList, nil)
 			Expect(err).To(MatchError(fakeErr))
@@ -703,9 +718,7 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should return nil because the list does not contain items", func() {
-			c.EXPECT().List(ctx, podList)
-
-			obj, err := NewestObject(ctx, c, podList, nil)
+			obj, err := NewestObject(ctx, fakeClient, podList, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(obj).To(BeNil())
 		})
@@ -717,10 +730,12 @@ var _ = Describe("kubernetes", func() {
 		)
 
 		It("should return the newest object w/o filter func", func() {
-			c.EXPECT().List(ctx, podList).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
-				*list = corev1.PodList{Items: []corev1.Pod{*obj1, *obj2, *obj3}}
-				return nil
-			})
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+					*list.(*corev1.PodList) = corev1.PodList{Items: []corev1.Pod{*obj1, *obj2, *obj3}}
+					return nil
+				},
+			}).Build()
 
 			obj, err := NewestObject(ctx, c, podList, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -734,10 +749,12 @@ var _ = Describe("kubernetes", func() {
 				return obj.Name != "obj2"
 			}
 
-			c.EXPECT().List(ctx, podList).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
-				*list = corev1.PodList{Items: []corev1.Pod{*obj1, *obj2, *obj3}}
-				return nil
-			})
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+					*list.(*corev1.PodList) = corev1.PodList{Items: []corev1.Pod{*obj1, *obj2, *obj3}}
+					return nil
+				},
+			}).Build()
 
 			obj, err := NewestObject(ctx, c, podList, filterFn)
 			Expect(err).NotTo(HaveOccurred())
@@ -770,12 +787,6 @@ var _ = Describe("kubernetes", func() {
 				podTemplatehashKey: rs3PodTemplateHash,
 			}
 
-			rsListOptions = []any{
-				client.InNamespace(namespace),
-				client.MatchingLabels(labels),
-			}
-			podListOptions []any
-
 			deployment = &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -792,6 +803,7 @@ var _ = Describe("kubernetes", func() {
 			replicaSet1 = &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name + "-" + rs1PodTemplateHash,
+					Namespace:         namespace,
 					Labels:            rs1Labels,
 					UID:               "replicaset1",
 					CreationTimestamp: metav1.Now(),
@@ -811,6 +823,7 @@ var _ = Describe("kubernetes", func() {
 			replicaSet2 = &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name + "-" + rs2PodTemplateHash,
+					Namespace:         namespace,
 					Labels:            rs2Labels,
 					UID:               "replicaset2",
 					CreationTimestamp: metav1.Time{Time: time.Now().Add(+time.Hour)},
@@ -830,6 +843,7 @@ var _ = Describe("kubernetes", func() {
 			replicaSet3 = &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name + "-" + rs3PodTemplateHash,
+					Namespace:         namespace,
 					Labels:            rs3Labels,
 					UID:               "replicaset3",
 					CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
@@ -849,6 +863,7 @@ var _ = Describe("kubernetes", func() {
 
 			pod1 = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Name:              "pod1",
+				Namespace:         namespace,
 				UID:               "pod1",
 				Labels:            rs1Labels,
 				CreationTimestamp: metav1.Now(),
@@ -861,6 +876,7 @@ var _ = Describe("kubernetes", func() {
 			}}
 			pod2 = &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 				Name:              "pod2",
+				Namespace:         namespace,
 				UID:               "pod2",
 				Labels:            rs1Labels,
 				CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
@@ -873,14 +889,12 @@ var _ = Describe("kubernetes", func() {
 			}}
 		)
 
-		BeforeEach(func() {
-			podSelector, err := metav1.LabelSelectorAsSelector(replicaSet1.Spec.Selector)
-			Expect(err).NotTo(HaveOccurred())
-			podListOptions = append(rsListOptions, client.MatchingLabelsSelector{Selector: podSelector})
-		})
-
 		It("should return an error because the newest ReplicaSet determination failed", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).Return(fakeErr)
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return fakeErr
+				},
+			}).Build()
 
 			pod, err := NewestPodForDeployment(ctx, c, deployment)
 			Expect(err).To(MatchError(fakeErr))
@@ -888,19 +902,25 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should return nil because no replica set found", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...)
-
-			pod, err := NewestPodForDeployment(ctx, c, deployment)
+			pod, err := NewestPodForDeployment(ctx, fakeClient, deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod).To(BeNil())
 		})
 
 		It("should return an error because listing pods failed", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}}
-				return nil
-			})
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), podListOptions...).Return(fakeErr)
+			rsList := []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, c client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+					if _, ok := list.(*corev1.PodList); ok {
+						return fakeErr
+					}
+					return c.List(ctx, list)
+				},
+			}).Build()
+
+			for _, rs := range rsList {
+				Expect(c.Create(ctx, rs.DeepCopy())).To(Succeed())
+			}
 
 			pod, err := NewestPodForDeployment(ctx, c, deployment)
 			Expect(err).To(MatchError(fakeErr))
@@ -910,6 +930,7 @@ var _ = Describe("kubernetes", func() {
 		It("should return an error because the replicasSet has no pod selector", func() {
 			rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{
 				Name:              "rs",
+				Namespace:         namespace,
 				Labels:            rs1Labels,
 				UID:               "rs",
 				CreationTimestamp: metav1.Now(),
@@ -922,12 +943,9 @@ var _ = Describe("kubernetes", func() {
 			}}
 			rsError := fmt.Errorf("no pod selector specified in replicaSet %s/%s", rs.Namespace, rs.Name)
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*rs}}
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, rs)).To(Succeed())
 
-			pod, err := NewestPodForDeployment(ctx, c, deployment)
+			pod, err := NewestPodForDeployment(ctx, fakeClient, deployment)
 			Expect(err).To(MatchError(rsError))
 			Expect(pod).To(BeNil())
 		})
@@ -936,6 +954,7 @@ var _ = Describe("kubernetes", func() {
 			rs := &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "rs",
+					Namespace:         namespace,
 					Labels:            rs1Labels,
 					UID:               "rs",
 					CreationTimestamp: metav1.Now(),
@@ -954,12 +973,9 @@ var _ = Describe("kubernetes", func() {
 			}
 			rsError := fmt.Errorf("no matchLabels or matchExpressions specified in replicaSet %s/%s", rs.Namespace, rs.Name)
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*rs}}
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, rs)).To(Succeed())
 
-			pod, err := NewestPodForDeployment(ctx, c, deployment)
+			pod, err := NewestPodForDeployment(ctx, fakeClient, deployment)
 			Expect(err).To(MatchError(rsError))
 			Expect(pod).To(BeNil())
 		})
@@ -968,6 +984,7 @@ var _ = Describe("kubernetes", func() {
 			rs := &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "rs",
+					Namespace:         namespace,
 					Labels:            rs1Labels,
 					UID:               "rs",
 					CreationTimestamp: metav1.Now(),
@@ -984,37 +1001,39 @@ var _ = Describe("kubernetes", func() {
 					}},
 			}
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*rs}}
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, rs)).To(Succeed())
 
-			pod, err := NewestPodForDeployment(ctx, c, deployment)
+			pod, err := NewestPodForDeployment(ctx, fakeClient, deployment)
 			Expect(err).To(MatchError(ContainSubstring("for 'in', 'notin' operators, values set can't be empty")))
 			Expect(pod).To(BeNil())
 		})
 
 		It("should return nil because no pod was found", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}}
-				return nil
-			})
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), podListOptions...)
+			rsList := []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}
+			for _, rs := range rsList {
+				Expect(fakeClient.Create(ctx, rs.DeepCopy())).To(Succeed())
+			}
 
-			pod, err := NewestPodForDeployment(ctx, c, deployment)
+			pod, err := NewestPodForDeployment(ctx, fakeClient, deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pod).To(BeNil())
 		})
 
 		It("should return the newest pod", func() {
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.ReplicaSetList{}), rsListOptions...).DoAndReturn(func(_ context.Context, list *appsv1.ReplicaSetList, _ ...client.ListOption) error {
-				*list = appsv1.ReplicaSetList{Items: []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}}
-				return nil
-			})
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), podListOptions...).DoAndReturn(func(_ context.Context, list *corev1.PodList, _ ...client.ListOption) error {
-				*list = corev1.PodList{Items: []corev1.Pod{*pod1, *pod2}}
-				return nil
-			})
+			rsList := []appsv1.ReplicaSet{*replicaSet1, *replicaSet2, *replicaSet3}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(_ context.Context, c client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
+					if podList, ok := list.(*corev1.PodList); ok {
+						podList.Items = []corev1.Pod{*pod1, *pod2}
+						return nil
+					}
+					return c.List(ctx, list)
+				},
+			}).Build()
+
+			for _, rs := range rsList {
+				Expect(c.Create(ctx, rs.DeepCopy())).To(Succeed())
+			}
 
 			pod, err := NewestPodForDeployment(ctx, c, deployment)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/kubernetes/leaderelection_test.go
+++ b/pkg/utils/kubernetes/leaderelection_test.go
@@ -12,22 +12,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("LeaderElection", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-
 		ctx       = context.TODO()
 		fakeErr   = errors.New("fake err")
 		namespace = "namespace"
@@ -36,26 +34,34 @@ var _ = Describe("LeaderElection", func() {
 
 		holderIdentity             = "leader1"
 		leaseDurationSeconds int32 = 42
-		acquireTime                = metav1.Time{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023, time.Local)}
-		renewTime                  = metav1.Time{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023, time.Local)}
-		acquireTimeMicro           = metav1.MicroTime{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023, time.Local)}
-		renewTimeMicro             = metav1.MicroTime{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023, time.Local)}
+		acquireTime                = metav1.Time{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023000, time.Local)}
+		renewTime                  = metav1.Time{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023000, time.Local)}
+		acquireTimeMicro           = metav1.MicroTime{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023000, time.Local)}
+		renewTimeMicro             = metav1.MicroTime{Time: time.Date(2020, 12, 14, 13, 18, 29, 176023000, time.Local)}
 		leaderTransitions    int32 = 24
 
-		objectMetaInvalid = metav1.ObjectMeta{Annotations: map[string]string{"control-plane.alpha.kubernetes.io/leader": "[foo]"}}
-		objectMetaValid   = metav1.ObjectMeta{Annotations: map[string]string{"control-plane.alpha.kubernetes.io/leader": fmt.Sprintf(`{
+		objectMetaInvalid = metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{"control-plane.alpha.kubernetes.io/leader": "[foo]"},
+		}
+		objectMetaValid = metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{"control-plane.alpha.kubernetes.io/leader": fmt.Sprintf(`{
   "holderIdentity":%q,
   "leaseDurationSeconds":%d,
   "acquireTime":%q,
   "renewTime":%q,
   "leaderTransitions":%d
 }`,
-			holderIdentity,
-			leaseDurationSeconds,
-			acquireTime.Format(time.RFC3339Nano),
-			renewTime.Format(time.RFC3339Nano),
-			leaderTransitions,
-		)}}
+				holderIdentity,
+				leaseDurationSeconds,
+				acquireTime.Format(time.RFC3339Nano),
+				renewTime.Format(time.RFC3339Nano),
+				leaderTransitions,
+			)},
+		}
 		leaseSpecValid = coordinationv1.LeaseSpec{
 			HolderIdentity:       &holderIdentity,
 			LeaseDurationSeconds: &leaseDurationSeconds,
@@ -65,55 +71,60 @@ var _ = Describe("LeaderElection", func() {
 		}
 	)
 
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#ReadLeaderElectionRecord", func() {
+		var fakeClient client.Client
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		})
+
 		Context("endpoints lock", func() {
 			BeforeEach(func() {
 				lock = "endpoints"
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).Return(fakeErr)
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should fail if the object has no leader election annotation", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{}))
+				endpoints := &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				Expect(fakeClient.Create(ctx, endpoints)).To(Succeed())
+
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring("could not find key \"control-plane.alpha.kubernetes.io/leader\" in annotations")))
 			})
 
 			It("should fail if the leader election annotation cannot be unmarshalled", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
-					(&corev1.Endpoints{ObjectMeta: objectMetaInvalid}).DeepCopyInto(obj)
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.Endpoints{ObjectMeta: objectMetaInvalid})).To(Succeed())
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring("failed to unmarshal leader election record")))
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Endpoints{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Endpoints, _ ...client.GetOption) error {
-					(&corev1.Endpoints{ObjectMeta: objectMetaValid}).DeepCopyInto(obj)
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.Endpoints{ObjectMeta: objectMetaValid})).To(Succeed())
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(Equal(&resourcelock.LeaderElectionRecord{
 					HolderIdentity:       holderIdentity,
 					LeaseDurationSeconds: int(leaseDurationSeconds),
@@ -131,39 +142,47 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Return(fakeErr)
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should fail if the object has no leader election annotation", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{}))
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+				}
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				Expect(fakeClient.Create(ctx, configMap)).To(Succeed())
+
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring("could not find key \"control-plane.alpha.kubernetes.io/leader\" in annotations")))
 			})
 
 			It("should fail if the leader election annotation cannot be unmarshalled", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
-					(&corev1.ConfigMap{ObjectMeta: objectMetaInvalid}).DeepCopyInto(obj)
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{ObjectMeta: objectMetaInvalid})).To(Succeed())
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring("failed to unmarshal leader election record")))
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.ConfigMap, _ ...client.GetOption) error {
-					(&corev1.ConfigMap{ObjectMeta: objectMetaValid}).DeepCopyInto(obj)
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{ObjectMeta: objectMetaValid})).To(Succeed())
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(Equal(&resourcelock.LeaderElectionRecord{
 					HolderIdentity:       holderIdentity,
 					LeaseDurationSeconds: int(leaseDurationSeconds),
@@ -181,20 +200,32 @@ var _ = Describe("LeaderElection", func() {
 			})
 
 			It("should fail if the object cannot be retrieved", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).Return(fakeErr)
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetesscheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+							return fakeErr
+						},
+					}).
+					Build()
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(BeNil())
 				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should successfully return the leader election record", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&coordinationv1.Lease{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *coordinationv1.Lease, _ ...client.GetOption) error {
-					(&coordinationv1.Lease{Spec: leaseSpecValid}).DeepCopyInto(obj)
-					return nil
-				})
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: leaseSpecValid,
+				}
 
-				lock, err := ReadLeaderElectionRecord(ctx, c, lock, namespace, name)
+				Expect(fakeClient.Create(ctx, lease)).To(Succeed())
+
+				lock, err := ReadLeaderElectionRecord(ctx, fakeClient, lock, namespace, name)
 				Expect(lock).To(Equal(&resourcelock.LeaderElectionRecord{
 					HolderIdentity:       holderIdentity,
 					LeaseDurationSeconds: int(leaseDurationSeconds),

--- a/pkg/utils/kubernetes/managedseed_test.go
+++ b/pkg/utils/kubernetes/managedseed_test.go
@@ -10,19 +10,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/gardener/gardener/pkg/api/indexer"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 const (
@@ -34,6 +31,7 @@ var _ = Describe("managedseed", func() {
 	var (
 		ctx         context.Context
 		managedSeed *seedmanagementv1alpha1.ManagedSeed
+		fakeErr     = errors.New("fake")
 	)
 
 	BeforeEach(func() {
@@ -90,65 +88,61 @@ var _ = Describe("managedseed", func() {
 		})
 
 		It("should fail if listing the ManagedSeeds fails", func() {
-			_, err := GetManagedSeedWithReader(ctx, failingListReader{fakeClient}, namespace, name)
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
+
+			_, err := GetManagedSeedWithReader(ctx, fakeClient, namespace, name)
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("#GetManagedSeedByName", func() {
 		var (
-			ctrl *gomock.Controller
-			c    *mockclient.MockClient
-
-			seedName = "foo"
+			seedName   = "foo"
+			fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetes.GardenScheme).
+					Build()
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			c = mockclient.NewMockClient(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		It("should return nil since the ManagedSeed is not found", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-			managedSeed, err := GetManagedSeedByName(ctx, c, seedName)
+			managedSeed, err := GetManagedSeedByName(ctx, fakeClient, seedName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(managedSeed).To(BeNil())
 		})
 
 		It("should return an error since reading the ManagedSeed failed", func() {
-			fakeErr := errors.New("fake")
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).Return(fakeErr)
-
-			managedSeed, err := GetManagedSeedByName(ctx, c, seedName)
+			managedSeed, err := GetManagedSeedByName(ctx, fakeClient, seedName)
 			Expect(err).To(MatchError(fakeErr))
 			Expect(managedSeed).To(BeNil())
 		})
 
 		It("should return the ManagedSeed since reading it succeeded", func() {
-			expected := &seedmanagementv1alpha1.ManagedSeed{ObjectMeta: metav1.ObjectMeta{Name: seedName}}
+			expected := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seedName,
+					Namespace: "garden",
+				},
+			}
+			Expect(fakeClient.Create(ctx, expected)).To(Succeed())
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: "garden", Name: seedName}, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed, _ ...client.GetOption) error {
-				expected.DeepCopyInto(obj)
-				return nil
-			})
-
-			managedSeed, err := GetManagedSeedByName(ctx, c, seedName)
+			managedSeed, err := GetManagedSeedByName(ctx, fakeClient, seedName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(managedSeed).To(Equal(expected))
 		})
 	})
 })
-
-type failingListReader struct {
-	client.Reader
-}
-
-func (failingListReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
-	return errors.New("fake")
-}

--- a/pkg/utils/kubernetes/object_test.go
+++ b/pkg/utils/kubernetes/object_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,93 +20,121 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Object", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-
-		ctx     = context.TODO()
-		fakeErr = errors.New("fake err")
-
-		obj1 = &corev1.Secret{}
-		obj2 = &appsv1.Deployment{}
-		objs = []client.Object{obj1, obj2}
+		ctx        = context.TODO()
+		fakeErr    = errors.New("fake err")
+		fakeClient client.Client
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 	})
 
 	Describe("#DeleteObjects", func() {
 		It("should fail because an object fails to delete", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, obj1).Return(fakeErr),
-			)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			Expect(DeleteObjects(ctx, c, objs...)).To(MatchError(fakeErr))
+			obj1 := &corev1.Secret{}
+			obj2 := &appsv1.Deployment{}
+			Expect(DeleteObjects(ctx, fakeClient, obj1, obj2)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because an object fails to delete", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, obj1),
-				c.EXPECT().Delete(ctx, obj2).Return(fakeErr),
-			)
+		It("should fail because the second object fails to delete", func() {
+			callCount := 0
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						callCount++
+						if callCount == 2 {
+							return fakeErr
+						}
+						return cl.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
 
-			Expect(DeleteObjects(ctx, c, objs...)).To(MatchError(fakeErr))
+			obj1 := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "default"}}
+			obj2 := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d1", Namespace: "default"}}
+			Expect(fakeClient.Create(ctx, obj1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, obj2)).To(Succeed())
+
+			Expect(DeleteObjects(ctx, fakeClient, obj1, obj2)).To(MatchError(fakeErr))
 		})
 
 		It("should successfully delete all objects", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, obj1),
-				c.EXPECT().Delete(ctx, obj2),
-			)
+			obj1 := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "default"}}
+			obj2 := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d1", Namespace: "default"}}
+			Expect(fakeClient.Create(ctx, obj1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, obj2)).To(Succeed())
 
-			Expect(DeleteObjects(ctx, c, objs...)).To(Succeed())
+			Expect(DeleteObjects(ctx, fakeClient, obj1, obj2)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj1), &corev1.Secret{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj2), &appsv1.Deployment{})).To(BeNotFoundError())
 		})
 	})
 
 	Describe("#DeleteObject", func() {
 		It("should fail to delete the object", func() {
-			c.EXPECT().Delete(ctx, obj1).Return(fakeErr)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			Expect(DeleteObject(ctx, c, obj1)).To(MatchError(fakeErr))
+			Expect(DeleteObject(ctx, fakeClient, &corev1.Secret{})).To(MatchError(fakeErr))
 		})
 
 		It("should not fail to delete the object (not found error)", func() {
-			c.EXPECT().Delete(ctx, obj1).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-			Expect(DeleteObject(ctx, c, obj1)).To(Succeed())
+			Expect(DeleteObject(ctx, fakeClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"}})).To(Succeed())
 		})
 
 		It("should not fail to delete the object (no match error)", func() {
-			c.EXPECT().Delete(ctx, obj1).Return(&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}})
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{}}
+					},
+				}).
+				Build()
 
-			Expect(DeleteObject(ctx, c, obj1)).To(Succeed())
+			Expect(DeleteObject(ctx, fakeClient, &corev1.Secret{})).To(Succeed())
 		})
 
 		It("should successfully delete the object", func() {
-			c.EXPECT().Delete(ctx, obj1)
+			obj := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "default"}}
+			Expect(fakeClient.Create(ctx, obj)).To(Succeed())
 
-			Expect(DeleteObject(ctx, c, obj1)).To(Succeed())
+			Expect(DeleteObject(ctx, fakeClient, obj)).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj), &corev1.Secret{})).To(BeNotFoundError())
 		})
 	})
 
 	Describe("#DeleteObjectsFromListConditionally", func() {
 		var (
-			obj1       = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "1"}}
-			obj2       = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "2"}}
-			obj3       = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "3"}}
-			listObject = &corev1.NamespaceList{Items: []corev1.Namespace{*obj1, *obj2, *obj3}}
+			obj1 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "1"}}
+			obj2 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "2"}}
+			obj3 = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "3"}}
 
 			predicateFn = func(obj runtime.Object) bool {
 				acc, _ := meta.Accessor(obj)
@@ -117,19 +143,39 @@ var _ = Describe("Object", func() {
 		)
 
 		It("should return an error if deleting an object failed", func() {
-			c.EXPECT().Delete(ctx, obj1)
-			c.EXPECT().Delete(ctx, obj3).Return(fakeErr)
+			Expect(fakeClient.Create(ctx, obj1.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, obj3.DeepCopy())).To(Succeed())
 
-			err := DeleteObjectsFromListConditionally(ctx, c, listObject, predicateFn)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithObjects(obj1.DeepCopy(), obj3.DeepCopy()).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						if obj.GetName() == "3" {
+							return fakeErr
+						}
+						return cl.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			listObject := &corev1.NamespaceList{Items: []corev1.Namespace{*obj1, *obj2, *obj3}}
+
+			err := DeleteObjectsFromListConditionally(ctx, fakeClient, listObject, predicateFn)
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(fakeErr)))
 		})
 
 		It("should successfully delete the relevant objects", func() {
-			c.EXPECT().Delete(ctx, obj1)
-			c.EXPECT().Delete(ctx, obj3)
+			Expect(fakeClient.Create(ctx, obj1.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, obj2.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, obj3.DeepCopy())).To(Succeed())
 
-			Expect(DeleteObjectsFromListConditionally(ctx, c, listObject, predicateFn)).To(Succeed())
+			Expect(DeleteObjectsFromListConditionally(ctx, fakeClient, &corev1.NamespaceList{Items: []corev1.Namespace{*obj1, *obj2, *obj3}}, predicateFn)).To(Succeed())
+
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj1), &corev1.Namespace{})).To(BeNotFoundError())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj2), &corev1.Namespace{})).To(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj3), &corev1.Namespace{})).To(BeNotFoundError())
 		})
 	})
 
@@ -147,36 +193,41 @@ var _ = Describe("Object", func() {
 		})
 
 		It("should return an error because the listing failed", func() {
-			c.EXPECT().List(ctx, gomock.Any(), client.InNamespace(namespace), client.Limit(1)).Return(fakeErr)
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return fakeErr
+					},
+				}).
+				Build()
 
-			inUse, err := ResourcesExist(ctx, c, objList, scheme, listOpts...)
+			inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
 			Expect(err).To(MatchError(fakeErr))
 			Expect(inUse).To(BeTrue())
 		})
 
 		Context("with partialObjectMetadataList", func() {
-			var partialObjectMetadataList *metav1.PartialObjectMetadataList
-
 			BeforeEach(func() {
-				partialObjectMetadataList = &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "SecretList"}}
 				listOpts = append(listOpts, client.MatchingFields{"metadata.name": "foo"})
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetesscheme.Scheme).
+					WithIndex(&corev1.Secret{}, "metadata.name", func(obj client.Object) []string {
+						return []string{obj.GetName()}
+					}).
+					Build()
 			})
 
 			It("should return true because objects found", func() {
-				c.EXPECT().List(ctx, partialObjectMetadataList, client.InNamespace(namespace), client.MatchingFields{"metadata.name": "foo"}, client.Limit(1)).DoAndReturn(func(_ context.Context, list *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
-					(&metav1.PartialObjectMetadataList{Items: []metav1.PartialObjectMetadata{{}}}).DeepCopyInto(list)
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: namespace}})).To(Succeed())
 
-				inUse, err := ResourcesExist(ctx, c, objList, scheme, listOpts...)
+				inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(inUse).To(BeTrue())
 			})
 
 			It("should return false because no objects found", func() {
-				c.EXPECT().List(ctx, partialObjectMetadataList, client.InNamespace(namespace), client.MatchingFields{"metadata.name": "foo"}, client.Limit(1))
-
-				inUse, err := ResourcesExist(ctx, c, objList, scheme, listOpts...)
+				inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(inUse).To(BeFalse())
 			})
@@ -185,23 +236,38 @@ var _ = Describe("Object", func() {
 		Context("with objectList", func() {
 			BeforeEach(func() {
 				listOpts = append(listOpts, client.MatchingFields{"data.foo": "bar"})
+
+				fakeClient = fakeclient.NewClientBuilder().
+					WithScheme(kubernetesscheme.Scheme).
+					WithIndex(&corev1.Secret{}, "data.foo", func(obj client.Object) []string {
+						s, ok := obj.(*corev1.Secret)
+						if !ok {
+							return nil
+						}
+						if v, ok := s.Data["foo"]; ok {
+							return []string{string(v)}
+						}
+						return nil
+					}).
+					Build()
 			})
 
 			It("should return true because objects found", func() {
-				c.EXPECT().List(ctx, objList, client.InNamespace(namespace), client.MatchingFields{"data.foo": "bar"}, client.Limit(1)).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
-					list.Items = []corev1.Secret{{}}
-					return nil
-				})
+				Expect(fakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: namespace,
+					},
+					Data: map[string][]byte{"foo": []byte("bar")},
+				})).To(Succeed())
 
-				inUse, err := ResourcesExist(ctx, c, objList, scheme, listOpts...)
+				inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(inUse).To(BeTrue())
 			})
 
 			It("should return false because no objects found", func() {
-				c.EXPECT().List(ctx, objList, client.InNamespace(namespace), client.MatchingFields{"data.foo": "bar"}, client.Limit(1))
-
-				inUse, err := ResourcesExist(ctx, c, objList, scheme, listOpts...)
+				inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(inUse).To(BeFalse())
 			})

--- a/pkg/utils/kubernetes/scaling_test.go
+++ b/pkg/utils/kubernetes/scaling_test.go
@@ -6,128 +6,116 @@ package kubernetes_test
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("scale", func() {
 	var (
-		ctrl          *gomock.Controller
-		runtimeClient *mockclient.MockClient
-		sw            *mockclient.MockSubResourceClient
-		key           = client.ObjectKey{Name: "foo", Namespace: "bar"}
-		statefulSet   = &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.Name,
-				Namespace: key.Namespace,
-			},
-		}
-		deployment = &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.Name,
-				Namespace: key.Namespace,
-			},
-		}
-		statefulSetWith2Replicas = appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Generation: 2,
-			},
-			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To[int32](2),
-			},
-			Status: appsv1.StatefulSetStatus{
-				ObservedGeneration: 2,
-				Replicas:           2,
-				AvailableReplicas:  2,
-			},
-		}
+		ctx        = context.TODO()
+		fakeClient client.Client
+		key        = client.ObjectKey{Name: "foo", Namespace: "bar"}
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		runtimeClient = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockSubResourceClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 	})
 
 	Context("ScaleStatefulSet", func() {
 		It("sets scale to 2", func() {
-			runtimeClient.EXPECT().SubResource("scale").Return(sw)
-			sw.EXPECT().Patch(context.TODO(), statefulSet, getPatch(2))
-			Expect(ScaleStatefulSet(context.TODO(), runtimeClient, key, 2)).To(Succeed(), "scale succeeds")
+			Expect(fakeClient.Create(ctx, &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+			})).To(Succeed())
+
+			Expect(ScaleStatefulSet(ctx, fakeClient, key, 2)).To(Succeed())
+
+			ss := &appsv1.StatefulSet{}
+			Expect(fakeClient.Get(ctx, key, ss)).To(Succeed())
+			Expect(ss.Spec.Replicas).To(Equal(ptr.To[int32](2)))
 		})
 	})
 
 	Context("ScaleDeployment", func() {
 		It("sets scale to 2", func() {
-			runtimeClient.EXPECT().SubResource("scale").Return(sw)
-			sw.EXPECT().Patch(context.TODO(), deployment, getPatch(2))
-			Expect(ScaleDeployment(context.TODO(), runtimeClient, key, 2)).To(Succeed(), "scale succeeds")
+			Expect(fakeClient.Create(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+			})).To(Succeed())
+
+			Expect(ScaleDeployment(ctx, fakeClient, key, 2)).To(Succeed())
+
+			dep := &appsv1.Deployment{}
+			Expect(fakeClient.Get(ctx, key, dep)).To(Succeed())
+			Expect(dep.Spec.Replicas).To(Equal(ptr.To[int32](2)))
 		})
 	})
 
 	Describe("#WaitUntilDeploymentScaledToDesiredReplicas", func() {
 		It("should wait until deployment was scaled", func() {
-			runtimeClient.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&appsv1.Deployment{})).DoAndReturn(
-				func(_ context.Context, _ types.NamespacedName, deploy *appsv1.Deployment, _ ...client.GetOption) error {
-					*deploy = appsv1.Deployment{
-						ObjectMeta: metav1.ObjectMeta{
-							Generation: 2,
-						},
-						Spec: appsv1.DeploymentSpec{
-							Replicas: ptr.To[int32](2),
-						},
-						Status: appsv1.DeploymentStatus{
-							ObservedGeneration: 2,
-							Replicas:           2,
-							AvailableReplicas:  2,
-						},
-					}
-					return nil
-				})
-			Expect(WaitUntilDeploymentScaledToDesiredReplicas(context.TODO(), runtimeClient, key, 2)).To(Succeed(), "scale done")
+			Expect(fakeClient.Create(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: ptr.To[int32](2)},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					AvailableReplicas:  2,
+				},
+			})).To(Succeed())
+
+			Expect(WaitUntilDeploymentScaledToDesiredReplicas(ctx, fakeClient, key, 2)).To(Succeed())
 		})
 	})
 
 	Describe("#WaitUntilStatefulSetScaledToDesiredReplicas", func() {
 		It("should wait until statefulset was scaled", func() {
-			runtimeClient.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(
-				func(_ context.Context, _ types.NamespacedName, deploy *appsv1.StatefulSet, _ ...client.GetOption) error {
-					*deploy = statefulSetWith2Replicas
-					return nil
-				})
-			Expect(WaitUntilStatefulSetScaledToDesiredReplicas(context.TODO(), runtimeClient, key, 2)).To(Succeed(), "scale done")
+			Expect(fakeClient.Create(ctx, &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Generation: 2},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](2)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					AvailableReplicas:  2,
+				},
+			})).To(Succeed())
+
+			Expect(WaitUntilStatefulSetScaledToDesiredReplicas(ctx, fakeClient, key, 2)).To(Succeed())
 		})
 	})
 
 	Describe("#ScaleStatefulSetAndWaitUntilScaled", func() {
 		It("should scale and wait until statefulset was scaled", func() {
-			runtimeClient.EXPECT().SubResource("scale").Return(sw)
-			sw.EXPECT().Patch(context.TODO(), statefulSet, getPatch(2))
-			runtimeClient.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(
-				func(_ context.Context, _ types.NamespacedName, deploy *appsv1.StatefulSet, _ ...client.GetOption) error {
-					*deploy = statefulSetWith2Replicas
+			fakeClient := fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).WithInterceptorFuncs(interceptor.Funcs{
+				SubResourcePatch: func(_ context.Context, _ client.Client, subResourceName string, obj client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+					sts, ok := obj.(*appsv1.StatefulSet)
+					Expect(ok).To(BeTrue())
+					Expect(sts.Name).To(Equal(key.Name))
+					Expect(sts.Namespace).To(Equal(key.Namespace))
+					Expect(subResourceName).To(Equal("scale"))
+
 					return nil
-				})
-			Expect(ScaleStatefulSetAndWaitUntilScaled(context.TODO(), runtimeClient, key, 2)).To(Succeed(), "scale done")
+				},
+			}).Build()
+
+			Expect(fakeClient.Create(ctx, &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Generation: 2},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](2)},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					AvailableReplicas:  2,
+				},
+			})).To(Succeed())
+
+			Expect(ScaleStatefulSetAndWaitUntilScaled(ctx, fakeClient, key, 2)).To(Succeed())
 		})
 	})
 })
-
-func getPatch(replicas int) client.Patch {
-	return client.RawPatch(types.MergePatchType, fmt.Appendf(nil, `{"spec":{"replicas":%d}}`, replicas))
-}

--- a/pkg/utils/kubernetes/secretref_test.go
+++ b/pkg/utils/kubernetes/secretref_test.go
@@ -10,26 +10,25 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("secretref", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-
-		ctx context.Context
+		ctx        context.Context
+		fakeClient client.Client
 
 		secretRef               *corev1.SecretReference
 		secret                  *corev1.Secret
@@ -41,10 +40,8 @@ var _ = Describe("secretref", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-
 		ctx = context.TODO()
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 
 		secretRef = &corev1.SecretReference{
 			Name:      name,
@@ -122,26 +119,27 @@ var _ = Describe("secretref", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#GetSecretByReference", func() {
 		It("should get the secret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-				*s = *secret
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := kubernetesutils.GetSecretByReference(ctx, c, secretRef)
+			result, err := kubernetesutils.GetSecretByReference(ctx, fakeClient, secretRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(secret))
+			Expect(result.Name).To(Equal(secret.Name))
+			Expect(result.Data).To(Equal(secret.Data))
 		})
 
 		It("should fail if getting the secret failed", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetSecretByReference(ctx, c, secretRef)
+			result, err := kubernetesutils.GetSecretByReference(ctx, fakeClient, secretRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -149,20 +147,27 @@ var _ = Describe("secretref", func() {
 
 	Describe("#GetSecretMetadataByReference", func() {
 		It("should get the secret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadata{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *metav1.PartialObjectMetadata, _ ...client.GetOption) error {
-				*s = *secretPartialObjectMeta
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 
-			result, err := kubernetesutils.GetSecretMetadataByReference(ctx, c, secretRef)
+			result, err := kubernetesutils.GetSecretMetadataByReference(ctx, fakeClient, secretRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(secretPartialObjectMeta))
+			Expect(result.Name).To(Equal(secretPartialObjectMeta.Name))
+			Expect(result.Namespace).To(Equal(secretPartialObjectMeta.Namespace))
+			Expect(result.OwnerReferences).To(Equal(secretPartialObjectMeta.OwnerReferences))
+			Expect(result.TypeMeta).To(Equal(secretPartialObjectMeta.TypeMeta))
 		})
 
 		It("should fail if getting the secret failed", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadata{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetSecretMetadataByReference(ctx, c, secretRef)
+			result, err := kubernetesutils.GetSecretMetadataByReference(ctx, fakeClient, secretRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -170,26 +175,32 @@ var _ = Describe("secretref", func() {
 
 	Describe("#GetSecretByObjectReference", func() {
 		It("should get the secret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-				*s = *secret
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secret.DeepCopy())).To(Succeed())
 
-			result, err := kubernetesutils.GetSecretByObjectReference(ctx, c, objectRef)
+			result, err := kubernetesutils.GetSecretByObjectReference(ctx, fakeClient, objectRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(secret))
+			Expect(result.Name).To(Equal(secret.Name))
+			Expect(result.Namespace).To(Equal(secret.Namespace))
+			Expect(result.Data).To(Equal(secret.Data))
 		})
 
 		It("should fail if getting the secret failed", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetSecretByObjectReference(ctx, c, objectRef)
+			result, err := kubernetesutils.GetSecretByObjectReference(ctx, fakeClient, objectRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		It("should fail if object reference is nil", func() {
-			_, err := kubernetesutils.GetSecretByObjectReference(ctx, c, nil)
+			_, err := kubernetesutils.GetSecretByObjectReference(ctx, fakeClient, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ref is nil"))
 		})
@@ -202,7 +213,7 @@ var _ = Describe("secretref", func() {
 				Namespace:  namespace,
 			}
 
-			_, err := kubernetesutils.GetSecretByObjectReference(ctx, c, ref)
+			_, err := kubernetesutils.GetSecretByObjectReference(ctx, fakeClient, ref)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("objectRef does not refer to secret"))
 		})
@@ -210,29 +221,31 @@ var _ = Describe("secretref", func() {
 
 	Describe("#GetCredentialsByObjectReference", func() {
 		It("should get referenced Secret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-				*s = *secret
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secret.DeepCopy())).To(Succeed())
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(secret))
+			Expect(result.GetName()).To(Equal(secret.Name))
+			Expect(result.GetNamespace()).To(Equal(secret.Namespace))
 		})
 
 		It("should fail to get referenced Secret if reading it fails", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		It("should get referenced InternalSecret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, i *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
-				*i = *internalSecret
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, internalSecret.DeepCopy())).To(Succeed())
 
 			objectRef = &corev1.ObjectReference{
 				APIVersion: "core.gardener.cloud/v1beta1",
@@ -241,13 +254,21 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(internalSecret))
+			Expect(result.GetName()).To(Equal(internalSecret.Name))
+			Expect(result.GetNamespace()).To(Equal(internalSecret.Namespace))
 		})
 
 		It("should fail to get referenced InternalSecret if reading it fails", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
 			objectRef = &corev1.ObjectReference{
 				APIVersion: "core.gardener.cloud/v1beta1",
@@ -256,16 +277,13 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
 
 		It("should get referenced WorkloadIdentity", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, wi *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-				*wi = *workloadIdentity
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, workloadIdentity.DeepCopy())).To(Succeed())
 
 			objectRef = &corev1.ObjectReference{
 				APIVersion: "security.gardener.cloud/v1alpha1",
@@ -274,13 +292,21 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(workloadIdentity))
+			Expect(result.GetName()).To(Equal(workloadIdentity.Name))
+			Expect(result.GetNamespace()).To(Equal(workloadIdentity.Namespace))
 		})
 
 		It("should fail to get referenced WorkloadIdentity if reading it fails", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
 			objectRef = &corev1.ObjectReference{
 				APIVersion: "security.gardener.cloud/v1alpha1",
@@ -289,7 +315,7 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *objectRef)
+			result, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *objectRef)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -302,77 +328,89 @@ var _ = Describe("secretref", func() {
 				Namespace:  namespace,
 			}
 
-			_, err := kubernetesutils.GetCredentialsByObjectReference(ctx, c, *ref)
+			_, err := kubernetesutils.GetCredentialsByObjectReference(ctx, fakeClient, *ref)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("unsupported credentials reference: garden/foo, foo.bar/v1alpha1, Kind=Baz"))
 		})
 	})
 
 	Describe("#DeleteSecretByReference", func() {
-		BeforeEach(func() {
-			secret = &corev1.Secret{
+		It("should delete the secret if it exists", func() {
+			secretToDelete := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
 				},
 			}
-		})
 
-		It("should delete the secret if it exists", func() {
-			c.EXPECT().Delete(ctx, secret).Return(nil)
+			Expect(fakeClient.Create(ctx, secretToDelete)).To(Succeed())
 
-			err := kubernetesutils.DeleteSecretByReference(ctx, c, secretRef)
+			err := kubernetesutils.DeleteSecretByReference(ctx, fakeClient, secretRef)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the secret was deleted
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretToDelete), &corev1.Secret{})).To(BeNotFoundError())
 		})
 
 		It("should succeed if the secret doesn't exist", func() {
-			c.EXPECT().Delete(ctx, secret).Return(apierrors.NewNotFound(corev1.Resource("secret"), name))
-
-			err := kubernetesutils.DeleteSecretByReference(ctx, c, secretRef)
+			err := kubernetesutils.DeleteSecretByReference(ctx, fakeClient, secretRef)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fail if deleting the secret failed", func() {
-			c.EXPECT().Delete(ctx, secret).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			err := kubernetesutils.DeleteSecretByReference(ctx, c, secretRef)
+			err := kubernetesutils.DeleteSecretByReference(ctx, fakeClient, secretRef)
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("#DeleteSecretByObjectReference", func() {
-		BeforeEach(func() {
-			secret = &corev1.Secret{
+		It("should delete the secret if it exists", func() {
+			secretToDelete := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
 				},
 			}
-		})
 
-		It("should delete the secret if it exists", func() {
-			c.EXPECT().Delete(ctx, secret).Return(nil)
+			Expect(fakeClient.Create(ctx, secretToDelete)).To(Succeed())
 
-			err := kubernetesutils.DeleteSecretByObjectReference(ctx, c, objectRef)
+			err := kubernetesutils.DeleteSecretByObjectReference(ctx, fakeClient, objectRef)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the secret was deleted
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secretToDelete), &corev1.Secret{})).To(BeNotFoundError())
 		})
 
 		It("should succeed if the secret doesn't exist", func() {
-			c.EXPECT().Delete(ctx, secret).Return(apierrors.NewNotFound(corev1.Resource("secret"), name))
-
-			err := kubernetesutils.DeleteSecretByObjectReference(ctx, c, objectRef)
+			err := kubernetesutils.DeleteSecretByObjectReference(ctx, fakeClient, objectRef)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fail if deleting the secret failed", func() {
-			c.EXPECT().Delete(ctx, secret).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			err := kubernetesutils.DeleteSecretByObjectReference(ctx, c, objectRef)
+			err := kubernetesutils.DeleteSecretByObjectReference(ctx, fakeClient, objectRef)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fail if object reference is nil", func() {
-			err := kubernetesutils.DeleteSecretByObjectReference(ctx, c, nil)
+			err := kubernetesutils.DeleteSecretByObjectReference(ctx, fakeClient, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ref is nil"))
 		})
@@ -385,7 +423,7 @@ var _ = Describe("secretref", func() {
 				Namespace:  namespace,
 			}
 
-			err := kubernetesutils.DeleteSecretByObjectReference(ctx, c, ref)
+			err := kubernetesutils.DeleteSecretByObjectReference(ctx, fakeClient, ref)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("objectRef does not refer to secret"))
 		})
@@ -393,20 +431,25 @@ var _ = Describe("secretref", func() {
 
 	Describe("#GetCredentialsByCrossVersionObjectReference", func() {
 		It("should get referenced Secret", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-				*s = *secret
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, secret.DeepCopy())).To(Succeed())
 
-			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, *crossVersionRef, namespace)
+			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, *crossVersionRef, namespace)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(secret))
+			Expect(result.GetName()).To(Equal(secret.Name))
+			Expect(result.GetNamespace()).To(Equal(secret.Namespace))
 		})
 
 		It("should fail to get referenced Secret if reading it fails", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, *crossVersionRef, namespace)
+			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, *crossVersionRef, namespace)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -418,14 +461,12 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, wi *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-				*wi = *workloadIdentity
-				return nil
-			})
+			Expect(fakeClient.Create(ctx, workloadIdentity.DeepCopy())).To(Succeed())
 
-			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, ref, namespace)
+			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, ref, namespace)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(workloadIdentity))
+			Expect(result.GetName()).To(Equal(workloadIdentity.Name))
+			Expect(result.GetNamespace()).To(Equal(workloadIdentity.Namespace))
 		})
 
 		It("should fail to get referenced WorkloadIdentity if reading it fails", func() {
@@ -435,9 +476,16 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).Return(fmt.Errorf("error"))
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return fmt.Errorf("error")
+					},
+				}).
+				Build()
 
-			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, ref, namespace)
+			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, ref, namespace)
 			Expect(err).To(HaveOccurred())
 			Expect(result).To(BeNil())
 		})
@@ -449,20 +497,19 @@ var _ = Describe("secretref", func() {
 				Name:       name,
 			}
 
-			_, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, ref, namespace)
+			_, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, ref, namespace)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("unsupported credentials reference: garden/foo, foo.bar/v1alpha1, Kind=Baz"))
 		})
 
 		It("should use the provided namespace parameter", func() {
 			differentNamespace := "different-namespace"
-			secret.Namespace = differentNamespace
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: differentNamespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret, _ ...client.GetOption) error {
-				*s = *secret
-				return nil
-			})
+			secretInDifferentNs := secret.DeepCopy()
+			secretInDifferentNs.Namespace = differentNamespace
 
-			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, c, *crossVersionRef, differentNamespace)
+			Expect(fakeClient.Create(ctx, secretInDifferentNs)).To(Succeed())
+
+			result, err := kubernetesutils.GetCredentialsByCrossVersionObjectReference(ctx, fakeClient, *crossVersionRef, differentNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.GetNamespace()).To(Equal(differentNamespace))
 		})

--- a/pkg/utils/kubernetes/statefulset_test.go
+++ b/pkg/utils/kubernetes/statefulset_test.go
@@ -6,26 +6,25 @@ package kubernetes_test
 
 import (
 	"context"
-	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 )
 
 var _ = Describe("Statefulset.", func() {
 	Describe("#GetContainerResourcesInStatefulSet", func() {
 		var (
-			ctrl              *gomock.Controller
-			c                 *mockclient.MockClient
+			ctx               = context.TODO()
+			fakeClient        client.Client
 			testNamespace     string
 			testStatefulset   string
 			statefulSet       *appsv1.StatefulSet
@@ -33,6 +32,8 @@ var _ = Describe("Statefulset.", func() {
 		)
 
 		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+
 			expectedResources = &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -44,8 +45,6 @@ var _ = Describe("Statefulset.", func() {
 				},
 			}
 
-			ctrl = gomock.NewController(GinkgoT())
-			c = mockclient.NewMockClient(ctrl)
 			testNamespace = "test-namespace"
 			testStatefulset = "test-vali"
 
@@ -62,35 +61,22 @@ var _ = Describe("Statefulset.", func() {
 			}
 		})
 
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		It("should return container resources when statefulset contains one container", func() {
-			var (
-				ctx = context.TODO()
-			)
-
 			statefulSet.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:      "container-1",
 					Resources: *expectedResources,
 				},
 			}
+			Expect(fakeClient.Create(ctx, statefulSet)).To(Succeed())
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
-
-			rr, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
+			rr, err := GetContainerResourcesInStatefulSet(ctx, fakeClient, client.ObjectKeyFromObject(statefulSet))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
+			Expect(rr).To(HaveLen(1))
 			Expect(rr["container-1"]).To(Equal(expectedResources))
 		})
 
 		It("should return all container resources when statefulset contains two containers", func() {
-			var (
-				ctx = context.TODO()
-			)
-
 			statefulSet.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:      "container-1",
@@ -101,25 +87,19 @@ var _ = Describe("Statefulset.", func() {
 					Resources: *expectedResources,
 				},
 			}
+			Expect(fakeClient.Create(ctx, statefulSet)).To(Succeed())
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
-
-			rr, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
+			rr, err := GetContainerResourcesInStatefulSet(ctx, fakeClient, client.ObjectKeyFromObject(statefulSet))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
+			Expect(rr).To(HaveLen(2))
 			Expect(rr["container-1"]).To(Equal(expectedResources))
 			Expect(rr["container-2"]).To(Equal(expectedResources))
 		})
 
-		It("should return error if statefulSet is not found", func() {
-			var (
-				ctx = context.TODO()
-			)
-
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset}, gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(errors.New("error"))
-
-			_, err := GetContainerResourcesInStatefulSet(ctx, c, client.ObjectKey{Namespace: testNamespace, Name: testStatefulset})
-			Expect(err).To(HaveOccurred())
+		It("should return nil if statefulSet is not found", func() {
+			rr, err := GetContainerResourcesInStatefulSet(ctx, fakeClient, client.ObjectKeyFromObject(statefulSet))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

This is **Part 1** of a multi-PR series migrating test suites from `mock` clients to `fake` clients across the codebase. This PR covers two packages:

- `pkg/controllermanager/` 
- `pkg/utils/` 

`fake` clients from `sigs.k8s.io/controller-runtime/pkg/client/fake` are easier to maintain, remove the need for expectation-heavy mock setup, and more closely reflect real API server behavior by operating on an in-memory object store.


**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14572

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
