### PR TITLE
Fixed gardener discovery server not being available in istio-native exposure

### DIFF
--- a/pkg/component/gardener/discoveryserver/discoveryserver_test.go
+++ b/pkg/component/gardener/discoveryserver/discoveryserver_test.go
@@ -461,7 +461,7 @@ var _ = Describe("GardenerDiscoveryServer", func() {
 				Gateways: []string{"gardener-discovery-server"},
 				Tls: []*istioapinetworkingv1alpha3.TLSRoute{{
 					Match: []*istioapinetworkingv1alpha3.TLSMatchAttributes{{
-						Port:     10443,
+						Port:     443,
 						SniHosts: []string{"discovery.local.gardener.cloud"},
 					}},
 					Route: []*istioapinetworkingv1alpha3.RouteDestination{{

--- a/pkg/utils/istio/virtualservice.go
+++ b/pkg/utils/istio/virtualservice.go
@@ -19,7 +19,7 @@ func VirtualServiceWithSNIMatch(virtualService *istionetworkingv1beta1.VirtualSe
 			Gateways: []string{gatewayName},
 			Tls: []*istioapinetworkingv1beta1.TLSRoute{{
 				Match: []*istioapinetworkingv1beta1.TLSMatchAttributes{{
-					Port:     port,
+					Port:     443,
 					SniHosts: hosts,
 				}},
 				Route: []*istioapinetworkingv1beta1.RouteDestination{{

--- a/pkg/utils/istio/virtualservice_test.go
+++ b/pkg/utils/istio/virtualservice_test.go
@@ -30,7 +30,7 @@ var _ = Describe("VirtualService", func() {
 		Expect(virtualService.Spec.Gateways[0]).To(Equal(gatewayName))
 		Expect(virtualService.Spec.Tls).To(HaveLen(1))
 		Expect(virtualService.Spec.Tls[0].Match).To(HaveLen(1))
-		Expect(virtualService.Spec.Tls[0].Match[0].Port).To(Equal(port))
+		Expect(virtualService.Spec.Tls[0].Match[0].Port).To(Equal(uint32(443)))
 		Expect(virtualService.Spec.Tls[0].Match[0].SniHosts).To(Equal(hosts))
 		Expect(virtualService.Spec.Tls[0].Route).To(HaveLen(1))
 		Expect(virtualService.Spec.Tls[0].Route[0].Destination.Host).To(Equal(destinationHost))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:

Fixed gardener discovery server not being available in istio-native exposure.

After #14587, gardener discovery server was no longer accessible because the SNI match of the `VirtualService` matched on the incorrect port. This worked for `kube-apiserver` as `Gateway` and target port were the same.
No other component uses the corresponding helper function.

**Which issue(s) this PR fixes**:
Part of #13448

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
