### PR TITLE
Introduce `istio-role` label to clearly label seed/garden istio pods

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -1,8 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- if .Values.enforceSpreadAcrossHosts }}
   annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+    resources.gardener.cloud/deletion-propagation-on-invalid-update: "Orphan"
+  {{- if .Values.enforceSpreadAcrossHosts }}
     high-availability-config.resources.gardener.cloud/host-spread: "true"
   {{- end }}
   name: istio-ingressgateway
@@ -25,7 +27,9 @@ spec:
       labels:
 {{ toYaml .Values.labels | indent 8 }}
 {{ toYaml .Values.networkPolicyLabels | indent 8 }}
-{{ toYaml .Values.podLabels | indent 8 }}
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
 {{ toYaml .Values.labels | indent 8 }}
 {{ toYaml .Values.networkPolicyLabels | indent 8 }}
+{{- with .Values.extraEnvoyPodLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -25,9 +25,7 @@ spec:
       labels:
 {{ toYaml .Values.labels | indent 8 }}
 {{ toYaml .Values.networkPolicyLabels | indent 8 }}
-{{- with .Values.extraEnvoyPodLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+{{ toYaml .Values.podLabels | indent 8 }}
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -1,5 +1,6 @@
 labels:
   app: istio-ingressgateway
+extraEnvoyPodLabels: {}
 networkPolicyLabels:
   to-target: allowed
 annotations: {}

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -1,6 +1,6 @@
 labels:
   app: istio-ingressgateway
-extraEnvoyPodLabels: {}
+podLabels: {}
 networkPolicyLabels:
   to-target: allowed
 annotations: {}

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"maps"
 	"path/filepath"
 	"strings"
 
@@ -35,6 +34,7 @@ var (
 type IngressGatewayValues struct {
 	Annotations                        map[string]string
 	Labels                             map[string]string
+	PodLabels                          map[string]string // TODO(maboehm): Remove this parameter after one release (v1.143)
 	NetworkPolicyLabels                map[string]string
 	LoadBalancerClass                  *string
 	ExternalTrafficPolicy              *corev1.ServiceExternalTrafficPolicy
@@ -100,20 +100,10 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			},
 		}
 
-		// TODO(maboehm): Remove this migration logic after one release (v1.143).
-		// Add "cascade: Orphan" annotation to the deployment.
-		podLabels := map[string]string{}
-		labels := maps.Clone(istioIngressGateway.Labels)
-		if v, ok := istioIngressGateway.Labels[RoleKey]; ok {
-			// don't use the new label yet in namespaced selectors, but make sure it is added to every pod
-			podLabels[RoleKey] = v
-			delete(labels, RoleKey)
-		}
-
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
-			"labels":                             labels,
-			"podLabels":                          podLabels,
+			"labels":                             istioIngressGateway.Labels,
+			"podLabels":                          istioIngressGateway.PodLabels,
 			"networkPolicyLabels":                istioIngressGateway.NetworkPolicyLabels,
 			"annotations":                        istioIngressGateway.Annotations,
 			"loadBalancerClass":                  istioIngressGateway.LoadBalancerClass,

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -100,21 +100,20 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			},
 		}
 
-		// TODO(maboehm): Remove this migration logic after one gardener release and after
-		// https://github.com/gardener/gardener/pull/14642 has been merged. Add "cascade: Orphan" annotation to the
-		// deployment.
-		extraEnvoyPodLabels := map[string]string{}
+		// TODO(maboehm): Remove this migration logic after one release (v1.143).
+		// Add "cascade: Orphan" annotation to the deployment.
+		podLabels := map[string]string{}
 		labels := maps.Clone(istioIngressGateway.Labels)
 		if v, ok := istioIngressGateway.Labels[RoleKey]; ok {
 			// don't use the new label yet in namespaced selectors, but make sure it is added to every pod
-			extraEnvoyPodLabels[RoleKey] = v
+			podLabels[RoleKey] = v
 			delete(labels, RoleKey)
 		}
 
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
 			"labels":                             labels,
-			"extraEnvoyPodLabels":                extraEnvoyPodLabels,
+			"podLabels":                          podLabels,
 			"networkPolicyLabels":                istioIngressGateway.NetworkPolicyLabels,
 			"annotations":                        istioIngressGateway.Annotations,
 			"loadBalancerClass":                  istioIngressGateway.LoadBalancerClass,

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"strings"
 
@@ -99,9 +100,25 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			},
 		}
 
+		// TODO(maboehm): Start using "istio=virtual-garden-ingressgateway" after one gardener release:
+		//  - Update istio label on envoy pods (extraEnvoyPodLabels)
+		//  - Keep "istio-role", remove "istio" label in namespaced selectors (labels)
+		//  - Remove the temporary label ("istio-role") from the gateway labels (istioIngressGateway.Labels)
+		// After one more gardener release, remove the migration code and temporary label
+		extraEnvoyPodLabels := map[string]string{}
+		labels := maps.Clone(istioIngressGateway.Labels)
+		if v := istioIngressGateway.Labels[IstioRoleLabel]; v == IstioRoleVirtualGarden {
+			// don't use the new label yet in namespaced selectors, but make sure it is added to every pod
+			extraEnvoyPodLabels[IstioRoleLabel] = v
+			delete(labels, IstioRoleLabel)
+			// make sure every other component that creates a Gateway does not use the old label
+			delete(istioIngressGateway.Labels, DefaultZoneKey)
+		}
+
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
-			"labels":                             istioIngressGateway.Labels,
+			"labels":                             labels,
+			"extraEnvoyPodLabels":                extraEnvoyPodLabels,
 			"networkPolicyLabels":                istioIngressGateway.NetworkPolicyLabels,
 			"annotations":                        istioIngressGateway.Annotations,
 			"loadBalancerClass":                  istioIngressGateway.LoadBalancerClass,

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -105,7 +105,7 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 		// deployment.
 		extraEnvoyPodLabels := map[string]string{}
 		labels := maps.Clone(istioIngressGateway.Labels)
-		if v := istioIngressGateway.Labels[RoleKey]; v == RoleGarden {
+		if v, ok := istioIngressGateway.Labels[RoleKey]; ok {
 			// don't use the new label yet in namespaced selectors, but make sure it is added to every pod
 			extraEnvoyPodLabels[RoleKey] = v
 			delete(labels, RoleKey)

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -100,19 +100,15 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 			},
 		}
 
-		// TODO(maboehm): Start using "istio=virtual-garden-ingressgateway" after one gardener release:
-		//  - Update istio label on envoy pods (extraEnvoyPodLabels)
-		//  - Keep "istio-role", remove "istio" label in namespaced selectors (labels)
-		//  - Remove the temporary label ("istio-role") from the gateway labels (istioIngressGateway.Labels)
-		// After one more gardener release, remove the migration code and temporary label
+		// TODO(maboehm): Remove this migration logic after one gardener release and after
+		// https://github.com/gardener/gardener/pull/14642 has been merged. Add "cascade: Orphan" annotation to the
+		// deployment.
 		extraEnvoyPodLabels := map[string]string{}
 		labels := maps.Clone(istioIngressGateway.Labels)
-		if v := istioIngressGateway.Labels[IstioRoleLabel]; v == IstioRoleVirtualGarden {
+		if v := istioIngressGateway.Labels[RoleKey]; v == RoleGarden {
 			// don't use the new label yet in namespaced selectors, but make sure it is added to every pod
-			extraEnvoyPodLabels[IstioRoleLabel] = v
-			delete(labels, IstioRoleLabel)
-			// make sure every other component that creates a Gateway does not use the old label
-			delete(istioIngressGateway.Labels, DefaultZoneKey)
+			extraEnvoyPodLabels[RoleKey] = v
+			delete(labels, RoleKey)
 		}
 
 		values := map[string]any{

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -1003,6 +1003,10 @@ var _ = Describe("istiod", func() {
 									Type:   resourcesv1alpha1.ResourcesHealthy,
 									Status: gardencorev1beta1.ConditionTrue,
 								},
+								{
+									Type:   resourcesv1alpha1.ResourcesProgressing,
+									Status: gardencorev1beta1.ConditionFalse,
+								},
 							},
 						},
 					})).To(Succeed())

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -1040,6 +1040,7 @@ func makeIngressGateway(namespace string, annotations, labels map[string]string,
 			IstiodNamespace:     "istio-test-system",
 			Annotations:         annotations,
 			Labels:              labels,
+			PodLabels:           map[string]string{"pod-label": "foo"},
 			NetworkPolicyLabels: networkPolicyLabels,
 			Ports: []corev1.ServicePort{
 				{Name: "foo", Port: 999, TargetPort: intstr.FromInt32(999)},

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -37,12 +37,13 @@ import (
 const (
 	// DefaultZoneKey is the label key for the istio default ingress gateway.
 	DefaultZoneKey = "istio"
-	// IstioRoleLabel is a temporary pod label key used to migrate the virtual-garden-isio-ingress pods away from the
-	// overlapping selector `istio=ingressgateway`.
-	// TODO(maboehm): Remove after the migration is complete
-	IstioRoleLabel = "istio-role"
-	// IstioRoleVirtualGarden is the label value for the virtual garden ingress gateway pods.
-	IstioRoleVirtualGarden = "virtual-garden-ingressgateway"
+	// RoleKey is the label key used to clearly differentiate between the istio ingress gateways deployed for
+	// the runtime cluster and the seed cluster.
+	RoleKey = "istio-role"
+	// RoleGarden is the label value for the virtual garden ingress gateway pods.
+	RoleGarden = "garden"
+	// RoleSeed is the label value for the seed ingress gateway pods.
+	RoleSeed = "seed"
 	// IstiodServiceName is the name of the istiod service.
 	IstiodServiceName = "istiod"
 	// IstiodPort is the port of the istiod service.

--- a/pkg/component/networking/istio/istiod.go
+++ b/pkg/component/networking/istio/istiod.go
@@ -37,6 +37,12 @@ import (
 const (
 	// DefaultZoneKey is the label key for the istio default ingress gateway.
 	DefaultZoneKey = "istio"
+	// IstioRoleLabel is a temporary pod label key used to migrate the virtual-garden-isio-ingress pods away from the
+	// overlapping selector `istio=ingressgateway`.
+	// TODO(maboehm): Remove after the migration is complete
+	IstioRoleLabel = "istio-role"
+	// IstioRoleVirtualGarden is the label value for the virtual garden ingress gateway pods.
+	IstioRoleVirtualGarden = "virtual-garden-ingressgateway"
 	// IstiodServiceName is the name of the istiod service.
 	IstiodServiceName = "istiod"
 	// IstiodPort is the port of the istiod service.

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -27,6 +27,7 @@ spec:
         app: istio-ingressgateway
         foo: bar
         to-target: allowed
+        pod-label: foo
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -1,6 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+    resources.gardener.cloud/deletion-propagation-on-invalid-update: "Orphan"
   name: istio-ingressgateway
   namespace: test-ingress
   labels:

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -222,7 +222,7 @@ const (
 	zoneInfix          = "--zone--"
 )
 
-// GetIstioZoneLabels returns the labels to be used for istio with the mandatory zone label set.
+// GetIstioZoneLabels returns the labels to be used for the seed istio with the mandatory zone label set.
 func GetIstioZoneLabels(labels map[string]string, zone *string) map[string]string {
 	// Use "istio" for the default gateways and v1beta1constants.LabelExposureClassHandlerName for exposure classes
 	zonekey := istio.DefaultZoneKey
@@ -236,7 +236,10 @@ func GetIstioZoneLabels(labels map[string]string, zone *string) map[string]strin
 	if zone != nil {
 		zoneValue = fmt.Sprintf("%s%s%s", zoneValue, zoneInfix, *zone)
 	}
-	return utils.MergeStringMaps(labels, map[string]string{zonekey: zoneValue})
+	return utils.MergeStringMaps(labels, map[string]string{
+		zonekey:       zoneValue,
+		istio.RoleKey: istio.RoleSeed,
+	})
 }
 
 // IsZonalIstioExtension indicates whether the namespace related to the given labels is a zonal istio extension.

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -52,6 +52,7 @@ func NewIstio(
 	priorityClassName string,
 	istiodEnabled bool,
 	labels map[string]string,
+	podLabels map[string]string, // TODO(maboehm): Remove this parameter after one release (v1.143)
 	networkPolicyLabels []string,
 	lbAnnotations map[string]string,
 	loadBalancerClass *string,
@@ -102,6 +103,7 @@ func NewIstio(
 		Ports:                              servicePorts,
 		LoadBalancerIP:                     serviceExternalIP,
 		Labels:                             labels,
+		PodLabels:                          podLabels,
 		NetworkPolicyLabels:                policyLabels,
 		Namespace:                          namePrefix + ingressNamespace,
 		PriorityClassName:                  priorityClassName,
@@ -222,7 +224,7 @@ const (
 	zoneInfix          = "--zone--"
 )
 
-// GetIstioZoneLabels returns the labels to be used for the seed istio with the mandatory zone label set.
+// GetIstioZoneLabels returns the labels to be used for istio with the mandatory zone label set.
 func GetIstioZoneLabels(labels map[string]string, zone *string) map[string]string {
 	// Use "istio" for the default gateways and v1beta1constants.LabelExposureClassHandlerName for exposure classes
 	zonekey := istio.DefaultZoneKey
@@ -236,10 +238,7 @@ func GetIstioZoneLabels(labels map[string]string, zone *string) map[string]strin
 	if zone != nil {
 		zoneValue = fmt.Sprintf("%s%s%s", zoneValue, zoneInfix, *zone)
 	}
-	return utils.MergeStringMaps(labels, map[string]string{
-		zonekey:       zoneValue,
-		istio.RoleKey: istio.RoleSeed,
-	})
+	return utils.MergeStringMaps(labels, map[string]string{zonekey: zoneValue})
 }
 
 // IsZonalIstioExtension indicates whether the namespace related to the given labels is a zonal istio extension.

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -151,7 +151,8 @@ func checkAdditionalIstioGateway(cl client.Client,
 	externalTrafficPolicy *corev1.ServiceExternalTrafficPolicy,
 	serviceExternalIP *string,
 	zone *string,
-	dualstack bool) {
+	dualstack bool,
+) {
 	var (
 		zones                    []string
 		enforceSpreadAcrossHosts bool
@@ -542,12 +543,12 @@ var _ = Describe("Istio", func() {
 			Expect(GetIstioZoneLabels(labels, zone)).To(matcher)
 		},
 
-		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value"})),
-		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role"})),
-		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway"})),
-		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone"})),
-		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone"})),
-		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone"})),
+		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value", istio.RoleKey: istio.RoleSeed})),
+		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role", istio.RoleKey: istio.RoleSeed})),
+		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
 	)
 
 	DescribeTable("#IsZonalIstioExtension",

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -39,6 +39,7 @@ type istioTestValues struct {
 	priorityClassName                  string
 	istiodEnabled                      bool
 	labels                             map[string]string
+	podLabels                          map[string]string
 	kubeAPIServerPolicyLabel           string
 	lbAnnotations                      map[string]string
 	loadBalancerClass                  *string
@@ -71,7 +72,7 @@ func createIstio(testValues istioTestValues) istio.Interface {
 		testValues.priorityClassName,
 		testValues.istiodEnabled,
 		testValues.labels,
-		nil,
+		testValues.podLabels,
 		[]string{testValues.kubeAPIServerPolicyLabel},
 		testValues.lbAnnotations,
 		testValues.loadBalancerClass,
@@ -130,6 +131,7 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 				Ports:                              testValues.servicePorts,
 				LoadBalancerIP:                     testValues.serviceExternalIP,
 				Labels:                             testValues.labels,
+				PodLabels:                          testValues.podLabels,
 				NetworkPolicyLabels:                networkPolicyLabels,
 				Namespace:                          "shared-istio-test-some-istio-ingress",
 				PriorityClassName:                  testValues.priorityClassName,
@@ -228,6 +230,7 @@ var _ = Describe("Istio", func() {
 			priorityClassName:                  "some-high-priority-class",
 			istiodEnabled:                      true,
 			labels:                             map[string]string{"some": "labelValue"},
+			podLabels:                          map[string]string{"pod": "labels"},
 			kubeAPIServerPolicyLabel:           "to-all-test-kube-apiserver",
 			lbAnnotations:                      map[string]string{"some": "annotationValue"},
 			loadBalancerClass:                  ptr.To("non-default-load-balancer-class"),

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -71,6 +71,7 @@ func createIstio(testValues istioTestValues) istio.Interface {
 		testValues.priorityClassName,
 		testValues.istiodEnabled,
 		testValues.labels,
+		nil,
 		[]string{testValues.kubeAPIServerPolicyLabel},
 		testValues.lbAnnotations,
 		testValues.loadBalancerClass,
@@ -543,12 +544,12 @@ var _ = Describe("Istio", func() {
 			Expect(GetIstioZoneLabels(labels, zone)).To(matcher)
 		},
 
-		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value", istio.RoleKey: istio.RoleSeed})),
-		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role", istio.RoleKey: istio.RoleSeed})),
-		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway", istio.RoleKey: istio.RoleSeed})),
-		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
-		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
-		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
+		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value"})),
+		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role"})),
+		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway"})),
+		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone"})),
+		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone"})),
+		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone"})),
 	)
 
 	DescribeTable("#IsZonalIstioExtension",

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -360,6 +360,10 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, seedIsGar
 		v1beta1constants.PriorityClassNameSeedSystemCritical,
 		!seedIsGarden,
 		labels,
+		// TODO(maboehm): Always set this label in sharedcomponent.GetIstioZoneLabels() after on release (v1.143)
+		map[string]string{
+			istio.RoleKey: istio.RoleSeed,
+		},
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),
 		},

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -26,7 +26,7 @@ var _ = Describe("istioconfig", func() {
 		var (
 			defaultServiceName         = "default-service"
 			defaultNamespaceName       = "default-namespace"
-			defaultLabels              = map[string]string{"default": "label", "istio": "gateway", "istio-role": "seed"}
+			defaultLabels              = map[string]string{"default": "label", "istio": "gateway"}
 			exposureClassName          = "my-exposureclass"
 			exposureClassHandlerName   = "my-handler"
 			exposureClassServiceName   = "exposure-service"
@@ -138,19 +138,19 @@ var _ = Describe("istioconfig", func() {
 			Entry("non-pinned control plane with exposure class", nil, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"istio-role": "seed"})),
+				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
 				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName+"--"+zoneName),
-				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName, "istio-role": "seed"})),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName})),
 				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (multi zone) with exposure class", &multiZone, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"istio-role": "seed"})),
+				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
 				Equal(defaultLabels),
 			),
 		)
@@ -189,7 +189,7 @@ var _ = Describe("istioconfig", func() {
 				Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 					Equal(exposureClassServiceName),
 					Equal(exposureClassNamespaceName),
-					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler", "istio-role": "seed"})),
+					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler"})),
 					Equal(defaultLabels),
 				),
 			)

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -26,7 +26,7 @@ var _ = Describe("istioconfig", func() {
 		var (
 			defaultServiceName         = "default-service"
 			defaultNamespaceName       = "default-namespace"
-			defaultLabels              = map[string]string{"default": "label", "istio": "gateway"}
+			defaultLabels              = map[string]string{"default": "label", "istio": "gateway", "istio-role": "seed"}
 			exposureClassName          = "my-exposureclass"
 			exposureClassHandlerName   = "my-handler"
 			exposureClassServiceName   = "exposure-service"
@@ -138,19 +138,19 @@ var _ = Describe("istioconfig", func() {
 			Entry("non-pinned control plane with exposure class", nil, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"istio-role": "seed"})),
 				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName+"--"+zoneName),
-				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName})),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName, "istio-role": "seed"})),
 				Equal(defaultLabels),
 			),
 			Entry("pinned control plane (multi zone) with exposure class", &multiZone, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"istio-role": "seed"})),
 				Equal(defaultLabels),
 			),
 		)
@@ -189,7 +189,7 @@ var _ = Describe("istioconfig", func() {
 				Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 					Equal(exposureClassServiceName),
 					Equal(exposureClassNamespaceName),
-					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler"})),
+					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler", "istio-role": "seed"})),
 					Equal(defaultLabels),
 				),
 			)

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -909,9 +909,10 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 		v1beta1constants.DefaultSNIIngressNamespace,
 		v1beta1constants.PriorityClassNameGardenSystemCritical,
 		true,
-		sharedcomponent.GetIstioZoneLabels(map[string]string{
-			istio.IstioRoleLabel: istio.IstioRoleVirtualGarden,
-		}, nil),
+		map[string]string{
+			istio.DefaultZoneKey: "ingressgateway",
+			istio.RoleKey:        istio.RoleGarden,
+		},
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),
 		},

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -911,7 +911,10 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 		true,
 		map[string]string{
 			istio.DefaultZoneKey: "ingressgateway",
-			istio.RoleKey:        istio.RoleGarden,
+		},
+		// TODO(maboehm): Merge the podLabels into labels after on release (v1.143)
+		map[string]string{
+			istio.RoleKey: istio.RoleGarden,
 		},
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -909,7 +909,9 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 		v1beta1constants.DefaultSNIIngressNamespace,
 		v1beta1constants.PriorityClassNameGardenSystemCritical,
 		true,
-		sharedcomponent.GetIstioZoneLabels(nil, nil),
+		sharedcomponent.GetIstioZoneLabels(map[string]string{
+			istio.IstioRoleLabel: istio.IstioRoleVirtualGarden,
+		}, nil),
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),
 		},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area networking
/kind bug

**What this PR does / why we need it**:
Starts fixing the overlapping istio label issue by using an additional label to explicitly differentiate the two: `istio-role=seed|garden`

For now, this label is only added to the envoy pods, but other selectors are not changed.

In a follow up PR, the label selectors can be updated by setting the existing `labels` field and dropping the `podLabels` fields again.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14424

**Special notes for your reviewer**:
I tested a lot that applying this change causes no interruptions, by introducing stricter dependencies in the reconcile graphs. Might make sense if you double check this.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
