### PR TITLE
remote setup: Disable Garden VPA by default

### DIFF
--- a/dev-setup/garden/overlays/remote/garden.yaml.tmpl
+++ b/dev-setup/garden/overlays/remote/garden.yaml.tmpl
@@ -28,6 +28,11 @@ spec:
       region: ""
       # Enter zones of your runtime cluster
       zones: []
+    settings:
+      verticalPodAutoscaler:
+        # If using a Gardener Shoot, make sure that the Shoot cluster has VPA enabled. Otherwise, enable VPA below in the Garden spec.
+        # Don't enable VPA for both the Shoot control plane and the Garden runtime cluster. 2 VPA deployments acting on the same cluster cause endless VPA eviction loops.
+        enabled: false
   virtualCluster:
     dns:
       domains:

--- a/dev-setup/gardenlet/overlays/remote/gardenlet.yaml.tmpl
+++ b/dev-setup/gardenlet/overlays/remote/gardenlet.yaml.tmpl
@@ -83,6 +83,6 @@ spec:
           scheduling:
             visible: true
           verticalPodAutoscaler:
-            # If using a Gardener shoot, make sure that the shoot cluster has VPA enabled. Otherwise, enable VPA below in the seed spec.
-            # Don't enable VPA for both the shoot control plane and the seed. 2 VPA deployments acting on the same cluster cause endless VPA eviction loops.
+            # If using a Gardener Shoot, make sure that the Shoot cluster has VPA enabled. Otherwise, enable VPA below in the Seed spec.
+            # Don't enable VPA for both the Shoot control plane and the Seed cluster. 2 VPA deployments acting on the same cluster cause endless VPA eviction loops.
             enabled: false

--- a/docs/deployment/getting_started_remotely.md
+++ b/docs/deployment/getting_started_remotely.md
@@ -178,7 +178,7 @@ kubectl wait --for=condition=gardenletready seed remote --timeout=5m
 Alternatively, you can run `kubectl get seed remote` and wait for the `STATUS` to indicate readiness:
 
 ```bash
-NAME                  STATUS   PROVIDER   REGION         AGE    VERSION      K8S VERSION
+NAME     STATUS   PROVIDER   REGION         AGE    VERSION        K8S VERSION
 remote   Ready    gcp        europe-west1   111m   v1.137.0-dev   v1.34.7
 ```
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With the new remote setup, the VPA for the Garden cluster is enabled by default. This causes again 2 VPA stacks to be deployed for the same clusters. 2 VPA deployments acting on the same cluster cause endless VPA eviction loops.
Similar to https://github.com/gardener/gardener/pull/10593.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
remote setup: Garden VPA is disabled by default to avoid two VPA deployments to act on the same cluster causing endless eviction loops.
```
