### PR TITLE
Fix `cloud-controller-manager-local` for self-hosted shoots

### DIFF
--- a/dev-setup/gardenadm/machines/machine.yaml
+++ b/dev-setup/gardenadm/machines/machine.yaml
@@ -59,6 +59,10 @@ spec:
           - name: IMAGEVECTOR_OVERWRITE_CHARTS
             value: /gardenadm/imagevector-overwrite-charts.yaml
         volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
         - name: containerd
           mountPath: /var/lib/containerd
         - name: modules
@@ -107,6 +111,13 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+      - name: run
+        emptyDir:
+          medium: Memory
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
+          type: Socket
       - name: containerd
         emptyDir: {}
       - name: modules

--- a/pkg/provider-local/charts/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
+++ b/pkg/provider-local/charts/seed-controlplane/charts/cloud-controller-manager/templates/deployment.yaml
@@ -33,12 +33,26 @@ spec:
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed
         {{- if (include "is-shoot" .) }}
+        # Case: CCM is responsible for shoot clusters - in addition, CCM also runs in the kind cluster's kube-system
+        # namespace, but we don't deploy NetworkPolicies there, so no special labeling is needed.
         {{- if hasPrefix "shoot-" .Release.Namespace }}
-        networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed
+        # Case: CCM runs in shoot namespace next to control plane (hosted shoot scenario)
+        networking.resources.gardener.cloud/to-kube-apiserver-tcp-443: allowed # Allows communication to kube-apiserver
+                                                                               # of shoot (e.g., for watching Services).
         # Needed for looking up where machine pods are running for setting up routes on the load balancer containers.
-        networking.gardener.cloud/to-runtime-apiserver: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed # Allows communication to the kind apiserver - needed
+                                                                # for looking up where machine pods are running for
+                                                                # setting up routes on the load balancer containers.
         {{- else }}
-        networking.gardener.cloud/to-apiserver: allowed
+        # Case: CCM runs in kube-system namespace (self-hosted shoot scenario)
+        networking.gardener.cloud/to-apiserver: allowed # Allows communication to kube-apiserver running in the cluster
+                                                        # itself (e.g., for watching Services).
+        {{- if .Values.hasManagedInfrastructure }}
+        networking.gardener.cloud/to-public-networks: allowed # Allows communication to the kind apiserver (running
+                                                              # outside the self-hosted shoot) - needed for looking up
+                                                              # where machine pods are running for setting up routes on
+                                                              # the load balancer containers.
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- with .Values.podLabels }}

--- a/pkg/provider-local/controller/infrastructure/actuator.go
+++ b/pkg/provider-local/controller/infrastructure/actuator.go
@@ -47,78 +47,82 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, infrastructur
 		return fmt.Errorf("could not create client for infrastructure resources: %w", err)
 	}
 
-	networkPolicyAllowMachinePods := emptyNetworkPolicy("allow-machine-pods", infrastructure.Namespace)
-	networkPolicyAllowMachinePods.Spec = networkingv1.NetworkPolicySpec{
-		Ingress: []networkingv1.NetworkPolicyIngressRule{{
-			From: []networkingv1.NetworkPolicyPeer{
-				{
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}},
-				},
-				// Allow traffic from load balancer containers in the Docker kind network.
-				{
-					IPBlock: &networkingv1.IPBlock{CIDR: loadbalancer.InternalRangeV4},
-				},
-				{
-					IPBlock: &networkingv1.IPBlock{CIDR: loadbalancer.InternalRangeV6},
+	// We don't need these resources in case we're operating in the kube-system namespace (only the case for self-hosted
+	// shoots) - we will never have machine pods there.
+	if infrastructure.Namespace != metav1.NamespaceSystem {
+		networkPolicyAllowMachinePods := emptyNetworkPolicy("allow-machine-pods", infrastructure.Namespace)
+		networkPolicyAllowMachinePods.Spec = networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}},
+					},
+					// Allow traffic from load balancer containers in the Docker kind network.
+					{
+						IPBlock: &networkingv1.IPBlock{CIDR: loadbalancer.InternalRangeV4},
+					},
+					{
+						IPBlock: &networkingv1.IPBlock{CIDR: loadbalancer.InternalRangeV6},
+					},
+				}},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}},
+					},
+					{
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
+						PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
+					},
 				},
 			}},
-		},
-		Egress: []networkingv1.NetworkPolicyEgressRule{{
-			To: []networkingv1.NetworkPolicyPeer{
-				{
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "machine"}},
-				},
-				{
-					NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
-					PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "registry"}},
-				},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "machine"},
 			},
-		}},
-		PodSelector: metav1.LabelSelector{
-			MatchLabels: map[string]string{"app": "machine"},
-		},
-		PolicyTypes: []networkingv1.PolicyType{
-			networkingv1.PolicyTypeIngress,
-			networkingv1.PolicyTypeEgress,
-		},
-	}
-
-	// The machines service is used to add NetworkPolicies for accessing the machine ports,
-	// e.g., access from the Bastion pod to port 22
-	service := emptyService(infrastructure.Namespace)
-	service.Spec = corev1.ServiceSpec{
-		Type:     corev1.ServiceTypeClusterIP,
-		Selector: map[string]string{"app": "machine"},
-		Ports: []corev1.ServicePort{
-			{
-				Name:        "ssh",
-				Port:        22,
-				Protocol:    corev1.ProtocolTCP,
-				AppProtocol: ptr.To("ssh"),
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
 			},
-		},
-	}
-
-	if cluster.Shoot.Spec.Networking == nil || cluster.Shoot.Spec.Networking.Nodes == nil {
-		return fmt.Errorf("shoot specification does not contain node network CIDR required for VPN tunnel")
-	}
-
-	objects := []client.Object{
-		networkPolicyAllowMachinePods,
-		service,
-	}
-
-	for _, ipFamily := range cluster.Shoot.Spec.Networking.IPFamilies {
-		ipPoolObj, err := ipPool(cluster.ObjectMeta, string(ipFamily), *cluster.Shoot.Spec.Networking.Nodes)
-		if err != nil {
-			return err
 		}
-		objects = append(objects, ipPoolObj)
-	}
 
-	for _, obj := range objects {
-		if err := providerClient.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
-			return err
+		// The machines service is used to add NetworkPolicies for accessing the machine ports,
+		// e.g., access from the Bastion pod to port 22
+		service := emptyService(infrastructure.Namespace)
+		service.Spec = corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{"app": "machine"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "ssh",
+					Port:        22,
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: ptr.To("ssh"),
+				},
+			},
+		}
+
+		if cluster.Shoot.Spec.Networking == nil || cluster.Shoot.Spec.Networking.Nodes == nil {
+			return fmt.Errorf("shoot specification does not contain node network CIDR required for VPN tunnel")
+		}
+
+		objects := []client.Object{
+			networkPolicyAllowMachinePods,
+			service,
+		}
+
+		for _, ipFamily := range cluster.Shoot.Spec.Networking.IPFamilies {
+			ipPoolObj, err := ipPool(cluster.ObjectMeta, string(ipFamily), *cluster.Shoot.Spec.Networking.Nodes)
+			if err != nil {
+				return err
+			}
+			objects = append(objects, ipPoolObj)
+		}
+
+		for _, obj := range objects {
+			if err := providerClient.Patch(ctx, obj, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/provider-local/machine-provider/local/create_machine.go
+++ b/pkg/provider-local/machine-provider/local/create_machine.go
@@ -188,6 +188,14 @@ func (d *localDriver) applyPod(
 						MountPath: "/var/lib/containerd",
 					},
 					{
+						Name:      "run",
+						MountPath: "/run",
+					},
+					{
+						Name:      "docker-socket",
+						MountPath: "/var/run/docker.sock",
+					},
+					{
 						Name:      "modules",
 						MountPath: "/lib/modules",
 						ReadOnly:  true,
@@ -226,6 +234,23 @@ func (d *localDriver) applyPod(
 				Name: "containerd",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: "run",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			},
+			{
+				Name: "docker-socket",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/run/docker.sock",
+						Type: ptr.To(corev1.HostPathSocket),
+					},
 				},
 			},
 			{

--- a/skaffold-gardenadm.yaml
+++ b/skaffold-gardenadm.yaml
@@ -1205,12 +1205,6 @@ profiles:
         value: local-skaffold/machine-controller-manager-provider-local
       - op: remove
         path: /build/artifacts/4
-      # remove gardener-extension-provider-local/loadbalancer image (not needed in unmanaged infra scenario)
-      - op: test
-        path: /build/artifacts/2/image
-        value: local-skaffold/gardener-extension-provider-local/loadbalancer
-      - op: remove
-        path: /build/artifacts/2
   - name: managed-infra
     manifests:
       kustomize:


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes two issues preventing `cloud-controller-manager-local` from working in self-hosted shoots

1. Managed infrastructure: `NetworkPolicy` blocked the CCM from communicating with the kind API server.
2. The Docker socket was not mounted into machine pods. Mounting it required special care because the `kindest/node` image runs systemd, which mounts a fresh tmpfs on `/run` early in the boot sequence — shadowing any bind mount at `/var/run/docker.sock`. The socket is therefore mounted at `/host-docker.sock` with a systemd oneshot unit that symlinks it to the conventional path after the `/run` tmpfs is in place.

The change in the `Infrastructure` controller is cosmetic (skip deploying unnecessary machine-related resources into `kube-system` of self-hosted shoots where machine pods never run).

Example `LoadBalancer` service in a managed-infra self-hosted shoot after this fix:

```
root@machine-shoot--garden--root-control-plane-z1-bdb7b-qq4p9:/# k get svc foo
NAME   TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)         AGE
foo    LoadBalancer   10.4.118.247   172.18.255.225   443:31926/TCP   28s
```

**Which issue(s) this PR fixes**:
Follow-up of #14415.

**Release note**:
```other developer
NONE
```