### PR TITLE
Reduce update interval of Prometheus health check rules

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         # The scrape job for the shoot prometheus is excluded,

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/healthcheck.yaml.tmpl
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/healthcheck.yaml.tmpl
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck

--- a/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/longterm/assets/prometheusrules/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck

--- a/pkg/component/observability/monitoring/prometheus/seed/assets/prometheusrules/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/seed/assets/prometheusrules/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/worker/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck

--- a/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/healthcheck.yaml
+++ b/pkg/component/observability/monitoring/prometheus/shoot/assets/prometheusrules/workerless/healthcheck.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   groups:
     - name: healthcheck
+      interval: 5s
       rules:
         # healthcheck{task="target:down"} is present for each scrape job target that is down.
         - record: healthcheck


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR speeds up the detection of Prometheus health check state changes by reducing the rule evaluation interval from 60s to 5s. This change affects only this step in the Prometheus health check path. The scrape interval for detecting unhealthy samples and the care controller reconciliation delay that updates the condition status remain unchanged.

The impact on storage and performance is expected to be negligible. From a storage perspective, Prometheus health check series represent an insignificant subset of the TSDB, so the increased sample frequency has little effect. From a performance perspective, the evaluated queries are rather inexpensive.

**Special notes for your reviewer**:

/cc @istvanballok @rfranzke 

**Release note**:

```other operator
The Prometheus health check rule evaluation interval has been reduced from 60s to 5s for faster detection of health check state changes.
```
