### PR TITLE
Fix guestbook test for IPv6 clusters

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"path/filepath"
 	"slices"
@@ -200,7 +201,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 func (t *GuestBookTest) Test(ctx context.Context) {
 	shoot := t.framework.Shoot
 	// define guestbook app urls
-	guestBookAppURL := "http://" + t.guestBookAppHost
+	guestBookAppURL := "http://" + net.JoinHostPort(t.guestBookAppHost, "80")
 	pushString := "foobar-" + shoot.Name
 	pushURL := fmt.Sprintf("%s/rpush/guestbook/%s", guestBookAppURL, pushString)
 	pullURL := fmt.Sprintf("%s/lrange/guestbook", guestBookAppURL)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes the guestbook test for clusters that use IPv6 and run on cloud providers that expose the IP instead of the hostname in external LoadBalancers' status, e.g for GCP:
```
status:
  loadBalancer:
    ingress:
    - ip: 2600:1900:4010:26b:8000:4:0:0
```

Previously the guestbook test tried to reach this via `http://2600:1900:4010:26b:8000:4:0:0:80` whereas the correct format is to use square brackets - `http://[2600:1900:4010:26b:8000:4:0:0]:80` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the guestbook TM test to fail against IPv6 Shoot clusters in now fixed.
```
