### PR TITLE
Expose CA flag `max-binpacking-time`

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -2201,6 +2201,18 @@ boolean
 <p>EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>maxBinpackingTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#duration-v1-meta">Duration</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up.<br />If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -329,6 +329,7 @@ spec:
   #   expander: "priority,least-waste" # see: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/FAQ.md#what-are-expanders
   #   maxGracefulTerminationSeconds: 600
   #   maxNodeProvisionTime: 20m
+  #   maxBinpackingTime: 5m
   #   initialNodeGroupBackoffDuration: 5m
   #   maxNodeGroupBackoffDuration: 30m
   #   nodeGroupBackoffResetTimeout: 3h

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1580,6 +1580,8 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxNodeGroupBackoffDuration, fldPath.Child("maxNodeGroupBackoffDuration"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.NodeGroupBackoffResetTimeout, fldPath.Child("nodeGroupBackoffResetTimeout"))...)
 
+	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxBinpackingTime, fldPath.Child("maxBinpackingTime"))...)
+
 	return allErrs
 }
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -1579,7 +1579,6 @@ func ValidateClusterAutoscaler(autoScaler core.ClusterAutoscaler, kubernetesVers
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.InitialNodeGroupBackoffDuration, fldPath.Child("initialNodeGroupBackoffDuration"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxNodeGroupBackoffDuration, fldPath.Child("maxNodeGroupBackoffDuration"))...)
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.NodeGroupBackoffResetTimeout, fldPath.Child("nodeGroupBackoffResetTimeout"))...)
-
 	allErrs = append(allErrs, ValidatePositiveDuration(autoScaler.MaxBinpackingTime, fldPath.Child("maxBinpackingTime"))...)
 
 	return allErrs

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -4437,6 +4437,16 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field":  Equal("nodeGroupBackoffResetTimeout"),
 					"Detail": Equal("must be non-negative"),
 				})))),
+				Entry("valid with maxBinpackingTime", core.ClusterAutoscaler{
+					MaxBinpackingTime: &metav1.Duration{Duration: time.Minute},
+				}, version_1_32, BeEmpty()),
+				Entry("invalid with negative maxBinpackingTime", core.ClusterAutoscaler{
+					MaxBinpackingTime: &negativeDuration,
+				}, version_1_32, ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("maxBinpackingTime"),
+					"Detail": Equal("must be non-negative"),
+				})))),
 			)
 
 			Describe("taint validation", func() {

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -610,6 +610,9 @@ type ClusterAutoscaler struct {
 	IgnoreDaemonsetsUtilization *bool
 	// EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
 	EmitPerNodeGroupMetrics *bool
+	// MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up.
+	// If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).
+	MaxBinpackingTime *metav1.Duration
 	// Verbosity allows CA to modify its log level.
 	Verbosity *int32
 }

--- a/pkg/apis/core/v1beta1/defaults_shoot.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot.go
@@ -427,6 +427,9 @@ func SetDefaults_ClusterAutoscaler(obj *ClusterAutoscaler) {
 	if obj.NodeGroupBackoffResetTimeout == nil {
 		obj.NodeGroupBackoffResetTimeout = &metav1.Duration{Duration: 3 * time.Hour}
 	}
+	if obj.MaxBinpackingTime == nil {
+		obj.MaxBinpackingTime = &metav1.Duration{Duration: 5 * time.Minute}
+	}
 }
 
 // SetDefaults_NginxIngress sets default values for NginxIngress objects.

--- a/pkg/apis/core/v1beta1/defaults_shoot_test.go
+++ b/pkg/apis/core/v1beta1/defaults_shoot_test.go
@@ -1071,6 +1071,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.InitialNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 30 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NodeGroupBackoffResetTimeout).To(PointTo(Equal(metav1.Duration{Duration: 3 * time.Hour})))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxBinpackingTime).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 		})
 
 		It("should not overwrite the already set values for ClusterAutoscaler field", func() {
@@ -1094,6 +1095,7 @@ var _ = Describe("Shoot defaulting", func() {
 				InitialNodeGroupBackoffDuration: &metav1.Duration{Duration: 10 * time.Minute},
 				MaxNodeGroupBackoffDuration:     &metav1.Duration{Duration: 20 * time.Minute},
 				NodeGroupBackoffResetTimeout:    &metav1.Duration{Duration: 1 * time.Hour},
+				MaxBinpackingTime:               &metav1.Duration{Duration: 10 * time.Minute},
 			}
 
 			SetObjectDefaults_Shoot(obj)
@@ -1117,6 +1119,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.InitialNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 20 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NodeGroupBackoffResetTimeout).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxBinpackingTime).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
 		})
 
 		It("should sync MaxScaleDownParallelism value with MaxEmptyBulkDelete when the latter is set and the former is not", func() {
@@ -1162,6 +1165,7 @@ var _ = Describe("Shoot defaulting", func() {
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.InitialNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxNodeGroupBackoffDuration).To(PointTo(Equal(metav1.Duration{Duration: 20 * time.Minute})))
 			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.NodeGroupBackoffResetTimeout).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
+			Expect(obj.Spec.Kubernetes.ClusterAutoscaler.MaxBinpackingTime).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 		})
 	})
 

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -2215,6 +2215,20 @@ func (m *ClusterAutoscaler) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.MaxBinpackingTime != nil {
+		{
+			size, err := m.MaxBinpackingTime.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintGenerated(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xba
+	}
 	if m.EmitPerNodeGroupMetrics != nil {
 		i--
 		if *m.EmitPerNodeGroupMetrics {
@@ -14300,6 +14314,10 @@ func (m *ClusterAutoscaler) Size() (n int) {
 	if m.EmitPerNodeGroupMetrics != nil {
 		n += 3
 	}
+	if m.MaxBinpackingTime != nil {
+		l = m.MaxBinpackingTime.Size()
+		n += 2 + l + sovGenerated(uint64(l))
+	}
 	return n
 }
 
@@ -18953,6 +18971,7 @@ func (this *ClusterAutoscaler) String() string {
 		`MaxNodeGroupBackoffDuration:` + strings.Replace(fmt.Sprintf("%v", this.MaxNodeGroupBackoffDuration), "Duration", "v11.Duration", 1) + `,`,
 		`NodeGroupBackoffResetTimeout:` + strings.Replace(fmt.Sprintf("%v", this.NodeGroupBackoffResetTimeout), "Duration", "v11.Duration", 1) + `,`,
 		`EmitPerNodeGroupMetrics:` + valueToStringGenerated(this.EmitPerNodeGroupMetrics) + `,`,
+		`MaxBinpackingTime:` + strings.Replace(fmt.Sprintf("%v", this.MaxBinpackingTime), "Duration", "v11.Duration", 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -27460,6 +27479,42 @@ func (m *ClusterAutoscaler) Unmarshal(dAtA []byte) error {
 			}
 			b := bool(v != 0)
 			m.EmitPerNodeGroupMetrics = &b
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxBinpackingTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MaxBinpackingTime == nil {
+				m.MaxBinpackingTime = &v11.Duration{}
+			}
+			if err := m.MaxBinpackingTime.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -608,6 +608,11 @@ message ClusterAutoscaler {
   // EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
   // +optional
   optional bool emitPerNodeGroupMetrics = 22;
+
+  // MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up.
+  // If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).
+  // +optional
+  optional .k8s.io.apimachinery.pkg.apis.meta.v1.Duration maxBinpackingTime = 23;
 }
 
 // ClusterAutoscalerOptions contains the cluster autoscaler configurations for a worker pool.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -778,6 +778,10 @@ type ClusterAutoscaler struct {
 	// EmitPerNodeGroupMetrics emits additional per node group metrics (default: false).
 	// +optional
 	EmitPerNodeGroupMetrics *bool `json:"emitPerNodeGroupMetrics,omitempty" protobuf:"varint,22,opt,name=emitPerNodeGroupMetrics"`
+	// MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up.
+	// If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).
+	// +optional
+	MaxBinpackingTime *metav1.Duration `json:"maxBinpackingTime,omitempty" protobuf:"bytes,23,opt,name=maxBinpackingTime"`
 }
 
 // ExpanderMode is type used for Expander values

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3072,6 +3072,7 @@ func autoConvert_v1beta1_ClusterAutoscaler_To_core_ClusterAutoscaler(in *Cluster
 	out.MaxNodeGroupBackoffDuration = (*metav1.Duration)(unsafe.Pointer(in.MaxNodeGroupBackoffDuration))
 	out.NodeGroupBackoffResetTimeout = (*metav1.Duration)(unsafe.Pointer(in.NodeGroupBackoffResetTimeout))
 	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
+	out.MaxBinpackingTime = (*metav1.Duration)(unsafe.Pointer(in.MaxBinpackingTime))
 	return nil
 }
 
@@ -3102,6 +3103,7 @@ func autoConvert_core_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *core.Cl
 	out.MaxDrainParallelism = (*int32)(unsafe.Pointer(in.MaxDrainParallelism))
 	out.IgnoreDaemonsetsUtilization = (*bool)(unsafe.Pointer(in.IgnoreDaemonsetsUtilization))
 	out.EmitPerNodeGroupMetrics = (*bool)(unsafe.Pointer(in.EmitPerNodeGroupMetrics))
+	out.MaxBinpackingTime = (*metav1.Duration)(unsafe.Pointer(in.MaxBinpackingTime))
 	out.Verbosity = (*int32)(unsafe.Pointer(in.Verbosity))
 	return nil
 }

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1104,6 +1104,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MaxBinpackingTime != nil {
+		in, out := &in.MaxBinpackingTime, &out.MaxBinpackingTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1099,6 +1099,11 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.MaxBinpackingTime != nil {
+		in, out := &in.MaxBinpackingTime, &out.MaxBinpackingTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.Verbosity != nil {
 		in, out := &in.Verbosity, &out.Verbosity
 		*out = new(int32)

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -2632,6 +2632,12 @@ func schema_pkg_apis_core_v1beta1_ClusterAutoscaler(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"maxBinpackingTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxBinpackingTime is the maximum time spent on binpacking for a single scale-up. If binpacking is limited by this, scale-up continues with the already calculated scale-up options (default: 5m).",
+							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -506,6 +506,7 @@ func (c *clusterAutoscaler) computeCommand(workersHavePriorityConfigured bool) [
 		fmt.Sprintf("--new-pod-scale-up-delay=%s", c.config.NewPodScaleUpDelay.Duration),
 		fmt.Sprintf("--max-nodes-total=%d", c.maxNodesTotal),
 		fmt.Sprintf("--emit-per-nodegroup-metrics=%t", *c.config.EmitPerNodeGroupMetrics),
+		fmt.Sprintf("--max-binpacking-time=%s", c.config.MaxBinpackingTime.Duration),
 	)
 
 	for _, taint := range c.config.StartupTaints {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -119,13 +119,13 @@ var _ = Describe("ClusterAutoscaler", func() {
 			},
 		}
 
-		configExpander                            = gardencorev1beta1.ClusterAutoscalerExpanderRandom
-		configMaxGracefulTerminationSeconds int32 = 60 * 60 * 24
-		configMaxNodeProvisionTime                = &metav1.Duration{Duration: time.Second}
-		// add the 3 new config options here
+		configExpander                              = gardencorev1beta1.ClusterAutoscalerExpanderRandom
+		configMaxGracefulTerminationSeconds   int32 = 60 * 60 * 24
+		configMaxNodeProvisionTime                  = &metav1.Duration{Duration: time.Second}
 		configInitialNodeGroupBackoffDuration       = &metav1.Duration{Duration: 10 * time.Minute}
 		configMaxNodeGroupBackoffDuration           = &metav1.Duration{Duration: 20 * time.Minute}
 		configNodeGroupBackoffResetTimeout          = &metav1.Duration{Duration: time.Hour}
+		configMaxBinpackingTime                     = &metav1.Duration{Duration: 10 * time.Minute}
 		configScaleDownDelayAfterAdd                = &metav1.Duration{Duration: time.Second}
 		configScaleDownDelayAfterDelete             = &metav1.Duration{Duration: time.Second}
 		configScaleDownDelayAfterFailure            = &metav1.Duration{Duration: time.Second}
@@ -163,6 +163,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			MaxScaleDownParallelism:         configMaxScaleDownParallelism,
 			MaxDrainParallelism:             configMaxDrainParallelism,
 			NewPodScaleUpDelay:              configNewPodScaleUpDelay,
+			MaxBinpackingTime:               configMaxBinpackingTime,
 		}
 
 		genericTokenKubeconfigSecretName = "generic-token-kubeconfig"
@@ -329,6 +330,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					"--new-pod-scale-up-delay=0s",
 					"--max-nodes-total=0",
 					"--emit-per-nodegroup-metrics=false",
+					"--max-binpacking-time=5m0s",
 				)
 			} else {
 				commandConfigFlags = append(commandConfigFlags,
@@ -351,6 +353,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					fmt.Sprintf("--new-pod-scale-up-delay=%s", configNewPodScaleUpDelay.Duration),
 					"--max-nodes-total=0",
 					fmt.Sprintf("--emit-per-nodegroup-metrics=%t", configEmitPerNodeGroupMetrics),
+					fmt.Sprintf("--max-binpacking-time=%s", configMaxBinpackingTime.Duration),
 					fmt.Sprintf("--startup-taint=%s", configTaints[0]),
 					fmt.Sprintf("--startup-taint=%s", configTaints[1]),
 					fmt.Sprintf("--status-taint=%s", configTaints[0]),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement api-change

**What this PR does / why we need it**:
This PR updated the shoot API to add a new field: `.spec.kubernetes.clusterAutoscaler.maxBinpackingTime`

This field is to be passed on to cluster-autoscaler as a configurable flag and is meant to help users who wish to increase their `BinpackingTime` to allow for longer time to be spent on binpacking for a single scale-up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `Shoot` API now supports configuring `cluster-autoscaler`'s `maxBinpackingTime` flag for specifying a longer duration to be spent on binpacking for scale-up.
```
