### PR TITLE
Fix a couple checks in TM tests related to removal of `nginx-ingress` and `kubernetes-dashboard` addons for Kubernetes `1.35` 

### DIFF
--- a/test/testmachinery/shoots/applications/shoot_app.go
+++ b/test/testmachinery/shoots/applications/shoot_app.go
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("Shoot application testing", func() {
 		k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 		framework.ExpectNoError(err)
 
-		if versionutils.ConstraintK8sLess135.Check(k8sVersion) {
+		if !versionutils.ConstraintK8sLess135.Check(k8sVersion) {
 			ginkgo.Skip("The kubernetes-dashboard addon is forbidden starting with Kubernetes 1.35")
 		}
 

--- a/test/testmachinery/shoots/applications/shoot_app.go
+++ b/test/testmachinery/shoots/applications/shoot_app.go
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("Shoot application testing", func() {
 		k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
 		framework.ExpectNoError(err)
 
-		if !versionutils.ConstraintK8sLess135.Check(k8sVersion) {
+		if versionutils.ConstraintK8sGreaterEqual135.Check(k8sVersion) {
 			ginkgo.Skip("The kubernetes-dashboard addon is forbidden starting with Kubernetes 1.35")
 		}
 

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -12,14 +12,12 @@ package cp_migration_test
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 
-	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	. "github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/applications"
 	shootmigration "github.com/gardener/gardener/test/utils/shoots/migration"
@@ -112,10 +110,6 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 
 	if t.Shoot.Status.IsHibernated {
 		return nil
-	}
-
-	if !v1beta1helper.NginxIngressEnabled(t.Shoot.Spec.Addons) {
-		return errors.New("the shoot must have the nginx-ingress addon enabled")
 	}
 
 	ginkgo.By("Create test Secret and Service Account")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR removes the check whether the `nginx-ingress` addon is enabled for a shoot for the control plane migration TM tests. This check is already preformed in the call to `guestBookApp.DeployGuestBookApp(ctx)` and properly takes into account the k8s version (`nginx-ingress` addon is disabled for k8s `>=1.35`)

The PR also flips around the condition used to check if the `kubernetes-dashboard` test should be skipped, so that it is skipped for k8s >=1.35. The `kubernetes-dashboard` can still be enabled for k8s <1.35 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
