### PR TITLE
Prepare serviceaccount discovery secret migration from `v1beta1constants.LabelPublicKeys` to `v1beta1constants.LabelDiscoveryPublic`

### DIFF
--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -45,7 +45,7 @@ func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 			v1beta1constants.ProjectName:          b.Garden.Project.Name,
 			v1beta1constants.LabelShootName:       b.Shoot.GetInfo().Name,
 			v1beta1constants.LabelShootNamespace:  b.Shoot.GetInfo().Namespace,
-			v1beta1constants.LabelPublicKeys:      v1beta1constants.LabelPublicKeysServiceAccount, // TODO(vpnachev): Remove this label after v1.144 is released.
+			v1beta1constants.LabelPublicKeys:      v1beta1constants.LabelPublicKeysServiceAccount, // TODO(vpnachev): Remove this label after v1.145 is released.
 			v1beta1constants.LabelDiscoveryPublic: v1beta1constants.LabelPublicKeysServiceAccount,
 		}
 		secret.Data = map[string][]byte{

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys.go
@@ -42,10 +42,11 @@ func (b *Botanist) SyncPublicServiceAccountKeys(ctx context.Context) error {
 	secret := b.emptyPublicServiceAccountKeysSecret()
 	_, err = controllerutil.CreateOrUpdate(ctx, b.GardenClient, secret, func() error {
 		secret.Labels = map[string]string{
-			v1beta1constants.ProjectName:         b.Garden.Project.Name,
-			v1beta1constants.LabelShootName:      b.Shoot.GetInfo().Name,
-			v1beta1constants.LabelShootNamespace: b.Shoot.GetInfo().Namespace,
-			v1beta1constants.LabelPublicKeys:     v1beta1constants.LabelPublicKeysServiceAccount,
+			v1beta1constants.ProjectName:          b.Garden.Project.Name,
+			v1beta1constants.LabelShootName:       b.Shoot.GetInfo().Name,
+			v1beta1constants.LabelShootNamespace:  b.Shoot.GetInfo().Namespace,
+			v1beta1constants.LabelPublicKeys:      v1beta1constants.LabelPublicKeysServiceAccount, // TODO(vpnachev): Remove this label after v1.144 is released.
+			v1beta1constants.LabelDiscoveryPublic: v1beta1constants.LabelPublicKeysServiceAccount,
 		}
 		secret.Data = map[string][]byte{
 			"openid-config": oidReqBytes,

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -93,7 +93,8 @@ var _ = Describe("ServiceAccountKeys", func() {
 				ResourceVersion: "1",
 				Labels: map[string]string{
 					"shoot.gardener.cloud/namespace":            "bar",
-					"authentication.gardener.cloud/public-keys": "serviceaccount",
+					"authentication.gardener.cloud/public-keys": "serviceaccount", // TODO(vpnachev): Remove this label after v1.144 is released.
+					"discovery.gardener.cloud/public":           "serviceaccount",
 					"project.gardener.cloud/name":               "project-name",
 					"shoot.gardener.cloud/name":                 "foo",
 				},

--- a/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
+++ b/pkg/gardenlet/operation/botanist/serviceaccountkeys_test.go
@@ -93,7 +93,7 @@ var _ = Describe("ServiceAccountKeys", func() {
 				ResourceVersion: "1",
 				Labels: map[string]string{
 					"shoot.gardener.cloud/namespace":            "bar",
-					"authentication.gardener.cloud/public-keys": "serviceaccount", // TODO(vpnachev): Remove this label after v1.144 is released.
+					"authentication.gardener.cloud/public-keys": "serviceaccount", // TODO(vpnachev): Remove this label after v1.145 is released.
 					"discovery.gardener.cloud/public":           "serviceaccount",
 					"project.gardener.cloud/name":               "project-name",
 					"shoot.gardener.cloud/name":                 "foo",


### PR DESCRIPTION
**How to categorize this PR?**
/area security quality
/kind cleanup

**What this PR does / why we need it**:
Prepare serviceaccount discovery secret migration from `v1beta1constants.LabelPublicKeys` to `v1beta1constants.LabelDiscoveryPublic`

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/11224/

**Special notes for your reviewer**:
Discovery server adds support for the new label with https://github.com/gardener/gardener-discovery-server/pull/196


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
:warning: The secrets in the `gardener-system-shoot-issuer` namespace containing shoot's OIDC discovery documents will stop to be labeled with `authentication.gardener.cloud/public-keys=serviceaccount` after Gardener v1.145.0 is released. Clients relying on this label must migrate to `discovery.gardener.cloud/public=serviceaccount` before that. For backward compatibility, it is advised to support both labels for some time. 
```


/cc @gardener/gardener-discovery-server-maintainers 