### PR TITLE
[GEP-28] Tolerate transient errors while waiting until the `shoot-gardener-node-agent` ManagedResource gets healthy

### DIFF
--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -196,17 +196,23 @@ func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx co
 	timeoutCtx, cancel := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
 	defer cancel()
 
-	if err := managedresources.WaitUntilHealthy(timeoutCtx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, GardenerNodeAgentManagedResourceName); err != nil {
-		return fmt.Errorf("the operating system configs for the worker nodes were not populated yet: %w", err)
-	}
-
-	timeoutCtx2, cancel2 := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
-	defer cancel2()
-
 	retryFn := retry.SevereError
 	if tolerateErrors {
 		retryFn = retry.MinorError
 	}
+
+	if err := retry.Until(timeoutCtx, IntervalWaitOperatingSystemConfigUpdated, func(ctx context.Context) (done bool, err error) {
+		if err := managedresources.WaitUntilHealthy(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, GardenerNodeAgentManagedResourceName); err != nil {
+			return retryFn(fmt.Errorf("the operating system configs for the worker nodes were not populated yet: %w", err))
+		}
+
+		return retry.Ok()
+	}); err != nil {
+		return err
+	}
+
+	timeoutCtx2, cancel2 := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
+	defer cancel2()
 
 	return retry.Until(timeoutCtx2, IntervalWaitOperatingSystemConfigUpdated, func(ctx context.Context) (done bool, err error) {
 		workerPoolToNodes, err := WorkerPoolToNodesMap(ctx, b.ShootClientSet.Client())

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -201,6 +201,10 @@ func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx co
 		retryFn = retry.MinorError
 	}
 
+	// managedresources.WaitUntilHealthy internally treats transient errors while getting the ManagedResource (e.g., "connection refused")
+	// as severe, causing it to abort immediately and return error.
+	// For self-hosted shoots (tolerateErrors=true), the API server may be transiently unavailable
+	// during static pod rollout, so we wrap the call in a retry loop to tolerate such transient failures.
 	if err := retry.Until(timeoutCtx, IntervalWaitOperatingSystemConfigUpdated, func(ctx context.Context) (done bool, err error) {
 		if err := managedresources.WaitUntilHealthy(ctx, b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, GardenerNodeAgentManagedResourceName); err != nil {
 			return retryFn(fmt.Errorf("the operating system configs for the worker nodes were not populated yet: %w", err))

--- a/pkg/gardenlet/operation/botanist/worker_test.go
+++ b/pkg/gardenlet/operation/botanist/worker_test.go
@@ -7,6 +7,7 @@ package botanist_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -540,6 +541,77 @@ var _ = Describe("Worker", func() {
 			)
 
 			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, false)).To(Succeed())
+		})
+
+		It("should succeed when tolerating errors and the managed resource becomes healthy after a transient error", func() {
+			DeferCleanup(test.WithVars(
+				&IntervalWaitOperatingSystemConfigUpdated, time.Millisecond,
+				&GetTimeoutWaitOperatingSystemConfigUpdated, func(*shootpkg.Shoot) time.Duration { return time.Second },
+			))
+
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Workers: []gardencorev1beta1.Worker{
+							{Name: "pool1"},
+						},
+					},
+				},
+			})
+
+			seedInterface.EXPECT().Client().Return(seedClient).AnyTimes()
+			gomock.InOrder(
+				// First call: transient error (simulates connection refused during static pod rollout)
+				seedClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: "shoot-gardener-node-agent"}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+					Return(fmt.Errorf("dial tcp 10.2.0.99:443: connect: connection refused")),
+				// Second call: ManagedResource is healthy
+				seedClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: controlPlaneNamespace, Name: "shoot-gardener-node-agent"},
+					gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(clientGet(&resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Status: resourcesv1alpha1.ManagedResourceStatus{
+						ObservedGeneration: 1,
+						Conditions: []gardencorev1beta1.Condition{
+							{
+								Type:   resourcesv1alpha1.ResourcesApplied,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+							{
+								Type:   resourcesv1alpha1.ResourcesHealthy,
+								Status: gardencorev1beta1.ConditionTrue,
+							},
+						},
+					},
+				})),
+			)
+
+			shootInterface.EXPECT().Client().Return(shootClient).AnyTimes()
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
+				*list = corev1.NodeList{Items: []corev1.Node{{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"worker.gardener.cloud/pool":                            "pool1",
+							"worker.gardener.cloud/kubernetes-version":              "1.26.0",
+							"worker.gardener.cloud/gardener-node-agent-secret-name": "gardener-node-agent-pool1-5dcdf",
+						},
+						Annotations: map[string]string{"checksum/cloud-config-data": "foo"},
+					},
+				}}}
+				return nil
+			}).AnyTimes()
+			shootClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.SecretList{}), operatingSystemConfigSecretListOptions).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
+				*list = corev1.SecretList{Items: []corev1.Secret{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "gardener-node-agent-pool1-5dcdf",
+						Labels:      map[string]string{"worker.gardener.cloud/pool": "pool1"},
+						Annotations: map[string]string{"checksum/data-script": "foo"},
+					},
+				}}}
+				return nil
+			}).AnyTimes()
+
+			Expect(botanist.WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx, true)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:
`gardenadm init` deploys the control plane components (static pods) in the following step: https://github.com/gardener/gardener/blob/c8ca51630c682542ddc4807cdd102ca56be7e95a/pkg/gardenadm/cmd/init/init.go#L365-L369. Later, it waits until the control plane components (static pods) are ready in the following step: https://github.com/gardener/gardener/blob/c8ca51630c682542ddc4807cdd102ca56be7e95a/pkg/gardenadm/cmd/init/init.go#L370-L376. The wait consists of waiting until the `shoot-gardener-node-agent` ManagedResource is healthy and waiting until the OperatingSystemConfig is updated for all worker pools. See the [`WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools` func](https://github.com/gardener/gardener/blob/526ca2f5fbce83cda15a35ccef2844ec35ffb8ea/pkg/gardenlet/operation/botanist/worker.go#L195-L228).

The flake described in https://github.com/gardener/gardener/issues/14484 occurs in https://github.com/gardener/gardener/blob/526ca2f5fbce83cda15a35ccef2844ec35ffb8ea/pkg/gardenlet/operation/botanist/worker.go#L199-L201. The wait for the `shoot-gardener-node-agent` ManagedResource does not tolerate errors and fails the whole `gardenadm init` flow due to transient errors. Transient errors occur because the first step from above deploys the static pods (incl. kube-apiserver). The static pods are being rolled out and the kube-apiserver is expected to fail wait transient errors during this rollout.

This PR ignores transient errors in the wait for the `shoot-gardener-node-agent` ManagedResource. Transient errors are now retried.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14484

**Special notes for your reviewer**:
On the master branch (16afe9dcdf0c6e13619a2b49c802921410d0b3c5), I can reproduce the issue 5/5 (5 times fails from 5 tries).
On this PR, I am not able to reproduce the issue 0/3 (0 times fails from 3 tries).

The script that I used for reproducing the issue:
```bash
#!/usr/bin/env bash

set -o errexit
set -o nounset
set -o pipefail

# Create the setup according to the local setup with gardenadm
make kind-single-node-up
export KUBECONFIG=$PWD/dev-setup/kubeconfigs/runtime/kubeconfig
make gardenadm-up

# Create control plane Node
kubectl -n gardenadm-unmanaged-infra exec -it machine-0 -- gardenadm init -d /gardenadm/resources --use-bootstrap-etcd
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug was fixed where `gardenadm init` could fail due to a transient error while fetching the `shoot-gardener-node-agent` ManagedResource when the Kubernetes API server is temporarily unavailable due to static pod rollout.
```
