### PR TITLE
[operator] Deploy `BackupEntry` object in `Garden` controller alongside `BackupBucket`

### DIFF
--- a/charts/gardener/operator/templates/clusterrole.yaml
+++ b/charts/gardener/operator/templates/clusterrole.yaml
@@ -187,6 +187,7 @@ rules:
   - extensions.gardener.cloud
   resources:
   - backupbuckets
+  - backupentries
   - dnsrecords
   verbs:
   - get

--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - --heartbeat-renew-interval-seconds={{ .Values.controllers.heartbeat.renewIntervalSeconds }}
         {{- if .Values.gardener.runtimeCluster.enabled }}
         - --disable-webhooks=controlplane,networkpolicy,prometheus,shoot
-        - --controllers=backupbucket,dnsrecord,local-ext-shoot
+        - --controllers=backupbucket,backupentry,dnsrecord,local-ext-shoot
         - --extension-classes=garden
         {{- else }}
         - --extension-classes=seed,shoot

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -302,6 +302,7 @@ func applyReconcileOptions(reconcileOpts *extensionscmdcontroller.ReconcilerOpti
 	config := reconcileOpts.Completed()
 
 	localbackupbucket.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localbackupentry.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localbastion.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localcontrolplane.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localextensionseedcontroller.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
@@ -318,6 +319,7 @@ func applyGeneralOptions(generalOpts *extensionscmdcontroller.GeneralOptions) {
 	localworker.DefaultAddOptions.SelfHostedShootCluster = config.SelfHostedShootCluster
 
 	localbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localbackupentry.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localcontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localextensionseedcontroller.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -88,8 +88,9 @@ It contains configuration for the following scenarios:
 - The deployment of `ControllerRegistration` and `ControllerDeployment` resources in the (virtual) garden cluster.
 - The deployment of [extension admissions charts](../extensions/admission.md) in runtime and virtual clusters.
 
-With regard to the `Garden` reconciliation process, there are specific types of extensions that are of key interest, namely the `BackupBucket`, `DNSRecord`, and `Extension` types.
+With regard to the `Garden` reconciliation process, there are specific types of extensions that are of key interest, namely the `BackupBucket`, `BackupEntry`, `DNSRecord`, and `Extension` types.
 The `BackupBucket` extension is utilized to manage the backup bucket dedicated to the garden's main etcd.
+The `BackupEntry` extension manages the backup entry within the bucket, using the provider-generated credentials from the `BackupBucket`.
 The `DNSRecord` extension type is essential to manage the API server and ingress DNS records.
 Lastly, the `Extension` type plays a crucial role in managing generic Gardener extensions which deploy various components within the runtime cluster. These extensions can be activated and configured in the `.spec.extensions` field of the `Garden` resource. These extensions can supplement functionality and provide new capabilities.
 
@@ -113,7 +114,7 @@ Each one is described in more details below.
 
 ##### Runtime
 
-Extensions can manage resources required by the `Garden` resource (e.g. `BackupBucket`, `DNSRecord`, `Extension`) in the runtime cluster.
+Extensions can manage resources required by the `Garden` resource (e.g. `BackupBucket`, `BackupEntry`, `DNSRecord`, `Extension`) in the runtime cluster.
 Since the environment in the runtime cluster may differ from that of a `Seed`, the extension is installed in the runtime cluster with a distinct set of Helm chart values specified in `.spec.deployment.extension.runtimeValues`.
 If no `runtimeValues` are provided, the extension deployment for the runtime garden is considered superfluous and the deployment is uninstalled.
 The configuration allows for precise control over various extension parameters, such as requested resources, [priority classes](../development/priority-classes.md), and more.
@@ -123,7 +124,7 @@ Besides the values configured in `.spec.deployment.extension.runtimeValues`, a r
 ```yaml
 gardener:
   runtimeCluster:
-    enabled: true # indicates the extension is enabled for the Garden cluster, e.g. for handling `BackupBucket`, `DNSRecord` and `Extension` objects.
+    enabled: true # indicates the extension is enabled for the Garden cluster, e.g. for handling `BackupBucket`, `BackupEntry`, `DNSRecord` and `Extension` objects.
     priorityClassName: gardener-garden-system-200
 ```
 

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -49,7 +49,7 @@ The `.spec.class` field identifies the different deployment cases.
 #### Garden
 
 Extension controllers serve the garden (run in garden runtime), e.g., installing certificates for API and ingress endpoints.
-In the course of the `Garden` reconciliation, the `gardener-operator` creates `BackupBucket`, `DNSRecord` and `Extension` resources (group `extensions.gardener.cloud`) which triggers the responsible extension controllers to reconcile them.
+In the course of the `Garden` reconciliation, the `gardener-operator` creates `BackupBucket`, `BackupEntry`, `DNSRecord` and `Extension` resources (group `extensions.gardener.cloud`) which triggers the responsible extension controllers to reconcile them.
 
 #### Seed
 

--- a/pkg/component/extensions/backupentry/backupentry.go
+++ b/pkg/component/extensions/backupentry/backupentry.go
@@ -39,6 +39,7 @@ type Interface interface {
 	SetType(string)
 	SetProviderConfig(*runtime.RawExtension)
 	SetRegion(string)
+	SetSecretRef(corev1.SecretReference)
 	SetBackupBucketProviderStatus(*runtime.RawExtension)
 }
 
@@ -50,6 +51,8 @@ type Values struct {
 	Type string
 	// ProviderConfig contains the provider config for the BackupEntry extension.
 	ProviderConfig *runtime.RawExtension
+	// Class is the extension class of this BackupEntry.
+	Class *extensionsv1alpha1.ExtensionClass
 	// Region is the infrastructure region of the BackupEntry.
 	Region string
 	// SecretRef is a reference to a secret with the infrastructure credentials.
@@ -114,6 +117,7 @@ func (b *backupEntry) deploy(ctx context.Context, operation string) (extensionsv
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           b.values.Type,
 				ProviderConfig: b.values.ProviderConfig,
+				Class:          b.values.Class,
 			},
 			Region:                     b.values.Region,
 			SecretRef:                  b.values.SecretRef,
@@ -207,6 +211,10 @@ func (b *backupEntry) SetProviderConfig(providerConfig *runtime.RawExtension) {
 
 func (b *backupEntry) SetRegion(region string) {
 	b.values.Region = region
+}
+
+func (b *backupEntry) SetSecretRef(secretRef corev1.SecretReference) {
+	b.values.SecretRef = secretRef
 }
 
 func (b *backupEntry) SetBackupBucketProviderStatus(providerStatus *runtime.RawExtension) {

--- a/pkg/component/extensions/backupentry/backupentry_test.go
+++ b/pkg/component/extensions/backupentry/backupentry_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -54,6 +55,7 @@ var _ = Describe("#BackupEntry", func() {
 		bucketName                 = "bucketname"
 		providerType               = "foo"
 		providerConfig             = &runtime.RawExtension{Raw: []byte(`{"bar":"foo"}`)}
+		class                      = ptr.To(extensionsv1alpha1.ExtensionClassShoot)
 		backupBucketProviderStatus = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
 		secretRef                  = corev1.SecretReference{
 			Name:      "secretname",
@@ -79,6 +81,7 @@ var _ = Describe("#BackupEntry", func() {
 			Name:                       name,
 			Type:                       providerType,
 			ProviderConfig:             providerConfig,
+			Class:                      class,
 			Region:                     region,
 			SecretRef:                  secretRef,
 			BucketName:                 bucketName,
@@ -103,6 +106,7 @@ var _ = Describe("#BackupEntry", func() {
 				DefaultSpec: extensionsv1alpha1.DefaultSpec{
 					Type:           providerType,
 					ProviderConfig: providerConfig,
+					Class:          class,
 				},
 				Region:                     region,
 				SecretRef:                  secretRef,

--- a/pkg/component/extensions/backupentry/mock/mocks.go
+++ b/pkg/component/extensions/backupentry/mock/mocks.go
@@ -15,6 +15,7 @@ import (
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gomock "go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -132,6 +133,18 @@ func (m *MockInterface) SetRegion(arg0 string) {
 func (mr *MockInterfaceMockRecorder) SetRegion(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRegion", reflect.TypeOf((*MockInterface)(nil).SetRegion), arg0)
+}
+
+// SetSecretRef mocks base method.
+func (m *MockInterface) SetSecretRef(arg0 v1.SecretReference) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSecretRef", arg0)
+}
+
+// SetSecretRef indicates an expected call of SetSecretRef.
+func (mr *MockInterfaceMockRecorder) SetSecretRef(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecretRef", reflect.TypeOf((*MockInterface)(nil).SetSecretRef), arg0)
 }
 
 // SetType mocks base method.

--- a/pkg/component/extensions/crds/crds.go
+++ b/pkg/component/extensions/crds/crds.go
@@ -48,12 +48,12 @@ func NewCRD(client client.Client, includeGeneralCRDs, includeShootCRDs bool) (co
 		crds        []string
 		generalCRDs = []string{
 			backupBucketCRD,
+			backupEntryCRD,
 			dnsRecordCRD,
 			extensionCRD,
 		}
 
 		shootCRDs = []string{
-			backupEntryCRD,
 			bastionCRD,
 			clusterCRD,
 			containerRuntimeCRD,

--- a/pkg/component/extensions/crds/crds_test.go
+++ b/pkg/component/extensions/crds/crds_test.go
@@ -104,7 +104,7 @@ var _ = Describe("#CRDs", func() {
 			},
 
 			Entry("BackupBucket", "backupbuckets.extensions.gardener.cloud", Succeed()),
-			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", BeNotFoundError()),
+			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", Succeed()),
 			Entry("Bastion", "bastions.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("Cluster", "clusters.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("ContainerRuntime", "containerruntimes.extensions.gardener.cloud", BeNotFoundError()),
@@ -127,7 +127,7 @@ var _ = Describe("#CRDs", func() {
 			},
 
 			Entry("BackupBucket", "backupbuckets.extensions.gardener.cloud", Succeed()),
-			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", BeNotFoundError()),
+			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", Succeed()),
 			Entry("Bastion", "bastions.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("Cluster", "clusters.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("ContainerRuntime", "containerruntimes.extensions.gardener.cloud", BeNotFoundError()),
@@ -154,7 +154,7 @@ var _ = Describe("#CRDs", func() {
 			},
 
 			Entry("BackupBucket", "backupbuckets.extensions.gardener.cloud", BeNotFoundError()),
-			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", Succeed()),
+			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("Bastion", "bastions.extensions.gardener.cloud", Succeed()),
 			Entry("Cluster", "clusters.extensions.gardener.cloud", Succeed()),
 			Entry("ContainerRuntime", "containerruntimes.extensions.gardener.cloud", Succeed()),
@@ -177,7 +177,7 @@ var _ = Describe("#CRDs", func() {
 			},
 
 			Entry("BackupBucket", "backupbuckets.extensions.gardener.cloud", BeNotFoundError()),
-			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", Succeed()),
+			Entry("BackupEntry", "backupentries.extensions.gardener.cloud", BeNotFoundError()),
 			Entry("Bastion", "bastions.extensions.gardener.cloud", Succeed()),
 			Entry("Cluster", "clusters.extensions.gardener.cloud", Succeed()),
 			Entry("ContainerRuntime", "containerruntimes.extensions.gardener.cloud", Succeed()),
@@ -222,7 +222,7 @@ var _ = Describe("#CRDs", func() {
 			Expect(crdDeployer.Destroy(ctx)).To(Succeed(), "extensions crds deletion succeeds")
 
 			Expect(c.Get(ctx, client.ObjectKey{Name: "backupbuckets.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
-			Expect(c.Get(ctx, client.ObjectKey{Name: "backupentries.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "backupentries.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "bastions.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "clusters.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "containerruntimes.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
@@ -241,7 +241,7 @@ var _ = Describe("#CRDs", func() {
 			Expect(crdDeployer.Destroy(ctx)).To(Succeed(), "extensions crds deletion succeeds")
 
 			Expect(c.Get(ctx, client.ObjectKey{Name: "backupbuckets.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, client.ObjectKey{Name: "backupentries.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKey{Name: "backupentries.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "bastions.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "clusters.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "containerruntimes.extensions.gardener.cloud"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())

--- a/pkg/operator/controller/extension/required/runtime/add.go
+++ b/pkg/operator/controller/extension/required/runtime/add.go
@@ -43,6 +43,7 @@ type extension struct {
 
 var runtimeClusterExtensions = []extension{
 	{objectKind: extensionsv1alpha1.BackupBucketResource, object: &extensionsv1alpha1.BackupBucket{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.BackupBucketList{} }},
+	{objectKind: extensionsv1alpha1.BackupEntryResource, object: &extensionsv1alpha1.BackupEntry{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.BackupEntryList{} }},
 	{objectKind: extensionsv1alpha1.DNSRecordResource, object: &extensionsv1alpha1.DNSRecord{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.DNSRecordList{} }},
 	{objectKind: extensionsv1alpha1.ExtensionResource, object: &extensionsv1alpha1.Extension{}, newObjectListFunc: func() client.ObjectList { return &extensionsv1alpha1.ExtensionList{} }},
 }

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/apiserver"
 	"github.com/gardener/gardener/pkg/component/autoscaling/vpa"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
+	extensionsbackupentry "github.com/gardener/gardener/pkg/component/extensions/backupentry"
 	extensioncrds "github.com/gardener/gardener/pkg/component/extensions/crds"
 	"github.com/gardener/gardener/pkg/component/extensions/extension"
 	runtimegardensystem "github.com/gardener/gardener/pkg/component/garden/system/runtime"
@@ -115,6 +116,7 @@ type components struct {
 
 	extensions extension.Interface
 
+	etcdMainBackupEntry                  extensionsbackupentry.Interface
 	etcdMain                             etcd.Interface
 	etcdEvents                           etcd.Interface
 	kubeAPIServerService                 component.DeployWaiter
@@ -239,6 +241,11 @@ func (r *Reconciler) instantiateComponents(
 
 	// garden extensions
 	c.extensions = r.newExtensions(log, garden, extensionList)
+
+	// etcd backup entry
+	if helper.GetETCDMainBackup(garden) != nil {
+		c.etcdMainBackupEntry = r.newEtcdMainBackupEntry(log, garden)
+	}
 
 	// virtual garden control plane components
 	c.etcdMain, err = r.newEtcd(log, garden, secretsManager, v1beta1constants.ETCDRoleMain, etcd.ClassImportant)
@@ -1816,6 +1823,36 @@ func discoveryServerTLSSecretName(garden *operatorv1alpha1.Garden, wildcardCertS
 		return config.TLSSecretName
 	}
 	return wildcardCertSecretName
+}
+
+// newEtcdMainBackupEntry creates a BackupEntry component for the ETCD main backup. The name follows the
+// <namespace>--<uid> convention so that the generic actuator's `ExtractShootDetailsFromBackupEntryName` can derive
+// the garden namespace and create the `etcd-backup` secret there.
+func (r *Reconciler) newEtcdMainBackupEntry(log logr.Logger, garden *operatorv1alpha1.Garden) extensionsbackupentry.Interface {
+	backup := helper.GetETCDMainBackup(garden)
+
+	var region string
+	switch {
+	case backup.Region != nil:
+		region = *backup.Region
+	case garden.Spec.RuntimeCluster.Provider.Region != nil:
+		region = *garden.Spec.RuntimeCluster.Provider.Region
+	}
+
+	bucketName, _ := etcdMainBackupBucketNameAndPrefix(garden)
+
+	return extensionsbackupentry.New(log, r.RuntimeClientSet.Client(), r.Clock, &extensionsbackupentry.Values{
+		Name:           r.GardenNamespace + "--" + string(garden.UID),
+		Type:           backup.Provider,
+		ProviderConfig: backup.ProviderConfig,
+		Class:          ptr.To(extensionsv1alpha1.ExtensionClassGarden),
+		Region:         region,
+		SecretRef: corev1.SecretReference{
+			Name:      backup.SecretRef.Name,
+			Namespace: r.GardenNamespace,
+		},
+		BucketName: bucketName,
+	}, extensionsbackupentry.DefaultInterval, extensionsbackupentry.DefaultSevereThreshold, extensionsbackupentry.DefaultTimeout)
 }
 
 func workloadIdentityTokenIssuerURL(garden *operatorv1alpha1.Garden) string {

--- a/pkg/operator/controller/garden/garden/reconciler_delete.go
+++ b/pkg/operator/controller/garden/garden/reconciler_delete.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/api/operator/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -294,6 +295,12 @@ func (r *Reconciler) delete(
 			SkipIf:       garden.Spec.DNS == nil,
 			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
 		})
+		destroyMainETCDBackupEntry = g.Add(flow.Task{
+			Name:         "Destroying main ETCD backup entry",
+			Fn:           component.OpDestroyAndWait(c.etcdMainBackupEntry).Destroy,
+			SkipIf:       helper.GetETCDMainBackup(garden) == nil,
+			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+		})
 		destroyMainETCDBackupBucket = g.Add(flow.Task{
 			Name: "Destroying main ETCD backup bucket",
 			Fn: func(ctx context.Context) error {
@@ -312,8 +319,8 @@ func (r *Reconciler) delete(
 					time.Minute,
 				)
 			},
-			SkipIf:       garden.Spec.VirtualCluster.ETCD == nil || garden.Spec.VirtualCluster.ETCD.Main == nil || garden.Spec.VirtualCluster.ETCD.Main.Backup == nil,
-			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed),
+			SkipIf:       helper.GetETCDMainBackup(garden) == nil,
+			Dependencies: flow.NewTaskIDs(syncPointVirtualGardenControlPlaneDestroyed, destroyMainETCDBackupEntry),
 		})
 		destroyEtcdDruid = g.Add(flow.Task{
 			Name:         "Destroying ETCD Druid",
@@ -389,6 +396,7 @@ func (r *Reconciler) delete(
 			waitUntilExtensionResourcesDeleted,
 			resetExtensionRequiredVirtualCondition,
 			destroyDNSRecords,
+			destroyMainETCDBackupEntry,
 			destroyMainETCDBackupBucket,
 			destroyEtcdDruid,
 			destroyIstio,

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -6,6 +6,7 @@ package garden
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -271,10 +272,27 @@ func (r *Reconciler) reconcile(
 			},
 			SkipIf: !backupConfigured,
 		})
+		deployEtcdBackupEntry = g.Add(flow.Task{
+			Name: "Reconciling main ETCD backup entry",
+			Fn: func(ctx context.Context) error {
+				if backupBucket.Status.GeneratedSecretRef != nil {
+					secretRef := *backupBucket.Status.GeneratedSecretRef
+					if secretRef.Namespace == "" {
+						secretRef.Namespace = r.GardenNamespace
+					}
+					c.etcdMainBackupEntry.SetSecretRef(secretRef)
+				}
+
+				c.etcdMainBackupEntry.SetBackupBucketProviderStatus(backupBucket.Status.ProviderStatus)
+				return component.OpWait(c.etcdMainBackupEntry).Deploy(ctx)
+			},
+			SkipIf:       !backupConfigured,
+			Dependencies: flow.NewTaskIDs(deployEtcdBackupBucket),
+		})
 		deployEtcds = g.Add(flow.Task{
 			Name:         "Deploying main and events ETCDs of virtual garden",
-			Fn:           r.deployEtcdsFunc(garden, c.etcdMain, c.etcdEvents, backupBucket),
-			Dependencies: flow.NewTaskIDs(waitUntilEtcdDruidReady, deployEtcdBackupBucket),
+			Fn:           r.deployEtcdsFunc(garden, c.etcdMain, c.etcdEvents),
+			Dependencies: flow.NewTaskIDs(waitUntilEtcdDruidReady, deployEtcdBackupEntry),
 		})
 		waitUntilEtcdsReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event ETCDs report readiness",
@@ -846,22 +864,29 @@ func (r *Reconciler) runRuntimeSetupFlow(ctx context.Context, log logr.Logger, g
 	return nil
 }
 
-func (r *Reconciler) deployEtcdMainBackupBucket(ctx context.Context, garden *operatorv1alpha1.Garden, backupBucket *extensionsv1alpha1.BackupBucket) error {
+func resolveETCDMainBackupConfig(garden *operatorv1alpha1.Garden) (*operatorv1alpha1.Backup, string, error) {
 	backup := helper.GetETCDMainBackup(garden)
 	if backup == nil {
-		return fmt.Errorf("no ETCD main backup configuration found in Garden resource")
+		return nil, "", errors.New("no ETCD main backup configuration found in Garden resource")
 	}
 
-	var bucketRegion string
-	if backup.Region != nil {
-		bucketRegion = *backup.Region
-	} else if garden.Spec.RuntimeCluster.Provider.Region != nil {
-		bucketRegion = *garden.Spec.RuntimeCluster.Provider.Region
-	} else {
-		return fmt.Errorf("no region found in spec.virtualCluster.etcd.main.backup.region of spec.runtimeCluster.provider.region in Garden resource")
+	switch {
+	case backup.Region != nil:
+		return backup, *backup.Region, nil
+	case garden.Spec.RuntimeCluster.Provider.Region != nil:
+		return backup, *garden.Spec.RuntimeCluster.Provider.Region, nil
+	default:
+		return nil, "", errors.New("no region found in spec.virtualCluster.etcd.main.backup.region or spec.runtimeCluster.provider.region in Garden resource")
+	}
+}
+
+func (r *Reconciler) deployEtcdMainBackupBucket(ctx context.Context, garden *operatorv1alpha1.Garden, backupBucket *extensionsv1alpha1.BackupBucket) error {
+	backup, bucketRegion, err := resolveETCDMainBackupConfig(garden)
+	if err != nil {
+		return err
 	}
 
-	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.RuntimeClientSet.Client(), backupBucket, func() error {
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, r.RuntimeClientSet.Client(), backupBucket, func() error {
 		metav1.SetMetaDataAnnotation(&backupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		metav1.SetMetaDataAnnotation(&backupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().Format(time.RFC3339Nano))
 
@@ -900,7 +925,7 @@ func etcdMainBackupBucketNameAndPrefix(garden *operatorv1alpha1.Garden) (string,
 	return "garden-" + string(garden.UID), prefix
 }
 
-func (r *Reconciler) deployEtcdsFunc(garden *operatorv1alpha1.Garden, etcdMain, etcdEvents etcd.Interface, backupBucket *extensionsv1alpha1.BackupBucket) func(context.Context) error {
+func (r *Reconciler) deployEtcdsFunc(garden *operatorv1alpha1.Garden, etcdMain, etcdEvents etcd.Interface) func(context.Context) error {
 	return func(ctx context.Context) error {
 		if backup := helper.GetETCDMainBackup(garden); backup != nil {
 			snapshotSchedule, err := timewindow.DetermineSchedule(
@@ -920,16 +945,11 @@ func (r *Reconciler) deployEtcdsFunc(garden *operatorv1alpha1.Garden, etcdMain, 
 				backupLeaderElection = r.Config.Controllers.Garden.ETCDConfig.BackupLeaderElection
 			}
 
-			secretRefName := backup.SecretRef.Name
-			if backupBucket.Status.GeneratedSecretRef != nil {
-				secretRefName = backupBucket.Status.GeneratedSecretRef.Name
-			}
-
 			container, prefix := etcdMainBackupBucketNameAndPrefix(garden)
 
 			etcdMain.SetBackupConfig(&etcd.BackupConfig{
 				Provider:             backup.Provider,
-				SecretRefName:        secretRefName,
+				SecretRefName:        v1beta1constants.BackupSecretName,
 				Container:            container,
 				Prefix:               prefix,
 				FullSnapshotSchedule: snapshotSchedule,

--- a/pkg/provider-local/controller/backupentry/add.go
+++ b/pkg/provider-local/controller/backupentry/add.go
@@ -19,14 +19,14 @@ import (
 )
 
 // ControllerName is the name of the controller.
-const ControllerName = "backupentry_controller"
+const ControllerName = "backupentry"
 
 var (
 	// DefaultAddOptions are the default AddOptions for AddToManager.
 	DefaultAddOptions = backupoptions.AddOptions{}
 
 	// supportedExtensionClasses are the extension classes supported by the backupentry controller.
-	supportedExtensionClasses = sets.New(extensionsv1alpha1.ExtensionClassShoot)
+	supportedExtensionClasses = sets.New(extensionsv1alpha1.ExtensionClassGarden, extensionsv1alpha1.ExtensionClassShoot)
 )
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.

--- a/pkg/utils/gardener/operator/garden.go
+++ b/pkg/utils/gardener/operator/garden.go
@@ -56,6 +56,7 @@ func ComputeRequiredExtensionsForGarden(garden *operatorv1alpha1.Garden, extensi
 
 	if operatorv1alpha1helper.GetETCDMainBackup(garden) != nil {
 		requiredExtensions.Insert(gardener.ExtensionsID(extensionsv1alpha1.BackupBucketResource, garden.Spec.VirtualCluster.ETCD.Main.Backup.Provider))
+		requiredExtensions.Insert(gardener.ExtensionsID(extensionsv1alpha1.BackupEntryResource, garden.Spec.VirtualCluster.ETCD.Main.Backup.Provider))
 	}
 
 	for _, provider := range operatorv1alpha1helper.GetDNSProviders(garden) {

--- a/pkg/utils/gardener/operator/garden_test.go
+++ b/pkg/utils/gardener/operator/garden_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Garden", func() {
 			Expect(ComputeRequiredExtensionsForGarden(garden, extensionList).UnsortedList()).To(BeEmpty())
 		})
 
-		It("should return required BackupBucket extension type", func() {
+		It("should return required BackupBucket and BackupEntry extension types", func() {
 			garden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
 				Main: &operatorv1alpha1.ETCDMain{
 					Backup: &operatorv1alpha1.Backup{
@@ -103,6 +103,7 @@ var _ = Describe("Garden", func() {
 
 			Expect(ComputeRequiredExtensionsForGarden(garden, extensionList).UnsortedList()).To(ConsistOf(
 				"BackupBucket/local-infrastructure",
+				"BackupEntry/local-infrastructure",
 			))
 		})
 
@@ -163,6 +164,7 @@ var _ = Describe("Garden", func() {
 
 			Expect(ComputeRequiredExtensionsForGarden(garden, extensionList).UnsortedList()).To(ConsistOf(
 				"BackupBucket/local-infrastructure",
+				"BackupEntry/local-infrastructure",
 				"DNSRecord/local-dns",
 				"Extension/local-extension-1",
 				"Extension/local-extension-2",

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -87,6 +87,7 @@ build:
             - pkg/component/crddeployer
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants
+            - pkg/component/extensions/backupentry
             - pkg/component/extensions/crds
             - pkg/component/extensions/dnsrecord
             - pkg/component/extensions/extension

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -515,7 +515,6 @@ var _ = Describe("Seed controller tests", func() {
 						"machines.machine.sapcloud.io",
 						"machinesets.machine.sapcloud.io",
 						// extensions
-						"backupentries.extensions.gardener.cloud",
 						"bastions.extensions.gardener.cloud",
 						"clusters.extensions.gardener.cloud",
 						"containerruntimes.extensions.gardener.cloud",
@@ -529,6 +528,7 @@ var _ = Describe("Seed controller tests", func() {
 					crdsSharedWithGardenCluster = []string{
 						// extensions
 						"backupbuckets.extensions.gardener.cloud",
+						"backupentries.extensions.gardener.cloud",
 						"dnsrecords.extensions.gardener.cloud",
 						"extensions.extensions.gardener.cloud",
 						// etcd-druid

--- a/test/integration/operator/extension/required/runtime/runtime_suite_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_suite_test.go
@@ -75,6 +75,7 @@ var _ = BeforeSuite(func() {
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "operator", "10-crd-operator.gardener.cloud_gardens.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_backupbuckets.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_backupbuckets.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_backupentries.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_dnsrecords.yaml"),
 					filepath.Join("..", "..", "..", "..", "..", "..", "pkg", "component", "extensions", "crds", "assets", "crd-extensions.gardener.cloud_extensions.yaml"),
 				},

--- a/test/integration/operator/extension/required/runtime/runtime_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_test.go
@@ -50,6 +50,10 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 						Kind: "BackupBucket",
 						Type: backupBucketProvider,
 					},
+					{
+						Kind: "BackupEntry",
+						Type: backupBucketProvider,
+					},
 				},
 			},
 		}
@@ -285,13 +289,35 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 			},
 		}
 
+		backupEntry := &extensionsv1alpha1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: extensionPrefix + "-entry",
+			},
+			Spec: extensionsv1alpha1.BackupEntrySpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Class: ptr.To[extensionsv1alpha1.ExtensionClass]("garden"),
+					Type:  backupBucketProvider,
+				},
+				Region:     "region",
+				BucketName: extensionPrefix + "-bucket",
+				SecretRef: corev1.SecretReference{
+					Name: "test-bar-bucket",
+				},
+			},
+		}
+
 		Expect(testClient.Create(ctx, backupBucket)).To(Succeed())
+		Expect(testClient.Create(ctx, backupEntry)).To(Succeed())
 		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, backupEntry)).To(Succeed())
 			Expect(testClient.Delete(ctx, backupBucket)).To(Succeed())
 		})
 
 		Eventually(func() error {
 			return mgrClient.Get(ctx, client.ObjectKeyFromObject(backupBucket), backupBucket)
+		}).Should(Succeed())
+		Eventually(func() error {
+			return mgrClient.Get(ctx, client.ObjectKeyFromObject(backupEntry), backupEntry)
 		}).Should(Succeed())
 
 		Expect(testClient.Delete(ctx, garden)).To(Succeed())
@@ -315,7 +341,7 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 		))
 	})
 
-	It("should report provider extension as not required during garden deletion after backupbucket is gone", func() {
+	It("should report provider extension as not required during garden deletion after backup resources are gone", func() {
 		Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(providerExtension), providerExtension)).To(Succeed())
 			return providerExtension.Status.Conditions


### PR DESCRIPTION
**How to categorize this PR?**

/area backup
/kind enhancement
/cc @timuthy

**What this PR does / why we need it:**

The `gardener-operator` currently configures etcd backup by reading the `BackupBucket` status and directly passing the (generated) secret reference to the etcd component. While this works, it bypasses the standard extension contract that shoot clusters use: shoots deploy a `BackupEntry` extension object, and the provider's generic actuator is responsible for creating the `etcd-backup` secret.

This PR aligns the garden controller with the shoot flow by deploying an `extensionsv1alpha1.BackupEntry` alongside the existing `BackupBucket` when etcd backup is configured. The generic actuator then creates the `etcd-backup` secret from the `BackupBucket`'s `.status.generatedSecretRef`, just like it does for shoots. This removes the special handling from `deployEtcdsFunc` and ensures a consistent extension contract for both shoots and gardens.

The `BackupEntry` is named `<gardenNamespace>--<gardenUID>` so that the generic actuator's `ExtractShootDetailsFromBackupEntryName` can derive the garden namespace and deploy the `etcd-backup` secret there.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

**Release note:**
```noteworthy operator
When backup is configured in the `Garden` resource, the `gardener-operator` now requires a `BackupEntry` controller registration in the `operator.gardener.cloud/v1alpha1.Extension` resource of the backup provider when the new `BackupEntryForGarden` feature gate is enabled. If the `Extension` object for the provider does not yet include `BackupEntry` in `.spec.resources`, it must be added before upgrading `gardener-operator`. All provider extensions should also enable their `BackupEntry` controllers when running in the garden runtime cluster.
```
```noteworthy operator
The `gardener-operator` now deploys an `extensionsv1alpha1.BackupEntry` alongside the `BackupBucket` when etcd backup is configured (when `BackupEntryForGarden` feature gate is enabled), aligning the garden controller with the same extension contract that shoot clusters use for backup credential management.
```