### PR TITLE
Fix TM kubernetes update test when upgrading from 1.34 to 1.35

### DIFF
--- a/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
+++ b/test/testmachinery/system/shoot_kubernetes_update/kubernetes_update_test.go
@@ -154,6 +154,13 @@ func RunTest(
 	Expect(f.UpdateShootSpec(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 		if controlPlaneVersion != "" {
 			shoot.Spec.Kubernetes.Version = controlPlaneVersion
+
+			// TODO(plkokanov): Drop this handling when support for Kubernetes 1.34 is dropped.
+			oldK8sLess135 := versionutils.ConstraintK8sLess135.CheckVersion(f.Shoot.Spec.Kubernetes.Version)
+			newK8sGreaterEqual135 := versionutils.ConstraintK8sGreaterEqual135.CheckVersion(shoot.Spec.Kubernetes.Version)
+			if oldK8sLess135 && newK8sGreaterEqual135 {
+				shoot.Spec.Addons = nil
+			}
 		}
 
 		for i, worker := range shoot.Spec.Provider.Workers {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes the kubernetes upgrade tests by clearing the `shoot.spec.addons` field when upgrading from kubernetes <1.35 to kubernetes >=1.35, since `nginx-ingress` and `kubernetes-dashboard` addons were removed in 1.35.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
