### PR TITLE
Fix cluster-proportional autoscaling of `coredns` in Kubernetes >= 1.33

### DIFF
--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -834,10 +834,12 @@ func getLabels() map[string]string {
 
 func getClusterProportionalDNSAutoscalerLabels() map[string]string {
 	return map[string]string{
-		"origin":                        "gardener",
-		v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
-		corednsconstants.LabelKey:       clusterProportionalDNSAutoscalerLabelValue,
-		"kubernetes.io/cluster-service": "true",
+		"origin":                                            "gardener",
+		v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleSystemComponent,
+		corednsconstants.LabelKey:                           clusterProportionalDNSAutoscalerLabelValue,
+		"kubernetes.io/cluster-service":                     "true",
+		v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
+		v1beta1constants.LabelNetworkPolicyShootToAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 	}
 }
 

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -503,6 +503,8 @@ metadata:
     gardener.cloud/role: system-component
     k8s-app: coredns-autoscaler
     kubernetes.io/cluster-service: "true"
+    networking.gardener.cloud/to-apiserver: allowed
+    networking.gardener.cloud/to-dns: allowed
     origin: gardener
   name: coredns-autoscaler
   namespace: kube-system
@@ -517,6 +519,8 @@ spec:
         gardener.cloud/role: system-component
         k8s-app: coredns-autoscaler
         kubernetes.io/cluster-service: "true"
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
         origin: gardener
     spec:
       containers:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area auto-scaling
/kind bug

**What this PR does / why we need it**:

Fix cluster-proportional autoscaling of `coredns` in Kubernetes >= 1.33.

With #11502 a `deny-all` network policy was introduced in `kube-system` namespace. Unfortunately, we missed to adapt the `coredns-autoscaler` to this. Hence, cluster-proportional autoscaling of `coredns` was broken for Kubernetes >= 1.33.

This PR adds the missing network policy labels so that `coredns-autoscaler` can communicate with `kube-apiserver`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Cluster-proportional autoscaling of coredns now works with Kubernetes >= 1.33
```

/cc @DockToFuture @axel7born @domdom82 