### PR TITLE
Recover panic in `flow.Task`

### DIFF
--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -229,6 +229,14 @@ func (e *execution) runNode(ctx context.Context, id TaskID) {
 	e.stats.Running.Insert(id)
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("task %q recovered panic: %v", id, r)
+				log.Error(err, "Error")
+				e.done <- &nodeResult{TaskID: id, Error: err}
+			}
+		}()
+
 		start := e.flow.clock.Now().UTC()
 		log.V(1).Info("Started")
 		err := node.fn(ctx)

--- a/pkg/utils/flow/flow_test.go
+++ b/pkg/utils/flow/flow_test.go
@@ -7,6 +7,7 @@ package flow_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -112,6 +113,21 @@ var _ = Describe("Flow", func() {
 			Expect(err).To(HaveOccurred())
 			causes := flow.Causes(err)
 			Expect(causes.Errors).To(ConsistOf(err1, err2))
+		})
+
+		It("should recover from a panic and yield the correct errors", func() {
+			var (
+				panicErr = errors.New("panic error")
+
+				g      = flow.NewGraph("foo")
+				taskId = g.Add(flow.Task{Name: "x", Fn: func(_ context.Context) error { panic(panicErr) }})
+				f      = g.Compile()
+			)
+
+			err := f.Run(ctx, flow.Opts{})
+			Expect(err).To(HaveOccurred())
+			causes := flow.Causes(err)
+			Expect(causes.Errors).To(ConsistOf(fmt.Errorf("task %q recovered panic: %v", taskId, panicErr)))
 		})
 
 		It("should not process any function due to a canceled context", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Recover panic in `flow.Task` to avoid a panic of the complete controller which uses the flow package. Some extensions already have a "own" panic recovery (like [gardener-extension-provider-aws](https://github.com/gardener/gardener-extension-provider-aws/blob/25bad6cbd08d3105c4a9a47fc620c32e81382667/pkg/controller/infrastructure/infraflow/shared/basic_context.go#L125)) but I think it still makes sense to recover them globally. I also tested that the behavior will not change if a extension has already panic recovery (see example below).


**Which issue(s) this PR fixes**:
Fixes #14495

**Special notes for your reviewer**:

To test this you can use this small example:

```go
package main

import (
	"context"
	"fmt"

	"github.com/gardener/gardener/pkg/logger"
	"github.com/gardener/gardener/pkg/utils/flow"
)

func main() {
	log, _ := logger.NewZapLogger(logger.DebugLevel, logger.FormatText)
	g := flow.NewGraph("test")

	task1 := flow.Task{
		Name: "no panic test",
		Fn: func(_ context.Context) error {
			return nil
		},
	}

	task2 := flow.Task{
		Name: "own panic recover test",
		Fn: func(_ context.Context) error {
			defer func() {
				if r := recover(); r != nil {
					// just log panic but successful finish task
					log.Info("panic recovered", "panic", r)
				}
			}()
			panic("test2")
			return nil
		},
		Dependencies: make(flow.TaskIDs).Insert(g.Add(task1)),
	}

	task3 := flow.Task{
		Name: "panic test",
		Fn: func(_ context.Context) error {
			panic("test3")
			return nil
		},
		Dependencies: make(flow.TaskIDs).Insert(g.Add(task2)),
	}

	g.Add(task3)

	fmt.Println(g.Compile().Run(context.TODO(), flow.Opts{Log: log}))
}
```

This outputs:
```
 go run main.go
2026-04-16T15:01:44.703+0200    INFO    Starting        {"flow": "test"}
2026-04-16T15:01:44.703+0200    DEBUG   Started {"flow": "test", "task": "no panic test"}
2026-04-16T15:01:44.703+0200    DEBUG   Finished        {"flow": "test", "task": "no panic test", "duration": "29.976�s"}
2026-04-16T15:01:44.703+0200    INFO    Succeeded       {"flow": "test", "task": "no panic test"}
2026-04-16T15:01:44.704+0200    DEBUG   Started {"flow": "test", "task": "own panic recover test"}
2026-04-16T15:01:44.704+0200    INFO    panic recovered {"panic": "test2"}
2026-04-16T15:01:44.704+0200    DEBUG   Finished        {"flow": "test", "task": "own panic recover test", "duration": "34.715�s"}
2026-04-16T15:01:44.704+0200    INFO    Succeeded       {"flow": "test", "task": "own panic recover test"}
2026-04-16T15:01:44.704+0200    DEBUG   Started {"flow": "test", "task": "panic test"}
2026-04-16T15:01:44.704+0200    ERROR   Error   {"flow": "test", "task": "panic test", "error": "task \"panic test\" recovered panic: test3"}
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2.1
        /git/github/gardener/gardener/pkg/utils/flow/flow.go:235
runtime.gopanic
       /sdk/go1.26.1/src/runtime/panic.go:860
main.main.func3
        /tmp/flow/main.go:39
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func2
        /git/github/gardener/gardener/pkg/utils/flow/flow.go:242
2026-04-16T15:01:44.704+0200    INFO    Finished        {"flow": "test"}
flow "test" encountered task errors: [task "panic test" recovered panic: test3]
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
Added panic recovery to `flow.Task` to prevent a single task failure from crashing the entire controller. If you previously implemented custom panic recovery within your tasks, you  can consider removing that custom panic recovery.
```
