### PR TITLE
Fix istio-native `opentelemetry-collector` exposure.

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -673,7 +673,7 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 		gateway,
 		getLabels(),
 		o.values.IstioIngressGatewayLabels,
-		[]string{o.values.IngressHost},
+		[]string{o.values.IngressHost, o.values.ValiHost},
 		tlsSecretInIstioNamespace.Name,
 	)(); err != nil {
 		return nil, fmt.Errorf("failed to create gateway resource: %w", err)
@@ -684,7 +684,7 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
 		getLabels(),
-		[]string{o.values.IngressHost},
+		[]string{o.values.IngressHost, o.values.ValiHost},
 		name,
 		uint32(collectorconstants.KubeRBACProxyOTLPReceiverPort),
 		destinationHost,

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -830,7 +830,7 @@ func getGateway() *istionetworkingv1beta1.Gateway {
 					Number:   443,
 					Protocol: "HTTPS",
 				},
-				Hosts: []string{ingressHost},
+				Hosts: []string{ingressHost, valiHost},
 				Tls: &istioapinetworkingv1beta1.ServerTLSSettings{
 					Mode:           istioapinetworkingv1beta1.ServerTLSSettings_SIMPLE,
 					CredentialName: "some-namespace-logging-logging-tls",
@@ -850,7 +850,7 @@ func getVirtualService() *istionetworkingv1beta1.VirtualService {
 		Spec: istioapinetworkingv1beta1.VirtualService{
 			ExportTo: []string{"*"},
 			Gateways: []string{"logging"},
-			Hosts:    []string{ingressHost},
+			Hosts:    []string{ingressHost, valiHost},
 			Http: []*istioapinetworkingv1beta1.HTTPRoute{
 				{
 					Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{{


### PR DESCRIPTION
Unlike most other previous `Ingress` resources, the `opentelemtry-collector` used two domain names. Unfortunately, the second one was missed during the migration.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/area networking
/kind bug

**What this PR does / why we need it**:

Fix istio-native `opentelemetry-collector` exposure.

Unlike most other previous `Ingress` resources, the `opentelemtry-collector` used two domain names. Unfortunately, the second one was missed during the migration.

**Which issue(s) this PR fixes**:
Part of #13448

**Special notes for your reviewer**:

#14585 introduced the issue during the migration. You can compare https://github.com/ScheererJ/gardener/blame/188e846e5b01f1b97f341fa96b2284305da652a7/pkg/component/observability/opentelemetry/collector/collector.go#L651-L694 with https://github.com/ScheererJ/gardener/blame/7290869d83aa085befa227f70aadf7684abfaa25/pkg/component/observability/opentelemetry/collector/collector.go#L671-L724. The former uses two hosts, the latter just one.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
