### PR TITLE
Switch from listing `ControllerRegistrations` to getting them instead

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/required/add.go
+++ b/pkg/gardenlet/controller/controllerinstallation/required/add.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -202,28 +203,11 @@ func (r *Reconciler) MapObjectKindToControllerInstallations(log logr.Logger, obj
 		r.KindToRequiredTypes[objectKind] = newRequiredTypes
 		r.Lock.Unlock()
 
-		// Step 2: List all existing controller registrations and filter for those that are supporting resources for the
-		// extension kind this particular reconciler is responsible for.
-
-		controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
-		if err := r.GardenClient.List(ctx, controllerRegistrationList); err != nil {
-			log.Error(err, "Failed to list ControllerRegistrations")
-			return nil
-		}
-
-		controllerRegistrationNamesForKind := sets.New[string]()
-		for _, controllerRegistration := range controllerRegistrationList.Items {
-			for _, resource := range controllerRegistration.Spec.Resources {
-				if resource.Kind == objectKind {
-					controllerRegistrationNamesForKind.Insert(controllerRegistration.Name)
-					break
-				}
-			}
-		}
-
-		// Step 3: List all existing controller installation objects for the seed cluster this controller is responsible
-		// for and filter for those that reference registrations collected above. Then requeue those installations for
-		// the other reconciler to decide whether it is required or not.
+		// Step 2: List all existing controller installation objects for the seed cluster this controller is responsible
+		// for, then get each referenced ControllerRegistration to check if it handles the extension kind. Requeue those
+		// installations for the other reconciler to decide whether it is required or not.
+		// Note: we use Get instead of List for ControllerRegistrations to avoid requiring list permission, which is
+		// intentionally not granted to the shoot gardenlet in self-hosted shoot mode.
 
 		controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
 
@@ -242,11 +226,20 @@ func (r *Reconciler) MapObjectKindToControllerInstallations(log logr.Logger, obj
 		var requests []reconcile.Request
 
 		for _, obj := range controllerInstallationList.Items {
-			if !controllerRegistrationNamesForKind.Has(obj.Spec.RegistrationRef.Name) {
+			controllerRegistration := &gardencorev1beta1.ControllerRegistration{}
+			if err := r.GardenClient.Get(ctx, client.ObjectKey{Name: obj.Spec.RegistrationRef.Name}, controllerRegistration); err != nil {
+				if !apierrors.IsNotFound(err) {
+					log.Error(err, "Failed to get ControllerRegistration", "controllerRegistration", obj.Spec.RegistrationRef.Name)
+				}
 				continue
 			}
 
-			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: obj.Name}})
+			for _, resource := range controllerRegistration.Spec.Resources {
+				if resource.Kind == objectKind {
+					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: obj.Name}})
+					break
+				}
+			}
 		}
 
 		return requests

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -240,9 +240,24 @@ func (h *Health) getAllExtensionConditions(ctx context.Context) ([]healthchecker
 		return nil, nil, nil, nil, err
 	}
 
+	// Fetch ControllerRegistrations by getting each one referenced by the scoped installations.
+	// This avoids a global list, which is not permitted for the shoot gardenlet in self-hosted mode.
 	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
-	if err := h.gardenClient.List(ctx, controllerRegistrations); err != nil {
-		return nil, nil, nil, nil, err
+	seen := sets.New[string]()
+	for _, inst := range controllerInstallations.Items {
+		name := inst.Spec.RegistrationRef.Name
+		if seen.Has(name) {
+			continue
+		}
+		seen.Insert(name)
+		reg := gardencorev1beta1.ControllerRegistration{}
+		if err := h.gardenClient.Get(ctx, client.ObjectKey{Name: name}, &reg); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, nil, nil, nil, err
+			}
+			continue
+		}
+		controllerRegistrations.Items = append(controllerRegistrations.Items, reg)
 	}
 
 	var (


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

The shoot gardenlet in self-hosted shoot mode runs with a restricted garden API authorizer that does not permit listing ControllerRegistrations - only getting them by name (via graph path ControllerRegistration → ControllerInstallation → Shoot).
Two places were doing a global List on ControllerRegistrationList.

Both could be fixed by inverting the lookup: iterate the already-scoped ControllerInstallation list and Get each referenced ControllerRegistration by name. This requires only get permission, which the shoot authorizer grants via the graph.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
