### PR TITLE
Ignore missing CRD errors during resource deletion

### DIFF
--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -145,13 +145,19 @@ func DeleteExtensionObject(
 	deleteOpts ...client.DeleteOption,
 ) error {
 	if err := gardenerutils.ConfirmDeletion(ctx, c, obj); err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return nil
 		}
 		return err
 	}
 
-	return client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...))
+	if err := c.Delete(ctx, obj, deleteOpts...); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // DeleteExtensionObjects lists all extension objects and loops over them. It executes the given predicateFunc for
@@ -220,7 +226,7 @@ func WaitUntilExtensionObjectDeleted(
 
 	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				return retry.Ok()
 			}
 			return retry.SevereError(err)
@@ -488,6 +494,9 @@ func applyFuncToExtensionObjects(
 	applyFunc func(ctx context.Context, object extensionsv1alpha1.Object) error,
 ) ([]flow.TaskFn, error) {
 	if err := c.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -17,6 +17,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/mock/gomock"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	testclock "k8s.io/utils/clock/testing"
@@ -345,6 +346,16 @@ var _ = Describe("extensions", func() {
 			Expect(DeleteExtensionObject(ctx, c, expected)).To(Succeed())
 		})
 
+		It("should not return error if CRD does not exist (NoMatchError)", func() {
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{}), gomock.Any()).Return(&meta.NoKindMatchError{
+				GroupKind:        expected.GetObjectKind().GroupVersionKind().GroupKind(),
+				SearchedVersions: []string{"v1alpha1"},
+			})
+
+			Expect(DeleteExtensionObject(ctx, mc, expected)).To(Succeed())
+		})
+
 		It("should not return error if deleted successfully", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 			Expect(DeleteExtensionObject(ctx, c, expected)).To(Succeed())
@@ -391,6 +402,25 @@ var _ = Describe("extensions", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should not return error if CRD does not exist (NoMatchError)", func() {
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().List(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}), client.InNamespace(namespace)).Return(&meta.NoKindMatchError{
+				GroupKind:        expected.GetObjectKind().GroupVersionKind().GroupKind(),
+				SearchedVersions: []string{"v1alpha1"},
+			})
+
+			list := &extensionsv1alpha1.WorkerList{}
+			err := DeleteExtensionObjects(
+				ctx,
+				mc,
+				list,
+				namespace,
+				func(_ extensionsv1alpha1.Object) bool { return true },
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("#WaitUntilExtensionObjectsDeleted", func() {
@@ -413,11 +443,31 @@ var _ = Describe("extensions", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should return success if all extensions CRs are deleted", func() {
+			It("should not return error if all extensions CRs are deleted", func() {
 				list := &extensionsv1alpha1.WorkerList{}
 				err := WaitUntilExtensionObjectsDeleted(
 					ctx,
 					c,
+					log,
+					list,
+					extensionsv1alpha1.WorkerResource,
+					namespace, defaultInterval, defaultTimeout,
+					nil,
+				)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not return error if CRD does not exist (NoMatchError)", func() {
+				mc := mockclient.NewMockClient(ctrl)
+				mc.EXPECT().List(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.WorkerList{}), client.InNamespace(namespace)).Return(&meta.NoKindMatchError{
+					GroupKind:        expected.GetObjectKind().GroupVersionKind().GroupKind(),
+					SearchedVersions: []string{"v1alpha1"},
+				})
+
+				list := &extensionsv1alpha1.WorkerList{}
+				err := WaitUntilExtensionObjectsDeleted(
+					ctx,
+					mc,
 					log,
 					list,
 					extensionsv1alpha1.WorkerResource,
@@ -521,8 +571,21 @@ var _ = Describe("extensions", func() {
 			Expect(v1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
 		})
 
-		It("should return success if extensions CRs gets deleted", func() {
+		It("should not return error if extensions CRs gets deleted", func() {
 			err := WaitUntilExtensionObjectDeleted(ctx, c, log,
+				expected, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultTimeout)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not return error if CRD does not exist (NoMatchError)", func() {
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, client.ObjectKeyFromObject(expected), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).Return(&meta.NoKindMatchError{
+				GroupKind:        expected.GetObjectKind().GroupVersionKind().GroupKind(),
+				SearchedVersions: []string{"v1alpha1"},
+			})
+
+			err := WaitUntilExtensionObjectDeleted(ctx, mc, log,
 				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultTimeout)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/utils/gardener/vpa.go
+++ b/pkg/utils/gardener/vpa.go
@@ -10,6 +10,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -53,7 +55,13 @@ func ReconcileVPAForGardenerComponent(ctx context.Context, c client.Client, name
 
 // DeleteVPAForGardenerComponent deletes a VPA for a Gardener component.
 func DeleteVPAForGardenerComponent(ctx context.Context, c client.Client, name, namespace string) error {
-	return client.IgnoreNotFound(c.Delete(ctx, emptyVPA(name, namespace)))
+	if err := c.Delete(ctx, emptyVPA(name, namespace)); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func emptyVPA(name, namespace string) *vpaautoscalingv1.VerticalPodAutoscaler {

--- a/pkg/utils/gardener/vpa_test.go
+++ b/pkg/utils/gardener/vpa_test.go
@@ -11,12 +11,16 @@ import (
 	. "github.com/onsi/gomega"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/gardener"
@@ -87,6 +91,24 @@ var _ = Describe("VPA", func() {
 			Expect(DeleteVPAForGardenerComponent(ctx, fakeClient, name, namespace)).To(Succeed())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(vpa), vpa)).To(BeNotFoundError())
+		})
+
+		It("should succeed when CRD does not exist (NoMatchError)", func() {
+			noMatchErr := &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "test.gardener.cloud", Kind: "TestResource"},
+				SearchedVersions: []string{"v1alpha1"},
+			}
+
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+						return noMatchErr
+					},
+				}).
+				Build()
+
+			Expect(DeleteVPAForGardenerComponent(ctx, fakeClient, name, namespace)).To(Succeed())
 		})
 	})
 })

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -77,6 +77,9 @@ func ResourcesExist(ctx context.Context, reader client.Reader, objList client.Ob
 	}
 
 	if err := reader.List(ctx, objects, append(listOpts, client.Limit(1))...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
 		return true, err
 	}
 

--- a/pkg/utils/kubernetes/object_test.go
+++ b/pkg/utils/kubernetes/object_test.go
@@ -207,6 +207,25 @@ var _ = Describe("Object", func() {
 			Expect(inUse).To(BeTrue())
 		})
 
+		It("should return false without error when CRD does not exist (NoMatchError)", func() {
+			noMatchErr := &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "test.gardener.cloud", Kind: "TestResource"},
+				SearchedVersions: []string{"v1alpha1"},
+			}
+			fakeClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetesscheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+						return noMatchErr
+					},
+				}).
+				Build()
+
+			inUse, err := ResourcesExist(ctx, fakeClient, objList, scheme, listOpts...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inUse).To(BeFalse())
+		})
+
 		Context("with partialObjectMetadataList", func() {
 			BeforeEach(func() {
 				listOpts = append(listOpts, client.MatchingFields{"metadata.name": "foo"})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

During resource deletion errors caused by missing CRDs for the resource type are now ignored. If there is no CRD there can also be no resource of the type. This is an issue especially during `Seed` deletion, see #14641.

**Which issue(s) this PR fixes**:
Fixes #14641

**Special notes for your reviewer**:

I have not thoroughly checkt all usage of the modified functions. Based on the function names, the changed behavior should not have negative consequences. Please let me know if you expect issues in some area, I'm not aware of.

If we could get a backport of this fix to Gardner 1.139, we might be able to validate the fix on our stuck seed in GDCA.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Errors during resource deletion caused by missing CRDs are now ignored
```
