### PR TITLE
hack/usage/wait-for.sh: Prevent `unbound variable`

### DIFF
--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -71,6 +71,6 @@ while [ "${retries}" -lt "${TIMEOUT}" ]; do
 done
 
 if [ "${retries}" -ge "${TIMEOUT}" ]; then
-  echo -e "${RED}❌ ERROR: Last operation state not 'Succeeded' or ${condition} not met for ${RESOURCE_TYPE}/${OBJECT_NAME} after ${TIMEOUT} seconds.${NO_COLOR}"
+  echo -e "${RED}❌ ERROR: Last operation state not 'Succeeded' or conditions not met for ${RESOURCE_TYPE}/${OBJECT_NAME} after ${TIMEOUT} seconds.${NO_COLOR}"
   exit 1
 fi


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
`make garden-up` in the [`Deploying Gardener Remotely`](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_remotely.md):
```
⏳ Checking last operation state and conditions for garden/remote with a timeout of 900 seconds...
./dev-setup/../hack/usage/wait-for.sh: line 74: condition: unbound variable
make: *** [garden-up] Error 1
```

The issue was a configuration problem in the Garden resource manifest on my side.
This PR fixes the `unbound variable` in the `hack/usage/wait-for.sh` script.

Where there are no conditions passed to `hack/usage/wait-for.sh` (see https://github.com/gardener/gardener/blob/5cafe521bb88bb3d7b3b270f1d806869a18fcd8f/dev-setup/garden.sh#L29), then the `condition` variable will be unbound when the resource is unhealthy.

This PR removes the `condition` variable usage as conditions are optional for the script. When there are no condition passed , we cannot report a failing condition.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
