### PR TITLE
Increase gardenadm unmanaged e2e timeout from `10m` to `15m`

### DIFF
--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -187,7 +187,11 @@ var (
 )
 
 func getTimeoutWaitOperatingSystemConfigUpdated(shoot *shootpkg.Shoot) time.Duration {
-	return shoot.OSCSyncJitterPeriod.Duration + controllerutils.DefaultReconciliationTimeout
+	reconciliationTimeout := controllerutils.DefaultReconciliationTimeout
+	if shoot.IsSelfHosted() && !shoot.HasManagedInfrastructure() {
+		reconciliationTimeout = 10 * time.Minute
+	}
+	return shoot.OSCSyncJitterPeriod.Duration + reconciliationTimeout
 }
 
 // WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools waits for a maximum of 2*GetTimeoutWaitOperatingSystemConfigUpdated

--- a/pkg/gardenlet/operation/botanist/worker.go
+++ b/pkg/gardenlet/operation/botanist/worker.go
@@ -190,8 +190,9 @@ func getTimeoutWaitOperatingSystemConfigUpdated(shoot *shootpkg.Shoot) time.Dura
 	return shoot.OSCSyncJitterPeriod.Duration + controllerutils.DefaultReconciliationTimeout
 }
 
-// WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools waits for a maximum of 6 minutes until all the nodes for all
-// the worker pools in the Shoot have successfully applied the desired version of their operating system config.
+// WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools waits for a maximum of 2*GetTimeoutWaitOperatingSystemConfigUpdated
+// until all the nodes for all the worker pools in the Shoot have successfully applied the desired version of their
+// operating system config.
 func (b *Botanist) WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools(ctx context.Context, tolerateErrors bool) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, GetTimeoutWaitOperatingSystemConfigUpdated(b.Shoot))
 	defer cancel()

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -97,7 +97,7 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
-			}, SpecTimeout(10*time.Minute))
+			}, SpecTimeout(15*time.Minute))
 
 			It("copy admin kubeconfig and create client", func(ctx SpecContext) {
 				tempDir, err := os.MkdirTemp("", "tmp")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:

Some `gardenadm-unmanaged-infra-*` tests were failing, because `gardenadm init` takes longer than `10m`:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14620/pull-gardener-e2e-kind-gardenadm-unmanaged-infra-external-gardener/2046120112477442048
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14575/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2045594749213085696

---

Also fixes a stale comment on WaitUntilOperatingSystemConfigUpdatedForAllWorkerPools which claimed a 6-minute timeout but referenced the wrong reasoning.

The function creates two independent contexts from the parent `ctx`, each with a timeout of `GetTimeoutWaitOperatingSystemConfigUpdated`. They run sequentially - first `WaitUntilHealthy`, then the `retry.Until` loop - so the function can block for up to 2 * `GetTimeoutWaitOperatingSystemConfigUpdated` in total.
The first context timing out does not cancel the second, because both are derived independently from `ctx

**Which issue(s) this PR fixes**:
Part of #12624

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
