### PR TITLE
🐛 secretsrotation: tolerate partial API discovery failures during ETCD encryption key rotation

### DIFF
--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -270,10 +270,10 @@ func GetResourcesForRewrite(
 			return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
 		}
 		for failedGV := range failedGroups {
-			for _, gr := range groupResourcesToEncrypt {
-				if gr.Group == failedGV.Group {
-					return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
-				}
+			if slices.ContainsFunc(groupResourcesToEncrypt, func(gr schema.GroupResource) bool {
+				return gr.Group == failedGV.Group
+			}) {
+				return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
 			}
 		}
 	}

--- a/pkg/utils/gardener/secretsrotation/etcd.go
+++ b/pkg/utils/gardener/secretsrotation/etcd.go
@@ -265,7 +265,17 @@ func GetResourcesForRewrite(
 
 	resourceLists, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
-		return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
+		failedGroups, isPartialFailure := discovery.GroupDiscoveryFailedErrorGroups(err)
+		if !isPartialFailure {
+			return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
+		}
+		for failedGV := range failedGroups {
+			for _, gr := range groupResourcesToEncrypt {
+				if gr.Group == failedGV.Group {
+					return encryptedGVKs.UnsortedList(), "", fmt.Errorf("error discovering server preferred resources: %w", err)
+				}
+			}
+		}
 	}
 
 	for _, list := range resourceLists {

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -377,7 +377,6 @@ var _ = Describe("ETCD", func() {
 					{Group: "acme.stackit.de", Version: "v1alpha1"}: fmt.Errorf("stale GroupVersion discovery: acme.stackit.de/v1alpha1"),
 				},
 			}
-			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
 
 			list, message, err := GetResourcesForRewrite(fakeDiscoveryClient, resources, resources, defaultGVKs)
 			Expect(err).NotTo(HaveOccurred())
@@ -404,7 +403,6 @@ var _ = Describe("ETCD", func() {
 					{Group: "acme.stackit.de", Version: "v1alpha1"}: fmt.Errorf("stale GroupVersion discovery: acme.stackit.de/v1alpha1"),
 				},
 			}
-			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
 
 			_, _, err := GetResourcesForRewrite(fakeDiscoveryClient, resources, resources, defaultGVKs)
 			Expect(err).To(HaveOccurred())
@@ -413,7 +411,6 @@ var _ = Describe("ETCD", func() {
 
 		It("should fail on non-partial discovery errors", func() {
 			fakeDiscoveryClient.err = fmt.Errorf("connection refused")
-			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
 
 			_, _, err := GetResourcesForRewrite(fakeDiscoveryClient, []string{"configmaps"}, []string{"configmaps"}, nil)
 			Expect(err).To(HaveOccurred())

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -6,6 +6,7 @@ package secretsrotation_test
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -360,6 +362,64 @@ var _ = Describe("ETCD", func() {
 			))
 		})
 
+		It("should succeed with partial results when an unrelated API group fails discovery", func() {
+			var (
+				resources = []string{
+					"configmaps",
+					"managedresources.resources.gardener.cloud",
+				}
+
+				defaultGVKs = []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")}
+			)
+
+			fakeDiscoveryClient.err = &discovery.ErrGroupDiscoveryFailed{
+				Groups: map[schema.GroupVersion]error{
+					{Group: "acme.stackit.de", Version: "v1alpha1"}: fmt.Errorf("stale GroupVersion discovery: acme.stackit.de/v1alpha1"),
+				},
+			}
+			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
+
+			list, message, err := GetResourcesForRewrite(fakeDiscoveryClient, resources, resources, defaultGVKs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(message).To(Equal("Objects requiring to be rewritten after ETCD encryption key rotation"))
+			Expect(list).To(ConsistOf(
+				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+				schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+				schema.GroupVersionKind{Group: "resources.gardener.cloud", Version: "v1alpha1", Kind: "ManagedResource"},
+			))
+		})
+
+		It("should fail when a required API group fails discovery", func() {
+			var (
+				resources = []string{
+					"configmaps",
+					"certificates.acme.stackit.de",
+				}
+
+				defaultGVKs = []schema.GroupVersionKind{corev1.SchemeGroupVersion.WithKind("Secret")}
+			)
+
+			fakeDiscoveryClient.err = &discovery.ErrGroupDiscoveryFailed{
+				Groups: map[schema.GroupVersion]error{
+					{Group: "acme.stackit.de", Version: "v1alpha1"}: fmt.Errorf("stale GroupVersion discovery: acme.stackit.de/v1alpha1"),
+				},
+			}
+			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
+
+			_, _, err := GetResourcesForRewrite(fakeDiscoveryClient, resources, resources, defaultGVKs)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error discovering server preferred resources"))
+		})
+
+		It("should fail on non-partial discovery errors", func() {
+			fakeDiscoveryClient.err = fmt.Errorf("connection refused")
+			DeferCleanup(func() { fakeDiscoveryClient.err = nil })
+
+			_, _, err := GetResourcesForRewrite(fakeDiscoveryClient, []string{"configmaps"}, []string{"configmaps"}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error discovering server preferred resources"))
+		})
+
 		It("should return the correct GVK list for the modified resources when the resources to encrypt and encrypted resources are not equal", func() {
 			var (
 				resourcesToEncrypt = []string{
@@ -394,6 +454,8 @@ var _ = Describe("ETCD", func() {
 
 type fakeDiscoveryWithServerPreferredResources struct {
 	*fakediscovery.FakeDiscovery
+	// err is returned alongside the resource lists (simulates partial discovery failures).
+	err error
 }
 
 func (c *fakeDiscoveryWithServerPreferredResources) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
@@ -495,5 +557,5 @@ func (c *fakeDiscoveryWithServerPreferredResources) ServerPreferredResources() (
 				},
 			},
 		},
-	}, nil
+	}, c.err
 }

--- a/pkg/utils/gardener/secretsrotation/etcd_test.go
+++ b/pkg/utils/gardener/secretsrotation/etcd_test.go
@@ -451,6 +451,7 @@ var _ = Describe("ETCD", func() {
 
 type fakeDiscoveryWithServerPreferredResources struct {
 	*fakediscovery.FakeDiscovery
+
 	// err is returned alongside the resource lists (simulates partial discovery failures).
 	err error
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug that prevents the credential rotation to successfully complete when an `APIService` is not available.
It tolerates partial API discovery failures during ETCD encryption key rotation for unrelated resources.

**Which issue(s) this PR fixes**:
Fixes #14676

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Rotating the etcd encryption key tolerates unavailable `APIServices`.
```
