### PR TITLE
Increase the garden Prometheus maximum metric retention to 30 days

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1556,7 +1556,7 @@ func (r *Reconciler) newPrometheusGarden(
 		PriorityClassName: v1beta1constants.PriorityClassNameGardenSystem100,
 		StorageCapacity:   resource.MustParse(getValidVolumeSize(garden.Spec.RuntimeCluster.Volume, "200Gi")),
 		Replicas:          2,
-		Retention:         ptr.To(monitoringv1.Duration("10d")),
+		Retention:         ptr.To(monitoringv1.Duration("30d")),
 		RetentionSize:     "190GB",
 		ScrapeTimeout:     "50s", // This is intentionally smaller than the scrape interval of 1m.
 		RuntimeVersion:    r.RuntimeVersion,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR increases the garden Prometheus time-based retention from 10 to 30 days. The rationale is that the current size-based retention of 190 GB should allow retaining metrics for longer than 10 days in the majority of Gardener landscapes.  The size-based retention remains unchanged to ensure that the maximum volume capacity is not exceeded. The new 30-day retention also aligns with other Prometheus instances in Gardener.

**Special notes for your reviewer**:

/cc @rickardsjp @istvanballok @chrkl 

**Release note**:

```other operator
The garden Prometheus maximum metric retention has been increased to 30 days.
```
