### PR TITLE
Replace `Ingress` exposure of Gardener Dashboard with Istio-native exposure

### DIFF
--- a/pkg/component/gardener/dashboard/dashboard.go
+++ b/pkg/component/gardener/dashboard/dashboard.go
@@ -86,6 +86,8 @@ type IngressValues struct {
 	Enabled bool
 	// Domains is the list of ingress domains.
 	Domains []string
+	// IstioIngressGatewayLabels are the labels for identifying the used istio ingress gateway.
+	IstioIngressGatewayLabels map[string]string
 	// WildcardCertSecretName is name of a secret containing the wildcard TLS certificate which is issued for the
 	// ingress domains. If not provided, a self-signed server certificate will be created.
 	WildcardCertSecretName *string
@@ -151,12 +153,12 @@ func (g *gardenerDashboard) Deploy(ctx context.Context) error {
 	}
 
 	if g.values.Ingress.Enabled {
-		ingress, err := g.ingress(ctx)
+		istioResources, err := g.istioResources(ctx)
 		if err != nil {
 			return err
 		}
 
-		if err := runtimeRegistry.Add(ingress); err != nil {
+		if err := runtimeRegistry.Add(istioResources...); err != nil {
 			return err
 		}
 	}

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/onsi/gomega/types"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,6 +39,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/gardener/dashboard"
+	comptest "github.com/gardener/gardener/pkg/component/test"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/gardener"
@@ -88,7 +92,10 @@ var _ = Describe("GardenerDashboard", func() {
 		service                   *corev1.Service
 		podDisruptionBudget       *policyv1.PodDisruptionBudget
 		vpa                       *vpaautoscalingv1.VerticalPodAutoscaler
-		ingress                   *networkingv1.Ingress
+		gateway                   *istionetworkingv1beta1.Gateway
+		virtualService            *istionetworkingv1beta1.VirtualService
+		destinationRule           *istionetworkingv1beta1.DestinationRule
+		tlsSecret                 *corev1.Secret
 		serviceMonitor            *monitoringv1.ServiceMonitor
 
 		clusterRole                      *rbacv1.ClusterRole
@@ -120,7 +127,7 @@ var _ = Describe("GardenerDashboard", func() {
 			&retry.UntilTimeout, fakeOps.UntilTimeout,
 		))
 
-		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(fakeClient, comptest.CmpOptsForIstio()...)
 
 		managedResourceRuntime = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
@@ -587,6 +594,7 @@ frontend:
 				},
 				Annotations: map[string]string{
 					"networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports": `[{"protocol":"TCP","port":9050}]`,
+					"networking.istio.io/exportTo": "*",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -663,7 +671,7 @@ frontend:
 				},
 			},
 		}
-		ingress = &networkingv1.Ingress{
+		gateway = &istionetworkingv1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "gardener-dashboard",
 				Namespace: namespace,
@@ -671,52 +679,89 @@ frontend:
 					"app":  "gardener",
 					"role": "dashboard",
 				},
-				Annotations: map[string]string{
-					"nginx.ingress.kubernetes.io/ssl-redirect":          "true",
-					"nginx.ingress.kubernetes.io/use-port-in-redirects": "true",
+			},
+			Spec: istioapinetworkingv1beta1.Gateway{
+				Servers: []*istioapinetworkingv1beta1.Server{{
+					Port: &istioapinetworkingv1beta1.Port{
+						Name:     "tls",
+						Number:   443,
+						Protocol: "HTTPS",
+					},
+					Hosts: []string{"dashboard.first", "dashboard.second"},
+					Tls: &istioapinetworkingv1beta1.ServerTLSSettings{
+						Mode:           istioapinetworkingv1beta1.ServerTLSSettings_SIMPLE,
+						CredentialName: "some-namespace-gardener-dashboard-gardener-dashboard-tls",
+					},
+				}},
+			},
+		}
+		virtualService = &istionetworkingv1beta1.VirtualService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-dashboard",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "dashboard",
 				},
 			},
-			Spec: networkingv1.IngressSpec{
-				IngressClassName: ptr.To("nginx-ingress-gardener"),
-				TLS: []networkingv1.IngressTLS{{
-					SecretName: "gardener-dashboard-tls",
-					Hosts:      []string{"dashboard.first", "dashboard.second"},
+			Spec: istioapinetworkingv1beta1.VirtualService{
+				ExportTo: []string{"*"},
+				Gateways: []string{"gardener-dashboard"},
+				Hosts:    []string{"dashboard.first", "dashboard.second"},
+				Http: []*istioapinetworkingv1beta1.HTTPRoute{{
+					Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{
+						{
+							Destination: &istioapinetworkingv1beta1.Destination{
+								Host: "gardener-dashboard.some-namespace.svc.cluster.local",
+								Port: &istioapinetworkingv1beta1.PortSelector{
+									Number: 8080,
+								},
+							},
+						},
+					},
 				}},
-				Rules: []networkingv1.IngressRule{
-					{
-						Host: "dashboard.first",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "gardener-dashboard",
-											Port: networkingv1.ServiceBackendPort{Number: 8080},
-										},
-									},
-									Path:     "/",
-									PathType: ptr.To(networkingv1.PathTypePrefix),
-								}},
-							},
+			},
+		}
+		destinationRule = &istionetworkingv1beta1.DestinationRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener-dashboard",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "dashboard",
+				},
+			},
+			Spec: istioapinetworkingv1beta1.DestinationRule{
+				ExportTo: []string{"*"},
+				Host:     "gardener-dashboard.some-namespace.svc.cluster.local",
+				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
+					LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+						LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+							FailoverPriority: []string{"topology.kubernetes.io/zone"},
+							Enabled:          wrapperspb.Bool(true),
 						},
 					},
-					{
-						Host: "dashboard.second",
-						IngressRuleValue: networkingv1.IngressRuleValue{
-							HTTP: &networkingv1.HTTPIngressRuleValue{
-								Paths: []networkingv1.HTTPIngressPath{{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "gardener-dashboard",
-											Port: networkingv1.ServiceBackendPort{Number: 8080},
-										},
-									},
-									Path:     "/",
-									PathType: ptr.To(networkingv1.PathTypePrefix),
-								}},
+					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
+						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
+							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+								Time:     &durationpb.Duration{Seconds: 7200},
+								Interval: &durationpb.Duration{Seconds: 75},
 							},
+							MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
 						},
 					},
+					OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{},
+					Tls:              &istioapinetworkingv1beta1.ClientTLSSettings{},
+				},
+			},
+		}
+		tlsSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-namespace-gardener-dashboard-gardener-dashboard-tls",
+				Namespace: "virtual-garden-istio-ingress",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "dashboard",
 				},
 			},
 		}
@@ -940,6 +985,15 @@ frontend:
 			JustBeforeEach(func() {
 				Expect(deployer.Deploy(ctx)).To(Succeed())
 
+				tlsSecretInGardenNamespace := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gardener-dashboard-tls",
+						Namespace: namespace,
+					},
+				}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(tlsSecretInGardenNamespace), tlsSecretInGardenNamespace)).To(Succeed())
+				tlsSecret.Data = tlsSecretInGardenNamespace.Data
+
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceRuntime), managedResourceRuntime)).To(Succeed())
 				expectedRuntimeMr := &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
@@ -992,7 +1046,10 @@ frontend:
 					service,
 					podDisruptionBudget,
 					vpa,
-					ingress,
+					gateway,
+					virtualService,
+					destinationRule,
+					tlsSecret,
 					serviceMonitor,
 				}
 				expectedVirtualObjects = []client.Object{

--- a/pkg/component/gardener/dashboard/ingress.go
+++ b/pkg/component/gardener/dashboard/ingress.go
@@ -52,11 +52,10 @@ func (g *gardenerDashboard) istioResources(ctx context.Context) ([]client.Object
 		}
 		tlsSecret = ingressTLSSecret
 	} else {
-		ingressTLSSecret, found := g.secretsManager.Get(tlsSecretName)
-		if !found {
-			return nil, fmt.Errorf("secret %q not found", tlsSecretName)
+		tlsSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tlsSecretName, Namespace: g.namespace}}
+		if err := g.client.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret); err != nil {
+			return nil, fmt.Errorf("failed to get TLS secret %q: %w", tlsSecretName, err)
 		}
-		tlsSecret = ingressTLSSecret
 	}
 
 	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace

--- a/pkg/component/gardener/dashboard/ingress.go
+++ b/pkg/component/gardener/dashboard/ingress.go
@@ -6,13 +6,19 @@ package dashboard
 
 import (
 	"context"
+	"fmt"
 
-	networkingv1 "k8s.io/api/networking/v1"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
+	"github.com/gardener/gardener/pkg/utils/istio"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
@@ -25,8 +31,13 @@ func (g *gardenerDashboard) ingressHosts() []string {
 	return hosts
 }
 
-func (g *gardenerDashboard) ingress(ctx context.Context) (*networkingv1.Ingress, error) {
-	tlsSecretName := ptr.Deref(g.values.Ingress.WildcardCertSecretName, "")
+func (g *gardenerDashboard) istioResources(ctx context.Context) ([]client.Object, error) {
+	var (
+		gatewayName   = deploymentName
+		tlsSecretName = ptr.Deref(g.values.Ingress.WildcardCertSecretName, "")
+		tlsSecret     *corev1.Secret
+	)
+
 	if tlsSecretName == "" {
 		ingressTLSSecret, err := g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
 			Name:                        deploymentName + "-tls",
@@ -39,47 +50,56 @@ func (g *gardenerDashboard) ingress(ctx context.Context) (*networkingv1.Ingress,
 		if err != nil {
 			return nil, err
 		}
-		tlsSecretName = ingressTLSSecret.Name
+		tlsSecret = ingressTLSSecret
+	} else {
+		ingressTLSSecret, found := g.secretsManager.Get(tlsSecretName)
+		if !found {
+			return nil, fmt.Errorf("secret %q not found", tlsSecretName)
+		}
+		tlsSecret = ingressTLSSecret
 	}
 
-	obj := &networkingv1.Ingress{
+	// Istio expects the secret in the istio ingress gateway namespace => copy certificate to istio namespace
+	tlsSecretInIstioNamespace := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploymentName,
-			Namespace: g.namespace,
+			Name:      fmt.Sprintf("%s-%s-%s", g.namespace, deploymentName, tlsSecret.Name),
+			Namespace: operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DefaultSNIIngressNamespace,
 			Labels:    GetLabels(),
-			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/ssl-redirect":          "true",
-				"nginx.ingress.kubernetes.io/use-port-in-redirects": "true",
-			},
 		},
-		Spec: networkingv1.IngressSpec{
-			IngressClassName: ptr.To(v1beta1constants.SeedNginxIngressClass),
-			TLS: []networkingv1.IngressTLS{{
-				SecretName: tlsSecretName,
-				Hosts:      g.ingressHosts(),
-			}},
-		},
+		Data: tlsSecret.Data,
 	}
 
-	for _, host := range g.ingressHosts() {
-		obj.Spec.Rules = append(obj.Spec.Rules, networkingv1.IngressRule{
-			Host: host,
-			IngressRuleValue: networkingv1.IngressRuleValue{
-				HTTP: &networkingv1.HTTPIngressRuleValue{
-					Paths: []networkingv1.HTTPIngressPath{{
-						Backend: networkingv1.IngressBackend{
-							Service: &networkingv1.IngressServiceBackend{
-								Name: serviceName,
-								Port: networkingv1.ServiceBackendPort{Number: portServer},
-							},
-						},
-						Path:     "/",
-						PathType: ptr.To(networkingv1.PathTypePrefix),
-					}},
-				},
-			},
-		})
+	gateway := &istionetworkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: g.namespace}}
+	if err := istio.GatewayWithTLSTermination(
+		gateway,
+		GetLabels(),
+		g.values.Ingress.IstioIngressGatewayLabels,
+		g.ingressHosts(),
+		kubeapiserverconstants.Port,
+		tlsSecretInIstioNamespace.Name,
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create gateway resource: %w", err)
 	}
 
-	return obj, nil
+	destinationHost := kubernetesutils.FQDNForService(serviceName, g.namespace)
+	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: g.namespace}}
+	if err := istio.VirtualServiceForTLSTermination(
+		virtualService,
+		GetLabels(),
+		g.ingressHosts(),
+		gatewayName,
+		portServer,
+		destinationHost,
+		"",
+		"",
+	)(); err != nil {
+		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
+	}
+
+	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: g.namespace}}
+	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, GetLabels(), destinationHost)(); err != nil {
+		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
+	}
+
+	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }

--- a/pkg/component/gardener/dashboard/service.go
+++ b/pkg/component/gardener/dashboard/service.go
@@ -20,9 +20,10 @@ const serviceName = deploymentName
 func (g *gardenerDashboard) service() *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: g.namespace,
-			Labels:    GetLabels(),
+			Name:        serviceName,
+			Namespace:   g.namespace,
+			Labels:      GetLabels(),
+			Annotations: map[string]string{"networking.istio.io/exportTo": "*"},
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -293,7 +293,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.gardenerDashboard, err = r.newGardenerDashboard(garden, secretsManager, wildcardCertSecretName)
+	c.gardenerDashboard, err = r.newGardenerDashboard(garden, secretsManager, wildcardCertSecretName, c.istio.GetValues().IngressGateway)
 	if err != nil {
 		return
 	}
@@ -1310,7 +1310,19 @@ func (r *Reconciler) newGardenerScheduler(garden *operatorv1alpha1.Garden, secre
 	return gardenerscheduler.New(r.RuntimeClientSet.Client(), r.GardenNamespace, secretsManager, values), nil
 }
 
-func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secretsManager secretsmanager.Interface, wildcardCertSecretName *string) (gardenerdashboard.Interface, error) {
+func (r *Reconciler) newGardenerDashboard(
+	garden *operatorv1alpha1.Garden,
+	secretsManager secretsmanager.Interface,
+	wildcardCertSecretName *string,
+	ingressGatewayValues []istio.IngressGatewayValues,
+) (
+	gardenerdashboard.Interface,
+	error,
+) {
+	if len(ingressGatewayValues) != 1 {
+		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the dashboard config")
+	}
+
 	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenerDashboard)
 	if err != nil {
 		return nil, err
@@ -1322,9 +1334,10 @@ func (r *Reconciler) newGardenerDashboard(garden *operatorv1alpha1.Garden, secre
 		APIServerURL:     v1beta1helper.GetAPIServerDomain(garden.Spec.VirtualCluster.DNS.Domains[0].Name),
 		EnableTokenLogin: true,
 		Ingress: gardenerdashboard.IngressValues{
-			Enabled:                true,
-			Domains:                domainNames(garden.Spec.RuntimeCluster.Ingress.Domains),
-			WildcardCertSecretName: wildcardCertSecretName,
+			Enabled:                   true,
+			Domains:                   domainNames(garden.Spec.RuntimeCluster.Ingress.Domains),
+			IstioIngressGatewayLabels: ingressGatewayValues[0].Labels,
+			WildcardCertSecretName:    wildcardCertSecretName,
 		},
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request is based on #14567 which must be merged first. This PR remains in draft state until then.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/area networking
/area security
/kind enhancement

**What this PR does / why we need it**:

As `nginx-ingress` is retired, we need to change the exposure of `gardener-dashboard`, which is currently exposed via `nginx-ingress`. Istio ingress gateway is already deployed everywhere `gardener-dashboard` is running. Hence, it is a simple choice to switch to it.

Istio allows exposure via a multitude of APIs, among them `Ingress`, istio-native `Gateway`, and Gateway API. The `Ingress` support in istio was never really on par. Hence, we will not use it. Gateway API does not cover all use cases we need. Therefore, we use the same istio-native APIs, which we already use for `kube-apiserver` exposure. This unifies our ingress traffic architecture and simplifies it eventually when `nginx-ingress` is no longer used.

This change is the adaption of `gardener-dashboard` to istio-native exposure.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/13448

**Special notes for your reviewer**:

The change is analogous to https://github.com/gardener/gardener/pull/14142.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener Dashboard is now exposed directly via istio instead of nginx-ingress
```

/cc @rfranzke @axel7born @DockToFuture @domdom82