### PR TITLE
Remove usage of `nginx-ingress` Shoot addon in guestbook test

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -16,25 +16,20 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/resources/templates"
 )
@@ -79,11 +74,6 @@ func (t *GuestBookTest) WaitUntilRedisIsReady(ctx context.Context) {
 // WaitUntilGuestbookDeploymentIsReady waits until the guestbook deployment is ready.
 func (t *GuestBookTest) WaitUntilGuestbookDeploymentIsReady(ctx context.Context) {
 	Expect(t.framework.WaitUntilDeploymentIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)).To(Succeed())
-}
-
-// WaitUntilGuestbookIngressIsReady waits until the guestbook ingress is ready.
-func (t *GuestBookTest) WaitUntilGuestbookIngressIsReady(ctx context.Context) {
-	Expect(t.framework.WaitUntilIngressIsReady(ctx, GuestBook, t.framework.Namespace, t.framework.ShootClient)).To(Succeed())
 }
 
 // WaitUntilGuestbookLoadBalancerIsReady waits until the guestbook Service of type=LoadBalancer is ready.
@@ -134,12 +124,6 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	}
 
 	shoot := t.framework.Shoot
-	k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
-	Expect(err).NotTo(HaveOccurred())
-
-	if versionutils.ConstraintK8sLess135.Check(k8sVersion) && !v1beta1helper.NginxIngressEnabled(shoot.Spec.Addons) {
-		Fail("The test requires .spec.addons.nginxIngress.enabled to be true for Kubernetes versions less than 1.35")
-	}
 
 	By("Apply redis chart")
 	masterValues := map[string]any{
@@ -203,27 +187,12 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 		"HelmDeployNamespace": t.framework.Namespace,
 		"KubeVersion":         shoot.Spec.Kubernetes.Version,
 	}
-	// TODO(ialidzhikov): Clean up the guestbook test not to use use Ingress when Kubernetes 1.34 is no longer supported.
-	if versionutils.ConstraintK8sLess135.Check(k8sVersion) {
-		allowedCharacters := "0123456789abcdefghijklmnopqrstuvwxyz"
-		randURLSuffix, err := utils.GenerateRandomStringFromCharset(3, allowedCharacters)
-		Expect(err).NotTo(HaveOccurred())
-
-		t.guestBookAppHost = fmt.Sprintf("guestbook-%s.ingress.%s", randURLSuffix, *shoot.Spec.DNS.Domain)
-
-		guestBookValues["ShootDNSHost"] = t.guestBookAppHost
-	}
 
 	Expect(t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, templates.GuestbookAppName, guestBookValues)).To(Succeed())
 
 	t.WaitUntilGuestbookDeploymentIsReady(ctx)
 
-	if versionutils.ConstraintK8sLess135.Check(k8sVersion) {
-		t.WaitUntilGuestbookIngressIsReady(ctx)
-	} else {
-		loadBalancerIngress := t.WaitUntilGuestbookLoadBalancerIsReady(ctx)
-		t.guestBookAppHost = loadBalancerIngress
-	}
+	t.guestBookAppHost = t.WaitUntilGuestbookLoadBalancerIsReady(ctx)
 
 	By("Guestbook app was deployed successfully!")
 }
@@ -283,7 +252,6 @@ func (t *GuestBookTest) Cleanup(ctx context.Context) {
 	By("Clean up guestbook app resources")
 
 	Expect(kubernetesutils.DeleteObjects(ctx, t.framework.ShootClient.Client(),
-		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: t.framework.Namespace, Name: GuestBook}},
 	)).To(Succeed())

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -185,7 +185,6 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	By("Deploy the guestbook application")
 	guestBookValues := map[string]any{
 		"HelmDeployNamespace": t.framework.Namespace,
-		"KubeVersion":         shoot.Spec.Kubernetes.Version,
 	}
 
 	Expect(t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, templates.GuestbookAppName, guestBookValues)).To(Succeed())

--- a/test/framework/resources/templates/guestbook-app.yaml.tpl
+++ b/test/framework/resources/templates/guestbook-app.yaml.tpl
@@ -30,39 +30,6 @@ spec:
               name: redis
               key: redis-password
 ---
-{{- if semverCompare "< 1.35-0" .KubeVersion }}
-kind: Service
-apiVersion: v1
-metadata:
-  name: guestbook
-  namespace: {{ .HelmDeployNamespace }}
-spec:
-  selector:
-    app: guestbook
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 8080
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: guestbook
-  namespace: {{ .HelmDeployNamespace }}
-spec:
-  ingressClassName: nginx
-  rules:
-  - host: {{ .ShootDNSHost }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: guestbook
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-{{- else }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -76,4 +43,3 @@ spec:
       port: 80
       targetPort: 8080
   type: LoadBalancer
-{{- end -}}

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -230,13 +230,6 @@ func setKubernetesVersionDependentSettings(shoot *gardencorev1beta1.Shoot) {
 		if shoot.Spec.Addons == nil {
 			shoot.Spec.Addons = &gardencorev1beta1.Addons{}
 		}
-		if shoot.Spec.Addons.NginxIngress == nil {
-			shoot.Spec.Addons.NginxIngress = &gardencorev1beta1.NginxIngress{
-				Addon: gardencorev1beta1.Addon{
-					Enabled: true,
-				},
-			}
-		}
 		if shoot.Spec.Addons.KubernetesDashboard == nil {
 			shoot.Spec.Addons.KubernetesDashboard = &gardencorev1beta1.KubernetesDashboard{
 				Addon: gardencorev1beta1.Addon{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area testing
/kind enhancement

**What this PR does / why we need it**:

Remove usage of `nginx-ingress` Shoot addon in guestbook test.

In the context of #13448, we want to make it possible to completely shut down `nginx-ingress` before all Shoot clusters have migrated to Kubernetes `v1.35`. #14636 allows to disable the addon whenever the landscape operator wants to. Hence, the value in testing the addon becomes smaller over time. Therefore, let's not use it in the tests anymore to allow a seamless transition into a world without `nginx-ingress`.

**Which issue(s) this PR fixes**:

Part of #13448.

**Special notes for your reviewer**:

Continues the work begun with #13995.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The TM tests no longer rely on the `nginx-ingress` addon for any Kubernetes release.
```
