### PR TITLE
[GEP-28] Validate cluster type for `--print-join-command` and `--print-connect-command` in `gardenadm token create`

### DIFF
--- a/pkg/gardenadm/cmd/token/create/create.go
+++ b/pkg/gardenadm/cmd/token/create/create.go
@@ -10,10 +10,14 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
 	tokenutils "github.com/gardener/gardener/pkg/gardenadm/cmd/token/utils"
@@ -75,6 +79,18 @@ func run(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed creating client set: %w", err)
 	}
 
+	if opts.PrintJoinCommand {
+		if err := validateIsShootCluster(ctx, clientSet.Client()); err != nil {
+			return fmt.Errorf("failed validating that the cluster is a Shoot: %w", err)
+		}
+	}
+
+	if opts.PrintConnectCommand {
+		if err := validateIsGardenCluster(clientSet.Client()); err != nil {
+			return fmt.Errorf("failed validating that the cluster is the garden: %w", err)
+		}
+	}
+
 	if err := clientSet.Client().Get(ctx, client.ObjectKey{Name: bootstraptokenutil.BootstrapTokenSecretName(opts.Token.ID), Namespace: metav1.NamespaceSystem}, &corev1.Secret{}); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("failed checking if bootstrap token with ID %q already exists: %w", opts.Token.ID, err)
 	} else if err == nil {
@@ -116,4 +132,26 @@ func printConnectCommand(clientSet kubernetes.Interface, bootstrapTokenSecret *c
 		utils.EncodeBase64(clientSet.RESTConfig().CAData),
 		clientSet.RESTConfig().Host,
 	)
+}
+
+func validateIsShootCluster(ctx context.Context, c client.Client) error {
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ConfigMapNameShootInfo, Namespace: metav1.NamespaceSystem}}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(configMap), configMap); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed checking whether cluster is a Shoot: %w", err)
+		}
+		return fmt.Errorf("`--print-join-command` can only be used when the kubeconfig points to a Shoot cluster (the %q ConfigMap was not found in the %q namespace)", v1beta1constants.ConfigMapNameShootInfo, metav1.NamespaceSystem)
+	}
+	return nil
+}
+
+func validateIsGardenCluster(c client.Client) error {
+	shootGVK := gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")
+	if _, err := c.RESTMapper().RESTMapping(shootGVK.GroupKind(), shootGVK.Version); err != nil {
+		if !meta.IsNoMatchError(err) {
+			return fmt.Errorf("failed checking whether cluster is the garden: %w", err)
+		}
+		return fmt.Errorf("`--print-connect-command` can only be used when the kubeconfig points to the garden cluster (the %q API is not available)", gardencorev1beta1.SchemeGroupVersion)
+	}
+	return nil
 }

--- a/pkg/gardenadm/cmd/token/create/create_test.go
+++ b/pkg/gardenadm/cmd/token/create/create_test.go
@@ -13,11 +13,15 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenadm/cmd"
@@ -97,7 +101,13 @@ var _ = Describe("Create", func() {
 				Expect(command.Flags().Set("print-join-command", "true")).To(Succeed())
 			})
 
+			It("should return an error because the cluster is not a Shoot", func() {
+				Expect(command.RunE(command, []string{token})).To(MatchError(ContainSubstring("`--print-join-command` can only be used when the kubeconfig points to a Shoot cluster")))
+			})
+
 			It("should successfully print the join command", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ConfigMapNameShootInfo, Namespace: metav1.NamespaceSystem}})).To(Succeed())
+
 				Expect(command.RunE(command, []string{token})).To(Succeed())
 				Eventually(stdOut).Should(Say(`gardenadm join --bootstrap-token abcdef.1234567890abcdef --ca-certificate "Y2EtZGF0YQ==" some-host
 `))
@@ -111,7 +121,17 @@ var _ = Describe("Create", func() {
 				Expect(command.Flags().Set("shoot-namespace", "namespace")).To(Succeed())
 			})
 
+			It("should return an error because the cluster is not a garden", func() {
+				Expect(command.RunE(command, []string{token})).To(MatchError(ContainSubstring("`--print-connect-command` can only be used when the kubeconfig points to the garden cluster")))
+			})
+
 			It("should successfully print the connect command", func() {
+				restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gardencorev1beta1.SchemeGroupVersion})
+				restMapper.Add(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"), meta.RESTScopeNamespace)
+
+				fakeClient = fakeclient.NewClientBuilder().WithRESTMapper(restMapper).Build()
+				clientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).WithRESTConfig(restConfig).Build()
+
 				Expect(command.RunE(command, []string{token})).To(Succeed())
 				Eventually(stdOut).Should(Say(`gardenadm connect --bootstrap-token abcdef.1234567890abcdef --ca-certificate "Y2EtZGF0YQ==" some-host
 `))


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
`gardenadm token create --print-join-command` now validates that the kubeconfig points to a Shoot cluster by checking for the `shoot-info` ConfigMap in `kube-system`. `gardenadm token create --print-connect-command` validates that the kubeconfig points to the garden cluster by checking whether the `core.gardener.cloud/v1beta1` API is available via the REST mapper. This prevents users from accidentally creating bootstrap tokens against the wrong cluster.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```other developer
NONE
```