### PR TITLE
[gardenlet] Support additional target namespaces for shoot gardener-resource-manager

### DIFF
--- a/charts/gardener/operator/files/crd-extensions.yaml
+++ b/charts/gardener/operator/files/crd-extensions.yaml
@@ -351,6 +351,18 @@ spec:
                     ControllerResource is a combination of a kind (DNSProvider, Infrastructure, Generic, ...) and the actual type for this
                     kind (aws-route53, gcp, auditlog, ...).
                   properties:
+                    additionalShootTargetNamespaces:
+                      description: |-
+                        AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the
+                        shoot gardener-resource-manager should watch when this extension is active on a shoot.
+                        These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,
+                        kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots
+                        must declare them here so the gardener-resource-manager can manage resources in those namespaces.
+                        This field can only be set for resources of kind "Extension".
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     autoEnable:
                       description: |-
                         AutoEnable determines if this resource is automatically enabled for shoot or seed clusters, or both.

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3069,6 +3069,18 @@ boolean
 <p>ClusterCompatibility defines the compatibility of this resource with different cluster types.<br />If compatibility is not specified, it will be defaulted to 'shoot'.<br />This field can only be set for resources of kind "Extension".</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>additionalShootTargetNamespaces</code></br>
+<em>
+string array
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the<br />shoot gardener-resource-manager should watch when this extension is active on a shoot.<br />These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,<br />kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots<br />must declare them here so the gardener-resource-manager can manage resources in those namespaces.<br />This field can only be set for resources of kind "Extension".</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
@@ -351,6 +351,18 @@ spec:
                     ControllerResource is a combination of a kind (DNSProvider, Infrastructure, Generic, ...) and the actual type for this
                     kind (aws-route53, gcp, auditlog, ...).
                   properties:
+                    additionalShootTargetNamespaces:
+                      description: |-
+                        AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the
+                        shoot gardener-resource-manager should watch when this extension is active on a shoot.
+                        These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,
+                        kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots
+                        must declare them here so the gardener-resource-manager can manage resources in those namespaces.
+                        This field can only be set for resources of kind "Extension".
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
                     autoEnable:
                       description: |-
                         AutoEnable determines if this resource is automatically enabled for shoot or seed clusters, or both.

--- a/pkg/api/core/validation/controllerregistration.go
+++ b/pkg/api/core/validation/controllerregistration.go
@@ -14,6 +14,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -127,6 +128,9 @@ func ValidateControllerResources(resources []core.ControllerResource, clusterTyp
 			if resource.Lifecycle != nil {
 				allErrs = append(allErrs, field.Forbidden(idxPath.Child("lifecycle"), fmt.Sprintf("field must not be set when kind != %s", extensionsv1alpha1.ExtensionResource)))
 			}
+			if len(resource.AdditionalShootTargetNamespaces) > 0 {
+				allErrs = append(allErrs, field.Forbidden(idxPath.Child("additionalShootTargetNamespaces"), fmt.Sprintf("field must not be set when kind != %s", extensionsv1alpha1.ExtensionResource)))
+			}
 
 			continue
 		}
@@ -177,6 +181,30 @@ func ValidateControllerResources(resources []core.ControllerResource, clusterTyp
 			}
 			if resource.Lifecycle.Migrate != nil && !availableExtensionStrategies.Has(*resource.Lifecycle.Migrate) {
 				allErrs = append(allErrs, field.NotSupported(lifecyclePath.Child("migrate"), *resource.Lifecycle.Migrate, sets.List(availableExtensionStrategies)))
+			}
+		}
+
+		if len(resource.AdditionalShootTargetNamespaces) > 0 {
+			nsPath := idxPath.Child("additionalShootTargetNamespaces")
+
+			defaultNamespaces := sets.New("kube-system", "kubernetes-dashboard", "kube-node-lease")
+			seenNamespaces := sets.New[string]()
+
+			for j, ns := range resource.AdditionalShootTargetNamespaces {
+				nsIdxPath := nsPath.Index(j)
+
+				for _, msg := range utilvalidation.IsDNS1123Label(ns) {
+					allErrs = append(allErrs, field.Invalid(nsIdxPath, ns, msg))
+				}
+
+				if seenNamespaces.Has(ns) {
+					allErrs = append(allErrs, field.Duplicate(nsIdxPath, ns))
+				}
+				seenNamespaces.Insert(ns)
+
+				if defaultNamespaces.Has(ns) {
+					allErrs = append(allErrs, field.Forbidden(nsIdxPath, fmt.Sprintf("namespace %q is already included in the default target namespaces", ns)))
+				}
 			}
 		}
 	}

--- a/pkg/api/core/validation/controllerregistration_test.go
+++ b/pkg/api/core/validation/controllerregistration_test.go
@@ -332,6 +332,7 @@ var _ = Describe("validation", func() {
 			ctrlResource.Lifecycle = &core.ControllerResourceLifecycle{
 				Reconcile: &strategy,
 			}
+			ctrlResource.AdditionalShootTargetNamespaces = []string{"custom-namespace"}
 			resources = []core.ControllerResource{ctrlResource}
 
 			errorList := ValidateControllerResources(resources, validModes, fldPath)
@@ -345,6 +346,9 @@ var _ = Describe("validation", func() {
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeForbidden),
 				"Field": Equal("resources[0].lifecycle"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeForbidden),
+				"Field": Equal("resources[0].additionalShootTargetNamespaces"),
 			}))))
 		})
 
@@ -516,6 +520,77 @@ var _ = Describe("validation", func() {
 				"Field": Equal("resources[0].lifecycle.migrate"),
 			}))))
 		})
+
+		It("should allow setting additionalShootTargetNamespaces for kind Extension", func() {
+			resources[0].Kind = "Extension"
+			resources[0].AdditionalShootTargetNamespaces = []string{"custom-namespace", "custom-ns"}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should forbid setting additionalShootTargetNamespaces for kind != Extension", func() {
+			resources[0].AdditionalShootTargetNamespaces = []string{"custom-namespace"}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeForbidden),
+				"Field": Equal("resources[0].additionalShootTargetNamespaces"),
+			}))))
+		})
+
+		It("should forbid invalid DNS labels in additionalShootTargetNamespaces", func() {
+			resources[0].Kind = "Extension"
+			resources[0].AdditionalShootTargetNamespaces = []string{"UPPER-CASE", "has spaces"}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("resources[0].additionalShootTargetNamespaces[0]"),
+			}))))
+			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("resources[0].additionalShootTargetNamespaces[1]"),
+			}))))
+		})
+
+		It("should forbid duplicate namespaces in additionalShootTargetNamespaces", func() {
+			resources[0].Kind = "Extension"
+			resources[0].AdditionalShootTargetNamespaces = []string{"custom-namespace", "custom-namespace"}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeDuplicate),
+				"Field": Equal("resources[0].additionalShootTargetNamespaces[1]"),
+			}))))
+		})
+
+		It("should forbid default namespaces in additionalShootTargetNamespaces", func() {
+			resources[0].Kind = "Extension"
+			resources[0].AdditionalShootTargetNamespaces = []string{"kube-system", "kubernetes-dashboard", "kube-node-lease"}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("resources[0].additionalShootTargetNamespaces[0]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("resources[0].additionalShootTargetNamespaces[1]"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("resources[0].additionalShootTargetNamespaces[2]"),
+				})),
+			))
+		})
+
 	})
 
 	Describe("#ValidateControllerResourcesUpdate", func() {

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -84,6 +84,13 @@ type ControllerResource struct {
 	// If compatibility is not specified, it will be defaulted to 'shoot'.
 	// This field can only be set for resources of kind "Extension".
 	ClusterCompatibility []ClusterType
+	// AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the
+	// shoot gardener-resource-manager should watch when this extension is active on a shoot.
+	// These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,
+	// kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots
+	// must declare them here so the gardener-resource-manager can manage resources in those namespaces.
+	// This field can only be set for resources of kind "Extension".
+	AdditionalShootTargetNamespaces []string
 }
 
 // DeploymentRef contains information about `ControllerDeployment` references.

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -3245,6 +3245,15 @@ func (m *ControllerResource) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.AdditionalShootTargetNamespaces) > 0 {
+		for iNdEx := len(m.AdditionalShootTargetNamespaces) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.AdditionalShootTargetNamespaces[iNdEx])
+			copy(dAtA[i:], m.AdditionalShootTargetNamespaces[iNdEx])
+			i = encodeVarintGenerated(dAtA, i, uint64(len(m.AdditionalShootTargetNamespaces[iNdEx])))
+			i--
+			dAtA[i] = 0x52
+		}
+	}
 	if len(m.ClusterCompatibility) > 0 {
 		for iNdEx := len(m.ClusterCompatibility) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.ClusterCompatibility[iNdEx])
@@ -14620,6 +14629,12 @@ func (m *ControllerResource) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
+	if len(m.AdditionalShootTargetNamespaces) > 0 {
+		for _, s := range m.AdditionalShootTargetNamespaces {
+			l = len(s)
+			n += 1 + l + sovGenerated(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -19187,6 +19202,7 @@ func (this *ControllerResource) String() string {
 		`WorkerlessSupported:` + valueToStringGenerated(this.WorkerlessSupported) + `,`,
 		`AutoEnable:` + fmt.Sprintf("%v", this.AutoEnable) + `,`,
 		`ClusterCompatibility:` + fmt.Sprintf("%v", this.ClusterCompatibility) + `,`,
+		`AdditionalShootTargetNamespaces:` + fmt.Sprintf("%v", this.AdditionalShootTargetNamespaces) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -29961,6 +29977,38 @@ func (m *ControllerResource) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ClusterCompatibility = append(m.ClusterCompatibility, ClusterType(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdditionalShootTargetNamespaces", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AdditionalShootTargetNamespaces = append(m.AdditionalShootTargetNamespaces, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -858,6 +858,16 @@ message ControllerResource {
   // This field can only be set for resources of kind "Extension".
   // +optional
   repeated string clusterCompatibility = 9;
+
+  // AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the
+  // shoot gardener-resource-manager should watch when this extension is active on a shoot.
+  // These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,
+  // kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots
+  // must declare them here so the gardener-resource-manager can manage resources in those namespaces.
+  // This field can only be set for resources of kind "Extension".
+  // +optional
+  // +listType=atomic
+  repeated string additionalShootTargetNamespaces = 10;
 }
 
 // ControllerResourceLifecycle defines the lifecycle of a controller resource.

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -97,6 +97,15 @@ type ControllerResource struct {
 	// This field can only be set for resources of kind "Extension".
 	// +optional
 	ClusterCompatibility []ClusterType `json:"clusterCompatibility,omitempty" protobuf:"bytes,9,rep,name=clusterCompatibility,casttype=ClusterType"`
+	// AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the
+	// shoot gardener-resource-manager should watch when this extension is active on a shoot.
+	// These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard,
+	// kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots
+	// must declare them here so the gardener-resource-manager can manage resources in those namespaces.
+	// This field can only be set for resources of kind "Extension".
+	// +optional
+	// +listType=atomic
+	AdditionalShootTargetNamespaces []string `json:"additionalShootTargetNamespaces,omitempty" protobuf:"bytes,10,rep,name=additionalShootTargetNamespaces"`
 }
 
 // DeploymentRef contains information about `ControllerDeployment` references.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3501,6 +3501,7 @@ func autoConvert_v1beta1_ControllerResource_To_core_ControllerResource(in *Contr
 	out.WorkerlessSupported = (*bool)(unsafe.Pointer(in.WorkerlessSupported))
 	out.AutoEnable = *(*[]core.ClusterType)(unsafe.Pointer(&in.AutoEnable))
 	out.ClusterCompatibility = *(*[]core.ClusterType)(unsafe.Pointer(&in.ClusterCompatibility))
+	out.AdditionalShootTargetNamespaces = *(*[]string)(unsafe.Pointer(&in.AdditionalShootTargetNamespaces))
 	return nil
 }
 
@@ -3518,6 +3519,7 @@ func autoConvert_core_ControllerResource_To_v1beta1_ControllerResource(in *core.
 	out.WorkerlessSupported = (*bool)(unsafe.Pointer(in.WorkerlessSupported))
 	out.AutoEnable = *(*[]ClusterType)(unsafe.Pointer(&in.AutoEnable))
 	out.ClusterCompatibility = *(*[]ClusterType)(unsafe.Pointer(&in.ClusterCompatibility))
+	out.AdditionalShootTargetNamespaces = *(*[]string)(unsafe.Pointer(&in.AdditionalShootTargetNamespaces))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1584,6 +1584,11 @@ func (in *ControllerResource) DeepCopyInto(out *ControllerResource) {
 		*out = make([]ClusterType, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalShootTargetNamespaces != nil {
+		in, out := &in.AdditionalShootTargetNamespaces, &out.AdditionalShootTargetNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1591,6 +1591,11 @@ func (in *ControllerResource) DeepCopyInto(out *ControllerResource) {
 		*out = make([]ClusterType, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalShootTargetNamespaces != nil {
+		in, out := &in.AdditionalShootTargetNamespaces, &out.AdditionalShootTargetNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -3385,6 +3385,26 @@ func schema_pkg_apis_core_v1beta1_ControllerResource(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"additionalShootTargetNamespaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalShootTargetNamespaces specifies additional namespaces in the shoot cluster that the shoot gardener-resource-manager should watch when this extension is active on a shoot. These namespaces are merged with the default target namespaces (kube-system, kubernetes-dashboard, kube-node-lease). Extensions that deploy ManagedResources targeting custom namespaces on shoots must declare them here so the gardener-resource-manager can manage resources in those namespaces. This field can only be set for resources of kind \"Extension\".",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"kind", "type"},
 			},

--- a/pkg/gardenlet/operation/botanist/botanist.go
+++ b/pkg/gardenlet/operation/botanist/botanist.go
@@ -133,6 +133,9 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := b.collectAdditionalGRMTargetNamespaces(ctx); err != nil {
+		return nil, err
+	}
 	o.Shoot.Components.ControlPlane.ResourceManager, err = b.DefaultResourceManager()
 	if err != nil {
 		return nil, err

--- a/pkg/gardenlet/operation/botanist/collect_grm_namespaces_test.go
+++ b/pkg/gardenlet/operation/botanist/collect_grm_namespaces_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package botanist
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/gardenlet/operation"
+	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
+)
+
+var _ = Describe("collectAdditionalGRMTargetNamespaces", func() {
+	var (
+		ctx        context.Context
+		b          *Botanist
+		fakeClient client.Client
+		s          *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		b = &Botanist{Operation: &operation.Operation{}}
+		b.Shoot = &shootpkg.Shoot{}
+
+		s = runtime.NewScheme()
+		Expect(gardencorev1beta1.AddToScheme(s)).To(Succeed())
+	})
+
+	It("should return empty when no ControllerRegistrations exist", func() {
+		fakeClient = fake.NewClientBuilder().WithScheme(s).Build()
+		b.GardenClient = fakeClient
+
+		Expect(b.collectAdditionalGRMTargetNamespaces(ctx)).To(Succeed())
+		Expect(b.Shoot.AdditionalGRMTargetNamespaces).To(BeEmpty())
+	})
+
+	It("should collect namespaces from Extension resources only", func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(
+				&gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-with-namespaces"},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Resources: []gardencorev1beta1.ControllerResource{
+							{
+								Kind:                            extensionsv1alpha1.ExtensionResource,
+								Type:                            "my-extension",
+								AdditionalShootTargetNamespaces: []string{"custom-namespace", "another-ns"},
+							},
+						},
+					},
+				},
+				&gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{Name: "infra-with-namespaces"},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Resources: []gardencorev1beta1.ControllerResource{
+							{
+								Kind:                            extensionsv1alpha1.InfrastructureResource,
+								Type:                            "my-infra",
+								AdditionalShootTargetNamespaces: []string{"should-be-ignored"},
+							},
+						},
+					},
+				},
+			).
+			Build()
+		b.GardenClient = fakeClient
+
+		Expect(b.collectAdditionalGRMTargetNamespaces(ctx)).To(Succeed())
+		Expect(b.Shoot.AdditionalGRMTargetNamespaces).To(Equal([]string{"another-ns", "custom-namespace"}))
+	})
+
+	It("should merge and deduplicate namespaces from multiple ControllerRegistrations", func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(
+				&gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-a"},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Resources: []gardencorev1beta1.ControllerResource{
+							{
+								Kind:                            extensionsv1alpha1.ExtensionResource,
+								Type:                            "ext-a",
+								AdditionalShootTargetNamespaces: []string{"shared-ns", "ns-a"},
+							},
+						},
+					},
+				},
+				&gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-b"},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Resources: []gardencorev1beta1.ControllerResource{
+							{
+								Kind:                            extensionsv1alpha1.ExtensionResource,
+								Type:                            "ext-b",
+								AdditionalShootTargetNamespaces: []string{"shared-ns", "ns-b"},
+							},
+						},
+					},
+				},
+			).
+			Build()
+		b.GardenClient = fakeClient
+
+		Expect(b.collectAdditionalGRMTargetNamespaces(ctx)).To(Succeed())
+		Expect(b.Shoot.AdditionalGRMTargetNamespaces).To(Equal([]string{"ns-a", "ns-b", "shared-ns"}))
+	})
+
+	It("should skip resources without AdditionalShootTargetNamespaces", func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(
+				&gardencorev1beta1.ControllerRegistration{
+					ObjectMeta: metav1.ObjectMeta{Name: "ext-no-ns"},
+					Spec: gardencorev1beta1.ControllerRegistrationSpec{
+						Resources: []gardencorev1beta1.ControllerResource{
+							{
+								Kind: extensionsv1alpha1.ExtensionResource,
+								Type: "plain-ext",
+							},
+						},
+					},
+				},
+			).
+			Build()
+		b.GardenClient = fakeClient
+
+		Expect(b.collectAdditionalGRMTargetNamespaces(ctx)).To(Succeed())
+		Expect(b.Shoot.AdditionalGRMTargetNamespaces).To(BeEmpty())
+	})
+})

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -6,15 +6,19 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/gardener/resourcemanager"
 	"github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/features"
@@ -55,8 +59,12 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 			SchedulingProfile:                   v1beta1helper.ShootSchedulingProfile(b.Shoot.GetInfo()),
 			SecretNameServerCA:                  v1beta1constants.SecretNameCACluster,
 			SystemComponentTolerations:          gardenerutils.ExtractSystemComponentsTolerations(b.Shoot.GetInfo().Spec.Provider.Workers),
-			TargetNamespaces:                    []string{metav1.NamespaceSystem, v1beta1constants.KubernetesDashboardNamespace, corev1.NamespaceNodeLease},
-			TopologyAwareRoutingEnabled:         b.Shoot.TopologyAwareRoutingEnabled,
+			TargetNamespaces: sets.List(sets.New(
+				metav1.NamespaceSystem,
+				v1beta1constants.KubernetesDashboardNamespace,
+				corev1.NamespaceNodeLease,
+			).Insert(b.Shoot.AdditionalGRMTargetNamespaces...)),
+			TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
 			// TODO(vitanovs): Remove the VPAInPlaceUpdates webhook once the
 			// VPAInPlaceUpdates feature gates is deprecated.
 			VPAInPlaceUpdatesEnabled: features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates),
@@ -102,4 +110,26 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment
 func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
 	return kubernetesutils.ScaleDeployment(ctx, b.SeedClientSet.Client(), client.ObjectKey{Namespace: b.Shoot.ControlPlaneNamespace, Name: v1beta1constants.DeploymentNameGardenerResourceManager}, 1)
+}
+
+// collectAdditionalGRMTargetNamespaces lists all ControllerRegistrations and collects any
+// AdditionalShootTargetNamespaces declared by Extension resources. These are stored on the Shoot
+// struct so that DefaultResourceManager can merge them with the default target namespaces.
+func (b *Botanist) collectAdditionalGRMTargetNamespaces(ctx context.Context) error {
+	controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
+	if err := b.GardenClient.List(ctx, controllerRegistrationList); err != nil {
+		return fmt.Errorf("failed to list controller registrations: %w", err)
+	}
+
+	additionalNamespaces := sets.New[string]()
+	for _, cr := range controllerRegistrationList.Items {
+		for _, resource := range cr.Spec.Resources {
+			if resource.Kind == extensionsv1alpha1.ExtensionResource && len(resource.AdditionalShootTargetNamespaces) > 0 {
+				additionalNamespaces.Insert(resource.AdditionalShootTargetNamespaces...)
+			}
+		}
+	}
+
+	b.Shoot.AdditionalGRMTargetNamespaces = sets.List(additionalNamespaces)
+	return nil
 }

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -90,6 +90,49 @@ var _ = Describe("ResourceManager", func() {
 			Expect(resourceManager.GetValues().MachineNamespace).To(HaveValue(Equal("shoot--foo--bar")))
 		})
 
+		It("should use default target namespaces when no additional namespaces are configured", func() {
+			resourceManager, err := botanist.DefaultResourceManager()
+			Expect(resourceManager).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resourceManager.GetValues().TargetNamespaces).To(Equal([]string{
+				corev1.NamespaceNodeLease,
+				metav1.NamespaceSystem,
+				v1beta1constants.KubernetesDashboardNamespace,
+			}))
+		})
+
+		It("should merge additional GRM target namespaces with defaults", func() {
+			botanist.Shoot.AdditionalGRMTargetNamespaces = []string{"custom-namespace", "custom-ns"}
+
+			resourceManager, err := botanist.DefaultResourceManager()
+			Expect(resourceManager).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resourceManager.GetValues().TargetNamespaces).To(Equal([]string{
+				"custom-namespace",
+				"custom-ns",
+				corev1.NamespaceNodeLease,
+				metav1.NamespaceSystem,
+				v1beta1constants.KubernetesDashboardNamespace,
+			}))
+		})
+
+		It("should deduplicate additional GRM target namespaces that overlap with defaults", func() {
+			botanist.Shoot.AdditionalGRMTargetNamespaces = []string{"kube-system", "custom-namespace"}
+
+			resourceManager, err := botanist.DefaultResourceManager()
+			Expect(resourceManager).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resourceManager.GetValues().TargetNamespaces).To(Equal([]string{
+				"custom-namespace",
+				corev1.NamespaceNodeLease,
+				metav1.NamespaceSystem,
+				v1beta1constants.KubernetesDashboardNamespace,
+			}))
+		})
+
 		It("should consider node toleration configuration", func() {
 			notReadyTolerationSeconds := ptr.To[int64](60)
 			unreachableTolerationSeconds := ptr.To[int64](120)

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -108,6 +108,9 @@ type Shoot struct {
 	ResourcesToEncrypt                      []string
 	EncryptedResources                      []string
 	ServiceAccountIssuerHostname            *string
+	// AdditionalGRMTargetNamespaces contains additional namespaces for the shoot gardener-resource-manager,
+	// collected from active ControllerRegistrations.
+	AdditionalGRMTargetNamespaces []string
 
 	Components *Components
 }


### PR DESCRIPTION
/area control-plane
/kind api-change

**What this PR does / why we need it**:

Adds `AdditionalShootTargetNamespaces` to `ControllerResource` in the `ControllerRegistration` API. This allows extensions to declaratively specify additional namespaces that the shoot gardener-resource-manager (GRM) should watch.

Currently, the shoot GRM only watches three hardcoded namespaces (`kube-system`, `kubernetes-dashboard`, `kube-node-lease`). Extensions that deploy `ManagedResources` targeting custom namespaces on shoots have no supported way to make the GRM watch those namespaces. This forces extensions to use fragile workarounds (e.g., mutating the GRM ConfigMap via webhooks and restarting the GRM) that disrupt all ManagedResources on the shoot.

With this change, gardenlet collects `AdditionalShootTargetNamespaces` from all `ControllerRegistration` resources and merges them with the default namespace list when deploying the shoot GRM. This follows the exact pattern established in #13761 for the virtual garden GRM.

Memory impact is proportional to the number of resources in each additional namespace, not the namespace count itself. Adding 1-2 specific namespaces is negligible compared to the "all namespaces" scenario from #7473 (3.5 GiB). Future optimization of the GRM's per-namespace cache strategy (e.g., GVK-restricted or metadata-only informers for additional namespaces) could be pursued independently if the number of additional namespaces grows significantly.

**Which issue(s) this PR fixes**:
Fixes #14427

**Special notes for your reviewer**:

- This follows the pattern from #13761 (`AdditionalTargetNamespaces` for the virtual garden GRM)
- The field is restricted to `kind == "Extension"` resources, consistent with other Extension-only fields (`AutoEnable`, `ClusterCompatibility`, `Lifecycle`, `ReconcileTimeout`)
- Gardenlet collects namespaces from all ControllerRegistrations (not filtered per-shoot) — extra namespaces from inactive extensions are harmless (empty watch, negligible overhead)
- Validation enforces: valid DNS labels, no duplicates, cannot include default namespaces

cc @rfranzke @dnaeon

**Release note**:
```feature operator
Extensions can now declare additional namespaces for the shoot gardener-resource-manager via `AdditionalShootTargetNamespaces` in `ControllerRegistration.Spec.Resources[]`. The gardenlet merges these with the default target namespaces when deploying the shoot GRM.
```