### PR TITLE
Fix premature return in reconcileSeedWebhookConfig

### DIFF
--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -395,12 +395,14 @@ func (c *AddToManagerConfig) reconcileSeedWebhookConfig(mgr manager.Manager, web
 		defer cancel()
 
 		for _, webhookConfig := range webhookConfigs.GetWebhookConfigs() {
-			return retry.Until(timeoutCtx, time.Second, func(ctx context.Context) (bool, error) {
+			if err := retry.Until(timeoutCtx, time.Second, func(ctx context.Context) (bool, error) {
 				if err := extensionswebhook.ReconcileSeedWebhookConfig(ctx, mgr.GetClient(), webhookConfig, c.Server.OwnerNamespace, caBundle); err != nil {
 					return retry.MinorError(fmt.Errorf("error reconciling seed webhook config: %w", err))
 				}
 				return retry.Ok()
-			})
+			}); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/extensions/pkg/webhook/cmd/reconcile_test.go
+++ b/extensions/pkg/webhook/cmd/reconcile_test.go
@@ -14,33 +14,23 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
-
-type fakeManager struct {
-	manager.Manager
-
-	client client.Client
-}
-
-func (f *fakeManager) GetClient() client.Client {
-	return f.client
-}
 
 var _ = Describe("reconcileSeedWebhookConfig", func() {
 	var (
 		ctx        = context.Background()
 		fakeClient client.Client
-		mgr        *fakeManager
+		mgr        *test.FakeManager
 		config     *AddToManagerConfig
 		caBundle   = []byte("ca-bundle")
 	)
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-		mgr = &fakeManager{client: fakeClient}
+		mgr = &test.FakeManager{Client: fakeClient}
 		config = &AddToManagerConfig{}
 	})
 

--- a/extensions/pkg/webhook/cmd/reconcile_test.go
+++ b/extensions/pkg/webhook/cmd/reconcile_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+)
+
+type fakeManager struct {
+	manager.Manager
+
+	client client.Client
+}
+
+func (f *fakeManager) GetClient() client.Client {
+	return f.client
+}
+
+var _ = Describe("reconcileSeedWebhookConfig", func() {
+	var (
+		ctx        = context.Background()
+		fakeClient client.Client
+		mgr        *fakeManager
+		config     *AddToManagerConfig
+		caBundle   = []byte("ca-bundle")
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		mgr = &fakeManager{client: fakeClient}
+		config = &AddToManagerConfig{}
+	})
+
+	It("should reconcile both mutating and validating webhook configs", func() {
+		mutatingConfig := &admissionregistrationv1.MutatingWebhookConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "admissionregistration.k8s.io/v1",
+				Kind:       "MutatingWebhookConfiguration",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener-extension-admission-test",
+			},
+			Webhooks: []admissionregistrationv1.MutatingWebhook{{}},
+		}
+
+		validatingConfig := &admissionregistrationv1.ValidatingWebhookConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "admissionregistration.k8s.io/v1",
+				Kind:       "ValidatingWebhookConfiguration",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener-extension-admission-test",
+			},
+			Webhooks: []admissionregistrationv1.ValidatingWebhook{{}},
+		}
+
+		webhookConfigs := extensionswebhook.Configs{
+			MutatingWebhookConfig:   mutatingConfig,
+			ValidatingWebhookConfig: validatingConfig,
+		}
+
+		reconcileFn := config.reconcileSeedWebhookConfig(mgr, webhookConfigs, caBundle)
+		Expect(reconcileFn(ctx)).To(Succeed())
+
+		createdMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mutatingConfig), createdMutating)).To(Succeed())
+		Expect(createdMutating.Webhooks[0].ClientConfig.CABundle).To(Equal(caBundle))
+
+		createdValidating := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(validatingConfig), createdValidating)).To(Succeed())
+		Expect(createdValidating.Webhooks[0].ClientConfig.CABundle).To(Equal(caBundle))
+	})
+})


### PR DESCRIPTION
/area control-plane
/kind bug

**What this PR does / why we need it**:

Fixes a bug in `reconcileSeedWebhookConfig` where a `return` statement inside a `for` loop causes the function to exit after reconciling only the first webhook configuration.

When an extension registers both mutating and validating webhooks (e.g., admission controllers that have both a `Mutator` and `Validator`), `Configs.GetWebhookConfigs()` returns two objects: a `MutatingWebhookConfiguration` and a `ValidatingWebhookConfiguration`. The loop in `reconcileSeedWebhookConfig` is supposed to reconcile both, but `return retry.Until(...)` exits after the first iteration, so only the `MutatingWebhookConfiguration` is ever created in the cluster. The `ValidatingWebhookConfiguration` is silently skipped.

This was introduced in #13765 when retry logic was added to the reconciliation loop.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The fix changes `return retry.Until(...)` to `if err := retry.Until(...); err != nil { return err }` so the loop continues to the next webhook config on success.

The regression test lives in a new file `reconcile_test.go` using `package cmd` (internal) rather than in the existing `registration_test.go` (`package webhook_test`). This is necessary because `reconcileSeedWebhookConfig` is a private method on `AddToManagerConfig`. A test in e.g `registration_test.go` can only exercise the public `ReconcileSeedWebhookConfig` function, which works correctly on its own — the bug is in how the private wrapper iterates and returns. An external-package test that manually loops over `Configs.GetWebhookConfigs()` and calls `ReconcileSeedWebhookConfig` would always pass, even with the buggy code, because the manual loop doesn't contain the premature `return`. Only a test that calls the private `reconcileSeedWebhookConfig` directly can catch this regression.

**Release note**:
```bugfix dependency
The `reconcileSeedWebhookConfig` function now correctly reconciles both `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` for extensions that register both mutating and validating admission webhooks. Previously, only the first configuration was reconciled due to a premature return in the loop.
```
