### PR TITLE
Standardize observability labels + add missing labels in VictoriaLogs/OTel Collector

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -164,7 +164,6 @@ const (
 	// DeploymentNamePrometheusOperator is a constant for the name of a Kubernetes deployment object that contains
 	// the prometheus-operator pod.
 	DeploymentNamePrometheusOperator = "prometheus-operator"
-	// DaemonSetNameFluentBit is a constant for the name of a Kubernetes Daemonset object that contains
 	// MonitoringNamePrometheus is a constant for the name of a Prometheus object.
 	MonitoringNamePrometheus = "prometheus"
 	// DeploymentNameBlackBoxExporter is a constant for the name of a Kubernetes deployment object that contains
@@ -172,6 +171,12 @@ const (
 	DeploymentNameBlackBoxExporter = "blackbox-exporter"
 	// ConfigMapNameBlackBoxExporter is a constant for the name of a Kubernetes Configmap which holds the blackbox-exporter config.
 	ConfigMapNameBlackBoxExporter = "blackbox-exporter-config"
+	// DeploymentNameKubeStateMetrics is a constant for the name of a Kubernetes deployment object that contains
+	// the kube-state-metrics pod.
+	DeploymentNameKubeStateMetrics = "kube-state-metrics"
+	// DeploymentNameGardenerMetricsExporter is a constant for the name of a Kubernetes deployment object that contains
+	// the gardener-metrics-exporter pod.
+	DeploymentNameGardenerMetricsExporter = "gardener-metrics-exporter"
 	// DeploymentNameEventLogger is a constant for the name of a Kubernetes deployment object that contains
 	// the event-logger pod.
 	DeploymentNameEventLogger = "event-logger"
@@ -183,12 +188,21 @@ const (
 	DaemonSetNameFluentBit = "fluent-bit"
 	// ConfigMapNameFluentBitLua is a constant for the name of a Kubernetes Configmap which holds the lua scripts for fluent-bit.
 	ConfigMapNameFluentBitLua = "fluent-bit-lua-config"
-	// DeploymentNameKubeStateMetrics is a constant for the name of a Kubernetes deployment object that contains
-	// the kube-state-metrics pod.
-	DeploymentNameKubeStateMetrics = "kube-state-metrics"
-	// DeploymentNameGardenerMetricsExporter is a constant for the name of a Kubernetes deployment object that contains
-	// the gardener-metrics-exporter pod.
-	DeploymentNameGardenerMetricsExporter = "gardener-metrics-exporter"
+	// DeploymentNameOpenTelemetryOperator is a constant for the name of a Kubernetes deployment object that contains
+	// the opentelemetry-operator pod.
+	DeploymentNameOpenTelemetryOperator = "opentelemetry-operator"
+	// DeploymentNameOpenTelemetryCollector is a constant for the name of a Kubernetes deployment object that contains
+	// the opentelemetry-collector pod.
+	DeploymentNameOpenTelemetryCollector = "opentelemetry-collector"
+	// StatefulSetNameVali is a constant for the name of a Kubernetes stateful set object that contains
+	// the vali pod.
+	StatefulSetNameVali = "vali"
+	// DeploymentNameVictoriaOperator is a constant for the name of a Kubernetes deployment object that contains
+	// the victoria-operator pod.
+	DeploymentNameVictoriaOperator = "victoria-operator"
+	// StatefulSetNameVictoriaLogs is a constant for the name of a Kubernetes stateful set object that contains
+	// the victoria-logs pod.
+	StatefulSetNameVictoriaLogs = "victoria-logs"
 
 	// DeploymentNameVPAAdmissionController is a constant for the name of the VPA admission controller deployment.
 	DeploymentNameVPAAdmissionController = "vpa-admission-controller"
@@ -209,10 +223,6 @@ const (
 	// the machine-controller-manager pod.
 	DeploymentNameMachineControllerManager = "machine-controller-manager"
 
-	// DeploymentNameOpenTelemetryOperator is a constant for the name of a Kubernetes deployment object that contains
-	// the opentelemetry-operator pod.
-	DeploymentNameOpenTelemetryOperator = "opentelemetry-operator"
-
 	// ConfigMapNameShootInfo is the name of a ConfigMap in the kube-system namespace of shoot clusters which contains
 	// information about the shoot cluster.
 	ConfigMapNameShootInfo = "shoot-info"
@@ -228,9 +238,6 @@ const (
 	ETCDMain = "etcd-" + ETCDRoleMain
 	// ETCDEvents is a constant for the name of etcd-events Etcd object.
 	ETCDEvents = "etcd-" + ETCDRoleEvents
-	// StatefulSetNameVali is a constant for the name of a Kubernetes stateful set object that contains
-	// the vali pod.
-	StatefulSetNameVali = "vali"
 
 	// GardenerPurpose is a constant for the key in a label describing the purpose of the respective object.
 	GardenerPurpose = "gardener.cloud/purpose"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -158,6 +158,20 @@ const (
 	DeploymentNameGardenerResourceManager = "gardener-resource-manager"
 	// DeploymentNamePlutono is a constant for the name of a Kubernetes deployment object that contains the plutono pod.
 	DeploymentNamePlutono = "plutono"
+	// DeploymentNamePersesOperator is a constant for the name of a Kubernetes deployment object that contains
+	// the perses-operator pod.
+	DeploymentNamePersesOperator = "perses-operator"
+	// DeploymentNamePrometheusOperator is a constant for the name of a Kubernetes deployment object that contains
+	// the prometheus-operator pod.
+	DeploymentNamePrometheusOperator = "prometheus-operator"
+	// DaemonSetNameFluentBit is a constant for the name of a Kubernetes Daemonset object that contains
+	// MonitoringNamePrometheus is a constant for the name of a Prometheus object.
+	MonitoringNamePrometheus = "prometheus"
+	// DeploymentNameBlackBoxExporter is a constant for the name of a Kubernetes deployment object that contains
+	// the blackbox-exporter pod.
+	DeploymentNameBlackBoxExporter = "blackbox-exporter"
+	// ConfigMapNameBlackBoxExporter is a constant for the name of a Kubernetes Configmap which holds the blackbox-exporter config.
+	ConfigMapNameBlackBoxExporter = "blackbox-exporter-config"
 	// DeploymentNameEventLogger is a constant for the name of a Kubernetes deployment object that contains
 	// the event-logger pod.
 	DeploymentNameEventLogger = "event-logger"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -200,9 +200,9 @@ const (
 	// DeploymentNameVictoriaOperator is a constant for the name of a Kubernetes deployment object that contains
 	// the victoria-operator pod.
 	DeploymentNameVictoriaOperator = "victoria-operator"
-	// StatefulSetNameVictoriaLogs is a constant for the name of a Kubernetes stateful set object that contains
+	// DeploymentNameVictoriaLogs is a constant for the name of a Kubernetes stateful set object that contains
 	// the victoria-logs pod.
-	StatefulSetNameVictoriaLogs = "victoria-logs"
+	DeploymentNameVictoriaLogs = "victoria-logs"
 
 	// DeploymentNameVPAAdmissionController is a constant for the name of the VPA admission controller deployment.
 	DeploymentNameVPAAdmissionController = "vpa-admission-controller"

--- a/pkg/component/observability/logging/victoria/operator/victoria_operator.go
+++ b/pkg/component/observability/logging/victoria/operator/victoria_operator.go
@@ -32,19 +32,6 @@ import (
 )
 
 const (
-	// name is the base name for victoria-operator resources.
-	name = "victoria-operator"
-
-	// Resource names
-	containerName           = name
-	managedResourceName     = name
-	serviceAccountName      = name
-	deploymentName          = name
-	clusterRoleName         = name
-	clusterRoleBindingName  = name
-	podDisruptionBudgetName = name
-	vpaName                 = name
-
 	// Ports
 	healthProbePort = 8081
 	metricsPort     = 8080
@@ -92,33 +79,33 @@ func (v *victoriaOperator) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, managedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
+	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaOperator, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
 }
 
 func (v *victoriaOperator) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, managedResourceName)
+	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaOperator)
 }
 
 func (v *victoriaOperator) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, managedResourceName)
+	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaOperator)
 }
 
 func (v *victoriaOperator) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, managedResourceName)
+	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaOperator)
 }
 
 func (v *victoriaOperator) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceAccountName,
+			Name:      v1beta1constants.DeploymentNameVictoriaOperator,
 			Namespace: v.namespace,
-			Labels:    GetLabels(),
+			Labels:    getLabels(),
 		},
 		AutomountServiceAccountToken: ptr.To(false),
 	}
@@ -127,23 +114,23 @@ func (v *victoriaOperator) serviceAccount() *corev1.ServiceAccount {
 func (v *victoriaOperator) deployment() *appsv1.Deployment {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploymentName,
+			Name:      v1beta1constants.DeploymentNameVictoriaOperator,
 			Namespace: v.namespace,
-			Labels:    GetLabels(),
+			Labels:    getLabels(),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas:             ptr.To[int32](1),
 			RevisionHistoryLimit: ptr.To[int32](2),
-			Selector:             &metav1.LabelSelector{MatchLabels: GetLabels()},
+			Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
+					Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 						v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: v1beta1constants.DeploymentNameVictoriaOperator,
 					PriorityClassName:  v.values.PriorityClassName,
 					SecurityContext: &corev1.PodSecurityContext{
 						SeccompProfile: &corev1.SeccompProfile{
@@ -152,7 +139,7 @@ func (v *victoriaOperator) deployment() *appsv1.Deployment {
 					},
 					Containers: []corev1.Container{
 						{
-							Name:            containerName,
+							Name:            v1beta1constants.DeploymentNameVictoriaOperator,
 							Image:           v.values.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
@@ -240,15 +227,15 @@ func (v *victoriaOperator) deployment() *appsv1.Deployment {
 func (v *victoriaOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      vpaName,
+			Name:      v1beta1constants.DeploymentNameVictoriaOperator,
 			Namespace: v.namespace,
-			Labels:    GetLabels(),
+			Labels:    getLabels(),
 		},
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{
 				APIVersion: appsv1.SchemeGroupVersion.String(),
 				Kind:       "Deployment",
-				Name:       deploymentName,
+				Name:       v1beta1constants.DeploymentNameVictoriaOperator,
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
 				UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
@@ -256,7 +243,7 @@ func (v *victoriaOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName: containerName,
+						ContainerName: v1beta1constants.DeploymentNameVictoriaOperator,
 						MinAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
@@ -274,8 +261,8 @@ func (v *victoriaOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 func (v *victoriaOperator) clusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   clusterRoleName,
-			Labels: GetLabels(),
+			Name:   v1beta1constants.DeploymentNameVictoriaOperator,
+			Labels: getLabels(),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -331,18 +318,18 @@ func (v *victoriaOperator) clusterRole() *rbacv1.ClusterRole {
 func (v *victoriaOperator) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   clusterRoleBindingName,
-			Labels: GetLabels(),
+			Name:   v1beta1constants.DeploymentNameVictoriaOperator,
+			Labels: getLabels(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     clusterRoleName,
+			Name:     v1beta1constants.DeploymentNameVictoriaOperator,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      serviceAccountName,
+				Name:      v1beta1constants.DeploymentNameVictoriaOperator,
 				Namespace: v.namespace,
 			},
 		},
@@ -352,13 +339,13 @@ func (v *victoriaOperator) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 func (v *victoriaOperator) podDisruptionBudget() *policyv1.PodDisruptionBudget {
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podDisruptionBudgetName,
+			Name:      v1beta1constants.DeploymentNameVictoriaOperator,
 			Namespace: v.namespace,
-			Labels:    GetLabels(),
+			Labels:    getLabels(),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MaxUnavailable:             ptr.To(intstr.FromInt32(1)),
-			Selector:                   &metav1.LabelSelector{MatchLabels: GetLabels()},
+			Selector:                   &metav1.LabelSelector{MatchLabels: getLabels()},
 			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 		},
 	}
@@ -366,10 +353,9 @@ func (v *victoriaOperator) podDisruptionBudget() *policyv1.PodDisruptionBudget {
 	return pdb
 }
 
-// GetLabels returns the labels for the victoria-operator.
-func GetLabels() map[string]string {
+func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:                    name,
+		v1beta1constants.LabelApp:                    v1beta1constants.DeploymentNameVictoriaOperator,
 		v1beta1constants.LabelRole:                   v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole:                  v1beta1constants.GardenRoleObservability,
 		resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeController,

--- a/pkg/component/observability/logging/victorialogs/constants/constants.go
+++ b/pkg/component/observability/logging/victorialogs/constants/constants.go
@@ -11,8 +11,4 @@ const (
 	ServiceName = "logging-vl"
 	// PushEndpoint is the endpoint used by VictoriaLogs to receive logs.
 	PushEndpoint = "/insert/opentelemetry/v1/logs"
-	// ManagedResourceNameRuntime is the name of the managed resource which deploys VictoriaLogs.
-	ManagedResourceNameRuntime = "victoria-logs"
-	// VLSingleResourceName is the name of the VLSingle resource.
-	VLSingleResourceName = "victoria-logs"
 )

--- a/pkg/component/observability/logging/victorialogs/logging.go
+++ b/pkg/component/observability/logging/victorialogs/logging.go
@@ -15,7 +15,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
-	"github.com/gardener/gardener/pkg/component/observability/logging/victorialogs/constants"
 )
 
 const (
@@ -31,11 +30,11 @@ func generateClusterFilters() []*fluentbitv1alpha2.ClusterFilter {
 	return []*fluentbitv1alpha2.ClusterFilter{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   fmt.Sprintf("%s--%s", constants.VLSingleResourceName, vlsingleName),
+				Name:   fmt.Sprintf("%s--%s", v1beta1constants.StatefulSetNameVictoriaLogs, vlsingleName),
 				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
 			},
 			Spec: fluentbitv1alpha2.FilterSpec{
-				Match: fmt.Sprintf("kubernetes.*%s*%s*", vlsingleName, constants.VLSingleResourceName),
+				Match: fmt.Sprintf("kubernetes.*%s*%s*", vlsingleName, v1beta1constants.StatefulSetNameVictoriaLogs),
 				FilterItems: []fluentbitv1alpha2.FilterItem{
 					{
 						Parser: &fluentbitv1alpha2filter.Parser{

--- a/pkg/component/observability/logging/victorialogs/logging.go
+++ b/pkg/component/observability/logging/victorialogs/logging.go
@@ -30,11 +30,11 @@ func generateClusterFilters() []*fluentbitv1alpha2.ClusterFilter {
 	return []*fluentbitv1alpha2.ClusterFilter{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   fmt.Sprintf("%s--%s", v1beta1constants.StatefulSetNameVictoriaLogs, vlsingleName),
+				Name:   fmt.Sprintf("%s--%s", v1beta1constants.DeploymentNameVictoriaLogs, vlsingleName),
 				Labels: map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource},
 			},
 			Spec: fluentbitv1alpha2.FilterSpec{
-				Match: fmt.Sprintf("kubernetes.*%s*%s*", vlsingleName, v1beta1constants.StatefulSetNameVictoriaLogs),
+				Match: fmt.Sprintf("kubernetes.*%s*%s*", vlsingleName, v1beta1constants.DeploymentNameVictoriaLogs),
 				FilterItems: []fluentbitv1alpha2.FilterItem{
 					{
 						Parser: &fluentbitv1alpha2filter.Parser{

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -94,25 +94,25 @@ func (v *victoriaLogs) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, constants.ManagedResourceNameRuntime, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
 }
 
 func (v *victoriaLogs) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, constants.ManagedResourceNameRuntime)
+	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, constants.ManagedResourceNameRuntime)
+	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, constants.ManagedResourceNameRuntime)
+	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.VLSingle {
@@ -123,14 +123,14 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.V
 
 	vlSingle := &victoriametricsv1.VLSingle{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.VLSingleResourceName,
+			Name:      v1beta1constants.StatefulSetNameVictoriaLogs,
 			Namespace: v.namespace,
 			Labels:    getLabels(),
 		},
 		Spec: victoriametricsv1.VLSingleSpec{
 			PodMetadata: &victoriametricsv1beta1.EmbeddedObjectMetadata{
 				Labels: map[string]string{
-					v1beta1constants.LabelObservabilityApplication: constants.VLSingleResourceName,
+					v1beta1constants.LabelObservabilityApplication: v1beta1constants.StatefulSetNameVictoriaLogs,
 				},
 			},
 			CommonDefaultableParams: victoriametricsv1beta1.CommonDefaultableParams{
@@ -196,12 +196,13 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.V
 
 func getLabels() map[string]string {
 	return map[string]string{
+		v1beta1constants.LabelApp:   v1beta1constants.StatefulSetNameVictoriaLogs,
 		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
 		gardenerutils.NetworkPolicyLabel(constants.ServiceName, constants.VictoriaLogsPort): v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                               v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                      constants.VLSingleResourceName,
+		v1beta1constants.LabelObservabilityApplication:                                      v1beta1constants.StatefulSetNameVictoriaLogs,
 	}
 }
 
@@ -215,7 +216,7 @@ func (v *victoriaLogs) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{
 				Kind:       "Deployment",
-				Name:       "vlsingle-" + constants.VLSingleResourceName,
+				Name:       "vlsingle-" + v1beta1constants.StatefulSetNameVictoriaLogs,
 				APIVersion: appsv1.SchemeGroupVersion.String(),
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
@@ -249,7 +250,7 @@ func (v *victoriaLogs) getServiceMonitor() *monitoringv1.ServiceMonitor {
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 				"app.kubernetes.io/name":      "vlsingle",
-				"app.kubernetes.io/instance":  constants.VLSingleResourceName,
+				"app.kubernetes.io/instance":  v1beta1constants.StatefulSetNameVictoriaLogs,
 				"app.kubernetes.io/component": "monitoring",
 				"managed-by":                  "vm-operator",
 			}},

--- a/pkg/component/observability/logging/victorialogs/victorialogs.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs.go
@@ -94,25 +94,25 @@ func (v *victoriaLogs) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
+	return managedresources.CreateForSeedWithLabels(ctx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaLogs, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, serializedResources)
 }
 
 func (v *victoriaLogs) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
+	return managedresources.DeleteForSeed(ctx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
+	return managedresources.WaitUntilHealthy(timeoutCtx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, v1beta1constants.StatefulSetNameVictoriaLogs)
+	return managedresources.WaitUntilDeleted(timeoutCtx, v.client, v.namespace, v1beta1constants.DeploymentNameVictoriaLogs)
 }
 
 func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.VLSingle {
@@ -123,14 +123,14 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.V
 
 	vlSingle := &victoriametricsv1.VLSingle{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      v1beta1constants.StatefulSetNameVictoriaLogs,
+			Name:      v1beta1constants.DeploymentNameVictoriaLogs,
 			Namespace: v.namespace,
 			Labels:    getLabels(),
 		},
 		Spec: victoriametricsv1.VLSingleSpec{
 			PodMetadata: &victoriametricsv1beta1.EmbeddedObjectMetadata{
 				Labels: map[string]string{
-					v1beta1constants.LabelObservabilityApplication: v1beta1constants.StatefulSetNameVictoriaLogs,
+					v1beta1constants.LabelObservabilityApplication: v1beta1constants.DeploymentNameVictoriaLogs,
 				},
 			},
 			CommonDefaultableParams: victoriametricsv1beta1.CommonDefaultableParams{
@@ -196,13 +196,13 @@ func (v *victoriaLogs) vlSingle(imageRepo, imageTag string) *victoriametricsv1.V
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:   v1beta1constants.StatefulSetNameVictoriaLogs,
+		v1beta1constants.LabelApp:   v1beta1constants.DeploymentNameVictoriaLogs,
 		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
 		gardenerutils.NetworkPolicyLabel(constants.ServiceName, constants.VictoriaLogsPort): v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer:                               v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                      v1beta1constants.StatefulSetNameVictoriaLogs,
+		v1beta1constants.LabelObservabilityApplication:                                      v1beta1constants.DeploymentNameVictoriaLogs,
 	}
 }
 
@@ -216,7 +216,7 @@ func (v *victoriaLogs) getVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 		Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 			TargetRef: &autoscalingv1.CrossVersionObjectReference{
 				Kind:       "Deployment",
-				Name:       "vlsingle-" + v1beta1constants.StatefulSetNameVictoriaLogs,
+				Name:       "vlsingle-" + v1beta1constants.DeploymentNameVictoriaLogs,
 				APIVersion: appsv1.SchemeGroupVersion.String(),
 			},
 			UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
@@ -250,7 +250,7 @@ func (v *victoriaLogs) getServiceMonitor() *monitoringv1.ServiceMonitor {
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 				"app.kubernetes.io/name":      "vlsingle",
-				"app.kubernetes.io/instance":  v1beta1constants.StatefulSetNameVictoriaLogs,
+				"app.kubernetes.io/instance":  v1beta1constants.DeploymentNameVictoriaLogs,
 				"app.kubernetes.io/component": "monitoring",
 				"managed-by":                  "vm-operator",
 			}},

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -97,14 +97,14 @@ var _ = Describe("VictoriaLogs", func() {
 
 		vlSingle = &victoriametricsv1.VLSingle{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      victorialogsconstants.VLSingleResourceName,
+				Name:      v1beta1constants.StatefulSetNameVictoriaLogs,
 				Namespace: namespace,
 				Labels:    getLabels(),
 			},
 			Spec: victoriametricsv1.VLSingleSpec{
 				PodMetadata: &victoriametricsv1beta1.EmbeddedObjectMetadata{
 					Labels: map[string]string{
-						v1beta1constants.LabelObservabilityApplication: victorialogsconstants.VLSingleResourceName,
+						v1beta1constants.LabelObservabilityApplication: v1beta1constants.StatefulSetNameVictoriaLogs,
 					},
 				},
 				CommonDefaultableParams: victoriametricsv1beta1.CommonDefaultableParams{
@@ -152,7 +152,7 @@ var _ = Describe("VictoriaLogs", func() {
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
 					Kind:       "Deployment",
-					Name:       "vlsingle-" + victorialogsconstants.VLSingleResourceName,
+					Name:       "vlsingle-" + v1beta1constants.StatefulSetNameVictoriaLogs,
 					APIVersion: appsv1.SchemeGroupVersion.String(),
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
@@ -174,7 +174,7 @@ var _ = Describe("VictoriaLogs", func() {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 					"app.kubernetes.io/name":      "vlsingle",
-					"app.kubernetes.io/instance":  victorialogsconstants.VLSingleResourceName,
+					"app.kubernetes.io/instance":  v1beta1constants.StatefulSetNameVictoriaLogs,
 					"app.kubernetes.io/component": "monitoring",
 					"managed-by":                  "vm-operator",
 				}},

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -499,11 +499,12 @@ var _ = Describe("VictoriaLogs", func() {
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelRole:                            v1beta1constants.LabelObservability,
-		v1beta1constants.GardenRole:                           v1beta1constants.GardenRoleObservability,
-		gardenerutils.NetworkPolicyLabel("logging-vl", 9428):  v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelNetworkPolicyToDNS:              v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
+		v1beta1constants.LabelApp:                             "victoria-logs",
+		v1beta1constants.LabelRole:                            "observability",
+		v1beta1constants.GardenRole:                           "observability",
+		gardenerutils.NetworkPolicyLabel("logging-vl", 9428):  "allowed",
+		v1beta1constants.LabelNetworkPolicyToDNS:              "allowed",
+		v1beta1constants.LabelNetworkPolicyToRuntimeAPIServer: "allowed",
 		v1beta1constants.LabelObservabilityApplication:        "victoria-logs",
 	}
 }

--- a/pkg/component/observability/logging/victorialogs/victorialogs_test.go
+++ b/pkg/component/observability/logging/victorialogs/victorialogs_test.go
@@ -97,14 +97,14 @@ var _ = Describe("VictoriaLogs", func() {
 
 		vlSingle = &victoriametricsv1.VLSingle{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      v1beta1constants.StatefulSetNameVictoriaLogs,
+				Name:      v1beta1constants.DeploymentNameVictoriaLogs,
 				Namespace: namespace,
 				Labels:    getLabels(),
 			},
 			Spec: victoriametricsv1.VLSingleSpec{
 				PodMetadata: &victoriametricsv1beta1.EmbeddedObjectMetadata{
 					Labels: map[string]string{
-						v1beta1constants.LabelObservabilityApplication: v1beta1constants.StatefulSetNameVictoriaLogs,
+						v1beta1constants.LabelObservabilityApplication: v1beta1constants.DeploymentNameVictoriaLogs,
 					},
 				},
 				CommonDefaultableParams: victoriametricsv1beta1.CommonDefaultableParams{
@@ -152,7 +152,7 @@ var _ = Describe("VictoriaLogs", func() {
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
 					Kind:       "Deployment",
-					Name:       "vlsingle-" + v1beta1constants.StatefulSetNameVictoriaLogs,
+					Name:       "vlsingle-" + v1beta1constants.DeploymentNameVictoriaLogs,
 					APIVersion: appsv1.SchemeGroupVersion.String(),
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
@@ -174,7 +174,7 @@ var _ = Describe("VictoriaLogs", func() {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 					"app.kubernetes.io/name":      "vlsingle",
-					"app.kubernetes.io/instance":  v1beta1constants.StatefulSetNameVictoriaLogs,
+					"app.kubernetes.io/instance":  v1beta1constants.DeploymentNameVictoriaLogs,
 					"app.kubernetes.io/component": "monitoring",
 					"managed-by":                  "vm-operator",
 				}},

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -261,7 +261,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
-										Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
+										Name:      v1beta1constants.ConfigMapNameBlackBoxExporter,
 										MountPath: volumeMountPathConfig,
 									},
 								},
@@ -277,7 +277,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 						},
 						Volumes: []corev1.Volume{
 							{
-								Name: v1beta1constants.DeploymentNameBlackBoxExporter,
+								Name: v1beta1constants.ConfigMapNameBlackBoxExporter,
 								VolumeSource: corev1.VolumeSource{
 									ConfigMap: &corev1.ConfigMapVolumeSource{
 										LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
+++ b/pkg/component/observability/monitoring/blackboxexporter/blackboxexporter.go
@@ -43,9 +43,6 @@ import (
 )
 
 const (
-	labelValue    = "blackbox-exporter"
-	containerName = "blackbox-exporter"
-
 	volumeMountPathConfig = "/etc/blackbox_exporter"
 	dataKeyConfig         = "blackbox.yaml"
 
@@ -142,9 +139,9 @@ func (b *blackboxExporter) Destroy(ctx context.Context) error {
 
 func (b *blackboxExporter) managedResourceName() string {
 	if b.values.ClusterType == component.ClusterTypeSeed {
-		return "blackbox-exporter"
+		return v1beta1constants.DeploymentNameBlackBoxExporter
 	}
-	return "shoot-core-blackbox-exporter"
+	return fmt.Sprintf("shoot-core-%s", v1beta1constants.DeploymentNameBlackBoxExporter)
 }
 
 func (b *blackboxExporter) monitoringResourcesManagedResourceName() string {
@@ -190,7 +187,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 	var (
 		serviceAccount = &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter",
+				Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 				Labels:    getLabels(),
 			},
@@ -199,10 +196,10 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter-config",
+				Name:      v1beta1constants.ConfigMapNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 				Labels: map[string]string{
-					v1beta1constants.LabelApp:  "prometheus",
+					v1beta1constants.LabelApp:  v1beta1constants.MonitoringNamePrometheus,
 					v1beta1constants.LabelRole: v1beta1constants.GardenRoleMonitoring,
 				},
 			},
@@ -215,14 +212,14 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 	var (
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter",
+				Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 				Labels:    utils.MergeStringMaps(getLabels(), map[string]string{resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer}),
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas:             &b.values.Replicas,
 				RevisionHistoryLimit: ptr.To[int32](2),
-				Selector:             &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelApp: labelValue}},
+				Selector:             &metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelApp: v1beta1constants.DeploymentNameBlackBoxExporter}},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{},
@@ -240,7 +237,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 						},
 						Containers: []corev1.Container{
 							{
-								Name:  containerName,
+								Name:  v1beta1constants.DeploymentNameBlackBoxExporter,
 								Image: b.values.Image,
 								Args: []string{
 									fmt.Sprintf("--config.file=%s/%s", volumeMountPathConfig, dataKeyConfig),
@@ -264,7 +261,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{
-										Name:      "blackbox-exporter-config",
+										Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 										MountPath: volumeMountPathConfig,
 									},
 								},
@@ -280,7 +277,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 						},
 						Volumes: []corev1.Volume{
 							{
-								Name: "blackbox-exporter-config",
+								Name: v1beta1constants.DeploymentNameBlackBoxExporter,
 								VolumeSource: corev1.VolumeSource{
 									ConfigMap: &corev1.ConfigMapVolumeSource{
 										LocalObjectReference: corev1.LocalObjectReference{
@@ -297,10 +294,10 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter",
+				Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 				Labels: map[string]string{
-					v1beta1constants.LabelApp: labelValue,
+					v1beta1constants.LabelApp: v1beta1constants.DeploymentNameBlackBoxExporter,
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -313,18 +310,18 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 					},
 				},
 				Selector: map[string]string{
-					v1beta1constants.LabelApp: labelValue,
+					v1beta1constants.LabelApp: v1beta1constants.DeploymentNameBlackBoxExporter,
 				},
 			},
 		}
 
 		podDisruptionBudget = &policyv1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter",
+				Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 				Labels: map[string]string{
 					v1beta1constants.GardenRole: v1beta1constants.GardenRoleMonitoring,
-					v1beta1constants.LabelApp:   labelValue,
+					v1beta1constants.LabelApp:   v1beta1constants.DeploymentNameBlackBoxExporter,
 				},
 			},
 			Spec: policyv1.PodDisruptionBudgetSpec{
@@ -355,7 +352,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 	if b.values.VPAEnabled {
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "blackbox-exporter",
+				Name:      v1beta1constants.DeploymentNameBlackBoxExporter,
 				Namespace: b.runtimeNamespace(),
 			},
 			Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{
@@ -370,7 +367,7 @@ func (b *blackboxExporter) computeResourcesData() (map[string][]byte, error) {
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
-							ContainerName:       containerName,
+							ContainerName:       v1beta1constants.DeploymentNameBlackBoxExporter,
 							ControlledValues:    ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							ControlledResources: &[]corev1.ResourceName{corev1.ResourceMemory},
 						},
@@ -492,7 +489,7 @@ func (b *blackboxExporter) computeMonitoringResourcesData() (map[string][]byte, 
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:       labelValue,
+		v1beta1constants.LabelApp:       v1beta1constants.DeploymentNameBlackBoxExporter,
 		v1beta1constants.GardenRole:     v1beta1constants.GardenRoleMonitoring,
 		managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 	}

--- a/pkg/component/observability/monitoring/persesoperator/perses_operator.go
+++ b/pkg/component/observability/monitoring/persesoperator/perses_operator.go
@@ -16,11 +16,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
-const (
-	// managedResourceName is the name of the ManagedResource for the perses-operator resources.
-	managedResourceName = "perses-operator"
-)
-
 // TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy or
 // deleted.
 var TimeoutWaitForManagedResource = 5 * time.Minute
@@ -62,30 +57,30 @@ func (p *persesOperator) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, managedResourceName, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
+	return managedresources.CreateForSeedWithLabels(ctx, p.client, p.namespace, v1beta1constants.DeploymentNamePersesOperator, false, map[string]string{v1beta1constants.LabelCareConditionType: v1beta1constants.ObservabilityComponentsHealthy}, resources)
 }
 
 func (p *persesOperator) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, p.client, p.namespace, managedResourceName)
+	return managedresources.WaitUntilHealthy(timeoutCtx, p.client, p.namespace, v1beta1constants.DeploymentNamePersesOperator)
 }
 
 func (p *persesOperator) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, p.client, p.namespace, managedResourceName)
+	return managedresources.DeleteForSeed(ctx, p.client, p.namespace, v1beta1constants.DeploymentNamePersesOperator)
 }
 
 func (p *persesOperator) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, p.client, p.namespace, managedResourceName)
+	return managedresources.WaitUntilDeleted(timeoutCtx, p.client, p.namespace, v1beta1constants.DeploymentNamePersesOperator)
 }
 
 // GetLabels returns the labels for the perses-operator.
 func GetLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp: "perses-operator",
+		v1beta1constants.LabelApp: v1beta1constants.DeploymentNamePersesOperator,
 	}
 }

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -20,7 +20,7 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 			ObjectMeta: metav1.ObjectMeta{Name: "shoot-prometheus"},
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Selector: metav1.LabelSelector{MatchLabels: map[string]string{
-					v1beta1constants.LabelApp:  "prometheus",
+					v1beta1constants.LabelApp:  v1beta1constants.MonitoringNamePrometheus,
 					v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring,
 				}},
 				NamespaceSelector: monitoringv1.NamespaceSelector{Any: true},

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -416,7 +416,7 @@ func (p *prometheus) addCentralConfigsToRegistry(registry *managedresources.Regi
 
 func (p *prometheus) getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:  "prometheus",
+		v1beta1constants.LabelApp:  v1beta1constants.MonitoringNamePrometheus,
 		v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring,
 		"name":                     p.values.Name,
 	}

--- a/pkg/component/observability/monitoring/prometheus/component.go
+++ b/pkg/component/observability/monitoring/prometheus/component.go
@@ -411,7 +411,7 @@ func (p *prometheus) addCentralConfigsToRegistry(registry *managedresources.Regi
 
 func (p *prometheus) getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:  "prometheus",
+		v1beta1constants.LabelApp:  v1beta1constants.MonitoringNamePrometheus,
 		v1beta1constants.LabelRole: v1beta1constants.LabelMonitoring,
 		"name":                     p.values.Name,
 	}

--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator.go
@@ -93,6 +93,6 @@ func (p *prometheusOperator) WaitCleanup(ctx context.Context) error {
 // GetLabels returns the labels for the prometheus-operator.
 func GetLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp: "prometheus-operator",
+		v1beta1constants.LabelApp: v1beta1constants.DeploymentNamePrometheusOperator,
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -43,9 +43,9 @@ import (
 
 const (
 	managedResourceNameTarget  = "logging-target"
-	managedResourceName        = "opentelemetry-collector"
-	serviceMonitorName         = "opentelemetry-collector"
-	openTelemetryCollectorName = "gardener-opentelemetry-collector"
+	managedResourceName        = v1beta1constants.DeploymentNameOpenTelemetryCollector
+	serviceMonitorName         = v1beta1constants.DeploymentNameOpenTelemetryCollector
+	openTelemetryCollectorName = "gardener-" + v1beta1constants.DeploymentNameOpenTelemetryCollector
 
 	kubeRBACProxyName = "rbac-proxy"
 
@@ -318,7 +318,7 @@ func (o *otelCollector) serviceMonitor() *monitoringv1.ServiceMonitor {
 					// job label, prometheus-operator would choose job=logging (service name).
 					{
 						Action:      "replace",
-						Replacement: ptr.To("opentelemetry-collector"),
+						Replacement: ptr.To(v1beta1constants.DeploymentNameOpenTelemetryCollector),
 						TargetLabel: "job",
 					},
 					{
@@ -643,7 +643,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 }
 
 func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.AccessSecret {
-	return gardenerutils.NewShootAccessSecret("opentelemetry-collector", o.namespace).
+	return gardenerutils.NewShootAccessSecret(v1beta1constants.DeploymentNameOpenTelemetryCollector, o.namespace).
 		WithServiceAccountName(openTelemetryCollectorName).
 		WithTokenExpirationDuration("720h").
 		WithTargetSecret(collectorconstants.OpenTelemetryCollectorSecretName, metav1.NamespaceSystem)
@@ -734,7 +734,7 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 func (o *otelCollector) getLoggingAgentClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "gardener.cloud:logging:opentelemetry-collector",
+			Name:   fmt.Sprintf("gardener.cloud:logging:%s", v1beta1constants.DeploymentNameOpenTelemetryCollector),
 			Labels: map[string]string{v1beta1constants.LabelApp: openTelemetryCollectorName},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -793,11 +793,12 @@ func (o *otelCollector) getPrometheusLabel() string {
 
 func getLabels() map[string]string {
 	return map[string]string{
+		v1beta1constants.LabelApp:   v1beta1constants.DeploymentNameOpenTelemetryCollector,
 		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
 		gardenerutils.NetworkPolicyLabel(valiconstants.ServiceName, valiconstants.ValiPort):                         v1beta1constants.LabelNetworkPolicyAllowed,
 		gardenerutils.NetworkPolicyLabel(victorialogsconstants.ServiceName, victorialogsconstants.VictoriaLogsPort): v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                                                    v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                                              "opentelemetry-collector",
+		v1beta1constants.LabelObservabilityApplication:                                                              v1beta1constants.DeploymentNameOpenTelemetryCollector,
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -41,9 +41,9 @@ import (
 
 const (
 	managedResourceNameTarget  = "logging-target"
-	managedResourceName        = "opentelemetry-collector"
-	serviceMonitorName         = "opentelemetry-collector"
-	openTelemetryCollectorName = "gardener-opentelemetry-collector"
+	managedResourceName        = v1beta1constants.DeploymentNameOpenTelemetryCollector
+	serviceMonitorName         = v1beta1constants.DeploymentNameOpenTelemetryCollector
+	openTelemetryCollectorName = "gardener-" + v1beta1constants.DeploymentNameOpenTelemetryCollector
 
 	kubeRBACProxyName = "rbac-proxy"
 
@@ -309,7 +309,7 @@ func (o *otelCollector) serviceMonitor() *monitoringv1.ServiceMonitor {
 					// job label, prometheus-operator would choose job=logging (service name).
 					{
 						Action:      "replace",
-						Replacement: ptr.To("opentelemetry-collector"),
+						Replacement: ptr.To(v1beta1constants.DeploymentNameOpenTelemetryCollector),
 						TargetLabel: "job",
 					},
 					{
@@ -633,7 +633,7 @@ func (o *otelCollector) openTelemetryCollector(namespace, lokiEndpoint, genericT
 }
 
 func (o *otelCollector) newLoggingAgentShootAccessSecret() *gardenerutils.AccessSecret {
-	return gardenerutils.NewShootAccessSecret("opentelemetry-collector", o.namespace).
+	return gardenerutils.NewShootAccessSecret(v1beta1constants.DeploymentNameOpenTelemetryCollector, o.namespace).
 		WithServiceAccountName(openTelemetryCollectorName).
 		WithTokenExpirationDuration("720h").
 		WithTargetSecret(collectorconstants.OpenTelemetryCollectorSecretName, metav1.NamespaceSystem)
@@ -698,7 +698,7 @@ func (o *otelCollector) getIngress(secretName string) *networkingv1.Ingress {
 func (o *otelCollector) getLoggingAgentClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   "gardener.cloud:logging:opentelemetry-collector",
+			Name:   fmt.Sprintf("gardener.cloud:logging:%s", v1beta1constants.DeploymentNameOpenTelemetryCollector),
 			Labels: map[string]string{v1beta1constants.LabelApp: openTelemetryCollectorName},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -757,11 +757,12 @@ func (o *otelCollector) getPrometheusLabel() string {
 
 func getLabels() map[string]string {
 	return map[string]string{
+		v1beta1constants.LabelApp:   v1beta1constants.DeploymentNameOpenTelemetryCollector,
 		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
 		gardenerutils.NetworkPolicyLabel(valiconstants.ServiceName, valiconstants.ValiPort):                         v1beta1constants.LabelNetworkPolicyAllowed,
 		gardenerutils.NetworkPolicyLabel(victorialogsconstants.ServiceName, victorialogsconstants.VictoriaLogsPort): v1beta1constants.LabelNetworkPolicyAllowed,
 		v1beta1constants.LabelNetworkPolicyToDNS:                                                                    v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                                              "opentelemetry-collector",
+		v1beta1constants.LabelObservabilityApplication:                                                              v1beta1constants.DeploymentNameOpenTelemetryCollector,
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -26,7 +26,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -927,11 +926,12 @@ func getValitailClusterRoleBinding(name, appName, roleName, subjectName string) 
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
-		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
-		gardenerutils.NetworkPolicyLabel(valiconstants.ServiceName, valiconstants.ValiPort): v1beta1constants.LabelNetworkPolicyAllowed,
-		gardenerutils.NetworkPolicyLabel("logging-vl", 9428):                                v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                      "opentelemetry-collector",
+		v1beta1constants.LabelApp:                            "opentelemetry-collector",
+		v1beta1constants.LabelRole:                           "observability",
+		v1beta1constants.GardenRole:                          "observability",
+		gardenerutils.NetworkPolicyLabel("logging", 3100):    "allowed",
+		gardenerutils.NetworkPolicyLabel("logging-vl", 9428): "allowed",
+		v1beta1constants.LabelNetworkPolicyToDNS:             "allowed",
+		v1beta1constants.LabelObservabilityApplication:       "opentelemetry-collector",
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -29,7 +29,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
 	comptest "github.com/gardener/gardener/pkg/component/test"
@@ -1004,11 +1003,12 @@ func getValitailClusterRoleBinding(name, appName, roleName, subjectName string) 
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
-		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
-		gardenerutils.NetworkPolicyLabel(valiconstants.ServiceName, valiconstants.ValiPort): v1beta1constants.LabelNetworkPolicyAllowed,
-		gardenerutils.NetworkPolicyLabel("logging-vl", 9428):                                v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelNetworkPolicyToDNS:                                            v1beta1constants.LabelNetworkPolicyAllowed,
-		v1beta1constants.LabelObservabilityApplication:                                      "opentelemetry-collector",
+		v1beta1constants.LabelApp:                            "opentelemetry-collector",
+		v1beta1constants.LabelRole:                           "observability",
+		v1beta1constants.GardenRole:                          "observability",
+		gardenerutils.NetworkPolicyLabel("logging", 3100):    "allowed",
+		gardenerutils.NetworkPolicyLabel("logging-vl", 9428): "allowed",
+		v1beta1constants.LabelNetworkPolicyToDNS:             "allowed",
+		v1beta1constants.LabelObservabilityApplication:       "opentelemetry-collector",
 	}
 }

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -576,7 +576,6 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				serviceAccount,
 			))
 
-			// Expect(c.Get(ctx, client.ObjectKey{Name: kubeRBACProxyShootAccessSecretName, Namespace: namespace}, &corev1.Secret{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResourceSecret), customResourcesManagedResourceSecret)).To(Succeed())
 			Expect(customResourcesManagedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(customResourcesManagedResourceSecret.Immutable).To(Equal(ptr.To(true)))

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -28,16 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
-const (
-	// OperatorManagedResourceName is the name of the OpenTelemetry Operator managed resource.
-	OperatorManagedResourceName = name
-
-	name               = "opentelemetry-operator"
-	serviceAccountName = name
-	roleName           = name
-	clusterRoleName    = name
-)
-
 // Values keeps values for the OpenTelemetry Operator.
 type Values struct {
 	// Image is the image of the OpenTelemetry Operator.
@@ -93,11 +83,11 @@ func (o *openTelemetryOperator) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return managedresources.CreateForSeed(ctx, o.client, o.namespace, OperatorManagedResourceName, false, serializedResources)
+	return managedresources.CreateForSeed(ctx, o.client, o.namespace, v1beta1constants.DeploymentNameOpenTelemetryOperator, false, serializedResources)
 }
 
 func (o *openTelemetryOperator) Destroy(ctx context.Context) error {
-	return managedresources.DeleteForSeed(ctx, o.client, o.namespace, OperatorManagedResourceName)
+	return managedresources.DeleteForSeed(ctx, o.client, o.namespace, v1beta1constants.DeploymentNameOpenTelemetryOperator)
 }
 
 var timeoutWaitForManagedResources = 2 * time.Minute
@@ -106,19 +96,19 @@ func (o *openTelemetryOperator) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, o.client, o.namespace, OperatorManagedResourceName)
+	return managedresources.WaitUntilHealthy(timeoutCtx, o.client, o.namespace, v1beta1constants.DeploymentNameOpenTelemetryOperator)
 }
 
 func (o *openTelemetryOperator) WaitCleanup(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeoutWaitForManagedResources)
 	defer cancel()
 
-	return managedresources.WaitUntilDeleted(timeoutCtx, o.client, o.namespace, OperatorManagedResourceName)
+	return managedresources.WaitUntilDeleted(timeoutCtx, o.client, o.namespace, v1beta1constants.DeploymentNameOpenTelemetryOperator)
 }
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp:   name,
+		v1beta1constants.LabelApp:   v1beta1constants.DeploymentNameOpenTelemetryOperator,
 		v1beta1constants.LabelRole:  v1beta1constants.LabelObservability,
 		v1beta1constants.GardenRole: v1beta1constants.GardenRoleObservability,
 	}
@@ -127,7 +117,7 @@ func getLabels() map[string]string {
 func (o *openTelemetryOperator) serviceAccount() *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Namespace: o.namespace,
 			Labels:    getLabels(),
 		},
@@ -138,7 +128,7 @@ func (o *openTelemetryOperator) serviceAccount() *corev1.ServiceAccount {
 func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   clusterRoleName,
+			Name:   v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Labels: getLabels(),
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -229,17 +219,17 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 func (o *openTelemetryOperator) clusterRoleBinding() *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   clusterRoleName,
+			Name:   v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Labels: getLabels(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     clusterRoleName,
+			Name:     v1beta1constants.DeploymentNameOpenTelemetryOperator,
 		},
 		Subjects: []rbacv1.Subject{{
 			Kind:      rbacv1.ServiceAccountKind,
-			Name:      serviceAccountName,
+			Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Namespace: o.namespace,
 		}},
 	}
@@ -248,7 +238,7 @@ func (o *openTelemetryOperator) clusterRoleBinding() *rbacv1.ClusterRoleBinding 
 func (o *openTelemetryOperator) role() *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
+			Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Namespace: o.namespace,
 			Labels:    getLabels(),
 		},
@@ -270,21 +260,21 @@ func (o *openTelemetryOperator) role() *rbacv1.Role {
 func (o *openTelemetryOperator) roleBinding() *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
+			Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Namespace: o.namespace,
 			Labels:    getLabels(),
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
-				Name:      name,
+				Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 				Namespace: o.namespace,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
-			Name:     roleName,
+			Name:     v1beta1constants.DeploymentNameOpenTelemetryOperator,
 		},
 	}
 }
@@ -312,7 +302,7 @@ func (o *openTelemetryOperator) deployment() *appsv1.Deployment {
 					}),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: name,
+					ServiceAccountName: v1beta1constants.DeploymentNameOpenTelemetryOperator,
 					PriorityClassName:  o.values.PriorityClassName,
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: ptr.To(true),
@@ -322,7 +312,7 @@ func (o *openTelemetryOperator) deployment() *appsv1.Deployment {
 					},
 					Containers: []corev1.Container{
 						{
-							Name:            name,
+							Name:            v1beta1constants.DeploymentNameOpenTelemetryOperator,
 							Image:           o.values.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
@@ -376,7 +366,7 @@ func (o *openTelemetryOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 	vpaUpdateMode := vpaautoscalingv1.UpdateModeRecreate
 	return &vpaautoscalingv1.VerticalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 			Namespace: o.namespace,
 			Labels:    getLabels(),
 		},
@@ -392,7 +382,7 @@ func (o *openTelemetryOperator) vpa() *vpaautoscalingv1.VerticalPodAutoscaler {
 			ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 				ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 					{
-						ContainerName: name,
+						ContainerName: v1beta1constants.DeploymentNameOpenTelemetryOperator,
 						MinAllowed: corev1.ResourceList{
 							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -340,7 +340,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 	JustBeforeEach(func() {
 		operatorManagedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      OperatorManagedResourceName,
+				Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 				Namespace: namespace,
 			},
 		}
@@ -361,7 +361,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(operatorManagedResource), operatorManagedResource)).To(Succeed())
 			expectedMr := &resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            OperatorManagedResourceName,
+					Name:            v1beta1constants.DeploymentNameOpenTelemetryOperator,
 					Namespace:       namespace,
 					Labels:          map[string]string{v1beta1constants.GardenRole: "seed-system-component"},
 					ResourceVersion: "1",
@@ -430,7 +430,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 			It("should fail because the ManagedResource doesn't become healthy", func() {
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       OperatorManagedResourceName,
+						Name:       v1beta1constants.DeploymentNameOpenTelemetryOperator,
 						Namespace:  namespace,
 						Generation: 1,
 					},
@@ -457,7 +457,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:       OperatorManagedResourceName,
+						Name:       v1beta1constants.DeploymentNameOpenTelemetryOperator,
 						Namespace:  namespace,
 						Generation: 1,
 					},
@@ -486,7 +486,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 
 				operatorManagedResource := &resourcesv1alpha1.ManagedResource{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      OperatorManagedResourceName,
+						Name:      v1beta1constants.DeploymentNameOpenTelemetryOperator,
 						Namespace: namespace,
 					},
 				}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/area logging
/kind cleanup

**What this PR does / why we need it**:
Move hardcoded string variables in observability components to `pkg/apis/core/v1beta1/constants/types_constants.go` + add missing labels in OpenTelemetry + VictoriaLogs components.

**Release note**:
```other operator
Add label `app: victoria-logs` to all resources in the VictoriaLogs setup + add label `app: opentelemetry-collector` to all resources in the OpenTelemetry Collector setup.
```
