### PR TITLE
Add support for customizing the deletion propagation of `ManagedResources`

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -200,6 +200,12 @@ In some cases, it is not desirable to update or re-apply some of the cluster com
 For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets.
 This can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
 
+#### Handling invalid updates
+
+Sometimes, an update to a resource is forbidden because immutable fields are changes (for example the referenced role of a `(Cluster)RoleBinding`).
+By setting the annotation `resources.gardener.cloud/delete-on-invalid-update=true` (or any trothy value) bhe resource manager can optionally delete and re-create the resource in that case.
+Additionally, the annotation `resources.gardener.cloud/deletion-propagation-on-invalid-update` controls the deletion propagation (defaults to `Background`). Setting `Orphan` might be desirable when changing for example the label selectors of a deployment.
+
 #### Finalizing Deletion of Resources After Grace Period
 
 When a `ManagedResource` is deleted, the controller deletes all managed resources from the target cluster.

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -202,8 +202,8 @@ This can be done from the components that create the managed resource secrets, f
 
 #### Handling invalid updates
 
-Sometimes, an update to a resource is forbidden because immutable fields are changes (for example the referenced role of a `(Cluster)RoleBinding`).
-By setting the annotation `resources.gardener.cloud/delete-on-invalid-update=true` (or any trothy value) bhe resource manager can optionally delete and re-create the resource in that case.
+Sometimes, an update to a resource is forbidden because immutable fields are changed (for example the referenced role of a `(Cluster)RoleBinding`).
+By setting the annotation `resources.gardener.cloud/delete-on-invalid-update=true` (or any truthy value), the resource manager can optionally delete and re-create the resource in that case.
 Additionally, the annotation `resources.gardener.cloud/deletion-propagation-on-invalid-update` controls the deletion propagation (defaults to `Background`). Setting `Orphan` might be desirable when changing for example the label selectors of a deployment.
 
 #### Finalizing Deletion of Resources After Grace Period

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -20,6 +20,10 @@ const (
 	// DeleteOnInvalidUpdate is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will delete the object in case it faces an "Invalid" response during an update operation.
 	DeleteOnInvalidUpdate = "resources.gardener.cloud/delete-on-invalid-update"
+	// DeletionPropagationOnInvalidUpdate is a constant for an annotation on a resource managed by a ManagedResource. If set to
+	// a valid deletion propagation value (e.g., "Foreground", "Background", "Orphan"), the controller will use this value
+	// when deleting the object in case it faces an "Invalid" response during an update operation.
+	DeletionPropagationOnInvalidUpdate = "resources.gardener.cloud/deletion-propagation-on-invalid-update"
 	// KeepObject is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will not delete the object in case it is removed from the ManagedResource or the
 	// ManagedResource itself is deleted.

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -508,7 +508,7 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			}
 
 			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current, err) {
-				opts := []client.DeleteOption{}
+				var opts []client.DeleteOption
 				if propagationPolicy, err := deletionPropagation(current); err != nil {
 					return fmt.Errorf("invalid deletion propagation policy on object %s: %w", resource, err)
 				} else if propagationPolicy != "" {
@@ -649,7 +649,7 @@ func deletionPropagation(obj *unstructured.Unstructured) (metav1.DeletionPropaga
 	}
 	val := metav1.DeletionPropagation(raw)
 	if !validPropagationValues.Has(val) {
-		return "", fmt.Errorf("%q is invalid", raw)
+		return "", fmt.Errorf("%q is invalid, supported values: %+v", raw, sets.List(validPropagationValues))
 	}
 	return val, nil
 }

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -508,7 +508,15 @@ func (r *Reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			}
 
 			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current, err) {
-				if deleteErr := r.TargetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
+				opts := []client.DeleteOption{}
+				if propagationPolicy, err := deletionPropagation(current); err != nil {
+					return fmt.Errorf("invalid deletion propagation policy on object %s: %w", resource, err)
+				} else if propagationPolicy != "" {
+					resourceLogger.Info("Using custom deletion propagation", "propagationPolicy", propagationPolicy)
+					opts = append(opts, client.PropagationPolicy(propagationPolicy))
+				}
+
+				if deleteErr := r.TargetClient.Delete(ctx, current, opts...); client.IgnoreNotFound(deleteErr) != nil {
 					return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
 				}
 				// return error directly, so that the create after delete will be retried
@@ -626,6 +634,24 @@ func keyExistsAndValueTrue(kv map[string]string, key string) bool {
 	val, exists := kv[key]
 	valueTrue, _ := strconv.ParseBool(val)
 	return exists && valueTrue
+}
+
+var validPropagationValues = sets.New(
+	metav1.DeletePropagationBackground,
+	metav1.DeletePropagationForeground,
+	metav1.DeletePropagationOrphan,
+)
+
+func deletionPropagation(obj *unstructured.Unstructured) (metav1.DeletionPropagation, error) {
+	raw, ok := obj.GetAnnotations()[resourcesv1alpha1.DeletionPropagationOnInvalidUpdate]
+	if !ok {
+		return "", nil
+	}
+	val := metav1.DeletionPropagation(raw)
+	if !validPropagationValues.Has(val) {
+		return "", fmt.Errorf("%q is invalid", raw)
+	}
+	return val, nil
 }
 
 func (r *Reconciler) cleanOldResources(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource, index *objectIndex) (bool, error) {

--- a/pkg/resourcemanager/controller/managedresource/reconciler_test.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler_test.go
@@ -7,7 +7,10 @@ package managedresource
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 var _ = Describe("Controller", func() {
@@ -97,6 +100,30 @@ var _ = Describe("Controller", func() {
 
 			Expect(injectLabels(obj, labels)).To(Succeed())
 			Expect(obj).To(Equal(expected))
+		})
+	})
+
+	Describe("#deletionPropagation", func() {
+		var obj *unstructured.Unstructured
+
+		BeforeEach(func() {
+			obj = &unstructured.Unstructured{Object: map[string]any{}}
+		})
+
+		It("should return an empty string when the deletion propagation is not set", func() {
+			Expect(deletionPropagation(obj)).To(BeEmpty())
+		})
+
+		It("should return an error when the deletion propagation is invalid", func() {
+			Expect(unstructured.SetNestedField(obj.Object, "invalid", "metadata", "annotations", resourcesv1alpha1.DeletionPropagationOnInvalidUpdate)).To(Succeed())
+
+			Expect(deletionPropagation(obj)).Error().To(HaveOccurred())
+		})
+
+		It("should return the correct deletion propagation value when it is set", func() {
+			Expect(unstructured.SetNestedField(obj.Object, string(metav1.DeletePropagationOrphan), "metadata", "annotations", resourcesv1alpha1.DeletionPropagationOnInvalidUpdate)).To(Succeed())
+
+			Expect(deletionPropagation(obj)).To(Equal(metav1.DeletePropagationOrphan))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Adds a new option to how invalid updates of managed resources are handled - by specifying the deletion propagation, developers can use the resource manager for certain migration that previously required manual coding, for example when changing label selectors of deployments.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
This will be useful while migrating istio labels for https://github.com/gardener/gardener/issues/14424
Since envtest has no kubernetes controller-manager, I could not think of a great way to add a test for this - and seeing that we are working on replacing mocks, I figured adding a mock-based test for this small feature is also a bit overkill. Open to suggestions

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`ManagedResources` that use the `resources.gardener.cloud/delete-on-invalid-update` annotation can now also specify the deletion propagation with the annotation `resources.gardener.cloud/deletion-propagation-on-invalid-update`
```
