### PR TITLE
POC implementation for OTEL dataplane collector

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -18,24 +18,25 @@ The following tables are a summary of the feature gates that you can set on diff
 
 ## Feature Gates for Alpha or Beta Features
 
-| Feature                        | Default | Stage   | Since   | Until   |
-|--------------------------------|---------|---------|---------|---------|
-| DefaultSeccompProfile          | `false` | `Alpha` | `1.54`  |         |
-| InPlaceNodeUpdates             | `false` | `Alpha` | `1.113` |         |
-| IstioTLSTermination            | `false` | `Alpha` | `1.114` |         |
-| CloudProfileCapabilities       | `false` | `Alpha` | `1.117` |         |
-| OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
-| OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
-| UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` | `1.139` |
-| UseUnifiedHTTPProxyPort        | `true`  | `Beta`  | `1.140` |         |
-| VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |
-| VPAInPlaceUpdates              | `true`  | `Beta`  | `1.138` |         |
-| VictoriaLogsBackend            | `false` | `Alpha` | `1.137` |         |
-| CustomDNSServerInNodeLocalDNS  | `true`  | `Beta`  | `1.133` |         |
-| VPNBondingModeRoundRobin       | `false` | `Alpha` | `1.135` |         |
-| PrometheusHealthChecks         | `false` | `Alpha` | `1.135` |         |
-| RemoveVali                     | `false` | `Alpha` | `1.140` |         |
-| VersionClassificationLifecycle | `false` | `Alpha` | `1.137` |         |
+| Feature                         | Default | Stage   | Since   | Until   |
+|---------------------------------|---------|---------|---------|---------|
+| DefaultSeccompProfile           | `false` | `Alpha` | `1.54`  |         |
+| InPlaceNodeUpdates              | `false` | `Alpha` | `1.113` |         |
+| IstioTLSTermination             | `false` | `Alpha` | `1.114` |         |
+| CloudProfileCapabilities        | `false` | `Alpha` | `1.117` |         |
+| OpenTelemetryCollector          | `false` | `Alpha` | `1.124` | `1.135` |
+| OpenTelemetryCollector          | `true`  | `Beta`  | `1.136` |         |
+| UseUnifiedHTTPProxyPort         | `false` | `Alpha` | `1.130` | `1.139` |
+| UseUnifiedHTTPProxyPort         | `true`  | `Beta`  | `1.140` |         |
+| VPAInPlaceUpdates               | `false` | `Alpha` | `1.133` | `1.137` |
+| VPAInPlaceUpdates               | `true`  | `Beta`  | `1.138` |         |
+| VictoriaLogsBackend             | `false` | `Alpha` | `1.137` |         |
+| CustomDNSServerInNodeLocalDNS   | `true`  | `Beta`  | `1.133` |         |
+| VPNBondingModeRoundRobin        | `false` | `Alpha` | `1.135` |         |
+| PrometheusHealthChecks          | `false` | `Alpha` | `1.135` |         |
+| VersionClassificationLifecycle  | `false` | `Alpha` | `1.137` |         |
+| RemoveVali                      | `false` | `Alpha` | `1.140` |         |
+| OpenTelemetryDataplaneCollector | `false` | `Alpha` | `1.141` |         |
 
 ## Feature Gates for Graduated or Deprecated Features
 
@@ -275,3 +276,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | PrometheusHealthChecks         | `gardenlet`, `gardener-operator` | Enables care controllers to query Prometheus for enhanced health checks of monitoring components. Detected health issues are reported in the respective `Shoot`, `Seed`, or `Garden` resource.                                                                                                                                                                                                                                                                                                                                                           |
 | RemoveVali                     | `gardenlet`, `gardener-operator` | Enables the automatic removal of `Vali` log aggregation components once `VictoriaLogs` has been enabled for 2 weeks. Requires `VictoriaLogsBackend` feature gate to be enabled.                                                                                                                                                                                                                                                                                                                                                                          |
 | VersionClassificationLifecycle | `gardener-apiserver`             | Enables the features introduced by GEP-32, including lifecycle-based classification for Kubernetes and machine image versions.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| OpenTelemetryDataplaneCollector | `gardenlet`                      | Enables an `OpenTelemetry Collector` deployment in the shoot cluster's data plane for collecting metrics using Kubernetes service discovery. The collector uses the Prometheus receiver with `kubernetes_sd_config` to dynamically discover and scrape metrics from services annotated with `prometheus.io/scrape: "true"`. Collected metrics are exposed via a Prometheus exporter endpoint for scraping by the shoot's Prometheus instance.                                                                                                          |

--- a/docs/operations/network_policies.md
+++ b/docs/operations/network_policies.md
@@ -178,6 +178,7 @@ gardener.cloud--allow-to-dns               networking.gardener.cloud/to-dns=allo
 gardener.cloud--allow-to-apiserver         networking.gardener.cloud/to-apiserver=allowed
 gardener.cloud--allow-to-from-nginx        app=nginx-ingress
 gardener.cloud--allow-to-kubelet           networking.gardener.cloud/to-kubelet=allowed
+gardener.cloud--allow-to-node-exporter     networking.gardener.cloud/to-node-exporter=allowed
 gardener.cloud--allow-to-public-networks   networking.gardener.cloud/to-public-networks=allowed
 gardener.cloud--allow-vpn                  app=vpn-shoot
 ```

--- a/docs/proposals/otel-dataplane-metrics-collector-plan.md
+++ b/docs/proposals/otel-dataplane-metrics-collector-plan.md
@@ -1,0 +1,589 @@
+# Plan: OTEL Collector Agent for Data-Plane Metrics Filtering
+
+## Problem Statement
+
+**Current Architecture:**
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Shoot Data-Plane                                                            │
+│  ┌──────────┐  ┌──────────┐  ┌─────────────┐                               │
+│  │ kubelet  │  │ cadvisor │  │node-exporter│  ...                          │
+│  │ /metrics │  │ /metrics │  │  /metrics   │                               │
+│  └────┬─────┘  └────┬─────┘  └──────┬──────┘                               │
+│       │             │               │                                       │
+│       └─────────────┼───────────────┘                                       │
+│                     │ ALL metrics                                           │
+└─────────────────────┼───────────────────────────────────────────────────────┘
+                      │ via kube-apiserver /proxy
+                      ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Seed Control-Plane (shoot--project--name namespace)                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │ CP Prometheus                                                         │  │
+│  │  - Scrapes via /api/v1/nodes/${node}/proxy/metrics                   │  │
+│  │  - Receives ALL metrics over the network                             │  │
+│  │  - Applies MetricRelabelConfigs (filtering) AFTER receiving          │  │
+│  │  - Stores only filtered metrics in TSDB                              │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Issues:**
+1. Full metric set transferred over network (wasted bandwidth)
+2. Filtering happens in control-plane after data transfer
+3. Unnecessary network costs, especially with many shoots
+
+---
+
+## Goal
+
+Deploy an OTEL collector agent in the shoot data-plane that:
+1. Scrapes the same targets locally (kubelet, cadvisor, node-exporter, etc.)
+2. Applies the same filtering rules **before** sending data
+3. Exposes a single Prometheus endpoint with pre-filtered metrics
+4. CP Prometheus scrapes only this single endpoint
+
+**Target Architecture:**
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Shoot Data-Plane                                                            │
+│                                                                             │
+│  Node 1              Node 2              Node N                             │
+│  ┌──────────┐        ┌──────────┐        ┌──────────┐                      │
+│  │ kubelet  │        │ kubelet  │        │ kubelet  │                      │
+│  │ /metrics │        │ /metrics │        │ /metrics │                      │
+│  │ /cadvisor│        │ /cadvisor│        │ /cadvisor│                      │
+│  └────┬─────┘        └────┬─────┘        └────┬─────┘                      │
+│       │                   │                   │                             │
+│       └───────────────────┼───────────────────┘                             │
+│                           │ scrape all nodes                                │
+│                           ▼                                                 │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │ OTEL Collector Agent (Deployment + Service)                           │  │
+│  │  - prometheus receiver: scrapes ALL nodes' kubelet/cadvisor          │  │
+│  │  - filter processor: applies metric filtering                         │  │
+│  │  - prometheus exporter: exposes single /metrics endpoint              │  │
+│  │  - Service: otel-collector-agent:9090                                 │  │
+│  └────────────────────────────────┬─────────────────────────────────────┘  │
+│                                   │ FILTERED metrics (single endpoint)      │
+└───────────────────────────────────┼─────────────────────────────────────────┘
+                                    │ via kube-apiserver /proxy to Service
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Seed Control-Plane                                                          │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │ CP Prometheus                                                         │  │
+│  │  - Single scrape target: otel-collector-agent Service                 │  │
+│  │  - Receives pre-filtered, aggregated metrics from all nodes           │  │
+│  │  - Stores directly in TSDB                                            │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Current Scrape Targets (from scrapeconfigs.go)
+
+| ScrapeConfig Name | Target | Metrics Path | Key Filtered Metrics |
+|-------------------|--------|--------------|---------------------|
+| `cadvisor` | kubelet via API proxy | `/api/v1/nodes/${node}/proxy/metrics/cadvisor` | `container_cpu_*`, `container_memory_*`, `container_fs_*`, `container_network_*` |
+| `kube-kubelet` | kubelet via API proxy | `/api/v1/nodes/${node}/proxy/metrics` | `kubelet_running_pods`, `kubelet_volume_stats_*`, `kubelet_image_pull_*`, `process_*` |
+
+These are the primary bandwidth consumers - full metric sets transferred, then filtered.
+
+---
+
+## Implementation Plan
+
+### Phase 1: OTEL Collector Data-Plane Component
+
+#### 1.1 New Component Location
+
+```
+pkg/component/observability/opentelemetry/collector/dataplane/
+├── dataplane.go           # Main component (DaemonSet deployer)
+├── dataplane_test.go      # Unit tests
+├── config.go              # Collector configuration generation
+├── config_test.go         # Config tests
+└── constants/
+    └── constants.go       # Ports, names, etc.
+```
+
+#### 1.2 OTEL Collector Configuration
+
+The collector uses `kubernetes_sd_configs` to discover **all nodes** and scrapes each node's kubelet/cadvisor endpoints. This centralizes collection so CP Prometheus only needs to scrape a single endpoint.
+
+```yaml
+receivers:
+  prometheus/kubelet:
+    config:
+      scrape_configs:
+        - job_name: 'kubelet'
+          scheme: https
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true  # kubelet uses self-signed cert
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            # Scrape kubelet on each discovered node
+            - source_labels: [__meta_kubernetes_node_address_InternalIP]
+              target_label: __address__
+              replacement: ${1}:10250
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: node
+
+  prometheus/cadvisor:
+    config:
+      scrape_configs:
+        - job_name: 'cadvisor'
+          scheme: https
+          metrics_path: /metrics/cadvisor
+          tls_config:
+            ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            insecure_skip_verify: true
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_node_address_InternalIP]
+              target_label: __address__
+              replacement: ${1}:10250
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              target_label: node
+
+processors:
+  # Filter to match current MetricRelabelConfigs
+  filter/kubelet:
+    metrics:
+      include:
+        match_type: regexp
+        metric_names:
+          - kubelet_running_pods
+          - process_max_fds
+          - process_open_fds
+          - kubelet_volume_stats_available_bytes
+          - kubelet_volume_stats_capacity_bytes
+          - kubelet_volume_stats_used_bytes
+          - kubelet_image_pull_duration_seconds_bucket
+          - kubelet_image_pull_duration_seconds_sum
+          - kubelet_image_pull_duration_seconds_count
+
+  filter/cadvisor:
+    metrics:
+      include:
+        match_type: regexp
+        metric_names:
+          - container_cpu_cfs_periods_total
+          - container_cpu_cfs_throttled_seconds_total
+          - container_cpu_cfs_throttled_periods_total
+          - container_cpu_usage_seconds_total
+          - container_fs_inodes_total
+          - container_fs_limit_bytes
+          - container_fs_usage_bytes
+          - container_fs_reads_total
+          - container_fs_writes_total
+          - container_last_seen
+          - container_memory_working_set_bytes
+          - container_network_receive_bytes_total
+          - container_network_transmit_bytes_total
+
+  # Additional filtering: keep only kube-system namespace
+  filter/namespace:
+    metrics:
+      include:
+        match_type: expr
+        expressions:
+          - 'attributes["namespace"] == "" or attributes["namespace"] == "kube-system"'
+
+  batch:
+    timeout: 10s
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:9090"
+    namespace: ""
+    send_timestamps: true
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    metrics/kubelet:
+      receivers: [prometheus/kubelet]
+      processors: [filter/kubelet, filter/namespace, batch]
+      exporters: [prometheus]
+    metrics/cadvisor:
+      receivers: [prometheus/cadvisor]
+      processors: [filter/cadvisor, filter/namespace, batch]
+      exporters: [prometheus]
+```
+
+#### 1.3 Deployment
+
+A **Deployment** (not DaemonSet) is used so that:
+- CP Prometheus has a **single scrape target** instead of N targets (one per node)
+- The collector centrally scrapes all nodes and aggregates metrics
+- Simpler architecture with fewer moving parts
+
+```go
+// pkg/component/observability/opentelemetry/collector/dataplane/dataplane.go
+
+type Values struct {
+    Image              string
+    Namespace          string  // kube-system
+    Replicas           int32   // 1 for PoC, can scale for HA
+    PriorityClassName  string
+    // Metrics filter configuration (derived from scrapeconfigs.go)
+    KubeletMetrics     []string
+    CadvisorMetrics    []string
+}
+
+func (d *dataplaneCollector) deployment() *appsv1.Deployment {
+    return &appsv1.Deployment{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      "otel-collector-agent",
+            Namespace: d.values.Namespace,
+            Labels:    getLabels(),
+        },
+        Spec: appsv1.DeploymentSpec{
+            Replicas: ptr.To(d.values.Replicas),
+            Selector: &metav1.LabelSelector{MatchLabels: getLabels()},
+            Template: corev1.PodTemplateSpec{
+                Spec: corev1.PodSpec{
+                    ServiceAccountName: "otel-collector-agent",
+                    Containers: []corev1.Container{{
+                        Name:  "otel-collector",
+                        Image: d.values.Image,
+                        Args:  []string{"--config=/etc/otel/config.yaml"},
+                        Ports: []corev1.ContainerPort{{
+                            Name:          "metrics",
+                            ContainerPort: 9090,
+                        }},
+                        VolumeMounts: []corev1.VolumeMount{{
+                            Name:      "config",
+                            MountPath: "/etc/otel",
+                        }},
+                    }},
+                    Volumes: []corev1.Volume{{
+                        Name: "config",
+                        VolumeSource: corev1.VolumeSource{
+                            ConfigMap: &corev1.ConfigMapVolumeSource{
+                                LocalObjectReference: corev1.LocalObjectReference{
+                                    Name: "otel-collector-agent-config",
+                                },
+                            },
+                        },
+                    }},
+                },
+            },
+        },
+    }
+}
+
+func (d *dataplaneCollector) service() *corev1.Service {
+    return &corev1.Service{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      "otel-collector-agent",
+            Namespace: d.values.Namespace,
+            Labels:    getLabels(),
+        },
+        Spec: corev1.ServiceSpec{
+            Selector: getLabels(),
+            Ports: []corev1.ServicePort{{
+                Name:       "metrics",
+                Port:       9090,
+                TargetPort: intstr.FromInt(9090),
+            }},
+        },
+    }
+}
+```
+
+#### 1.4 RBAC Requirements
+
+Yes, RBAC is required for the collector to:
+1. Discover nodes via `kubernetes_sd_configs`
+2. Scrape kubelet metrics endpoints on each node
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-agent
+rules:
+  # For prometheus receiver kubernetes_sd_config (node discovery)
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  # For scraping kubelet /metrics and /metrics/cadvisor
+  - apiGroups: [""]
+    resources: ["nodes/metrics", "nodes/proxy"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-agent
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector-agent
+    namespace: kube-system
+```
+
+### Phase 2: Update CP Prometheus Scrape Configs
+
+#### 2.1 New Scrape Config for OTEL Collector
+
+Replace `cadvisor` and `kube-kubelet` scrape configs with a **single static target** pointing to the collector's Service:
+
+```go
+// In scrapeconfigs.go - add new config when feature enabled
+&monitoringv1alpha1.ScrapeConfig{
+    ObjectMeta: metav1.ObjectMeta{
+        Name: "otel-collector-dataplane",
+    },
+    Spec: monitoringv1alpha1.ScrapeConfigSpec{
+        HonorLabels: ptr.To(true),  // Preserve labels from collector (node, instance, etc.)
+        Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+        Authorization: &monitoringv1.SafeAuthorization{
+            Credentials: &corev1.SecretKeySelector{
+                LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+                Key:                  resourcesv1alpha1.DataKeyToken,
+            },
+        },
+        TLSConfig: &monitoringv1.SafeTLSConfig{
+            CA: monitoringv1.SecretOrConfigMap{
+                Secret: &corev1.SecretKeySelector{
+                    LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+                    Key:                  secretsutils.DataKeyCertificateBundle,
+                },
+            },
+        },
+        // Single static target: the OTEL collector Service via kube-apiserver proxy
+        StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+            Targets: []monitoringv1alpha1.Target{
+                v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port),
+            },
+        }},
+        RelabelConfigs: []monitoringv1.RelabelConfig{
+            {
+                TargetLabel: "__metrics_path__",
+                Replacement: ptr.To("/api/v1/namespaces/kube-system/services/otel-collector-agent:9090/proxy/metrics"),
+            },
+            {
+                Action:      "replace",
+                Replacement: ptr.To("otel-collector-dataplane"),
+                TargetLabel: "job",
+            },
+        },
+        // No MetricRelabelConfigs needed - already filtered at the collector!
+    },
+}
+```
+
+#### 2.2 Feature Flag
+
+Add new feature gate:
+
+```go
+// pkg/features/features.go
+OpenTelemetryDataPlaneMetrics featuregate.Feature = "OpenTelemetryDataPlaneMetrics"
+```
+
+### Phase 3: Botanist Integration
+
+#### 3.1 Add Component to Shoot System Components
+
+```go
+// pkg/gardenlet/operation/botanist/botanist.go
+type Shoot struct {
+    Components struct {
+        SystemComponents struct {
+            // ... existing
+            OtelDataPlaneCollector dataplane.Interface  // NEW
+        }
+    }
+}
+```
+
+#### 3.2 Deploy Flow
+
+```go
+// pkg/gardenlet/operation/botanist/otel_dataplane.go
+func (b *Botanist) DefaultOtelDataPlaneCollector() (dataplane.Interface, error) {
+    if b.Shoot.IsWorkerless {
+        return component.NoOp(), nil
+    }
+
+    image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameOpentelemetryCollector)
+    if err != nil {
+        return nil, err
+    }
+
+    return dataplane.New(
+        b.SeedClientSet.Client(),
+        b.Shoot.ControlPlaneNamespace,
+        dataplane.Values{
+            Image:             image.String(),
+            KubeletMetrics:    getKubeletAllowedMetrics(),  // From scrapeconfigs.go
+            CadvisorMetrics:   getCadvisorAllowedMetrics(), // From scrapeconfigs.go
+        },
+        b.SecretsManager,
+    ), nil
+}
+
+func (b *Botanist) DeployOtelDataPlaneCollector(ctx context.Context) error {
+    if !features.DefaultFeatureGate.Enabled(features.OpenTelemetryDataPlaneMetrics) {
+        return b.Shoot.Components.SystemComponents.OtelDataPlaneCollector.Destroy(ctx)
+    }
+    return b.Shoot.Components.SystemComponents.OtelDataPlaneCollector.Deploy(ctx)
+}
+```
+
+### Phase 4: Local Setup Configuration
+
+#### 4.1 Enable Feature in Local Gardenlet
+
+```yaml
+# example/gardener-local/gardenlet/values.yaml
+config:
+  featureGates:
+    OpenTelemetryCollector: true
+    OpenTelemetryDataPlaneMetrics: true  # NEW
+```
+
+---
+
+## Phase 5: PoC - Connectivity Resilience Testing
+
+### 5.1 Test Scenario Setup
+
+Create controlled connectivity disruption between CP Prometheus and data-plane OTEL collector:
+
+```bash
+# 1. Deploy shoot with OTEL data-plane collector
+kubectl apply -f example/provider-local/shoot.yaml
+
+# 2. Verify metrics flow
+kubectl -n shoot--local--local port-forward svc/prometheus 9090:9090
+# Query: up{job="otel-collector-dataplane"}
+
+# 3. Simulate network partition using NetworkPolicy
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: block-otel-collector
+  namespace: shoot--local--local
+spec:
+  podSelector:
+    matchLabels:
+      app: prometheus
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: NOT-otel-collector  # Block traffic
+EOF
+
+# 4. Observe metrics gaps
+# 5. Remove NetworkPolicy and observe recovery
+```
+
+### 5.2 OTEL Collector Resilience Configuration
+
+Test different configurations to minimize data loss:
+
+```yaml
+# Option A: Memory-based buffering (default prometheus exporter behavior)
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:9090"
+
+# Option B: Use prometheusremotewrite exporter for push-based with retry
+exporters:
+  prometheusremotewrite:
+    endpoint: "http://prometheus:9090/api/v1/write"
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 5000
+```
+
+### 5.3 Metrics to Monitor During Test
+
+| Metric | Purpose |
+|--------|---------|
+| `otelcol_exporter_send_failed_metric_points` | Failed exports |
+| `otelcol_processor_dropped_metric_points` | Dropped during processing |
+| `otelcol_receiver_refused_metric_points` | Refused at receiver |
+| `prometheus_tsdb_head_samples_appended_total` | Samples stored in Prometheus |
+| `up{job="otel-collector-dataplane"}` | Collector reachability |
+
+### 5.4 Expected Findings
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Brief network blip (<30s) | Prometheus retry handles it, minimal/no data loss |
+| Extended outage (>scrape_interval) | Gaps in metrics, collector continues buffering locally |
+| Recovery after outage | Prometheus resumes scraping, no historical backfill (pull model) |
+
+**Recommendation from PoC:** If data loss during outages is unacceptable, consider:
+1. Using `prometheusremotewrite` exporter (push model) with retry queue
+2. Configuring aggressive retry on CP Prometheus side
+3. Running a small local Prometheus on data-plane as a buffer (complex)
+
+---
+
+## File Changes Summary
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `pkg/component/observability/opentelemetry/collector/dataplane/` | New | Data-plane collector component |
+| `pkg/features/features.go` | Modify | Add `OpenTelemetryDataPlaneMetrics` feature gate |
+| `pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go` | Modify | Add OTEL collector scrape config, conditionally disable cadvisor/kubelet |
+| `pkg/gardenlet/operation/botanist/botanist.go` | Modify | Add OtelDataPlaneCollector component |
+| `pkg/gardenlet/operation/botanist/otel_dataplane.go` | New | Default factory and deploy method |
+| `pkg/gardenlet/operation/shoot/shoot.go` | Modify | Initialize component |
+| `example/gardener-local/gardenlet/values.yaml` | Modify | Enable feature gate |
+| `imagevector/containers.yaml` | Verify | OTEL collector image present |
+
+---
+
+## RBAC Summary
+
+**Yes, explicit RBAC is required** for the data-plane collector because it needs to:
+
+1. **Node discovery**: `nodes` - get, list, watch (for `kubernetes_sd_configs`)
+2. **Kubelet metrics access**: `nodes/metrics`, `nodes/proxy` - get (for scraping `/metrics` and `/metrics/cadvisor`)
+
+---
+
+## Next Steps
+
+1. **Implement Phase 1** - Create data-plane collector component
+2. **Implement Phase 2** - Update scrape configs with feature flag
+3. **Test locally** - Verify bandwidth reduction and metric parity
+4. **Run PoC tests** - Connectivity resilience scenarios
+5. **Document findings** - Recommendations for production configuration

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -41,6 +41,7 @@ config:
     VictoriaLogsBackend: true
     VPNBondingModeRoundRobin: true
     PrometheusHealthChecks: true
+    OpenTelemetryDataplaneCollector: true
   etcdConfig:
     featureGates:
       UpgradeEtcdVersion: false

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -586,6 +586,8 @@ const (
 	LabelNetworkPolicyShootToAPIServer = "networking.gardener.cloud/to-apiserver"
 	// LabelNetworkPolicyShootToKubelet allows Egress traffic to the kubelets.
 	LabelNetworkPolicyShootToKubelet = "networking.gardener.cloud/to-kubelet"
+	// LabelNetworkPolicyShootToNodeExporter allows Egress traffic to the node exporter.
+	LabelNetworkPolicyShootToNodeExporter = "networking.gardener.cloud/to-node-exporter"
 	// LabelNetworkPolicyAllowed is a constant for allowing a network policy.
 	LabelNetworkPolicyAllowed = "allowed"
 	// LabelNetworkPolicyScrapeTargets is a constant for pod selector label which can be used on Services for components

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter.go
@@ -14,9 +14,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +29,9 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 )
@@ -79,44 +83,55 @@ type nodeExporter struct {
 
 func (n *nodeExporter) Deploy(ctx context.Context) error {
 	scrapeConfig := n.emptyScrapeConfig()
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, n.client, scrapeConfig, func() error {
-		metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", shoot.Label)
-		scrapeConfig.Spec = shoot.ClusterComponentScrapeConfigSpec(
-			name,
-			shoot.KubernetesServiceDiscoveryConfig{
-				Role:             monitoringv1alpha1.KubernetesRoleEndpoint,
-				ServiceName:      name,
-				EndpointPortName: portNameMetrics,
-			},
-			"node_boot_time_seconds",
-			"node_cpu_seconds_total",
-			"node_disk_read_bytes_total",
-			"node_disk_written_bytes_total",
-			"node_disk_io_time_weighted_seconds_total",
-			"node_disk_io_time_seconds_total",
-			"node_disk_write_time_seconds_total",
-			"node_disk_writes_completed_total",
-			"node_disk_read_time_seconds_total",
-			"node_disk_reads_completed_total",
-			"node_filesystem_avail_bytes",
-			"node_filesystem_files",
-			"node_filesystem_files_free",
-			"node_filesystem_free_bytes",
-			"node_filesystem_readonly",
-			"node_filesystem_size_bytes",
-			"node_load1",
-			"node_load15",
-			"node_load5",
-			"node_memory_.+",
-			"node_nf_conntrack_.+",
-			"node_scrape_collector_duration_seconds",
-			"node_scrape_collector_success",
-			"process_max_fds",
-			"process_open_fds",
-		)
-		return nil
-	}); err != nil {
-		return err
+
+	// When the OTEL dataplane collector is enabled, it handles scraping node-exporter metrics
+	// locally in the shoot cluster, so we skip creating the prometheus scrape config to avoid
+	// duplicate traffic.
+	if !features.DefaultFeatureGate.Enabled(features.OpenTelemetryDataplaneCollector) {
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, n.client, scrapeConfig, func() error {
+			metav1.SetMetaDataLabel(&scrapeConfig.ObjectMeta, "prometheus", shoot.Label)
+			scrapeConfig.Spec = shoot.ClusterComponentScrapeConfigSpec(
+				name,
+				shoot.KubernetesServiceDiscoveryConfig{
+					Role:             monitoringv1alpha1.KubernetesRoleEndpoint,
+					ServiceName:      name,
+					EndpointPortName: portNameMetrics,
+				},
+				"node_boot_time_seconds",
+				"node_cpu_seconds_total",
+				"node_disk_read_bytes_total",
+				"node_disk_written_bytes_total",
+				"node_disk_io_time_weighted_seconds_total",
+				"node_disk_io_time_seconds_total",
+				"node_disk_write_time_seconds_total",
+				"node_disk_writes_completed_total",
+				"node_disk_read_time_seconds_total",
+				"node_disk_reads_completed_total",
+				"node_filesystem_avail_bytes",
+				"node_filesystem_files",
+				"node_filesystem_files_free",
+				"node_filesystem_free_bytes",
+				"node_filesystem_readonly",
+				"node_filesystem_size_bytes",
+				"node_load1",
+				"node_load15",
+				"node_load5",
+				"node_memory_.+",
+				"node_nf_conntrack_.+",
+				"node_scrape_collector_duration_seconds",
+				"node_scrape_collector_success",
+				"process_max_fds",
+				"process_open_fds",
+			)
+			return nil
+		}); err != nil {
+			return err
+		}
+	} else {
+		// Delete the scrape config if it exists (cleanup from previous state)
+		if err := kubernetesutils.DeleteObjects(ctx, n.client, scrapeConfig); err != nil {
+			return err
+		}
 	}
 
 	prometheusRule := n.emptyPrometheusRule()
@@ -470,6 +485,11 @@ func (n *nodeExporter) computeResourcesData() (map[string][]byte, error) {
 
 		vpa *vpaautoscalingv1.VerticalPodAutoscaler
 	)
+
+	utilruntime.Must(gardenerutils.InjectNetworkPolicyAnnotationsForScrapeTargets(service, networkingv1.NetworkPolicyPort{
+		Port:     ptr.To(intstr.FromInt32(portMetrics)),
+		Protocol: ptr.To(corev1.ProtocolTCP),
+	}))
 
 	if n.values.VPAEnabled {
 		vpaUpdateMode := vpaautoscalingv1.UpdateModeRecreate

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_suite_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_suite_test.go
@@ -9,9 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/gardenlet/features"
 )
 
 func TestNodeExporter(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Component Observability Monitoring NodeExporter Suite")
 }

--- a/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
+++ b/pkg/component/observability/monitoring/nodeexporter/nodeexporter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/monitoring/nodeexporter"
 	componenttest "github.com/gardener/gardener/pkg/component/test"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
@@ -278,6 +279,8 @@ metadata:
 			serviceYAML = `apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"protocol":"TCP","port":16909}]'
   labels:
     component: node-exporter
   name: node-exporter
@@ -461,8 +464,10 @@ status: {}
 			Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 			actualScrapeConfig := &monitoringv1alpha1.ScrapeConfig{}
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), actualScrapeConfig)).To(Succeed())
-			Expect(actualScrapeConfig).To(DeepEqual(scrapeConfig))
+			if !features.DefaultFeatureGate.Enabled(features.OpenTelemetryDataplaneCollector) {
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), actualScrapeConfig)).To(Succeed())
+				Expect(actualScrapeConfig).To(DeepEqual(scrapeConfig))
+			}
 
 			actualPrometheusRule := &monitoringv1.PrometheusRule{}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), actualPrometheusRule)).To(Succeed())

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs.go
@@ -27,419 +27,520 @@ import (
 func CentralScrapeConfigs(namespace, clusterCASecretName string, isWorkerless bool) []*monitoringv1alpha1.ScrapeConfig {
 	out := []*monitoringv1alpha1.ScrapeConfig{
 		// We fetch kubelet metrics from seed's kube-system Prometheus and filter the metrics in shoot's namespace.
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "kube-kubelet-seed",
-			},
-			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorTimestamps: ptr.To(false),
-				MetricsPath:     ptr.To("/federate"),
-				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-					Role:       monitoringv1alpha1.KubernetesRoleService,
-					Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"garden"}},
-				}},
-				Params: map[string][]string{
-					"match[]": {
-						`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
-						`{__name__=~"container_.+",job="cadvisor",namespace="` + namespace + `"}`,
-						`{__name__=~"kube_.+",job="kube-state-metrics",namespace="` + namespace + `"}`,
-						`{__name__=~"etcddruid_.+",job="etcd-druid",etcd_namespace="` + namespace + `"}`,
-					},
-				},
-				RelabelConfigs: []monitoringv1.RelabelConfig{
-					{
-						SourceLabels: []monitoringv1.LabelName{
-							"__meta_kubernetes_service_name",
-							"__meta_kubernetes_service_port_name",
-						},
-						Regex:  "prometheus-cache;web",
-						Action: "keep",
-					},
-					{
-						Action:      "replace",
-						Replacement: ptr.To("kube-kubelet-seed"),
-						TargetLabel: "job",
-					},
-				},
-				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-					// "shoot-control-plane" references the namespace of the shoot control-plane pods in the seed
-					Replacement: ptr.To("shoot-control-plane"),
-					TargetLabel: "namespace",
-				}},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "annotated-seed-service-endpoints",
-			},
-			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorLabels: ptr.To(false),
-				KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-					Role:       monitoringv1alpha1.KubernetesRoleEndpoint,
-					Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{namespace}},
-				}},
-				SampleLimit: ptr.To(uint64(500)),
-				RelabelConfigs: []monitoringv1.RelabelConfig{
-					{
-						Action:      "replace",
-						Replacement: ptr.To("annotated-seed-service-endpoints"),
-						TargetLabel: "job",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
-						Action:       "keep",
-						Regex:        `true`,
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scheme"},
-						Action:       "replace",
-						Regex:        `(https?)`,
-						TargetLabel:  "__scheme__",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_path"},
-						Action:       "replace",
-						Regex:        `(.+)`,
-						TargetLabel:  "__metrics_path__",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
-						Action:       "replace",
-						Regex:        `([^:]+)(?::\d+)?;(\d+)`,
-						Replacement:  ptr.To("$1:$2"),
-						TargetLabel:  "__address__",
-					},
-					{
-						Action: "labelmap",
-						Regex:  `__meta_kubernetes_service_label_(.+)`,
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
-						Action:       "replace",
-						TargetLabel:  "job",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_name"},
-						Action:       "replace",
-						Regex:        `(.+)`,
-						TargetLabel:  "job",
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
-						TargetLabel:  "pod",
-					},
-				},
-				MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-					SourceLabels: []monitoringv1.LabelName{"__name__"},
-					Action:       "drop",
-					Regex:        `^rest_client_request_latency_seconds.+$`,
-				}},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "prometheus-" + Label,
-			},
-			Spec: monitoringv1alpha1.ScrapeConfigSpec{
-				HonorLabels: ptr.To(false),
-				StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-					Targets: []monitoringv1alpha1.Target{"localhost:9090"},
-				}},
-				RelabelConfigs: []monitoringv1.RelabelConfig{
-					{
-						Action:      "replace",
-						Replacement: ptr.To("prometheus-" + Label),
-						TargetLabel: "job",
-					},
-					{
-						Action: "labelmap",
-						Regex:  `__meta_kubernetes_service_label_(.+)`,
-					},
-					{
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
-						TargetLabel:  "pod",
-					},
-				},
-			},
-		},
+		kubeletSeedScrapeConfig(namespace),
+		annotatedSeedServiceEndpointsScrapeConfig(namespace),
+		prometheusShootScrapeConfig(),
 	}
 
 	if !isWorkerless {
-		out = append(out,
-			&monitoringv1alpha1.ScrapeConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cadvisor",
-				},
-				Spec: monitoringv1alpha1.ScrapeConfigSpec{
-					HonorLabels:     ptr.To(false),
-					HonorTimestamps: ptr.To(false),
-					Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
-					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-						Key:                  resourcesv1alpha1.DataKeyToken,
-					}},
-					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-						Key:                  secretsutils.DataKeyCertificateBundle,
-					}}},
-					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-						Role:            monitoringv1alpha1.KubernetesRoleNode,
-						APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
-						FollowRedirects: ptr.To(false),
-						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-							Key:                  resourcesv1alpha1.DataKeyToken,
-						}},
-						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-							Key:                  secretsutils.DataKeyCertificateBundle,
-						}}},
-					}},
-					RelabelConfigs: []monitoringv1.RelabelConfig{
-						{
-							Action:      "replace",
-							Replacement: ptr.To("cadvisor"),
-							TargetLabel: "job",
-						},
-						{
-							Action: "labelmap",
-							Regex:  `__meta_kubernetes_node_label_(.+)`,
-						},
-						{
-							TargetLabel: "__address__",
-							Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-							Regex:        `(.+)`,
-							Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
-							TargetLabel:  "__metrics_path__",
-						},
-						{
-							TargetLabel: "type",
-							Replacement: ptr.To("shoot"),
-						},
-					},
-					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
-						// get system services
-						{
-							SourceLabels: []monitoringv1.LabelName{"id"},
-							Action:       "replace",
-							Regex:        `^/system\.slice/(.+)\.service$`,
-							TargetLabel:  "systemd_service_name",
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"id"},
-							Action:       "replace",
-							Regex:        `^/system\.slice/(.+)\.service$`,
-							Replacement:  ptr.To(`$1`),
-							TargetLabel:  "container",
-						},
-						monitoringutils.StandardMetricRelabelConfig(
-							"container_cpu_cfs_periods_total",
-							"container_cpu_cfs_throttled_seconds_total",
-							"container_cpu_cfs_throttled_periods_total",
-							"container_cpu_usage_seconds_total",
-							"container_fs_inodes_total",
-							"container_fs_limit_bytes",
-							"container_fs_usage_bytes",
-							"container_fs_reads_total",
-							"container_fs_writes_total",
-							"container_last_seen",
-							"container_memory_working_set_bytes",
-							"container_network_receive_bytes_total",
-							"container_network_transmit_bytes_total",
-						)[0],
-						// We want to keep only metrics in kube-system namespace
-						{
-							SourceLabels: []monitoringv1.LabelName{"namespace"},
-							Action:       "keep",
-							// systemd containers don't have namespaces
-							Regex: `(^$|^kube-system$)`,
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
-							Action:       "drop",
-							// The system container POD is used for networking
-							Regex: `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
-							Action:       "keep",
-							Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
-							Action:       "drop",
-							Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
-							Regex:        `container_network.+;/`,
-							Replacement:  ptr.To("true"),
-							TargetLabel:  "host_network",
-						},
-						{
-							Regex:  `^id$`,
-							Action: "labeldrop",
-						},
-					},
-				},
-			},
-			&monitoringv1alpha1.ScrapeConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "kube-kubelet",
-				},
-				Spec: monitoringv1alpha1.ScrapeConfigSpec{
-					HonorLabels: ptr.To(false),
-					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
-					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-						Key:                  resourcesv1alpha1.DataKeyToken,
-					}},
-					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-						Key:                  secretsutils.DataKeyCertificateBundle,
-					}}},
-					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-						Role:            monitoringv1alpha1.KubernetesRoleNode,
-						APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
-						FollowRedirects: ptr.To(true),
-						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
-						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-							Key:                  resourcesv1alpha1.DataKeyToken,
-						}},
-						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-							Key:                  secretsutils.DataKeyCertificateBundle,
-						}}},
-					}},
-					RelabelConfigs: []monitoringv1.RelabelConfig{
-						{
-							Action:      "replace",
-							Replacement: ptr.To("kube-kubelet"),
-							TargetLabel: "job",
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
-							TargetLabel:  "instance",
-						},
-						{
-							Action: "labelmap",
-							Regex:  `__meta_kubernetes_node_label_(.+)`,
-						},
-						{
-							TargetLabel: "__address__",
-							Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-						},
-						{
-							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-							Regex:        `(.+)`,
-							Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
-							TargetLabel:  "__metrics_path__",
-						},
-						{
-							TargetLabel: "type",
-							Replacement: ptr.To("shoot"),
-						},
-					},
-					MetricRelabelConfigs: append(monitoringutils.StandardMetricRelabelConfig(
-						"kubelet_running_pods",
-						"process_max_fds",
-						"process_open_fds",
-						"kubelet_volume_stats_available_bytes",
-						"kubelet_volume_stats_capacity_bytes",
-						"kubelet_volume_stats_used_bytes",
-						"kubelet_image_pull_duration_seconds_bucket",
-						"kubelet_image_pull_duration_seconds_sum",
-						"kubelet_image_pull_duration_seconds_count",
-					), monitoringv1.RelabelConfig{
-						SourceLabels: []monitoringv1.LabelName{"namespace"},
-						Action:       "keep",
-						// Not all kubelet metrics have a namespace label. That's why we also need to match empty namespace (^$).
-						Regex: `(^$|^` + metav1.NamespaceSystem + `$)`,
-					}),
-				},
-			},
-		)
+		// Only add cadvisor and kube-kubelet scrape configs if OTEL dataplane collector is not enabled.
+		// Otherwise, the collector scrapes these targets already.
+		if !features.DefaultFeatureGate.Enabled(features.OpenTelemetryDataplaneCollector) {
+			out = append(out, cadvisorScrapeConfig(clusterCASecretName), kubeletScrapeConfig(clusterCASecretName))
+		} else {
+			out = append(out, opentelemetryCollectorDataplaneScrapeConfig(clusterCASecretName))
+		}
 
 		if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
-			nodeMetricsURL := fmt.Sprintf("/api/v1/nodes/${1}:%d/proxy/metrics", otelcomponent.MetricsPort)
-			out = append(out,
-				&monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "opentelemetry-collector-nodes",
-					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels: ptr.To(false),
-						Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
-						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-							Key:                  resourcesv1alpha1.DataKeyToken,
-						}},
-						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-							Key:                  secretsutils.DataKeyCertificateBundle,
-						}}},
-						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-							Role:            monitoringv1alpha1.KubernetesRoleNode,
-							APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
-							FollowRedirects: ptr.To(true),
-							Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
-							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
-								Key:                  resourcesv1alpha1.DataKeyToken,
-							}},
-							TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-								Key:                  secretsutils.DataKeyCertificateBundle,
-							}}},
-						}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								Action:      "replace",
-								Replacement: ptr.To("opentelemetry-collector-nodes"),
-								TargetLabel: "job",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-								TargetLabel:  "instance",
-							},
-							{
-								Action: "labelmap",
-								Regex:  `__meta_kubernetes_node_label_(.+)`,
-							},
-							{
-								TargetLabel: "__address__",
-								Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-								Regex:        `(.+)`,
-								Replacement:  ptr.To(nodeMetricsURL),
-								TargetLabel:  "__metrics_path__",
-							},
-							{
-								TargetLabel: "type",
-								Replacement: ptr.To("shoot"),
-							},
-						},
-						MetricRelabelConfigs: append(monitoringutils.StandardMetricRelabelConfig(
-							"otelcol_exporter_.*",
-							"otelcol_process_.*",
-							"otelcol_receiver_.*",
-							"otelcol_scraper_.*",
-							"otelcol_processor_*",
-						), monitoringv1.RelabelConfig{
-							Action: "keep",
-						}),
-					},
-				},
-			)
+			out = append(out, opentelemetryCollectorNodesScrapeConfig(clusterCASecretName))
 		}
 	}
 
 	return out
+}
+
+func kubeletSeedScrapeConfig(namespace string) *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-kubelet-seed",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			JobName:         ptr.To("kube-kubelet-seed"),
+			HonorTimestamps: ptr.To(false),
+			MetricsPath:     ptr.To("/federate"),
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				Role:       monitoringv1alpha1.KubernetesRoleService,
+				Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"garden"}},
+			}},
+			Params: map[string][]string{
+				"match[]": {
+					`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
+					`{__name__=~"container_.+",job="cadvisor",namespace="` + namespace + `"}`,
+					`{__name__=~"kube_.+",job="kube-state-metrics",namespace="` + namespace + `"}`,
+					`{__name__=~"etcddruid_.+",job="etcd-druid",etcd_namespace="` + namespace + `"}`,
+				},
+			},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					SourceLabels: []monitoringv1.LabelName{
+						"__meta_kubernetes_service_name",
+						"__meta_kubernetes_service_port_name",
+					},
+					Regex:  "prometheus-cache;web",
+					Action: "keep",
+				},
+			},
+			MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+				// "shoot-control-plane" references the namespace of the shoot control-plane pods in the seed
+				Replacement: ptr.To("shoot-control-plane"),
+				TargetLabel: "namespace",
+			}},
+		},
+	}
+}
+
+func annotatedSeedServiceEndpointsScrapeConfig(namespace string) *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "annotated-seed-service-endpoints",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			JobName:     ptr.To("annotated-seed-service-endpoints"),
+			HonorLabels: ptr.To(false),
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				Role:       monitoringv1alpha1.KubernetesRoleEndpoint,
+				Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{namespace}},
+			}},
+			SampleLimit: ptr.To(uint64(500)),
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
+					Action:       "keep",
+					Regex:        `true`,
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scheme"},
+					Action:       "replace",
+					Regex:        `(https?)`,
+					TargetLabel:  "__scheme__",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_path"},
+					Action:       "replace",
+					Regex:        `(.+)`,
+					TargetLabel:  "__metrics_path__",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
+					Action:       "replace",
+					Regex:        `([^:]+)(?::\d+)?;(\d+)`,
+					Replacement:  ptr.To("$1:$2"),
+					TargetLabel:  "__address__",
+				},
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_service_label_(.+)`,
+				},
+				{
+					// TODO(bobi-wan): aren't service_name labels populated
+					// only with role="service" in service discovery? This
+					// one uses role="endpoint" discovery.
+					// Also, why relabel the "job" label a second time?
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
+					Action:       "replace",
+					TargetLabel:  "job",
+				},
+				{
+					// TODO(bobi-wan): why relabel the "job" label a third time?
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_name"},
+					Action:       "replace",
+					Regex:        `(.+)`,
+					TargetLabel:  "job",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+					TargetLabel:  "pod",
+				},
+			},
+			MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+				SourceLabels: []monitoringv1.LabelName{"__name__"},
+				Action:       "drop",
+				Regex:        `^rest_client_request_latency_seconds.+$`,
+			}},
+		},
+	}
+}
+
+func prometheusShootScrapeConfig() *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prometheus-" + Label,
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			JobName:     ptr.To("prometheus-" + Label),
+			HonorLabels: ptr.To(false),
+			StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+				Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+			}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_service_label_(.+)`,
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+					TargetLabel:  "pod",
+				},
+			},
+		},
+	}
+}
+
+// used by prometheus when the OTEL dataplane deployment feature is not enabled.
+func cadvisorScrapeConfig(clusterCASecretName string) *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cadvisor",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			HonorLabels:     ptr.To(false),
+			HonorTimestamps: ptr.To(false),
+			Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
+			Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+				Key:                  resourcesv1alpha1.DataKeyToken,
+			}},
+			TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+				Key:                  secretsutils.DataKeyCertificateBundle,
+			}}},
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				// TODO(bobi-wan): why do we have a "node" role + a namespace configured?
+				Role:            monitoringv1alpha1.KubernetesRoleNode,
+				APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+				Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+				FollowRedirects: ptr.To(false),
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+					Key:                  secretsutils.DataKeyCertificateBundle,
+				}}},
+			}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				// OK
+				// Set in job_name already
+				{
+					Action:      "replace",
+					Replacement: ptr.To("cadvisor"),
+					TargetLabel: "job",
+				},
+				// OK
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_node_label_(.+)`,
+				},
+				// OK - leaving default <host>:<ip>
+				{
+					TargetLabel: "__address__",
+					Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+				},
+				// OK - leaving to /metrics/cadvisor
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+					Regex:        `(.+)`,
+					Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
+					TargetLabel:  "__metrics_path__",
+				},
+				// OK, added
+				{
+					TargetLabel: "type",
+					Replacement: ptr.To("shoot"),
+				},
+			},
+			MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+				// get system services
+				// NOT OK, id still there, missing systemd_service_name
+				{
+					SourceLabels: []monitoringv1.LabelName{"id"},
+					Action:       "replace",
+					Regex:        `^/system\.slice/(.+)\.service$`,
+					TargetLabel:  "systemd_service_name",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"id"},
+					Action:       "replace",
+					Regex:        `^/system\.slice/(.+)\.service$`,
+					Replacement:  ptr.To(`$1`),
+					TargetLabel:  "container",
+				},
+				monitoringutils.StandardMetricRelabelConfig(
+					"container_cpu_cfs_periods_total",
+					"container_cpu_cfs_throttled_seconds_total",
+					"container_cpu_cfs_throttled_periods_total",
+					"container_cpu_usage_seconds_total",
+					"container_fs_inodes_total",
+					"container_fs_limit_bytes",
+					"container_fs_usage_bytes",
+					"container_fs_reads_total",
+					"container_fs_writes_total",
+					"container_last_seen",
+					"container_memory_working_set_bytes",
+					"container_network_receive_bytes_total",
+					"container_network_transmit_bytes_total",
+				)[0],
+				// We want to keep only metrics in kube-system namespace
+				{
+					SourceLabels: []monitoringv1.LabelName{"namespace"},
+					Action:       "keep",
+					// systemd containers don't have namespaces
+					Regex: `(^$|^kube-system$)`,
+				},
+				// copied as is
+				{
+					SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
+					Action:       "drop",
+					// The system container POD is used for networking
+					Regex: `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
+				},
+				// copied as is
+				{
+					SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
+					Action:       "keep",
+					Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
+				},
+				// copied as is
+				{
+					SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
+					Action:       "drop",
+					Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
+				},
+				// copied as is
+				{
+					SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
+					Regex:        `container_network.+;/`,
+					Replacement:  ptr.To("true"),
+					TargetLabel:  "host_network",
+				},
+				{
+					Regex:  `^id$`,
+					Action: "labeldrop",
+				},
+			},
+		},
+	}
+}
+
+// used by prometheus when the OTEL dataplane deployment feature is not enabled.
+func kubeletScrapeConfig(clusterCASecretName string) *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-kubelet",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			HonorLabels: ptr.To(false),
+			Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+			Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+				Key:                  resourcesv1alpha1.DataKeyToken,
+			}},
+			TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+				Key:                  secretsutils.DataKeyCertificateBundle,
+			}}},
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				Role:            monitoringv1alpha1.KubernetesRoleNode,
+				APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
+				FollowRedirects: ptr.To(true),
+				Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+					Key:                  secretsutils.DataKeyCertificateBundle,
+				}}},
+			}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					Action:      "replace",
+					Replacement: ptr.To("kube-kubelet"),
+					TargetLabel: "job",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
+					TargetLabel:  "instance",
+				},
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_node_label_(.+)`,
+				},
+				{
+					TargetLabel: "__address__",
+					Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+					Regex:        `(.+)`,
+					Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
+					TargetLabel:  "__metrics_path__",
+				},
+				{
+					TargetLabel: "type",
+					Replacement: ptr.To("shoot"),
+				},
+			},
+			MetricRelabelConfigs: append(monitoringutils.StandardMetricRelabelConfig(
+				"kubelet_running_pods",
+				"process_max_fds",
+				"process_open_fds",
+				"kubelet_volume_stats_available_bytes",
+				"kubelet_volume_stats_capacity_bytes",
+				"kubelet_volume_stats_used_bytes",
+				"kubelet_image_pull_duration_seconds_bucket",
+				"kubelet_image_pull_duration_seconds_sum",
+				"kubelet_image_pull_duration_seconds_count",
+			), monitoringv1.RelabelConfig{
+				SourceLabels: []monitoringv1.LabelName{"namespace"},
+				Action:       "keep",
+				// Not all kubelet metrics have a namespace label. That's why we also need to match empty namespace (^$).
+				Regex: `(^$|^` + metav1.NamespaceSystem + `$)`,
+			}),
+		},
+	}
+}
+
+// this seems to be the scrape config for collecting OTEL agent data (the OTEL collector that  runs as a systemd unit/service on every shoot node)
+func opentelemetryCollectorNodesScrapeConfig(clusterCASecretName string) *monitoringv1alpha1.ScrapeConfig {
+	nodeMetricsURL := fmt.Sprintf("/api/v1/nodes/${1}:%d/proxy/metrics", otelcomponent.MetricsPort)
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "opentelemetry-collector-nodes",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			JobName:     ptr.To("opentelemetry-collector-nodes"),
+			HonorLabels: ptr.To(false),
+			Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+			Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+				Key:                  resourcesv1alpha1.DataKeyToken,
+			}},
+			TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+				Key:                  secretsutils.DataKeyCertificateBundle,
+			}}},
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				Role:            monitoringv1alpha1.KubernetesRoleNode,
+				APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
+				FollowRedirects: ptr.To(true),
+				// TODO(bobi-wan): role="node" + namespace filter again
+				Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+					Key:                  secretsutils.DataKeyCertificateBundle,
+				}}},
+			}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+					TargetLabel:  "instance",
+				},
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_node_label_(.+)`,
+				},
+				{
+					TargetLabel: "__address__",
+					Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+					Regex:        `(.+)`,
+					Replacement:  ptr.To(nodeMetricsURL),
+					TargetLabel:  "__metrics_path__",
+				},
+				{
+					TargetLabel: "type",
+					Replacement: ptr.To("shoot"),
+				},
+			},
+			MetricRelabelConfigs: append(monitoringutils.StandardMetricRelabelConfig(
+				"otelcol_exporter_.*",
+				"otelcol_process_.*",
+				"otelcol_receiver_.*",
+				"otelcol_scraper_.*",
+				"otelcol_processor_*",
+			), monitoringv1.RelabelConfig{
+				Action: "keep",
+			}),
+		},
+	}
+}
+
+// used by shoot prometheus to scrape the OTEL collector deployment.
+func opentelemetryCollectorDataplaneScrapeConfig(clusterCASecretName string) *monitoringv1alpha1.ScrapeConfig {
+	podMetricsURL := "/api/v1/namespaces/kube-system/pods/${1}/proxy/metrics"
+	return &monitoringv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "otel-collector-dataplane",
+		},
+		Spec: monitoringv1alpha1.ScrapeConfigSpec{
+			JobName:     ptr.To("otel-collector-dataplane"),
+			HonorLabels: ptr.To(true),
+			Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+			Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+				Key:                  resourcesv1alpha1.DataKeyToken,
+			}},
+			TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+				Key:                  secretsutils.DataKeyCertificateBundle,
+			}}},
+			KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+				Role:            monitoringv1alpha1.KubernetesRoleEndpoint,
+				APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
+				FollowRedirects: ptr.To(true),
+				Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+				Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: AccessSecretName},
+					Key:                  resourcesv1alpha1.DataKeyToken,
+				}},
+				TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+					Key:                  secretsutils.DataKeyCertificateBundle,
+				}}},
+			}},
+			RelabelConfigs: []monitoringv1.RelabelConfig{
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
+					Action:       "keep",
+					Regex:        "otel-collector-dataplane-deployment",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_endpoint_port_name"},
+					Action:       "keep",
+					Regex:        "metrics",
+				},
+				{
+					TargetLabel: "__address__",
+					Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+					Regex:        `(.+)`,
+					TargetLabel:  "__metrics_path__",
+					Replacement:  ptr.To(podMetricsURL),
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+					TargetLabel:  "pod",
+				},
+				{
+					SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_node_name"},
+					TargetLabel:  "instance",
+				},
+				{
+					Action: "labelmap",
+					Regex:  `__meta_kubernetes_pod_label_(.+)`,
+				},
+			},
+		},
+	}
 }

--- a/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/shoot/scrapeconfigs_test.go
@@ -16,10 +16,12 @@ import (
 	"k8s.io/utils/ptr"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus"
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	"github.com/gardener/gardener/pkg/features"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	testutils "github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -29,153 +31,164 @@ var _ = Describe("ScrapeConfigs", func() {
 			namespace           = "shoot--foo--bar"
 			clusterCASecretName = "ca-bundle-f23sa"
 
-			workerlessScrapeConfigs = []*monitoringv1alpha1.ScrapeConfig{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kube-kubelet-seed",
-					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorTimestamps: ptr.To(false),
-						MetricsPath:     ptr.To("/federate"),
-						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-							Role:       monitoringv1alpha1.KubernetesRoleService,
-							Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{v1beta1constants.GardenNamespace}},
-						}},
-						Params: map[string][]string{
-							"match[]": {
-								`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
-								`{__name__=~"container_.+",job="cadvisor",namespace="` + namespace + `"}`,
-								`{__name__=~"kube_.+",job="kube-state-metrics",namespace="` + namespace + `"}`,
-								`{__name__=~"etcddruid_.+",job="etcd-druid",etcd_namespace="` + namespace + `"}`,
-							},
-						},
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{
-									"__meta_kubernetes_service_name",
-									"__meta_kubernetes_service_port_name",
-								},
-								Regex:  "prometheus-cache;" + prometheus.ServicePorts().Web.Name,
-								Action: "keep",
-							},
-							{
-								Action:      "replace",
-								Replacement: ptr.To("kube-kubelet-seed"),
-								TargetLabel: "job",
-							},
-						},
-						MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-							Replacement: ptr.To("shoot-control-plane"),
-							TargetLabel: "namespace",
-						}},
-					},
+			kubeKubeletSeedScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-kubelet-seed",
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "annotated-seed-service-endpoints",
-					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels: ptr.To(false),
-						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-							Role:       "Endpoints",
-							Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{namespace}},
-						}},
-						SampleLimit: ptr.To(uint64(500)),
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								Action:      "replace",
-								Replacement: ptr.To("annotated-seed-service-endpoints"),
-								TargetLabel: "job",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
-								Action:       "keep",
-								Regex:        `true`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scheme"},
-								Action:       "replace",
-								Regex:        `(https?)`,
-								TargetLabel:  "__scheme__",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_path"},
-								Action:       "replace",
-								Regex:        `(.+)`,
-								TargetLabel:  "__metrics_path__",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
-								Action:       "replace",
-								Regex:        `([^:]+)(?::\d+)?;(\d+)`,
-								Replacement:  ptr.To("$1:$2"),
-								TargetLabel:  "__address__",
-							},
-							{
-								Action: "labelmap",
-								Regex:  `__meta_kubernetes_service_label_(.+)`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
-								Action:       "replace",
-								TargetLabel:  "job",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_name"},
-								Action:       "replace",
-								Regex:        `(.+)`,
-								TargetLabel:  "job",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
-								TargetLabel:  "pod",
-							},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorTimestamps: ptr.To(false),
+					MetricsPath:     ptr.To("/federate"),
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:       monitoringv1alpha1.KubernetesRoleService,
+						Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{v1beta1constants.GardenNamespace}},
+					}},
+					Params: map[string][]string{
+						"match[]": {
+							`{__name__=~"metering:.+",namespace="` + namespace + `"}`,
+							`{__name__=~"container_.+",job="cadvisor",namespace="` + namespace + `"}`,
+							`{__name__=~"kube_.+",job="kube-state-metrics",namespace="` + namespace + `"}`,
+							`{__name__=~"etcddruid_.+",job="etcd-druid",etcd_namespace="` + namespace + `"}`,
 						},
-						MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
-							SourceLabels: []monitoringv1.LabelName{"__name__"},
-							Action:       "drop",
-							Regex:        `^rest_client_request_latency_seconds.+$`,
-						}},
 					},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{
+								"__meta_kubernetes_service_name",
+								"__meta_kubernetes_service_port_name",
+							},
+							Regex:  "prometheus-cache;" + prometheus.ServicePorts().Web.Name,
+							Action: "keep",
+						},
+						{
+							Action:      "replace",
+							Replacement: ptr.To("kube-kubelet-seed"),
+							TargetLabel: "job",
+						},
+					},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+						Replacement: ptr.To("shoot-control-plane"),
+						TargetLabel: "namespace",
+					}},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "prometheus-shoot",
+			}
+
+			annotatedSeedServiceEndpointsScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "annotated-seed-service-endpoints",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels: ptr.To(false),
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:       "Endpoints",
+						Namespaces: &monitoringv1alpha1.NamespaceDiscovery{Names: []string{namespace}},
+					}},
+					SampleLimit: ptr.To(uint64(500)),
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("annotated-seed-service-endpoints"),
+							TargetLabel: "job",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scrape"},
+							Action:       "keep",
+							Regex:        `true`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_scheme"},
+							Action:       "replace",
+							Regex:        `(https?)`,
+							TargetLabel:  "__scheme__",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_path"},
+							Action:       "replace",
+							Regex:        `(.+)`,
+							TargetLabel:  "__metrics_path__",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"},
+							Action:       "replace",
+							Regex:        `([^:]+)(?::\d+)?;(\d+)`,
+							Replacement:  ptr.To("$1:$2"),
+							TargetLabel:  "__address__",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_service_label_(.+)`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
+							Action:       "replace",
+							TargetLabel:  "job",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_annotation_prometheus_io_name"},
+							Action:       "replace",
+							Regex:        `(.+)`,
+							TargetLabel:  "job",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+							TargetLabel:  "pod",
+						},
 					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels: ptr.To(false),
-						StaticConfigs: []monitoringv1alpha1.StaticConfig{{
-							Targets: []monitoringv1alpha1.Target{"localhost:9090"},
-						}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								Action:      "replace",
-								Replacement: ptr.To("prometheus-shoot"),
-								TargetLabel: "job",
-							},
-							{
-								Action: "labelmap",
-								Regex:  `__meta_kubernetes_service_label_(.+)`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
-								TargetLabel:  "pod",
-							},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{{
+						SourceLabels: []monitoringv1.LabelName{"__name__"},
+						Action:       "drop",
+						Regex:        `^rest_client_request_latency_seconds.+$`,
+					}},
+				},
+			}
+
+			prometheusShootScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "prometheus-shoot",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels: ptr.To(false),
+					StaticConfigs: []monitoringv1alpha1.StaticConfig{{
+						Targets: []monitoringv1alpha1.Target{"localhost:9090"},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("prometheus-shoot"),
+							TargetLabel: "job",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_service_label_(.+)`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+							TargetLabel:  "pod",
 						},
 					},
 				},
 			}
 
-			nonWorkerlessScrapeConfigs = append(
-				workerlessScrapeConfigs,
-				&monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cadvisor",
-					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels:     ptr.To(false),
-						HonorTimestamps: ptr.To(false),
-						Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
+			cadvisorScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cadvisor",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels:     ptr.To(false),
+					HonorTimestamps: ptr.To(false),
+					Scheme:          ptr.To(monitoringv1.SchemeHTTPS),
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+						Key:                  "token",
+					}},
+					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+						Key:                  "bundle.crt",
+					}}},
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:            "Node",
+						APIServer:       ptr.To("https://kube-apiserver:443"),
+						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
+						FollowRedirects: ptr.To(false),
 						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 							Key:                  "token",
@@ -184,104 +197,105 @@ var _ = Describe("ScrapeConfigs", func() {
 							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
 							Key:                  "bundle.crt",
 						}}},
-						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-							Role:            "Node",
-							APIServer:       ptr.To("https://kube-apiserver:443"),
-							Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
-							FollowRedirects: ptr.To(false),
-							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
-								Key:                  "token",
-							}},
-							TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-								Key:                  "bundle.crt",
-							}}},
-						}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								Action:      "replace",
-								Replacement: ptr.To("cadvisor"),
-								TargetLabel: "job",
-							},
-							{
-								Action: "labelmap",
-								Regex:  `__meta_kubernetes_node_label_(.+)`,
-							},
-							{
-								TargetLabel: "__address__",
-								Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-								Regex:        `(.+)`,
-								Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
-								TargetLabel:  "__metrics_path__",
-							},
-							{
-								TargetLabel: "type",
-								Replacement: ptr.To("shoot"),
-							},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("cadvisor"),
+							TargetLabel: "job",
 						},
-						MetricRelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"id"},
-								Action:       "replace",
-								Regex:        `^/system\.slice/(.+)\.service$`,
-								TargetLabel:  "systemd_service_name",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"id"},
-								Action:       "replace",
-								Regex:        `^/system\.slice/(.+)\.service$`,
-								Replacement:  ptr.To(`$1`),
-								TargetLabel:  "container",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Action:       "keep",
-								Regex:        `^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"namespace"},
-								Action:       "keep",
-								Regex:        `(^$|^kube-system$)`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
-								Action:       "drop",
-								Regex:        `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
-								Action:       "keep",
-								Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
-								Action:       "drop",
-								Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
-								Regex:        `container_network.+;/`,
-								Replacement:  ptr.To("true"),
-								TargetLabel:  "host_network",
-							},
-							{
-								Regex:  `^id$`,
-								Action: "labeldrop",
-							},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_node_label_(.+)`,
+						},
+						{
+							TargetLabel: "__address__",
+							Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							Regex:        `(.+)`,
+							Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics/cadvisor`),
+							TargetLabel:  "__metrics_path__",
+						},
+						{
+							TargetLabel: "type",
+							Replacement: ptr.To("shoot"),
+						},
+					},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"id"},
+							Action:       "replace",
+							Regex:        `^/system\.slice/(.+)\.service$`,
+							TargetLabel:  "systemd_service_name",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"id"},
+							Action:       "replace",
+							Regex:        `^/system\.slice/(.+)\.service$`,
+							Replacement:  ptr.To(`$1`),
+							TargetLabel:  "container",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"namespace"},
+							Action:       "keep",
+							Regex:        `(^$|^kube-system$)`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"container", "__name__"},
+							Action:       "drop",
+							Regex:        `POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface", "id"},
+							Action:       "keep",
+							Regex:        `container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__", "container", "interface"},
+							Action:       "drop",
+							Regex:        `container_network.+;POD;(.{5,}|tun0|en.+)`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__", "id"},
+							Regex:        `container_network.+;/`,
+							Replacement:  ptr.To("true"),
+							TargetLabel:  "host_network",
+						},
+						{
+							Regex:  `^id$`,
+							Action: "labeldrop",
 						},
 					},
 				},
-				&monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kube-kubelet",
-					},
-					Spec: monitoringv1alpha1.ScrapeConfigSpec{
-						HonorLabels: ptr.To(false),
-						Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+			}
+
+			kubeKubeletScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-kubelet",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels: ptr.To(false),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+						Key:                  "token",
+					}},
+					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+						Key:                  "bundle.crt",
+					}}},
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:            "Node",
+						APIServer:       ptr.To("https://kube-apiserver"),
+						FollowRedirects: ptr.To(true),
+						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
 						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
 							Key:                  "token",
@@ -290,64 +304,194 @@ var _ = Describe("ScrapeConfigs", func() {
 							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
 							Key:                  "bundle.crt",
 						}}},
-						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-							Role:            "Node",
-							APIServer:       ptr.To("https://kube-apiserver"),
-							FollowRedirects: ptr.To(true),
-							Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
-							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
-								Key:                  "token",
-							}},
-							TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-								Key:                  "bundle.crt",
-							}}},
-						}},
-						RelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								Action:      "replace",
-								Replacement: ptr.To("kube-kubelet"),
-								TargetLabel: "job",
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
-								TargetLabel:  "instance",
-							},
-							{
-								Action: "labelmap",
-								Regex:  `__meta_kubernetes_node_label_(.+)`,
-							},
-							{
-								TargetLabel: "__address__",
-								Replacement: ptr.To("kube-apiserver:443"),
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-								Regex:        `(.+)`,
-								Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
-								TargetLabel:  "__metrics_path__",
-							},
-							{
-								TargetLabel: "type",
-								Replacement: ptr.To("shoot"),
-							},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("kube-kubelet"),
+							TargetLabel: "job",
 						},
-						MetricRelabelConfigs: []monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Action:       "keep",
-								Regex:        `^(kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$`,
-							},
-							{
-								SourceLabels: []monitoringv1.LabelName{"namespace"},
-								Action:       "keep",
-								Regex:        `(^$|^kube-system$)`,
-							},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_address_InternalIP"},
+							TargetLabel:  "instance",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_node_label_(.+)`,
+						},
+						{
+							TargetLabel: "__address__",
+							Replacement: ptr.To("kube-apiserver:443"),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							Regex:        `(.+)`,
+							Replacement:  ptr.To(`/api/v1/nodes/${1}/proxy/metrics`),
+							TargetLabel:  "__metrics_path__",
+						},
+						{
+							TargetLabel: "type",
+							Replacement: ptr.To("shoot"),
+						},
+					},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$`,
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"namespace"},
+							Action:       "keep",
+							Regex:        `(^$|^kube-system$)`,
 						},
 					},
 				},
-			)
+			}
+
+			opentelemetryCollectorNodesScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "opentelemetry-collector-nodes",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					HonorLabels: ptr.To(false),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+						Key:                  "token",
+					}},
+					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+						Key:                  "bundle.crt",
+					}}},
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:            "Node",
+						APIServer:       ptr.To("https://kube-apiserver"),
+						FollowRedirects: ptr.To(true),
+						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
+						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+							Key:                  "token",
+						}},
+						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+							Key:                  "bundle.crt",
+						}}},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:      "replace",
+							Replacement: ptr.To("opentelemetry-collector-nodes"),
+							TargetLabel: "job",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							TargetLabel:  "instance",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_node_label_(.+)`,
+						},
+						{
+							TargetLabel: "__address__",
+							Replacement: ptr.To("kube-apiserver:443"),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
+							Regex:        `(.+)`,
+							Replacement:  ptr.To(`/api/v1/nodes/${1}:18888/proxy/metrics`),
+							TargetLabel:  "__metrics_path__",
+						},
+						{
+							TargetLabel: "type",
+							Replacement: ptr.To("shoot"),
+						},
+					},
+					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"__name__"},
+							Action:       "keep",
+							Regex:        `^(otelcol_exporter_.*|otelcol_process_.*|otelcol_receiver_.*|otelcol_scraper_.*|otelcol_processor_*)$`,
+						},
+						{
+							Action: "keep",
+						},
+					},
+				},
+			}
+
+			opentelemetryCollectorDataplaneScrapeConfig = &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "otel-collector-dataplane",
+				},
+				Spec: monitoringv1alpha1.ScrapeConfigSpec{
+					JobName:     ptr.To("otel-collector-dataplane"),
+					HonorLabels: ptr.To(true),
+					Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
+					Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+						Key:                  resourcesv1alpha1.DataKeyToken,
+					}},
+					TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+						Key:                  secretsutils.DataKeyCertificateBundle,
+					}}},
+					KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
+						Role:            monitoringv1alpha1.KubernetesRoleEndpoint,
+						APIServer:       ptr.To("https://" + v1beta1constants.DeploymentNameKubeAPIServer),
+						FollowRedirects: ptr.To(true),
+						Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{metav1.NamespaceSystem}},
+						Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
+							Key:                  resourcesv1alpha1.DataKeyToken,
+						}},
+						TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
+							Key:                  secretsutils.DataKeyCertificateBundle,
+						}}},
+					}},
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_service_name"},
+							Action:       "keep",
+							Regex:        "otel-collector-dataplane-deployment",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_endpoint_port_name"},
+							Action:       "keep",
+							Regex:        "metrics",
+						},
+						{
+							TargetLabel: "__address__",
+							Replacement: ptr.To(v1beta1constants.DeploymentNameKubeAPIServer + ":" + strconv.Itoa(kubeapiserverconstants.Port)),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+							Regex:        `(.+)`,
+							TargetLabel:  "__metrics_path__",
+							Replacement:  ptr.To("/api/v1/namespaces/kube-system/pods/${1}/proxy/metrics"),
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+							TargetLabel:  "pod",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_node_name"},
+							TargetLabel:  "instance",
+						},
+						{
+							Action: "labelmap",
+							Regex:  `__meta_kubernetes_pod_label_(.+)`,
+						},
+					},
+				},
+			}
+
+			workerlessScrapeConfigs = []*monitoringv1alpha1.ScrapeConfig{
+				kubeKubeletSeedScrapeConfig,
+				annotatedSeedServiceEndpointsScrapeConfig,
+				prometheusShootScrapeConfig,
+			}
 		)
 
 		BeforeEach(func() {
@@ -364,86 +508,46 @@ var _ = Describe("ScrapeConfigs", func() {
 		})
 
 		When("cluster is not workerless", func() {
-			It("should return expected scrape configs with OTel feature disabled", func() {
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(nonWorkerlessScrapeConfigs))
+			Context("OTel feature flag options", func() {
+				It("should return expected scrape configs with OTel feature disabled", func() {
+					items := append(
+						workerlessScrapeConfigs,
+						cadvisorScrapeConfig,
+						kubeKubeletScrapeConfig,
+					)
+					Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(ConsistOf(items))
+				})
+
+				It("should return expected scrape configs with OTel feature enabled", func() {
+					DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
+					items := append(
+						workerlessScrapeConfigs,
+						cadvisorScrapeConfig,
+						kubeKubeletScrapeConfig,
+						opentelemetryCollectorNodesScrapeConfig,
+					)
+					Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(items))
+				})
 			})
 
-			It("should return expected scrape configs with OTel feature enabled", func() {
-				DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryCollector, true))
-				items := append(
-					nonWorkerlessScrapeConfigs,
-					&monitoringv1alpha1.ScrapeConfig{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "opentelemetry-collector-nodes",
-						},
-						Spec: monitoringv1alpha1.ScrapeConfigSpec{
-							HonorLabels: ptr.To(false),
-							Scheme:      ptr.To(monitoringv1.SchemeHTTPS),
-							Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
-								Key:                  "token",
-							}},
-							TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-								Key:                  "bundle.crt",
-							}}},
-							KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{
-								Role:            "Node",
-								APIServer:       ptr.To("https://kube-apiserver"),
-								FollowRedirects: ptr.To(true),
-								Namespaces:      &monitoringv1alpha1.NamespaceDiscovery{Names: []string{"kube-system"}},
-								Authorization: &monitoringv1.SafeAuthorization{Credentials: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{Name: "shoot-access-prometheus-shoot"},
-									Key:                  "token",
-								}},
-								TLSConfig: &monitoringv1.SafeTLSConfig{CA: monitoringv1.SecretOrConfigMap{Secret: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{Name: clusterCASecretName},
-									Key:                  "bundle.crt",
-								}}},
-							}},
-							RelabelConfigs: []monitoringv1.RelabelConfig{
-								{
-									Action:      "replace",
-									Replacement: ptr.To("opentelemetry-collector-nodes"),
-									TargetLabel: "job",
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-									TargetLabel:  "instance",
-								},
-								{
-									Action: "labelmap",
-									Regex:  `__meta_kubernetes_node_label_(.+)`,
-								},
-								{
-									TargetLabel: "__address__",
-									Replacement: ptr.To("kube-apiserver:443"),
-								},
-								{
-									SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_node_name"},
-									Regex:        `(.+)`,
-									Replacement:  ptr.To(`/api/v1/nodes/${1}:18888/proxy/metrics`),
-									TargetLabel:  "__metrics_path__",
-								},
-								{
-									TargetLabel: "type",
-									Replacement: ptr.To("shoot"),
-								},
-							},
-							MetricRelabelConfigs: []monitoringv1.RelabelConfig{
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__"},
-									Action:       "keep",
-									Regex:        `^(otelcol_exporter_.*|otelcol_process_.*|otelcol_receiver_.*|otelcol_scraper_.*|otelcol_processor_*)$`,
-								},
-								{
-									Action: "keep",
-								},
-							},
-						},
-					},
-				)
-				Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(items))
+			Context("OTel Dataplane feature flag options", func() {
+				It("should return expected scrape configs with OTel Dataplane feature disabled", func() {
+					items := append(
+						workerlessScrapeConfigs,
+						cadvisorScrapeConfig,
+						kubeKubeletScrapeConfig,
+					)
+					Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(ConsistOf(items))
+				})
+
+				It("should return expected scrape configs with OTel Dataplane feature enabled", func() {
+					DeferCleanup(testutils.WithFeatureGate(features.DefaultFeatureGate, features.OpenTelemetryDataplaneCollector, true))
+					items := append(
+						workerlessScrapeConfigs,
+						opentelemetryCollectorDataplaneScrapeConfig,
+					)
+					Expect(shoot.CentralScrapeConfigs(namespace, clusterCASecretName, false)).To(HaveExactElements(items))
+				})
 			})
 		})
 	})

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/assets.go
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/assets.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplanedeployment
+
+import (
+	_ "embed"
+)
+
+// otelConfig contains the complete OpenTelemetry collector configuration
+// for scraping kubelet, cadvisor, and node-exporter metrics in the shoot data plane.
+//
+//go:embed assets/opentelemetry-collector-dataplane-config.yaml
+var otelConfig string

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/assets/opentelemetry-collector-dataplane-config.yaml
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/assets/opentelemetry-collector-dataplane-config.yaml
@@ -1,0 +1,120 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'kube-kubelet'
+          honor_labels: true
+          scrape_interval: 30s
+          scheme: https
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$
+
+        - job_name: 'cadvisor'
+          honor_labels: true
+          scrape_interval: 30s
+          scheme: https
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+          metrics_path: /metrics/cadvisor
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: node
+            - target_label: type
+              replacement: shoot
+          metric_relabel_configs:
+            - source_labels: [id]
+              action: replace
+              regex: ^/system\.slice/(.+)\.service$
+              target_label: systemd_service_name
+            - source_labels: [id]
+              action: replace
+              regex: ^/system\.slice/(.+)\.service$
+              target_label: container
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+            - source_labels: [namespace]
+              action: keep
+              regex: (^$|^kube-system$)
+            - source_labels: [container, __name__]
+              action: drop
+              regex: POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)
+            - source_labels: [__name__, container, interface, id]
+              action: keep
+              regex: container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*
+            - source_labels: [__name__, container, interface]
+              action: drop
+              regex: container_network.+;POD;(.{5,}|tun0|en.+)
+            - source_labels: [__name__, id]
+              regex: container_network.+;/
+              replacement: "true"
+              target_label: host_network
+            - regex: ^id$
+              action: labeldrop
+        - job_name: 'node-exporter'
+          honor_labels: true
+          scrape_interval: 30s
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - kube-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name]
+              action: keep
+              regex: node-exporter
+            - source_labels: [__meta_kubernetes_endpoint_port_name]
+              action: keep
+              regex: metrics
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              action: replace
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|node_boot_time_seconds|node_cpu_seconds_total|node_disk_read_bytes_total|node_disk_written_bytes_total|node_disk_io_time_weighted_seconds_total|node_disk_io_time_seconds_total|node_disk_write_time_seconds_total|node_disk_writes_completed_total|node_disk_read_time_seconds_total|node_disk_reads_completed_total|node_filesystem_avail_bytes|node_filesystem_files|node_filesystem_files_free|node_filesystem_free_bytes|node_filesystem_readonly|node_filesystem_size_bytes|node_load1|node_load15|node_load5|node_memory_.+|node_nf_conntrack_.+|node_scrape_collector_duration_seconds|node_scrape_collector_success|process_max_fds|process_open_fds)$
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1000
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8080"
+    send_timestamps: true
+    metric_expiration: 5m
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheus]

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment.go
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment.go
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplanedeployment
+
+import (
+	"context"
+	"time"
+
+	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	prometheusshoot "github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
+	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
+	"github.com/gardener/gardener/pkg/utils"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+)
+
+const (
+	managedResourceName = "shoot-core-otel-collector-dataplane"
+	componentName       = "otel-collector-dataplane-deployment"
+
+	labelKeyComponent = "component"
+	metricsPortName   = "metrics"
+	portMetrics       = int32(8080)
+
+	targetNamespace               = metav1.NamespaceSystem
+	TimeoutWaitForManagedResource = 2 * time.Minute
+)
+
+// Config is the OpenTelemetry Collector Dataplane Deployment configuration.
+type Config struct {
+	// Image is the container image used for the OTEL collector.
+	Image string
+	// Replicas is the number of replicas for the deployment.
+	Replicas int32
+}
+
+type dataplaneDeployment struct {
+	client    client.Client
+	namespace string
+	config    Config
+}
+
+// New creates a new instance of DeployWaiter for OpenTelemetry Collector Dataplane Deployment.
+func New(
+	client client.Client,
+	namespace string,
+	config Config,
+) component.DeployWaiter {
+	return &dataplaneDeployment{
+		client:    client,
+		namespace: namespace,
+		config:    config,
+	}
+}
+
+func (d *dataplaneDeployment) Deploy(ctx context.Context) error {
+	data, err := d.computeResourcesData()
+	if err != nil {
+		return err
+	}
+	return managedresources.CreateForShoot(ctx, d.client, d.namespace, managedResourceName, managedresources.LabelValueGardener, false, data)
+}
+
+func (d *dataplaneDeployment) Destroy(ctx context.Context) error {
+	err := kubernetesutils.DeleteObjects(ctx, d.client, d.emptyScrapeConfig())
+	if err != nil {
+		return err
+	}
+
+	return managedresources.DeleteForShoot(ctx, d.client, d.namespace, managedResourceName)
+}
+
+func (d *dataplaneDeployment) Wait(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilHealthy(timeoutCtx, d.client, d.namespace, managedResourceName)
+}
+
+func (d *dataplaneDeployment) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilDeleted(timeoutCtx, d.client, d.namespace, managedResourceName)
+}
+
+func (d *dataplaneDeployment) computeResourcesData() (map[string][]byte, error) {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+
+		serviceAccount     = d.getServiceAccount()
+		clusterRole        = d.getClusterRole()
+		clusterRoleBinding = d.getClusterRoleBinding(clusterRole.Name, serviceAccount.Name, serviceAccount.Namespace)
+		service            = d.getService()
+		configMap          = d.getCollectorConfigMap()
+		deployment         = d.getDeployment(configMap.Name, serviceAccount.Name)
+	)
+
+	return registry.AddAllAndSerialize(
+		serviceAccount,
+		clusterRole,
+		clusterRoleBinding,
+		service,
+		configMap,
+		deployment,
+	)
+}
+
+func (d *dataplaneDeployment) emptyScrapeConfig() *monitoringv1alpha1.ScrapeConfig {
+	return &monitoringv1alpha1.ScrapeConfig{ObjectMeta: monitoringutils.ConfigObjectMeta(componentName, d.namespace, prometheusshoot.Label)}
+}
+
+func (d *dataplaneDeployment) getServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: targetNamespace,
+			Labels:    getLabels(),
+		},
+		AutomountServiceAccountToken: ptr.To(true),
+	}
+}
+
+func (d *dataplaneDeployment) getClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   componentName,
+			Labels: getLabels(),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "services", "endpoints", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes/metrics"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+}
+
+func (d *dataplaneDeployment) getClusterRoleBinding(clusterRoleName, serviceAccountName, serviceAccountNamespace string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   componentName,
+			Labels: getLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: serviceAccountNamespace,
+			},
+		},
+	}
+}
+
+func (d *dataplaneDeployment) getCollectorConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: targetNamespace,
+			Labels:    getLabels(),
+		},
+		Data: map[string]string{
+			"config.yaml": d.getOTelConfig(),
+		},
+	}
+}
+
+func (d *dataplaneDeployment) getService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: targetNamespace,
+			Labels:    getLabels(),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     metricsPortName,
+					Port:     portMetrics,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Selector: getLabels(),
+		},
+	}
+}
+
+func (d *dataplaneDeployment) getDeployment(configMapName, serviceAccountName string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      componentName,
+			Namespace: targetNamespace,
+			Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+				v1beta1constants.GardenRole:     v1beta1constants.GardenRoleObservability,
+				managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
+			}),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas:             &d.config.Replicas,
+			RevisionHistoryLimit: ptr.To[int32](2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: getLabels(),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.MergeStringMaps(getLabels(), map[string]string{
+						v1beta1constants.GardenRole:                            v1beta1constants.GardenRoleObservability,
+						managedresources.LabelKeyOrigin:                        managedresources.LabelValueGardener,
+						v1beta1constants.LabelNetworkPolicyShootFromSeed:       v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyShootToAPIServer:    v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyShootToKubelet:      v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyToDNS:               v1beta1constants.LabelNetworkPolicyAllowed,
+						v1beta1constants.LabelNetworkPolicyShootToNodeExporter: v1beta1constants.LabelNetworkPolicyAllowed,
+					}),
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName:  v1beta1constants.PriorityClassNameShootSystem700,
+					ServiceAccountName: serviceAccountName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						RunAsUser:    ptr.To[int64](65534),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            componentName,
+							Image:           d.config.Image,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command: []string{
+								"/bin/otelcol",
+								"--config=/etc/otel-collector/config.yaml",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          metricsPortName,
+									ContainerPort: portMetrics,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/etc/otel-collector",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: configMapName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataplaneDeployment) getOTelConfig() string {
+	return otelConfig
+}
+
+func getLabels() map[string]string {
+	return map[string]string{
+		labelKeyComponent: componentName,
+	}
+}

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment_suite_test.go
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplanedeployment_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDataplaneDeployment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Observability OpenTelemetry DataplaneDeployment Suite")
+}

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment_test.go
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/dataplanedeployment_test.go
@@ -1,0 +1,364 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataplanedeployment_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/component"
+	. "github.com/gardener/gardener/pkg/component/observability/opentelemetry/dataplanedeployment"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("DataplaneDeployment", func() {
+	var (
+		ctx = context.Background()
+
+		namespace = "some-namespace"
+		image     = "some-otel-image:some-tag"
+
+		c            client.Client
+		component    component.DeployWaiter
+		consistOf    func(...client.Object) types.GomegaMatcher
+		customValues Values
+
+		managedResource       *resourcesv1alpha1.ManagedResource
+		managedResourceSecret *corev1.Secret
+
+		fakeOps *retryfake.Ops
+	)
+
+	BeforeEach(func() {
+		format.MaxDepth = 100000
+		format.MaxLength = 100000
+		format.TruncateThreshold = 100000
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		customValues = Values{
+			Image:    image,
+			Replicas: 1,
+		}
+
+		component = New(c, namespace, customValues)
+		consistOf = NewManagedResourceConsistOfObjectsMatcher(c)
+
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot-core-otel-collector-dataplane",
+				Namespace: namespace,
+			},
+		}
+
+		managedResourceSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "managedresource-shoot-core-otel-collector-dataplane",
+				Namespace: namespace,
+			},
+		}
+
+		fakeOps = &retryfake.Ops{MaxAttempts: 1}
+		DeferCleanup(test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+		))
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy all resources", func() {
+			Expect(component.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+
+			// this is test setup, it's not the behaviour being tested, so it OK to panic
+			if err := references.InjectAnnotations(managedResource); err != nil {
+				panic(err)
+			}
+
+			managedResourceSecret.Name = managedResource.Spec.SecretRefs[0].Name
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+
+			Expect(managedResource).To(consistOf(
+				getOtelCollectorDataplaneServiceAccount(),
+				getOtelCollectorDataplaneClusterRole(),
+				getOtelCollectorDataplaneClusterRoleBinding(),
+				getOtelCollectorDataplaneService(),
+				getOtelCollectorDataplaneConfigMap(),
+				getOtelCollectorDataplaneDeployment(image),
+			))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should delete managed resources", func() {
+			Expect(c.Create(ctx, managedResource)).To(Succeed())
+			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
+
+			Expect(component.Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
+		})
+	})
+
+	Describe("#Wait", func() {
+		It("should fail when MR does not exist", func() {
+			Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+		})
+
+		It("should succeed when MR is healthy", func() {
+			Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       managedResource.Name,
+					Namespace:  namespace,
+					Generation: 1,
+				},
+				Status: resourcesv1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue},
+						{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			})).To(Succeed())
+
+			Expect(component.Wait(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should succeed when deleted", func() {
+			Expect(component.WaitCleanup(ctx)).To(Succeed())
+		})
+	})
+})
+
+func getOtelCollectorDataplaneServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otel-collector-dataplane-deployment",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+		},
+		AutomountServiceAccountToken: ptr.To(true),
+	}
+}
+
+func getOtelCollectorDataplaneClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "otel-collector-dataplane-deployment",
+			Labels: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"nodes",
+					"services",
+					"endpoints",
+					"pods",
+				},
+				Verbs: []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"nodes/metrics",
+				},
+				Verbs: []string{"get"},
+			},
+		},
+	}
+}
+
+func getOtelCollectorDataplaneClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "otel-collector-dataplane-deployment",
+			Labels: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "otel-collector-dataplane-deployment",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "otel-collector-dataplane-deployment",
+				Namespace: "kube-system",
+			},
+		},
+	}
+}
+
+func getOtelCollectorDataplaneService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otel-collector-dataplane-deployment",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "metrics",
+					Port:     8080,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}
+
+func getOtelCollectorDataplaneConfigMap() *corev1.ConfigMap {
+	const configPath = "testdata/opentelemetry-collector-dataplane-config.test.yaml"
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read config file %s: %v", configPath, err))
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otel-collector-dataplane-deployment",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"component": "otel-collector-dataplane-deployment",
+			},
+		},
+		Data: map[string]string{
+			"config.yaml": string(data),
+		},
+	}
+}
+func getOtelCollectorDataplaneDeployment(image string) *appsv1.Deployment {
+	replicas := int32(1)
+	revHistory := int32(2)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otel-collector-dataplane-deployment",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"component":           "otel-collector-dataplane-deployment",
+				"gardener.cloud/role": "monitoring",
+				"origin":              "gardener",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas:             &replicas,
+			RevisionHistoryLimit: &revHistory,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"component": "otel-collector-dataplane-deployment",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"component":                                  "otel-collector-dataplane-deployment",
+						"gardener.cloud/role":                        "monitoring",
+						"networking.gardener.cloud/from-seed":        "allowed",
+						"networking.gardener.cloud/to-apiserver":     "allowed",
+						"networking.gardener.cloud/to-dns":           "allowed",
+						"networking.gardener.cloud/to-kubelet":       "allowed",
+						"networking.gardener.cloud/to-node-exporter": "allowed",
+						"origin": "gardener",
+					},
+				},
+				Spec: corev1.PodSpec{
+					PriorityClassName:  "gardener-shoot-system-700",
+					ServiceAccountName: "otel-collector-dataplane-deployment",
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						RunAsUser:    ptr.To(int64(65534)),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:    "otel-collector-dataplane-deployment",
+							Image:   image,
+							Command: []string{"/bin/otelcol", "--config=/etc/otel-collector/config.yaml"},
+							Ports: []corev1.ContainerPort{
+								{Name: "metrics", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+							},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									ReadOnly:  true,
+									MountPath: "/etc/otel-collector",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "otel-collector-dataplane-deployment",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/component/observability/opentelemetry/dataplanedeployment/testdata/opentelemetry-collector-dataplane-config.test.yaml
+++ b/pkg/component/observability/opentelemetry/dataplanedeployment/testdata/opentelemetry-collector-dataplane-config.test.yaml
@@ -1,0 +1,120 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'kube-kubelet'
+          honor_labels: true
+          scrape_interval: 30s
+          scheme: https
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+          metrics_path: /metrics
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|kubelet_running_pods|process_max_fds|process_open_fds|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_used_bytes|kubelet_image_pull_duration_seconds_bucket|kubelet_image_pull_duration_seconds_sum|kubelet_image_pull_duration_seconds_count)$
+
+        - job_name: 'cadvisor'
+          honor_labels: true
+          scrape_interval: 30s
+          scheme: https
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+          metrics_path: /metrics/cadvisor
+          kubernetes_sd_configs:
+            - role: node
+          relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_node_name]
+              action: replace
+              target_label: node
+            - target_label: type
+              replacement: shoot
+          metric_relabel_configs:
+            - source_labels: [id]
+              action: replace
+              regex: ^/system\.slice/(.+)\.service$
+              target_label: systemd_service_name
+            - source_labels: [id]
+              action: replace
+              regex: ^/system\.slice/(.+)\.service$
+              target_label: container
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_fs_reads_total|container_fs_writes_total|container_last_seen|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+            - source_labels: [namespace]
+              action: keep
+              regex: (^$|^kube-system$)
+            - source_labels: [container, __name__]
+              action: drop
+              regex: POD;(container_cpu_cfs_periods_total|container_cpu_cfs_throttled_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_inodes_total|container_fs_limit_bytes|container_fs_usage_bytes|container_last_seen|container_memory_working_set_bytes)
+            - source_labels: [__name__, container, interface, id]
+              action: keep
+              regex: container_network.+;;(eth0;/.+|(en.+|tunl0|eth0);/)|.+;.+;.*;.*
+            - source_labels: [__name__, container, interface]
+              action: drop
+              regex: container_network.+;POD;(.{5,}|tun0|en.+)
+            - source_labels: [__name__, id]
+              regex: container_network.+;/
+              replacement: "true"
+              target_label: host_network
+            - regex: ^id$
+              action: labeldrop
+        - job_name: 'node-exporter'
+          honor_labels: true
+          scrape_interval: 30s
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names:
+                  - kube-system
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_name]
+              action: keep
+              regex: node-exporter
+            - source_labels: [__meta_kubernetes_endpoint_port_name]
+              action: keep
+              regex: metrics
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              action: replace
+              target_label: instance
+            - source_labels: [__meta_kubernetes_pod_node_name]
+              action: replace
+              target_label: node
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              action: keep
+              regex: ^(up|node_boot_time_seconds|node_cpu_seconds_total|node_disk_read_bytes_total|node_disk_written_bytes_total|node_disk_io_time_weighted_seconds_total|node_disk_io_time_seconds_total|node_disk_write_time_seconds_total|node_disk_writes_completed_total|node_disk_read_time_seconds_total|node_disk_reads_completed_total|node_filesystem_avail_bytes|node_filesystem_files|node_filesystem_files_free|node_filesystem_free_bytes|node_filesystem_readonly|node_filesystem_size_bytes|node_load1|node_load15|node_load5|node_memory_.+|node_nf_conntrack_.+|node_scrape_collector_duration_seconds|node_scrape_collector_success|process_max_fds|process_open_fds)$
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1000
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8080"
+    send_timestamps: true
+    metric_expiration: 5m
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheus]

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -181,6 +181,7 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 			port443     = intstr.FromInt32(kubeapiserverconstants.Port)
 			port8053    = intstr.FromInt32(corednsconstants.PortServer)
 			port10250   = intstr.FromInt32(10250)
+			port16909   = intstr.FromInt32(16909)
 			protocolUDP = corev1.ProtocolUDP
 			protocolTCP = corev1.ProtocolTCP
 
@@ -272,6 +273,24 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 				},
 			}
+			// following the rest of the conventions, allow egress traffic to the node-exporter port and protocol.
+			//note: this pattern actually allows all such port-protocol egress traffic, irrespective where it goes. This seems to be the case, because we don't enforce labels on the receiving end of this pattern. (what should the node-exporter podselector be? should it be enforced through GRM?)
+			networkPolicyAllowToNodeExporter = &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gardener.cloud--allow-to-node-exporter",
+					Namespace: metav1.NamespaceSystem,
+					Annotations: map[string]string{
+						v1beta1constants.GardenerDescription: fmt.Sprintf("Allows egress traffic to node exporter in TCP "+
+							"port 16909 for pods labeled with '%s=%s'.", v1beta1constants.LabelNetworkPolicyShootToNodeExporter,
+							v1beta1constants.LabelNetworkPolicyAllowed),
+					},
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{v1beta1constants.LabelNetworkPolicyShootToNodeExporter: v1beta1constants.LabelNetworkPolicyAllowed}},
+					Egress:      []networkingv1.NetworkPolicyEgressRule{{Ports: []networkingv1.NetworkPolicyPort{{Port: &port16909, Protocol: &protocolTCP}}}},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				},
+			}
 			networkPolicyAllowToPublicNetworks = &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "gardener.cloud--allow-to-public-networks",
@@ -297,6 +316,7 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 			networkPolicyAllowToShootAPIServer,
 			networkPolicyAllowToDNS,
 			networkPolicyAllowToKubelet,
+			networkPolicyAllowToNodeExporter,
 			networkPolicyAllowToPublicNetworks,
 		); err != nil {
 			return nil, err

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -408,6 +408,36 @@ var _ = Describe("ShootSystem", func() {
 					},
 				}
 
+				networkPolicyToNodeExporter = &networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gardener.cloud--allow-to-node-exporter",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							"gardener.cloud/description": "Allows egress traffic to node exporter in TCP port 16909 for pods labeled with 'networking.gardener.cloud/to-node-exporter=allowed'.",
+						},
+					},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"networking.gardener.cloud/to-node-exporter": "allowed",
+							},
+						},
+						Egress: []networkingv1.NetworkPolicyEgressRule{
+							{
+								Ports: []networkingv1.NetworkPolicyPort{
+									{
+										Protocol: ptr.To(corev1.ProtocolTCP),
+										Port:     ptr.To(intstr.FromInt32(16909)),
+									},
+								},
+							},
+						},
+						PolicyTypes: []networkingv1.PolicyType{
+							networkingv1.PolicyTypeEgress,
+						},
+					},
+				}
+
 				networkPolicyToPublicNetworks = &networkingv1.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "gardener.cloud--allow-to-public-networks",
@@ -450,6 +480,7 @@ var _ = Describe("ShootSystem", func() {
 					networkPolicyToAPIServer,
 					networkPolicyToDNS,
 					networkPolicyToKubelet,
+					networkPolicyToNodeExporter,
 					networkPolicyToPublicNetworks,
 				))
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -113,6 +113,12 @@ const (
 	// owner: @rrhubenov
 	// alpha: v1.140.0
 	RemoveVali featuregate.Feature = "RemoveVali"
+
+	// OpenTelemetryDataplaneCollector enables an OpenTelemetry Collector deployment in the shoot cluster's data plane
+	// for collecting and filtering shoot related metrics
+	// owner: @bobi-wan @iypetrov
+	// alpha: v1.141.0
+	OpenTelemetryDataplaneCollector featuregate.Feature = "OpenTelemetryDataplaneCollector"
 )
 
 // DefaultFeatureGate is the central feature gate map used by all gardener components.
@@ -140,21 +146,22 @@ var DefaultFeatureGate = utilfeature.DefaultMutableFeatureGate
 
 // AllFeatureGates is the list of all feature gates.
 var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	DefaultSeccompProfile:          {Default: false, PreRelease: featuregate.Alpha},
-	NewWorkerPoolHash:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	InPlaceNodeUpdates:             {Default: false, PreRelease: featuregate.Alpha},
-	IstioTLSTermination:            {Default: false, PreRelease: featuregate.Alpha},
-	CloudProfileCapabilities:       {Default: false, PreRelease: featuregate.Alpha},
-	DoNotCopyBackupCredentials:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	OpenTelemetryCollector:         {Default: true, PreRelease: featuregate.Beta},
-	VictoriaLogsBackend:            {Default: false, PreRelease: featuregate.Alpha},
-	UseUnifiedHTTPProxyPort:        {Default: true, PreRelease: featuregate.Beta},
-	VPAInPlaceUpdates:              {Default: true, PreRelease: featuregate.Beta},
-	CustomDNSServerInNodeLocalDNS:  {Default: true, PreRelease: featuregate.Beta},
-	VPNBondingModeRoundRobin:       {Default: false, PreRelease: featuregate.Alpha},
-	PrometheusHealthChecks:         {Default: false, PreRelease: featuregate.Alpha},
-	VersionClassificationLifecycle: {Default: false, PreRelease: featuregate.Alpha},
-	RemoveVali:                     {Default: false, PreRelease: featuregate.Alpha},
+	DefaultSeccompProfile:           {Default: false, PreRelease: featuregate.Alpha},
+	NewWorkerPoolHash:               {Default: true, PreRelease: featuregate.Beta},
+	InPlaceNodeUpdates:              {Default: false, PreRelease: featuregate.Alpha},
+	IstioTLSTermination:             {Default: false, PreRelease: featuregate.Alpha},
+	CloudProfileCapabilities:        {Default: false, PreRelease: featuregate.Alpha},
+	DoNotCopyBackupCredentials:      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	OpenTelemetryCollector:          {Default: true, PreRelease: featuregate.Beta},
+	VictoriaLogsBackend:             {Default: false, PreRelease: featuregate.Alpha},
+	UseUnifiedHTTPProxyPort:         {Default: true, PreRelease: featuregate.Beta},
+	VPAInPlaceUpdates:               {Default: true, PreRelease: featuregate.Beta},
+	CustomDNSServerInNodeLocalDNS:   {Default: true, PreRelease: featuregate.Beta},
+	VPNBondingModeRoundRobin:        {Default: false, PreRelease: featuregate.Alpha},
+	PrometheusHealthChecks:          {Default: false, PreRelease: featuregate.Alpha},
+	VersionClassificationLifecycle:  {Default: false, PreRelease: featuregate.Alpha},
+	RemoveVali:                      {Default: false, PreRelease: featuregate.Alpha},
+	OpenTelemetryDataplaneCollector: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -403,10 +403,19 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(syncPointReadyForCleanup),
 		})
+		deleteOtelDataplaneDeployment = g.Add(flow.Task{
+			Name: "Deleting OTEL dataplane collector deployment from shoot cluster",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.Shoot.Components.SystemComponents.OtelDataplaneDeployment.Destroy(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources,
+			Dependencies: flow.NewTaskIDs(syncPointReadyForCleanup),
+		})
 		syncPointCleanedKubernetesResources = flow.NewTaskIDs(
 			cleanupWebhooks,
 			cleanExtendedAPIs,
 			cleanKubernetesResources,
+			deleteOtelDataplaneDeployment,
 			deleteMetricsServer,
 		)
 

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -763,6 +763,14 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilExtensionResourcesAfterKAPIReady, // Extensions might deploy webhooks for system components
 				waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
+		deployOtelDataplaneCollector = g.Add(flow.Task{
+			Name: "Deploying OTEL dataplane collector to shoot cluster",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.ReconcileOtelDataplaneDeployment(ctx)
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       o.Shoot.IsWorkerless || o.Shoot.HibernationEnabled,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
+		})
 		deployKubernetesDashboard = g.Add(flow.Task{
 			Name:   "Deploying addon Kubernetes Dashboard",
 			Fn:     flow.TaskFn(botanist.DeployKubernetesDashboard).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -790,6 +798,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			deployShootSystemResources,
 			deployCoreDNS,
 			deployNodeExporter,
+			deployOtelDataplaneCollector,
 			deployNodeLocalDNS,
 			deployMetricsServer,
 			deployVPNShoot,

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -31,5 +31,6 @@ func GetFeatures() []featuregate.Feature {
 		features.VPNBondingModeRoundRobin,
 		features.PrometheusHealthChecks,
 		features.RemoveVali,
+		features.OpenTelemetryDataplaneCollector,
 	}
 }

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -212,6 +212,10 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		if err != nil {
 			return nil, err
 		}
+		o.Shoot.Components.SystemComponents.OtelDataplaneDeployment, err = b.DefaultOtelDataplaneDeployment()
+		if err != nil {
+			return nil, err
+		}
 		o.Shoot.Components.SystemComponents.KubeProxy, err = b.DefaultKubeProxy()
 		if err != nil {
 			return nil, err

--- a/pkg/gardenlet/operation/botanist/oteldataplanedeployment.go
+++ b/pkg/gardenlet/operation/botanist/oteldataplanedeployment.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/imagevector"
+	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/dataplanedeployment"
+	"github.com/gardener/gardener/pkg/features"
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
+)
+
+// DefaultOtelDataplaneDeployment returns a deployer for the OTEL Collector dataplane deployment.
+func (b *Botanist) DefaultOtelDataplaneDeployment() (component.DeployWaiter, error) {
+	image, err := imagevector.Containers().FindImage(
+		imagevector.ContainerImageNameOpentelemetryCollector,
+		imagevectorutils.RuntimeVersion(b.ShootVersion()),
+		imagevectorutils.TargetVersion(b.ShootVersion()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	config := dataplanedeployment.Config{
+		Image:    image.String(),
+		Replicas: 1,
+	}
+
+	return dataplanedeployment.New(
+		b.SeedClientSet.Client(),
+		b.Shoot.ControlPlaneNamespace,
+		config,
+	), nil
+}
+
+// ReconcileOtelDataplaneDeployment deploys or destroys the OTEL dataplane collector deployment component
+// depending on whether the feature gate is enabled and shoot monitoring is enabled.
+func (b *Botanist) ReconcileOtelDataplaneDeployment(ctx context.Context) error {
+	if !features.DefaultFeatureGate.Enabled(features.OpenTelemetryDataplaneCollector) ||
+		!b.IsShootMonitoringEnabled() {
+		return b.Shoot.Components.SystemComponents.OtelDataplaneDeployment.Destroy(ctx)
+	}
+
+	return b.Shoot.Components.SystemComponents.OtelDataplaneDeployment.Deploy(ctx)
+}

--- a/pkg/gardenlet/operation/botanist/oteldataplanedeployment_test.go
+++ b/pkg/gardenlet/operation/botanist/oteldataplanedeployment_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation"
+	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
+	"github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("OtelDataplaneDeployment", func() {
+	var (
+		ctrl     *gomock.Controller
+		botanist *Botanist
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		botanist = &Botanist{
+			Operation: &Operation{
+				Shoot: &shoot.Shoot{},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#DefaultOtelDataplaneDeployment", func() {
+		var kubernetesClient *kubernetesmock.MockInterface
+
+		BeforeEach(func() {
+			kubernetesClient = kubernetesmock.NewMockInterface(ctrl)
+
+			botanist.SeedClientSet = kubernetesClient
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.31.1",
+					},
+				},
+			})
+		})
+
+		It("should successfully create an OTEL dataplane deployment", func() {
+			kubernetesClient.EXPECT().Client()
+
+			deployer, err := botanist.DefaultOtelDataplaneDeployment()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deployer).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -167,18 +167,19 @@ type Extensions struct {
 
 // SystemComponents contains references to system components.
 type SystemComponents struct {
-	APIServerProxy      apiserverproxy.Interface
-	BlackboxExporter    component.DeployWaiter
-	ClusterIdentity     clusteridentity.Interface
-	CoreDNS             coredns.Interface
-	KubeProxy           kubeproxy.Interface
-	MetricsServer       component.DeployWaiter
-	Namespaces          component.DeployWaiter
-	NodeLocalDNS        nodelocaldns.Interface
-	NodeProblemDetector component.DeployWaiter
-	NodeExporter        component.DeployWaiter
-	Resources           shootsystem.Interface
-	VPNShoot            vpnshoot.Interface
+	APIServerProxy          apiserverproxy.Interface
+	BlackboxExporter        component.DeployWaiter
+	ClusterIdentity         clusteridentity.Interface
+	CoreDNS                 coredns.Interface
+	KubeProxy               kubeproxy.Interface
+	MetricsServer           component.DeployWaiter
+	Namespaces              component.DeployWaiter
+	NodeLocalDNS            nodelocaldns.Interface
+	NodeProblemDetector     component.DeployWaiter
+	NodeExporter            component.DeployWaiter
+	Resources               shootsystem.Interface
+	VPNShoot                vpnshoot.Interface
+	OtelDataplaneDeployment component.DeployWaiter
 }
 
 // Addons contains references for the addons.

--- a/pkg/operator/features/features.go
+++ b/pkg/operator/features/features.go
@@ -21,5 +21,6 @@ func RegisterFeatureGates() {
 		features.VPAInPlaceUpdates,
 		features.PrometheusHealthChecks,
 		features.RemoveVali,
+		features.OpenTelemetryDataplaneCollector,
 	)))
 }

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -388,7 +388,7 @@ func (s *AccessSecret) WithKubeconfig(kubeconfigRaw *clientcmdv1.Config) *Access
 	return s
 }
 
-// WithTargetSecret sets the kubeconfig field of the AccessSecret.
+// WithTargetSecret sets the target secret name and namespace fields of the AccessSecret.
 func (s *AccessSecret) WithTargetSecret(name, namespace string) *AccessSecret {
 	s.targetSecretName = name
 	s.targetSecretNamespace = namespace

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -161,6 +161,7 @@ build:
             - pkg/component/observability/monitoring/utils
             - pkg/component/observability/opentelemetry/collector
             - pkg/component/observability/opentelemetry/collector/constants
+            - pkg/component/observability/opentelemetry/dataplanedeployment
             - pkg/component/observability/opentelemetry/operator
             - pkg/component/observability/plutono
             - pkg/component/seed/system
@@ -694,6 +695,7 @@ build:
             - pkg/component/observability/monitoring/utils
             - pkg/component/observability/opentelemetry/collector
             - pkg/component/observability/opentelemetry/collector/constants
+            - pkg/component/observability/opentelemetry/dataplanedeployment
             - pkg/component/observability/opentelemetry/operator
             - pkg/component/observability/plutono
             - pkg/component/seed/system

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1340,6 +1340,7 @@ build:
             - pkg/component/observability/monitoring/utils
             - pkg/component/observability/opentelemetry/collector
             - pkg/component/observability/opentelemetry/collector/constants
+            - pkg/component/observability/opentelemetry/dataplanedeployment
             - pkg/component/observability/opentelemetry/operator
             - pkg/component/observability/plutono
             - pkg/component/seed/system


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
Leaving this PR as a draft, as it's a POC and some discussion around it is needed. I want to keep it as the main place for technical discussion on the topic and an example implementation of the idea of scraping metrics on the data plane side.

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/area observability

/kind poc
/kind discussion

**What this PR does / why we need it**:
This PR is a POC for issues such as this one:
https://github.com/gardener/observability/issues/19

Currently, the shoot prometheus instance (further called just prometheus), which lives in the shoot control plane, scrapes different targets in the data plane. Examples of such targets are `kubelet`, `cadvisor` and `node-exporter`. It then applies filtering on the metrics received, but only after pulling all available metrics (server side filtering). Initially, the idea was that there is potential for reducing network traffic between the two planes. This PR gives an implementation that captures that potential.
In the PR, an [OTEL collector](https://opentelemetry.io/docs/collector/) is introduced in the data plane, scraping the target s residing there. The current implementation includes the examples above - `kubelet`, `cadvisor`, `node-exporter`, although more can be added. It then filters the metrics in the same plane/infra account, saving the internet traffic for the whole metric set. Then, the remaining metrics, which will be persisted, are scraped by prometheus. 
The POC has been merged with another effort around retaining metrics from the data plane during network outages between the two planes. I have not found hard technical requirements there, so it is more of an exploratory topic, but there is potential for a solution, as we now have a component, which resides in the data plane and can potentially persist metrics. This is not the main aim of the collector as a technology, though, so discussion can up whether a prometheus instance would be a better fit in stead. I hope this PR drives further discussion on the topic.


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Some technical notes/challenges:
- currently, the collector has a hard coded configuration (mostly, single deployment replica)
- the collector uses [prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md), which has the same configuration as prometheus itself. This does not work with ScrapeConfig objects out of the box, however. The configuration for the receiver is currently static, in a single file and needs to be ported for every scrape target. This will probably have to be changed, as there are also extensions which have metric targets in the data plane. Their configuration shouldn't have to be statically kept in g/g along all the rest.
- an additional network policy had to be created for scraping the node-exporter
  - This brings up the topic of the network policy mechanism used. This is probably a design decision, but I just want to underline that the annotated services/deployments currently don't have a podSelector in the policy, meaning they aren't limited to sending/receiving traffic to a port on specific pods, but to all pods (at least in the same namespace). This doesn't keep to the principle of least privilege.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
POC OTEL dataplane collector
```