### PR TITLE
It avoids adding unnecessary webhooks in the virtual garden to workerless shoots

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1367,7 +1367,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 
 		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
-	
+
 	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1356,8 +1356,16 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
-		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
+	if r.values.SystemComponentsConfigWebhookEnabled && !r.values.IsWorkerless {
+		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
+		if r.values.ResponsibilityMode == ForRuntime {
+			if systemComponentsNamespaceSelector.MatchLabels == nil {
+				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
+			}
+			systemComponentsNamespaceSelector.MatchLabels[resourcesv1alpha1.SystemComponentsConfigConsider] = "true"
+		}
+
+		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
 	if r.values.EndpointSliceHintsEnabled {

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1327,46 +1327,44 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 		}
 	}
 
-	webhooks := []admissionregistrationv1.MutatingWebhook{
-		r.newProjectedTokenMountMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn),
+	var webhooks []admissionregistrationv1.MutatingWebhook
+
+	if !r.values.IsWorkerless {
+		webhooks = append(webhooks, r.newProjectedTokenMountMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.HighAvailabilityConfigWebhookEnabled {
+	if r.values.HighAvailabilityConfigWebhookEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewHighAvailabilityConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.SchedulingProfile != nil && *r.values.SchedulingProfile == gardencorev1beta1.SchedulingProfileBinPacking {
+	if r.values.SchedulingProfile != nil && *r.values.SchedulingProfile == gardencorev1beta1.SchedulingProfileBinPacking && !r.values.IsWorkerless {
 		// pod scheduler name webhook should be active on all namespaces
 		webhooks = append(webhooks, NewPodSchedulerNameMutatingWebhook(&metav1.LabelSelector{}, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.DefaultSeccompProfileEnabled {
+	if r.values.DefaultSeccompProfileEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewSeccompProfileMutatingWebhook(r.values.NamePrefix, namespaceSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.KubernetesServiceHost != nil {
+	if r.values.KubernetesServiceHost != nil && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewKubernetesServiceHostMutatingWebhook(nil, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodKubeAPIServerLoadBalancingWebhook.Enabled {
+	if r.values.PodKubeAPIServerLoadBalancingWebhook.Enabled && !r.values.IsWorkerless {
 		for _, config := range r.values.PodKubeAPIServerLoadBalancingWebhook.Configs {
 			webhooks = append(webhooks, NewPodKubeAPIServerLoadBalancingMutatingWebhook(&metav1.LabelSelector{MatchLabels: config.NamespaceSelector}, config.ObjectSelector, config.KubeAPIServerNamePrefix, secretServerCA, buildClientConfigFn))
 		}
 	}
 
-	if r.values.SystemComponentsConfigWebhookEnabled {
-		systemComponentsNamespaceSelector := namespaceSelector.DeepCopy()
-		if r.values.ResponsibilityMode == ForRuntime {
-			if systemComponentsNamespaceSelector.MatchLabels == nil {
-				systemComponentsNamespaceSelector.MatchLabels = map[string]string{}
-			}
-			systemComponentsNamespaceSelector.MatchLabels[resourcesv1alpha1.SystemComponentsConfigConsider] = "true"
-		}
-
-		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
+	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
+		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
-	if r.values.PodTopologySpreadConstraintsEnabled {
+	if r.values.EndpointSliceHintsEnabled {
+		webhooks = append(webhooks, NewEndpointSliceHintsMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
+	}
+
+	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
 
@@ -2168,6 +2166,8 @@ func disableControllersAndWebhooksForWorkerlessShoot(config *resourcemanagerconf
 	config.Webhooks.HighAvailabilityConfig.Enabled = false
 	config.Webhooks.PodTopologySpreadConstraints.Enabled = false
 	config.Webhooks.KubernetesServiceHost.Enabled = false
+	config.Webhooks.SeccompProfile.Enabled = false
+	config.Webhooks.PodKubeAPIServerLoadBalancing.Enabled = false
 }
 
 func (r *resourceManager) healthPort() int32 {

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -1367,11 +1367,7 @@ func (r *resourceManager) newMutatingWebhookConfigurationWebhooks(
 
 		webhooks = append(webhooks, NewSystemComponentsConfigMutatingWebhook(systemComponentsNamespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}
-
-	if r.values.EndpointSliceHintsEnabled {
-		webhooks = append(webhooks, NewEndpointSliceHintsMutatingWebhook(namespaceSelector, secretServerCA, buildClientConfigFn))
-	}
-
+	
 	if r.values.PodTopologySpreadConstraintsEnabled && !r.values.IsWorkerless {
 		webhooks = append(webhooks, NewPodTopologySpreadConstraintsMutatingWebhook(r.values.NamePrefix, namespaceSelector, objectSelector, secretServerCA, buildClientConfigFn))
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -1278,7 +1278,10 @@ metadata:
     app: gardener-resource-manager
   name: gardener-resource-manager-shoot
   namespace: fake-ns
-webhooks:
+webhooks:`
+
+			if !cfg.IsWorkerless {
+				out += `
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1425,6 +1428,8 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: 2`
+			}
+
 			if cfg.PodKubeAPIServerLoadBalancingWebhook.Enabled {
 				out += `
 - admissionReviewVersions:
@@ -1490,7 +1495,9 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 10`
 			}
-			out += `
+
+			if !cfg.IsWorkerless {
+				out += `
 - admissionReviewVersions:
   - v1beta1
   - v1
@@ -1527,7 +1534,9 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: 10`
-			if matchLabelKeysInPodTopologySpreadFeatureGateDisabled {
+			}
+
+			if matchLabelKeysInPodTopologySpreadFeatureGateDisabled && !cfg.IsWorkerless {
 				out += `
 - admissionReviewVersions:
   - v1beta1
@@ -2480,6 +2489,26 @@ subjects:
 
 				resourceManager = New(fakeClient, deployNamespace, sm, cfg)
 				resourceManager.SetSecrets(secrets)
+
+				compressedData, err := test.BrotliCompressionForManifests(mutatingWebhookConfigurationYAML(), clusterRoleBindingTargetYAML)
+				Expect(err).NotTo(HaveOccurred())
+
+				managedResourceSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "managedresource-shoot-core-gardener-resource-manager",
+						Namespace: deployNamespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"data.yaml.br": compressedData,
+					},
+				}
+				utilruntime.Must(kubernetesutils.MakeUnique(managedResourceSecret))
+
+				managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{
+					{Name: managedResourceSecret.Name},
+				}
+				utilruntime.Must(references.InjectAnnotations(managedResource))
 			})
 
 			It("should disable controllers and webhooks properly in resource manager configuration", func() {


### PR DESCRIPTION
**How to categorize this PR?**
/good first issue
/kind enhancement

**What this PR does / why we need it**:

The gardener-resource-manager adds unnecessary webhooks in a workeless cluster 
There is an isWorkerLess field(boolean) in the Values struct in the resource-manager which can be used to keep a check on whether the Cluster(Shoot) is Wokerless or no and accordingly add the webhooks in the webhooks list.

Test helper function inside resource_manager_test.go statically generates its expected list and unconditionally expects projected-token-mount and the other disabled webhooks to be there without checking if the cluster is workerless or not so I have also modified the test to check if the shoot is workerless or no

**Which issue(s) this PR fixes**:
Fixes #13289

**Special notes for your reviewer**:
- Injected `!r.values.IsWorkerless` conditional checks into 8 webhook configs within `newMutatingWebhookConfigurationWebhooks`.
- Updated test expectations to dynamically pare down the mocked YAML payload based on `cfg.IsWorkerless`, matching real-world target behavior without throwing hash checksum mismatches during tests. 

**Release note**:
```other operator
NONE