### PR TITLE
Allow overriding optional Thanos sidecar image

### DIFF
--- a/pkg/component/observability/monitoring/prometheusoperator/deployment.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/deployment.go
@@ -23,6 +23,19 @@ const (
 )
 
 func (p *prometheusOperator) deployment() *appsv1.Deployment {
+	args := []string{
+		fmt.Sprintf("--prometheus-config-reloader=%s", p.values.ImageConfigReloader),
+		"--config-reloader-cpu-request=0",
+		"--config-reloader-cpu-limit=0",
+		"--config-reloader-memory-request=20M",
+		"--config-reloader-memory-limit=0",
+		"--enable-config-reloader-probes=false",
+	}
+
+	if p.values.ImageThanosSidecar != "" {
+		args = append(args, fmt.Sprintf("--thanos-default-base-image=%s", p.values.ImageThanosSidecar))
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
@@ -53,14 +66,7 @@ func (p *prometheusOperator) deployment() *appsv1.Deployment {
 							Name:            containerName,
 							Image:           p.values.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Args: []string{
-								fmt.Sprintf("--prometheus-config-reloader=%s", p.values.ImageConfigReloader),
-								"--config-reloader-cpu-request=0",
-								"--config-reloader-cpu-limit=0",
-								"--config-reloader-memory-request=20M",
-								"--config-reloader-memory-limit=0",
-								"--enable-config-reloader-probes=false",
-							},
+							Args:            args,
 							Env: []corev1.EnvVar{{
 								Name:  "GOGC",
 								Value: "30",

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
@@ -31,8 +31,11 @@ var TimeoutWaitForManagedResource = 5 * time.Minute
 type Values struct {
 	// Image defines the container image of prometheus-operator.
 	Image string
-	// Image defines the container image of config-reloader.
+	// ImageConfigReloader defines the container image of config-reloader.
 	ImageConfigReloader string
+	// ImageThanosSidecar optionally defines the default base image for Thanos sidecars.
+	// When non-empty, prometheus-operator is started with --thanos-default-base-image.
+	ImageThanosSidecar string
 	// PriorityClassName is the name of the priority class for the deployment.
 	PriorityClassName string
 }

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -435,6 +435,29 @@ var _ = Describe("PrometheusOperator", func() {
 					rolePrometheusShoot,
 				))
 			})
+
+			Context("with thanos sidecar image", func() {
+				BeforeEach(func() {
+					values.ImageThanosSidecar = "thanos-image:v0.35.0"
+					deployment.Spec.Template.Spec.Containers[0].Args = append(
+						deployment.Spec.Template.Spec.Containers[0].Args,
+						"--thanos-default-base-image=thanos-image:v0.35.0",
+					)
+				})
+
+				It("should successfully deploy all resources with thanos flag", func() {
+					Expect(managedResource).To(consistOf(
+						serviceAccount,
+						service,
+						deployment,
+						vpa,
+						clusterRole,
+						clusterRoleBinding,
+						clusterRolePrometheus,
+						rolePrometheusShoot,
+					))
+				})
+			})
 		})
 	})
 

--- a/pkg/component/shared/prometheus_operator.go
+++ b/pkg/component/shared/prometheus_operator.go
@@ -31,12 +31,19 @@ func NewPrometheusOperator(
 		return nil, err
 	}
 
+	// Thanos sidecar image is optional and available only when provided via IMAGEVECTOR_OVERWRITE.
+	var imageThanosSidecar string
+	if thanosImage, err := imagevector.Containers().FindImage("thanos"); err == nil {
+		imageThanosSidecar = thanosImage.String()
+	}
+
 	return prometheusoperator.New(
 		c,
 		gardenNamespaceName,
 		prometheusoperator.Values{
 			Image:               operatorImage.String(),
 			ImageConfigReloader: reloaderImage.String(),
+			ImageThanosSidecar:  imageThanosSidecar,
 			PriorityClassName:   priorityClassName,
 		},
 	), nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->

/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Allows operators to override the default Thanos sidecar base image used by Prometheus Operator via `IMAGEVECTOR_OVERWRITE`. When a `thanos` image entry is present in the override, the `--thanos-default-base-image` flag is set on the prometheus-operator deployment. When absent, the flag is omitted (no behavioral change for existing installations).

This is needed by operators who run custom Prometheus instances with Thanos sidecars behind private registries and want to control the image registry without pinning the full image+tag on every Prometheus CR.

No image is added to the base image vector, avoiding SBOM/CVE triage overhead for an image Gardener does not use.

**Which issue(s) this PR fixes**:
Fixes #14545

**Special notes for your reviewer**:
The `thanos` image name is intentionally not in `containers.yaml`. It only exists when injected via `IMAGEVECTOR_OVERWRITE`.

Instructions for local testing:

Add a `thanos` entry to the gardenlet's `imageVectorOverwrite` in `example/gardener-local/gardenlet/skaffold.yaml`:
```yaml
- name: thanos
  repository: quay.io/thanos/thanos
  tag: v0.36.1
```
Then `make kind-up && make gardener-up` and verify:

```
kubectl -n garden get deploy prometheus-operator -o jsonpath='{.spec.template.spec.containers[0].args}'
```

Should include `--thanos-default-base-image=quay.io/thanos/thanos:v0.36.1`.


**Release note**:
```feature operator
Prometheus Operator now supports overriding the default Thanos sidecar base image via `IMAGEVECTOR_OVERWRITE`.
```