### PR TITLE
Fix logging testmachinery tests after istio-native exposure

### DIFF
--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		shootValiPriorityClass = &schedulingv1.PriorityClass{}
 		shootValiConfMap       = &corev1.ConfigMap{}
 
-		plutonoIngress client.Object = &networkingv1.Ingress{}
+		plutonoVirtualService client.Object = &istionetworkingv1beta1.VirtualService{}
 		// This shoot is used as seed for this test only
 		shootClient     kubernetes.Interface
 		shootValiLabels = map[string]string{
@@ -260,13 +260,13 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 				shootValiPriorityClass),
 		)
 
-		// Get the plutono Ingress
+		// Get the plutono VirtualService
 		framework.ExpectNoError(
 			seedClient.Get(ctx,
 				types.NamespacedName{
 					Namespace: shootFramework.ShootSeedNamespace(),
 					Name:      v1beta1constants.DeploymentNamePlutono},
-				plutonoIngress),
+				plutonoVirtualService),
 		)
 	}, initializationTimeout)
 

--- a/test/testmachinery/shoots/logging/shoot_logging.go
+++ b/test/testmachinery/shoots/logging/shoot_logging.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 	shootFramework := framework.NewShootFramework(nil)
 
 	var (
-		plutonoIngress client.Object = &networkingv1.Ingress{}
+		plutonoVirtualService client.Object = &istionetworkingv1beta1.VirtualService{}
 
 		shootNamespace           = &corev1.Namespace{}
 		shootNamespaceLabelKey   = "gardener.cloud/test"
@@ -67,13 +67,13 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		shootNamespace.Name = shootFramework.ShootSeedNamespace()
 
 		seedClient := shootFramework.SeedClient.Client()
-		// Get the plutono Ingress
+		// Get the plutono VirtualService
 		framework.ExpectNoError(
 			seedClient.Get(ctx,
 				types.NamespacedName{
 					Namespace: shootFramework.ShootSeedNamespace(),
 					Name:      v1beta1constants.DeploymentNamePlutono},
-				plutonoIngress,
+				plutonoVirtualService,
 			),
 		)
 		// Set label to the testing namespace


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/area networking
/area testing
/kind bug

**What this PR does / why we need it**:

Fix logging testmachinery tests after istio-native exposure.

#14142 missed to adapt the logging testmachinery tests, which still tried to get the `Ingress` resource for `plutono`.

**Which issue(s) this PR fixes**:
Parth of #13448

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
