### PR TITLE
fix: Docker SDK requires published port to be defined in ExposedPorts+PortBindings

### DIFF
--- a/pkg/provider-local/cloud-provider/loadbalancer/container.go
+++ b/pkg/provider-local/cloud-provider/loadbalancer/container.go
@@ -42,12 +42,19 @@ func (p *Provider) createLoadBalancerContainer(ctx context.Context, name string,
 		return nil, fmt.Errorf("failed to determine port bindings for service: %w", err)
 	}
 
+	// Docker requires ExposedPorts in Config to match PortBindings for port publishing to work.
+	exposedPorts := nat.PortSet{}
+	for port := range portBindings {
+		exposedPorts[port] = struct{}{}
+	}
+
 	_, err = p.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
-			Hostname: name,
-			Image:    p.Config.LoadBalancer.Image,
-			Cmd:      []string{"envoy", "-c", envoyConfigFilePath},
+			Hostname:     name,
+			Image:        p.Config.LoadBalancer.Image,
+			Cmd:          []string{"envoy", "-c", envoyConfigFilePath},
+			ExposedPorts: exposedPorts,
 			Healthcheck: &container.HealthConfig{
 				Test:     []string{"CMD", "curl", "-sf", "--unix-socket", envoyAdminSocketPath, "http://localhost/ready"},
 				Interval: time.Second,


### PR DESCRIPTION
Docker SDK requires published port to be defined in ExposedPorts and PortBindings

**Bugfix**
**What this PR does / why we need it**:
Docker SDK requires ExposedPorts and PortBindings to match.
When using Docker CLI this is handled by CLI client.
https://github.com/docker/cli/blob/977ee838e0ec5eb81eef2ba822af900548807516/cli/command/container/opts.go#L468


**Which issue(s) this PR fixes**:
No issue reported.