### PR TITLE
Fix flaky integration test for node agent reconciliation delay reconciler in GRM

### DIFF
--- a/test/integration/resourcemanager/node/agentreconciliationdelay/agentreconciliationdelay_suite_test.go
+++ b/test/integration/resourcemanager/node/agentreconciliationdelay/agentreconciliationdelay_suite_test.go
@@ -84,6 +84,9 @@ var _ = BeforeSuite(func() {
 				&corev1.Node{}: {
 					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
 				},
+				&corev1.Secret{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
 			},
 		},
 		Controller: controllerconfig.Controller{

--- a/test/integration/resourcemanager/node/agentreconciliationdelay/agentreconciliationdelay_test.go
+++ b/test/integration/resourcemanager/node/agentreconciliationdelay/agentreconciliationdelay_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("AgentReconciliationDelay tests", func() {
 	When("#nodes = 1", func() {
 		BeforeEach(func() {
-			prepareNodes(1, false)
+			prepareNodes(1, nil)
 
 			By("Wait until manager has observed all nodes")
 			Eventually(func(g Gomega) int {
@@ -39,7 +39,7 @@ var _ = Describe("AgentReconciliationDelay tests", func() {
 
 	When("1 < #nodes <= max-delay-seconds", func() {
 		BeforeEach(func() {
-			prepareNodes(10, false)
+			prepareNodes(10, nil)
 
 			By("Wait until manager has observed all nodes")
 			Eventually(func(g Gomega) int {
@@ -70,7 +70,7 @@ var _ = Describe("AgentReconciliationDelay tests", func() {
 
 	When("#nodes > max-delay-seconds", func() {
 		BeforeEach(func() {
-			prepareNodes(31, false)
+			prepareNodes(31, nil)
 
 			By("Wait until manager has observed all nodes")
 			Eventually(func(g Gomega) int {
@@ -121,16 +121,15 @@ var _ = Describe("AgentReconciliationDelay tests", func() {
 
 	Context("ignore nodes with serial operating system config rollout", func() {
 		BeforeEach(func() {
-			prepareNodes(5, true)   // first group of nodes should be excluded
-			prepareNodes(10, false) // second group of nodes should be considered
-			prepareNodes(5, true)   // third group of nodes should be excluded
+			serial1 := prepareSecret() // first group of nodes should be excluded
+			serial2 := prepareSecret() // third group of nodes should be excluded
 
-			By("Wait until manager has observed all objects")
+			prepareNodes(5, serial1)
+			prepareNodes(10, nil) // second group of nodes should be considered
+			prepareNodes(5, serial2)
+
+			By("Wait until manager has observed all nodes")
 			Eventually(func(g Gomega) {
-				secretList := &corev1.SecretList{}
-				g.Expect(mgrClient.List(ctx, secretList)).To(Succeed())
-				g.Expect(secretList.Items).To(HaveLen(2))
-
 				nodeList := &corev1.NodeList{}
 				g.Expect(mgrClient.List(ctx, nodeList)).To(Succeed())
 				g.Expect(nodeList.Items).To(HaveLen(20))
@@ -173,26 +172,35 @@ var _ = Describe("AgentReconciliationDelay tests", func() {
 	})
 })
 
-func prepareNodes(count int, withSerialOSCReconciliation bool) {
+func prepareSecret() *corev1.Secret {
 	GinkgoHelper()
 
-	var gardenerNodeAgentSecret *corev1.Secret
-	if withSerialOSCReconciliation {
-		gardenerNodeAgentSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "gardener-node-agent-",
-			Namespace:    "kube-system",
-			Annotations:  map[string]string{"reconciliation.osc.node-agent.gardener.cloud/serial": "true"},
-			Labels:       map[string]string{"gardener.cloud/role": "operating-system-config"},
-		}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		GenerateName: "gardener-node-agent-",
+		Namespace:    "kube-system",
+		Annotations:  map[string]string{"reconciliation.osc.node-agent.gardener.cloud/serial": "true"},
+		Labels:       map[string]string{"gardener.cloud/role": "operating-system-config", testID: testRunID},
+	}}
 
-		Expect(testClient.Create(ctx, gardenerNodeAgentSecret)).To(Succeed())
-		By("Created gardener-node-agent Secret " + gardenerNodeAgentSecret.Name + " with serial OSC reconciliation for test")
+	Expect(testClient.Create(ctx, secret)).To(Succeed())
+	By("Created gardener-node-agent Secret " + secret.Name + " with serial OSC reconciliation for test")
 
-		DeferCleanup(func() {
-			Expect(client.IgnoreNotFound(testClient.Delete(ctx, gardenerNodeAgentSecret))).To(Succeed())
-			By("Deleted gardener-node-agent Secret " + gardenerNodeAgentSecret.Name + " with serial OSC reconciliation")
-		})
-	}
+	DeferCleanup(func() {
+		Expect(client.IgnoreNotFound(testClient.Delete(ctx, secret))).To(Succeed())
+		By("Deleted gardener-node-agent Secret " + secret.Name + " with serial OSC reconciliation")
+	})
+
+	By("Wait until manager has observed Secret " + secret.Name)
+	Eventually(func(g Gomega) {
+		s := &corev1.Secret{}
+		g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(secret), s)).To(Succeed())
+	}).Should(Succeed())
+
+	return secret
+}
+
+func prepareNodes(count int, gardenerNodeAgentSecret *corev1.Secret) {
+	GinkgoHelper()
 
 	for suffix := range count {
 		node := newNode(suffix, gardenerNodeAgentSecret)


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:

The `ignore nodes with serial operating system config rollout` test was flaky because node `Create` events triggered reconcile runs before the serial OSC secrets were in the manager cache. Those early reconciles saw all nodes as non-serial and annotated them. Once the cache caught up, the filtered node set was stable (`knownNodeNames` matched), so no further reconcile ran and the annotations on serial nodes were never removed.

- Split `prepareNodes(count, bool)` into `prepareSecret()` + `prepareNodes(count, *Secret)`: secrets are created and waited on individually before any nodes are created, so by the time the first node `Create` event fires a reconcile, the serial secrets are already in the cache.
- Add `testID: testRunID` label to test secrets and scope the manager cache to that label, consistent with how nodes are already isolated and preventing interference from other test runs.



**Which issue(s) this PR fixes**:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14554/pull-gardener-integration/2042762721740460032
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14420/pull-gardener-integration/2043698699611148288


**Special notes for your reviewer**:
After the fix:
```
❯ stress -p 32 ./test/integration/resourcemanager/node/agentreconciliationdelay/agentreconciliationdelay.test
...
3m0s: 399 runs so far, 0 failures, 32 active
3m5s: 413 runs so far, 0 failures, 32 active
3m10s: 423 runs so far, 0 failures, 32 active
3m15s: 432 runs so far, 0 failures, 32 active
3m20s: 445 runs so far, 0 failures, 32 active
3m25s: 459 runs so far, 0 failures, 32 active
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
