### PR TITLE
Fix: Mounting correct volume in KinD Node for Mac

### DIFF
--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -365,7 +365,9 @@ docker_socket() {
   # If the socket path contains .lima or .colima, we assume that Lima/Colima is used as Docker backend.
   # In this case, the socket on the host is a forward to /var/run/docker.sock in the guest VM.
   # Instead of mounting the socket on the host back into the VM, we directly use /var/run/docker.sock in the VM.
-  if [[ "$socket" == *"/.lima/"* || "$socket" == *"/.colima/"* ]]; then
+  # Similarly, Docker Desktop for Mac uses ~/.docker/run/docker.sock which is also a forwarded socket from its VM
+  # and cannot be bind-mounted into the kind node container.
+  if [[ "$socket" == *"/.lima/"* || "$socket" == *"/.colima/"* || "$socket" == *"/.docker/run/"* ]]; then
     socket="/var/run/docker.sock"
   fi
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

When creating a local KinD cluster on Mac (arm) following the [guide](https://gardener.cloud/docs/gardener/deployment/getting_started_locally/#setting-up-the-kind-cluster-garden-and-seed), I encountered this error:

```
 ✗ Preparing nodes 📦
Deleted nodes: ["gardener-local-control-plane"]
ERROR: failed to create cluster: command "docker run --name gardener-local-control-plane --hostname gardener-local-control-plane --label io.x-k8s.kind.role=control-plane --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --label io.x-k8s.kind.cluster=gardener-local --net kind --restart=on-failure:1 --init=false --cgroupns=private --volume=/Users/[username]/Documents/github/gardener/example/gardener-local/kube-apiserver:/etc/gardener-local/kube-apiserver:ro --volume=/Users/[username]/Documents/github/gardener/example/gardener-local/controlplane:/etc/gardener/controlplane:ro --volume=/Users/[username]/Documents/github/gardener/dev/local-backupbuckets:/etc/gardener/local-backupbuckets --volume=/Users/[username]/Documents/github/gardener/example/gardener-local/kind/resolv.conf:/etc/resolv.conf --volume=/Users/[username]/.docker/run/docker.sock:/var/run/docker.sock --publish=0.0.0.0:32379:32379/TCP --publish=172.18.255.4:443:30003/TCP --publish=172.18.255.3:443:31443/TCP --publish=127.0.0.1:54509:6443/TCP -e KUBECONFIG=/etc/kubernetes/admin.conf kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab" failed with error: exit status 125
Command Output: 9b06e2e30a19603df0399457f9eed4a9929772aa907a82e9af4eeb812546026c
docker: Error response from daemon: error while creating mount source path '/host_mnt/Users/[username]/.docker/run/docker.sock': mkdir /host_mnt/Users/[username]/.docker/run/docker.sock: operation not supported.
make: *** [kind-up] Error 1
```

This PR fixes that issue. (Generated with Claude Code, verified that it's working by me).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
