### PR TITLE
Local Setup DNS: Create `/etc/systemd/resolved.conf.d/` if not exists on Linux

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -136,7 +136,10 @@ EOF
       ${SUDO}mkdir -p /etc/resolver
       echo "$desired_resolver_config" | ${SUDO}tee /etc/resolver/local.gardener.cloud
     fi
-  elif [[ "$OSTYPE" == "linux"* && -d /etc/systemd/resolved.conf.d ]]; then
+  elif [[ "$OSTYPE" == "linux"* && -f /etc/systemd/resolved.conf ]]; then
+    if [[ ! -d /etc/systemd/resolved.conf.d ]]; then
+            ${SUDO}mkdir -p /etc/systemd/resolved.conf.d
+    fi
     if ! grep -q "$dns_ip" /etc/systemd/resolved.conf.d/gardener-local.conf || ! grep -q "$dns_ipv6" /etc/systemd/resolved.conf.d/gardener-local.conf ; then
       echo "Configuring systemd-resolved to resolve the local.gardener.cloud zone using the local setup's DNS server"
       cat <<EOF | ${SUDO}tee /etc/systemd/resolved.conf.d/gardener-local.conf


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

cc @timebertt 

**What this PR does / why we need it**:

While creating a local setup I got the following warning:
```
Warning: Unknown OS. Make sure your host resolves the local.gardener.cloud zone using the local setup's DNS server at ... or ... respectively.
```

On my Linux (Ubuntu 24.04.) the directory `/etc/systemd/resolved.conf.d` is not created by default. Still `systemd-resolved` is used.  I switched the check to the file `/etc/systemd/resolved.conf` and create the directory `/etc/systemd/resolved.conf.d/` if not existsing. With that change it works without manually creating the directory before.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
