### PR TITLE
Apply best-practices of envoy as edge-proxy to `istio-ingressgateway` configuration

### DIFF
--- a/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
+++ b/pkg/component/kubernetes/apiserverexposure/templates/envoyfilter-apiserver-proxy.yaml
@@ -24,6 +24,7 @@ spec:
       operation: ADD
       value:
         name: {{ .TargetClusterAPIServerProxy }}
+        per_connection_buffer_limit_bytes: 32768
         address:
           pipe:
             path: "@kube-apiservers/{{ .ControlPlaneNamespace }}"
@@ -41,6 +42,10 @@ spec:
                     log_format:
                       text_format_source:
                         inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n"
+              http2_protocol_options:
+                 max_concurrent_streams: 100
+                 initial_stream_window_size: 65536 # 64 KiB
+                 initial_connection_window_size: 1048576 # 1 MiB
               route_config:
                 name: {{ .TargetClusterAPIServerProxy }}
                 virtual_hosts:
@@ -158,6 +163,7 @@ spec:
         name: {{ .TargetClusterAPIServerProxy }}
         type: STATIC
         connect_timeout: 10s
+        per_connection_buffer_limit_bytes: 32768
         upstream_connection_options:
           tcp_keepalive:
             keepalive_interval: 75

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ports }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -8,6 +7,22 @@ metadata:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
   configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          http2_protocol_options:
+             max_concurrent_streams: 100
+             initial_stream_window_size: 65536 # 64 KiB
+             initial_connection_window_size: 1048576 # 1 MiB
 {{- range .Values.ports }}
   - applyTo: LISTENER
     match:
@@ -59,5 +74,4 @@ spec:
           name: 5
           int_value: 55
           state: STATE_LISTENING
-{{- end }}
 {{- end }}

--- a/pkg/component/networking/istio/test_charts/ingress_envoyfilter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_envoyfilter.yaml
@@ -8,6 +8,22 @@ metadata:
     foo: bar
 spec:
   configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          http2_protocol_options:
+             max_concurrent_streams: 100
+             initial_stream_window_size: 65536 # 64 KiB
+             initial_connection_window_size: 1048576 # 1 MiB
   - applyTo: LISTENER
     match:
       context: GATEWAY


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking robustness
/kind enhancement

**What this PR does / why we need it**:
In Gardener `istio-ingressgateway` acts as an edge proxy. It also is an HTTP proxy when `IstioTLSTermination` feature gate is active and since we are removing ingress-nginx for other components too.
Envoy recommends certain best-practices for this use case (see [here](https://www.envoyproxy.io/docs/envoy/latest/configuration/best_practices/edge)) which are not applied by Istio by default.
This PR applies the HTTP2 protocol options related recommendations. A discussion about timeouts and other safeguarding mechanism will follow. `apiserver-proxy` endpoints are considered as edge proxy too.

**Which issue(s) this PR fixes**:
Part of #8810 

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Certain best-practice Envoy settings for HTTP2 protocol options have been applied to `istio-ingressgateways`.
```
