### PR TITLE
chore: set revisionHistoryLimit on remaining Deployments and DaemonSet

### DIFF
--- a/pkg/component/networking/coredns/coredns.go
+++ b/pkg/component/networking/coredns/coredns.go
@@ -621,6 +621,7 @@ import custom/*.server
 				Labels:    getClusterProportionalDNSAutoscalerLabels(),
 			},
 			Spec: appsv1.DeploymentSpec{
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{corednsconstants.LabelKey: clusterProportionalDNSAutoscalerLabelValue},
 				},

--- a/pkg/component/networking/coredns/coredns_test.go
+++ b/pkg/component/networking/coredns/coredns_test.go
@@ -509,6 +509,7 @@ metadata:
   name: coredns-autoscaler
   namespace: kube-system
 spec:
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       k8s-app: coredns-autoscaler

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -430,6 +430,7 @@ func createCleanupDaemonSet(ctx context.Context, shootClient client.Client, alpi
 	_, err := controllerutil.CreateOrUpdate(ctx, shootClient, cleanupDaemonSet, func() error {
 		metav1.SetMetaDataLabel(&cleanupDaemonSet.ObjectMeta, v1beta1constants.LabelApp, labelValueAndCleanupName)
 		cleanupDaemonSet.Spec = appsv1.DaemonSetSpec{
+			RevisionHistoryLimit: ptr.To[int32](2),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					v1beta1constants.LabelApp: labelValueAndCleanupName,

--- a/pkg/provider-local/controller/extension/shootafterworker/actuator.go
+++ b/pkg/provider-local/controller/extension/shootafterworker/actuator.go
@@ -130,6 +130,7 @@ func getShootResources() (map[string][]byte, error) {
 				Labels:    labels,
 			},
 			Spec: appsv1.DeploymentSpec{
+				RevisionHistoryLimit: ptr.To[int32](2),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},


### PR DESCRIPTION
## What this PR does / why we need it

Per #13889, the component checklist now requires \`revisionHistoryLimit=2\` on every Deployment and DaemonSet. Three spots in this repo were still missing it:

- \`pkg/component/networking/nodelocaldns\`: cleanup DaemonSet (the main nodelocaldns DaemonSet in \`resources.go\` already has it).
- \`pkg/component/networking/coredns\`: cluster-proportional autoscaler Deployment (the main coredns Deployment already has it).
- \`pkg/provider-local/controller/extension/shootafterworker\`: actuator Deployment.

Updated the \`cpaDeploymentYAML\` fixture in \`coredns_test.go\` to match the new rendered output.

## Notes

- The cleanup DaemonSet in nodelocaldns is a temporary migration helper that creates one revision and is then removed; setting \`revisionHistoryLimit\` on it is harmless but technically redundant. Included for consistency with the rule's wording (\"every Deployment and DaemonSet\").
- This PR addresses the gaps in \`gardener/gardener\` itself. The extension repos listed in the issue's task list (gardener-extension-networking-*, gardener-extension-shoot-*) need separate PRs and aren't in scope here.

## Which issue(s) this PR fixes

Refs #13889

## Release note

\`\`\`other
\`\`\`