### PR TITLE
Update DinD to v29 in the remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -332,7 +332,7 @@ spec:
           source /usr/local/bin/tmux_functions.sh
           tmux new -d -s gardener -n gardener -x 2000 -y 2000
           tmux select-pane -T top; rm -f ~/.config/procps/toprc
-          for k in top Enter z C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
+          for k in top Enter z Z T 1 Enter C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
           new_pane "Set up the KinD cluster (Garden and Seed)" <<"EOF"
             sync_kubeconfig example/gardener-local/kind/local & sleep 1
             nice make kind-down kind-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
@@ -367,7 +367,7 @@ spec:
           source /usr/local/bin/tmux_functions.sh
           tmux new -d -s operator -n make -x 2000 -y 2000
           tmux select-pane -T top; rm -f ~/.config/procps/toprc
-          for k in top Enter z C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
+          for k in top Enter z Z T 1 Enter C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
           new_pane "make kind-multi-zone-up" <<"EOF"
             sync_kubeconfig dev-setup/kubeconfigs/runtime & sleep 1
             nice make kind-multi-zone-down kind-multi-zone-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s
@@ -425,7 +425,7 @@ spec:
           source /usr/local/bin/tmux_functions.sh
           tmux new -d -s operator-complete -n make -x 2000 -y 2000
           tmux select-pane -T top; rm -f ~/.config/procps/toprc
-          for k in top Enter z C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
+          for k in top Enter z Z T 1 Enter C c i t t m m V s 5 Enter E e W; do sleep .2; tmux send $k; done
           new_pane "make kind-multi-zone-up" <<"EOF"
             sync_kubeconfig dev-setup/kubeconfigs/runtime & sleep 1
             nice make kind-multi-zone-down kind-multi-zone-up && kubectl wait --for=condition=ready pod -A --all --timeout=-1s

--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -13,7 +13,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: dev
-        image: docker:26-dind
+        image: docker:29-dind
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

PR #14415 introduced `cloud-controller-manager-local`, which creates load balancers as Docker containers. In the remote local setup, where `docker:26-dind` was used, the load balancer containers were stuck in a creation loop, preventing the virtual garden istio ingress from succeeding.

The root cause appeared to be a difference between Docker v26 and v29. In Docker v26, we observed both `HostConfig.PortBindings` and `Config.ExposedPorts` had to be provided in order for the Docker daemon to process the port binding. In Docker v29, `HostConfig.PortBindings` sufficed. Unfortunately, we couldn't find a reference for this change in the Docker notes or documentation.

By updating the remote local setup DinD version to v29, it is also aligned with the Docker version used in the Prow jobs. 

**Special notes for your reviewer**:

/cc @istvanballok 

**Release note**:

```other developer
The DinD version used in the remote local setup has been updated to v29.
```
