### PR TITLE
[GEP-28] Remove port-forward for self-hosted shoot API server access in e2e tests

### DIFF
--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -167,14 +167,19 @@ NAME                                                    STATUS   ROLES    AGE   
 machine-shoot--garden--root-control-plane-58ffc-2l6s7   Ready    <none>   4m11s   v1.33.0
 ```
 
-You can also access the cluster's API server directly from your host machine after obtaining a kubeconfig for it:
+`gardenadm bootstrap` copies the kubeconfig from the control plane machine to the bootstrap cluster.
+You can also copy the kubeconfig to your local machine and use a port-forward to connect to the cluster's API server:
 
 ```shell
-$ ./hack/usage/generate-admin-kubeconfig-local.sh self-hosted-shoot > dev-setup/kubeconfigs/self-hosted-shoot/kubeconfig
-$ export KUBECONFIG=dev-setup/kubeconfigs/self-hosted-shoot/kubeconfig
+$ kubectl get secret -n shoot--garden--root kubeconfig -o jsonpath='{.data.kubeconfig}' | base64 --decode | sed 's/api.root.garden.external.local.gardener.cloud/localhost:6443/' > /tmp/shoot--garden--root.conf
+$ machine="$(kubectl -n shoot--garden--root get po -l app=machine -oname | head -1 | cut -d/ -f2)"
+$ kubectl -n shoot--garden--root port-forward pod/$machine 6443:443
+
+# in a new terminal
+$ export KUBECONFIG=/tmp/shoot--garden--root.conf
 $ kubectl get no
-NAME        STATUS   ROLES    AGE   VERSION
-machine-0   Ready    <none>   10m   v1.32.0
+NAME                                                    STATUS   ROLES    AGE     VERSION
+machine-shoot--garden--root-control-plane-58ffc-2l6s7   Ready    <none>   4m11s   v1.33.0
 ```
 
 ## Connecting the Self-Hosted Shoot Cluster to Gardener

--- a/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/unmanagedinfra/gardenadm.go
@@ -48,17 +48,10 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 
 	Describe("Single-node control plane", Ordered, Label("single"), func() {
 		var (
-			portForwardCtx    context.Context
-			cancelPortForward context.CancelFunc
-			shootClientSet    kubernetes.Interface
+			shootClientSet kubernetes.Interface
 
 			configDirectory = "/gardenadm/resources"
 		)
-
-		BeforeAll(func() {
-			portForwardCtx, cancelPortForward = context.WithCancel(context.Background())
-			DeferCleanup(func() { cancelPortForward() })
-		})
 
 		Context("gardenadm init + join", Ordered, Label("initjoin"), func() {
 			BeforeAll(func(ctx SpecContext) {
@@ -99,37 +92,20 @@ var _ = Describe("gardenadm unmanaged infrastructure scenario tests", Label("gar
 				Eventually(ctx, stdOut).Should(gbytes.Say("Your Shoot cluster control-plane has initialized successfully!"))
 			}, SpecTimeout(15*time.Minute))
 
-			It("copy admin kubeconfig and create client", func(ctx SpecContext) {
-				tempDir, err := os.MkdirTemp("", "tmp")
-				Expect(err).NotTo(HaveOccurred())
-				DeferCleanup(func() { Expect(os.RemoveAll(tempDir)).To(Succeed()) })
-				adminKubeconfigFile := filepath.Join(tempDir, "admin.conf")
+			It("should create a client for the self-hosted shoot API server", func(ctx SpecContext) {
+				var adminKubeconfig []byte
 
-				By("Copy admin kubeconfig to local file")
-				localPort := 6443
-				Eventually(ctx, func(g Gomega) error {
+				By("Read admin kubeconfig from control plane machine")
+				Eventually(ctx, func(g Gomega) {
 					stdOut, _, err := execute(ctx, 0, "cat", "/etc/kubernetes/admin.conf")
 					g.Expect(err).NotTo(HaveOccurred())
-
-					kubeconfig := strings.ReplaceAll(string(stdOut.Contents()), fmt.Sprintf("api.%s.%s.external.local.gardener.cloud", shootName, shootNamespace), fmt.Sprintf("localhost:%d", localPort))
-					return os.WriteFile(adminKubeconfigFile, []byte(kubeconfig), 0600)
+					adminKubeconfig = stdOut.Contents()
 				}).Should(Succeed())
-
-				By("Forward port to control plane machine pod")
-				fw, err := kubernetes.SetupPortForwarder(portForwardCtx, RuntimeClient.RESTConfig(), namespace, machinePodName(0), localPort, 443)
-				Expect(err).NotTo(HaveOccurred())
-
-				go func() {
-					if err := fw.ForwardPorts(); err != nil {
-						Fail("Error forwarding ports: " + err.Error())
-					}
-				}()
-
-				Eventually(func() chan struct{} { return fw.Ready() }).Should(BeClosed())
 
 				By("Create client set")
 				Eventually(func() error {
-					shootClientSet, err = kubernetes.NewClientFromFile("", adminKubeconfigFile,
+					var err error
+					shootClientSet, err = kubernetes.NewClientFromBytes(adminKubeconfig,
 						kubernetes.WithDisabledCachedClient(),
 						kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 					)


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind cleanup

**What this PR does / why we need it**:
Follow-up of #14370. Since the self-hosted shoot API server is now directly accessible from the host via DNS and KinD NodePort mapping, the port-forward and URL rewriting in the gardenadm unmanaged-infra e2e tests are no longer needed. This removes the `SetupPortForwarder` call, the server URL rewriting, and the temporary file handling — the `admin.conf` kubeconfig is now used as-is.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```NONE
```