### PR TITLE
[GEP-28] Fix `EveryNodeReady` condition for self-hosted shoots on unmanaged infra

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -747,6 +747,7 @@ func (h *Health) CheckClusterNodes(
 		if err := h.seedClient.Client().List(ctx, machineDeploymentList, client.InNamespace(h.shoot.ControlPlaneNamespace)); err != nil {
 			return nil, err
 		}
+
 		if msg, err := CheckNodesScaling(ctx, h.seedClient.Client(), nodesManagedByMCM, machineDeploymentList, h.shoot.ControlPlaneNamespace); err != nil {
 			if msg == "" {
 				return nil, err

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -717,11 +717,6 @@ func (h *Health) CheckClusterNodes(
 		return &c, nil
 	}
 
-	machineDeploymentList := &machinev1alpha1.MachineDeploymentList{}
-	if err := h.seedClient.Client().List(ctx, machineDeploymentList, client.InNamespace(h.shoot.ControlPlaneNamespace)); err != nil {
-		return nil, err
-	}
-
 	nodeList := convertWorkerPoolToNodesMappingToNodeList(workerPoolToNodes)
 	// only nodes that are managed by MCM are considered
 	nodesManagedByMCM := []*corev1.Node{}
@@ -730,12 +725,6 @@ func (h *Health) CheckClusterNodes(
 			continue
 		}
 		nodesManagedByMCM = append(nodesManagedByMCM, &node)
-	}
-	if msg, err := CheckNodesScaling(ctx, h.seedClient.Client(), nodesManagedByMCM, machineDeploymentList, h.shoot.ControlPlaneNamespace); err != nil {
-		if msg == "" {
-			return nil, err
-		}
-		return ptr.To(v1beta1helper.FailedCondition(h.clock, h.shoot.GetInfo().Status.LastOperation, h.conditionThresholds, condition, msg, err.Error())), nil
 	}
 
 	leaseList := &coordinationv1.LeaseList{}
@@ -753,7 +742,20 @@ func (h *Health) CheckClusterNodes(
 		return &c, nil
 	}
 
-	if !h.shoot.IsWorkerless && v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(h.seed.GetInfo().Spec.Settings) {
+	if !h.shoot.IsSelfHosted() || h.shoot.HasManagedInfrastructure() {
+		machineDeploymentList := &machinev1alpha1.MachineDeploymentList{}
+		if err := h.seedClient.Client().List(ctx, machineDeploymentList, client.InNamespace(h.shoot.ControlPlaneNamespace)); err != nil {
+			return nil, err
+		}
+		if msg, err := CheckNodesScaling(ctx, h.seedClient.Client(), nodesManagedByMCM, machineDeploymentList, h.shoot.ControlPlaneNamespace); err != nil {
+			if msg == "" {
+				return nil, err
+			}
+			return ptr.To(v1beta1helper.FailedCondition(h.clock, h.shoot.GetInfo().Status.LastOperation, h.conditionThresholds, condition, msg, err.Error())), nil
+		}
+	}
+
+	if !h.shoot.IsSelfHosted() && !h.shoot.IsWorkerless && v1beta1helper.SeedSettingDependencyWatchdogProberEnabled(h.seed.GetInfo().Spec.Settings) {
 		leaseList := &coordinationv1.LeaseList{}
 		if err := shootClient.Client().List(ctx, leaseList, client.InNamespace(corev1.NamespaceNodeLease)); err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

Before this change, the usual check for `EveryNodeReady` was executed, which contains getting the `MachineDeployment`s on the seed. This is not possible and leads to crashing checks, as we cannot leverage MCM in this case, therefore this API is not available.

Furthermore, the check for `SeedSettingDependencyWatchdogProberEnabled` is also disabled in all self-hosted shoot cases, as it assumes seed settings, which are not present in self-hosted shoot.

With this fix the conditions / constraints are the following:

```yaml
conditions:
  - lastTransitionTime: "2026-04-23T11:20:22Z"
    lastUpdateTime: "2026-04-23T11:20:22Z"
    message: Gardenlet is posting ready status.
    reason: GardenletReady
    status: "True"
    type: GardenletReady
  - lastTransitionTime: "2026-04-23T11:20:23Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: API server /healthz endpoint responded with success status code.
    reason: HealthzRequestSucceeded
    status: "True"
    type: APIServerAvailable
  - lastTransitionTime: "2026-04-23T14:13:04Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: 'Missing required etcds: [etcd-events etcd-main]'
    reason: EtcdMissing
    status: Progressing
    type: ControlPlaneHealthy
  - lastTransitionTime: "2026-04-23T14:13:04Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: 'Missing required deployments: [kube-state-metrics]'
    reason: DeploymentMissing
    status: Progressing
    type: ObservabilityComponentsHealthy
  - lastTransitionTime: "2026-04-23T11:20:23Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: All nodes are ready.
    reason: EveryNodeReady
    status: "True"
    type: EveryNodeReady
  - lastTransitionTime: "2026-04-23T14:13:04Z"
    lastUpdateTime: "2026-04-23T13:08:29Z"
    message: 'Deployment "kube-system/calico-typha-deploy" is unhealthy: condition
      "Progressing" has invalid status False (expected True) due to ProgressDeadlineExceeded:
      ReplicaSet "calico-typha-deploy-5fb68c5659" has timed out progressing.'
    reason: DeploymentUnhealthy
    status: Progressing
    type: SystemComponentsHealthy
  - lastTransitionTime: "2026-04-23T11:20:23Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: Backup Buckets are available.
    reason: BackupBucketsAvailable
    status: "True"
    type: BackupBucketsReady
  constraints:
  - codes:
    - ERR_PROBLEMATIC_WEBHOOK
    lastTransitionTime: "2026-04-23T14:13:04Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: 'MutatingWebhookConfiguration "gardener-extension-provider-local" is
      problematic: webhook "shoot.local.extensions.gardener.cloud" with failurePolicy
      "Fail" and 10s timeout might prevent worker nodes from properly joining the
      shoot cluster'
    reason: ProblematicWebhooks
    status: Progressing
    type: HibernationPossible
  - codes:
    - ERR_PROBLEMATIC_WEBHOOK
    lastTransitionTime: "2026-04-23T14:13:04Z"
    lastUpdateTime: "2026-04-23T11:20:23Z"
    message: 'MutatingWebhookConfiguration "gardener-extension-provider-local" is
      problematic: webhook "shoot.local.extensions.gardener.cloud" with failurePolicy
      "Fail" and 10s timeout might prevent worker nodes from properly joining the
      shoot cluster'
    reason: ProblematicWebhooks
    status: Progressing
    type: MaintenancePreconditionsSatisfied
```

Because of the presence of `provider-local`, the constraints complain about its webhooks.
Perhaps we can do something about this as well.

**Which issue(s) this PR fixes**:
Part of #2906

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed where the `EveryNodeReadyCondition` was showing and error for self-hosted shoots on unmanaged infrastructure.
```
