### PR TITLE
Replace `Ingress` exposure of OpenTelemetry Collector with Istio-native exposure

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -11,8 +11,9 @@ import (
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,7 @@ import (
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	collectorconstants "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector/constants"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/istio"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -67,6 +69,8 @@ type Values struct {
 	ShootNodeLoggingEnabled bool
 	// IngressHost is the name for the ingress to access the OpenTelemetry Collector.
 	IngressHost string
+	// IstioIngressGatewayLabels are the labels for identifying the used istio ingress gateway.
+	IstioIngressGatewayLabels map[string]string
 	// SecretNameServerCA is the name of the server CA secret.
 	SecretNameServerCA string
 	// PriorityClassName is the priority class name for the OpenTelemetry Collector pods.
@@ -152,7 +156,12 @@ func (o *otelCollector) Deploy(ctx context.Context) error {
 		}
 		genericTokenKubeconfigSecretName = genericTokenKubeconfigSecret.Name
 
-		objects = append(objects, o.getIngress(ingressTLSSecret.Name))
+		istioResources, err := o.getIstioResources(ingressTLSSecret)
+		if err != nil {
+			return fmt.Errorf("failed to get istio resources: %w", err)
+		}
+
+		objects = append(objects, istioResources...)
 
 		kubeRBACProxyClusterRoleBinding := o.getKubeRBACProxyClusterRoleBinding(kubeRBACProxyShootAccessSecret.ServiceAccountName)
 		loggingAgentClusterRole := o.getLoggingAgentClusterRole()
@@ -627,6 +636,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationPrefix+v1beta1constants.LabelNetworkPolicyScrapeTargets+resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix, fmt.Sprintf(`[{"protocol":"TCP","port":%d}]`, metricsPort))
 		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias, v1beta1constants.LabelNetworkPolicyShootNamespaceAlias)
 		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, resourcesv1alpha1.NetworkingNamespaceSelectors, `[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]`)
+		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "networking.istio.io/exportTo", "*")
 	}
 
 	return obj
@@ -639,60 +649,86 @@ func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.Access
 		WithTargetSecret(collectorconstants.OpenTelemetryCollectorSecretName, metav1.NamespaceSystem)
 }
 
-func (o *otelCollector) getIngress(secretName string) *networkingv1.Ingress {
-	return &networkingv1.Ingress{
+func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Object, error) {
+	var (
+		// Currently, all observability components are exposed via the same istio ingress gateway.
+		// When zonal gateways or exposure classes should be considered, the namespace needs to be dynamic.
+		// See https://github.com/gardener/gardener/issues/11860 for details.
+		ingressNamespace = v1beta1constants.DefaultSNIIngressNamespace
+		name             = "logging"
+	)
+
+	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
+	tlsSecretInIstioNamespace := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "logging",
-			Namespace: o.namespace,
-			// TODO(rrrhubenov): Research whether this annotation is required before promoting the `OpenTelemetryCollector` feature gate to GA.
-			Annotations: map[string]string{"nginx.ingress.kubernetes.io/backend-protocol": "GRPC"},
-			Labels:      getLabels(),
+			Name:      fmt.Sprintf("%s-%s-%s", o.namespace, name, tlsSecret.Name),
+			Namespace: ingressNamespace,
+			Labels:    getLabels(),
 		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
-			TLS: []networkingv1.IngressTLS{{
-				SecretName: secretName,
-				Hosts:      []string{o.values.IngressHost, o.values.ValiHost},
-			}},
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: o.values.IngressHost,
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{{
-								Backend: networkingv1.IngressBackend{
-									Service: &networkingv1.IngressServiceBackend{
-										Name: collectorconstants.ServiceName,
-										Port: networkingv1.ServiceBackendPort{Number: collectorconstants.KubeRBACProxyOTLPReceiverPort},
-									},
-								},
-								Path:     collectorconstants.PushEndpoint,
-								PathType: ptr.To(networkingv1.PathTypePrefix),
-							}},
-						},
-					},
+		Data: tlsSecret.Data,
+	}
+
+	gateway := &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: o.namespace}}
+	if err := istio.GatewayWithTLSTermination(
+		gateway,
+		getLabels(),
+		o.values.IstioIngressGatewayLabels,
+		[]string{o.values.IngressHost},
+		kubeapiserverconstants.Port,
+		tlsSecretInIstioNamespace.Name,
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create gateway resource: %w", err)
+	}
+
+	destinationHost := kubernetesutils.FQDNForService(collectorconstants.ServiceName, o.namespace)
+	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: o.namespace}}
+	if err := istio.VirtualServiceForTLSTermination(
+		virtualService,
+		getLabels(),
+		[]string{o.values.IngressHost},
+		name,
+		uint32(collectorconstants.KubeRBACProxyOTLPReceiverPort),
+		destinationHost,
+		"",
+		"",
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
+	}
+	if len(virtualService.Spec.Http) < 1 {
+		return nil, fmt.Errorf("unexpected number of HTTP routes in virtual service: got %d, want at least 1", len(virtualService.Spec.Http))
+	}
+	virtualService.Spec.Http[0].Match = []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+		Uri: &istioapinetworkingv1beta1.StringMatch{
+			MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{
+				Prefix: collectorconstants.PushEndpoint,
+			},
+		},
+	}}
+	// TODO(rrhubenov): Clean up the vali Ingress rule when the `OpenTelemetryCollector` feature gate is promoted to GA.
+	virtualService.Spec.Http = append(virtualService.Spec.Http, &istioapinetworkingv1beta1.HTTPRoute{
+		Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+			Uri: &istioapinetworkingv1beta1.StringMatch{
+				MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{
+					Prefix: valiconstants.PushEndpoint,
 				},
-				// TODO(rrhubenov): Clean up the vali Ingress rule when the `OpenTelemetryCollector` feature gate is promoted to GA.
-				{
-					Host: o.values.ValiHost,
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{{
-								Backend: networkingv1.IngressBackend{
-									Service: &networkingv1.IngressServiceBackend{
-										Name: collectorconstants.ServiceName,
-										Port: networkingv1.ServiceBackendPort{Number: collectorconstants.KubeRBACProxyValiPort},
-									},
-								},
-								Path:     valiconstants.PushEndpoint,
-								PathType: ptr.To(networkingv1.PathTypePrefix),
-							}},
-						},
-					},
+			},
+		}},
+		Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+			{
+				Destination: &istioapinetworkingv1beta1.Destination{
+					Host: destinationHost,
+					Port: &istioapinetworkingv1beta1.PortSelector{Number: uint32(collectorconstants.KubeRBACProxyValiPort)},
 				},
 			},
 		},
+	})
+
+	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: o.namespace}}
+	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, getLabels(), destinationHost)(); err != nil {
+		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
 	}
+
+	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }
 
 func (o *otelCollector) getLoggingAgentClusterRole() *rbacv1.ClusterRole {

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +32,7 @@ import (
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
+	comptest "github.com/gardener/gardener/pkg/component/test"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -102,7 +106,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		fakeSecretManager = fakesecretsmanager.New(c, namespace)
 		component = New(c, namespace, values, fakeSecretManager)
-		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(c, comptest.CmpOptsForIstio()...)
 
 		By("Create secrets managed outside of this package for which secretsmanager.Get() will be called")
 		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
@@ -328,6 +332,7 @@ var _ = Describe("OpenTelemetry Collector", func() {
 						resourcesv1alpha1.NetworkPolicyFromPolicyAnnotationSuffix: `[{"protocol":"TCP","port":8888}]`,
 					resourcesv1alpha1.NetworkingPodLabelSelectorNamespaceAlias: v1beta1constants.LabelNetworkPolicyShootNamespaceAlias,
 					resourcesv1alpha1.NetworkingNamespaceSelectors:             `[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]`,
+					"networking.istio.io/exportTo":                             "*",
 				},
 			},
 			Spec: otelv1beta1.OpenTelemetryCollectorSpec{
@@ -531,6 +536,14 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			component.WithAuthenticationProxy(false)
 			Expect(component.Deploy(ctx)).To(Succeed())
 
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "logging-tls",
+					Namespace: namespace,
+				},
+			}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
+
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			expectedMr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -556,7 +569,10 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			customResourcesManagedResourceSecret.Name = customResourcesManagedResource.Spec.SecretRefs[0].Name
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
-				getIngress(),
+				getGateway(),
+				getVirtualService(),
+				getDestinationRule(),
+				getTLSSecret(tlsSecret),
 				serviceMonitor,
 				serviceAccount,
 			))
@@ -575,6 +591,14 @@ var _ = Describe("OpenTelemetry Collector", func() {
 
 			component.WithAuthenticationProxy(true)
 			Expect(component.Deploy(ctx)).To(Succeed())
+
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "logging-tls",
+					Namespace: namespace,
+				},
+			}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
 			expectedMr := &resourcesv1alpha1.ManagedResource{
@@ -610,7 +634,10 @@ var _ = Describe("OpenTelemetry Collector", func() {
 			metav1.SetMetaDataLabel(&openTelemetryCollector.ObjectMeta, "networking.resources.gardener.cloud/to-kube-apiserver-tcp-443", "allowed")
 			Expect(customResourcesManagedResource).To(consistOf(
 				openTelemetryCollector,
-				getIngress(),
+				getGateway(),
+				getVirtualService(),
+				getDestinationRule(),
+				getTLSSecret(tlsSecret),
 				serviceMonitor,
 				serviceAccount,
 			))
@@ -789,70 +816,120 @@ var _ = Describe("OpenTelemetry Collector", func() {
 	})
 })
 
-func getIngress() *networkingv1.Ingress {
-	pathType := networkingv1.PathTypePrefix
-	annotations := map[string]string{"nginx.ingress.kubernetes.io/backend-protocol": "GRPC"}
-
-	return &networkingv1.Ingress{
+func getGateway() *istionetworkingv1beta1.Gateway {
+	return &istionetworkingv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        ingressName,
-			Namespace:   namespace,
-			Annotations: annotations,
-			Labels:      getLabels(),
+			Name:      "logging",
+			Namespace: namespace,
+			Labels:    getLabels(),
 		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: ptr.To("nginx-ingress-gardener"),
-			TLS: []networkingv1.IngressTLS{
+		Spec: istioapinetworkingv1beta1.Gateway{
+			Servers: []*istioapinetworkingv1beta1.Server{{
+				Port: &istioapinetworkingv1beta1.Port{
+					Name:     "tls",
+					Number:   443,
+					Protocol: "HTTPS",
+				},
+				Hosts: []string{ingressHost},
+				Tls: &istioapinetworkingv1beta1.ServerTLSSettings{
+					Mode:           istioapinetworkingv1beta1.ServerTLSSettings_SIMPLE,
+					CredentialName: "some-namespace-logging-logging-tls",
+				},
+			}},
+		},
+	}
+}
+
+func getVirtualService() *istionetworkingv1beta1.VirtualService {
+	return &istionetworkingv1beta1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "logging",
+			Namespace: namespace,
+			Labels:    getLabels(),
+		},
+		Spec: istioapinetworkingv1beta1.VirtualService{
+			ExportTo: []string{"*"},
+			Gateways: []string{"logging"},
+			Hosts:    []string{ingressHost},
+			Http: []*istioapinetworkingv1beta1.HTTPRoute{
 				{
-					SecretName: "logging-tls",
-					Hosts:      []string{ingressHost, valiHost},
+					Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+						Uri: &istioapinetworkingv1beta1.StringMatch{
+							MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/opentelemetry.proto.collector.logs.v1.LogsService/Export"},
+						},
+					}},
+					Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{{
+						Destination: &istioapinetworkingv1beta1.Destination{
+							Host: "opentelemetry-collector-collector.some-namespace.svc.cluster.local",
+							Port: &istioapinetworkingv1beta1.PortSelector{
+								Number: 8080,
+							},
+						},
+					}},
+				},
+				{
+					Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{
+						Uri: &istioapinetworkingv1beta1.StringMatch{
+							MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{Prefix: "/vali/api/v1/push"},
+						},
+					}},
+					Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{{
+						Destination: &istioapinetworkingv1beta1.Destination{
+							Host: "opentelemetry-collector-collector.some-namespace.svc.cluster.local",
+							Port: &istioapinetworkingv1beta1.PortSelector{
+								Number: 8081,
+							},
+						},
+					}},
 				},
 			},
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: ingressHost,
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "opentelemetry-collector-collector",
-											Port: networkingv1.ServiceBackendPort{
-												Number: 8080,
-											},
-										},
-									},
-									Path:     "/opentelemetry.proto.collector.logs.v1.LogsService/Export",
-									PathType: &pathType,
-								},
-							},
+		},
+	}
+}
+
+func getDestinationRule() *istionetworkingv1beta1.DestinationRule {
+	return &istionetworkingv1beta1.DestinationRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "logging",
+			Namespace: namespace,
+			Labels:    getLabels(),
+		},
+		Spec: istioapinetworkingv1beta1.DestinationRule{
+			ExportTo: []string{"*"},
+			Host:     "opentelemetry-collector-collector.some-namespace.svc.cluster.local",
+			TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
+				LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+					LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+						FailoverPriority: []string{"topology.kubernetes.io/zone"},
+						Enabled: &wrapperspb.BoolValue{
+							Value: true,
 						},
 					},
 				},
-				{
-					Host: valiHost,
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "opentelemetry-collector-collector",
-											Port: networkingv1.ServiceBackendPort{
-												Number: 8081,
-											},
-										},
-									},
-									Path:     "/vali/api/v1/push",
-									PathType: &pathType,
-								},
-							},
+				ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
+					Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
+						TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+							Time:     &durationpb.Duration{Seconds: 7200},
+							Interval: &durationpb.Duration{Seconds: 75},
 						},
+						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
 					},
 				},
+				OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{},
+				Tls:              &istioapinetworkingv1beta1.ClientTLSSettings{},
 			},
 		},
+	}
+}
+
+func getTLSSecret(tlsSecret *corev1.Secret) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-namespace-logging-logging-tls",
+			Namespace: "istio-ingress",
+			Labels:    getLabels(),
+		},
+		Data: tlsSecret.Data,
 	}
 }
 

--- a/pkg/gardenlet/operation/botanist/logging.go
+++ b/pkg/gardenlet/operation/botanist/logging.go
@@ -193,22 +193,28 @@ func (b *Botanist) DefaultOtelCollector() (collector.Interface, error) {
 		return nil, err
 	}
 
+	var istioLabels map[string]string
+	if !b.Shoot.IsSelfHosted() {
+		istioLabels = b.WildcardIstioLabels()
+	}
+
 	return collector.New(
 		b.SeedClientSet.Client(),
 		b.Shoot.ControlPlaneNamespace,
 		collector.Values{
-			Image:                   collectorImage.String(),
-			KubeRBACProxyImage:      kubeRBACProxyImage.String(),
-			LokiEndpoint:            "http://" + valiconstants.ServiceName + ":" + strconv.Itoa(valiconstants.ValiPort) + valiconstants.PushEndpoint,
-			Replicas:                b.Shoot.GetReplicas(1),
-			ShootNodeLoggingEnabled: b.isShootNodeLoggingEnabled(),
-			IngressHost:             b.ComputeOpenTelemetryCollectorHost(),
-			SecretNameServerCA:      v1beta1constants.SecretNameCACluster,
-			PriorityClassName:       v1beta1constants.PriorityClassNameShootControlPlane100,
-			ValiHost:                b.ComputeValiHost(),
-			ClusterType:             component.ClusterTypeShoot,
-			IsGardenCluster:         false,
-			VictoriaLogsBackend:     features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
+			Image:                     collectorImage.String(),
+			KubeRBACProxyImage:        kubeRBACProxyImage.String(),
+			LokiEndpoint:              "http://" + valiconstants.ServiceName + ":" + strconv.Itoa(valiconstants.ValiPort) + valiconstants.PushEndpoint,
+			Replicas:                  b.Shoot.GetReplicas(1),
+			ShootNodeLoggingEnabled:   b.isShootNodeLoggingEnabled(),
+			IngressHost:               b.ComputeOpenTelemetryCollectorHost(),
+			SecretNameServerCA:        v1beta1constants.SecretNameCACluster,
+			PriorityClassName:         v1beta1constants.PriorityClassNameShootControlPlane100,
+			ValiHost:                  b.ComputeValiHost(),
+			ClusterType:               component.ClusterTypeShoot,
+			IsGardenCluster:           false,
+			IstioIngressGatewayLabels: istioLabels,
+			VictoriaLogsBackend:       features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
 		},
 		b.SecretsManager,
 	), nil


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is based on #14567 which must be merged first. This PR remains in draft state until then.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:

As `nginx-ingress` is retired, we need to change the exposure of `opentelemetry-collector`, which is currently exposed via `nginx-ingress`. Istio ingress gateway is already deployed everywhere `opentelemetry-collector` is running. Hence, it is a simple choice to switch to it.

Istio allows exposure via a multitude of APIs, among them `Ingress`, istio-native `Gateway`, and Gateway API. The `Ingress` support in istio was never really on par. Hence, we will not use it. Gateway API does not cover all use cases we need. Therefore, we use the same istio-native APIs, which we already use for `kube-apiserver` exposure. This unifies our ingress traffic architecture and simplifies it eventually when `nginx-ingress` is no longer used.

This change is the adaption of `opentelemetry-collector` to istio-native exposure.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/13448

**Special notes for your reviewer**:

The change is analogous to https://github.com/gardener/gardener/pull/14142.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OpenTelemetry Collector is now exposed directly via istio instead of nginx-ingress
```

/cc @rfranzke @axel7born @DockToFuture @domdom82