### PR TITLE
Fix Shoot deletion getting stuck when `ControlPlane` was never created

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -1150,15 +1150,13 @@ func lastErrorsOperationInitializationFailure(lastErrors []gardencorev1beta1.Las
 	return lastErrors
 }
 
-func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, kubeAPIServerDeploymentFound bool, infrastructure *extensionsv1alpha1.Infrastructure) (bool, error) {
+func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, infrastructure *extensionsv1alpha1.Infrastructure) (bool, error) {
 	var (
 		namespace = o.Shoot.ControlPlaneNamespace
 		name      = o.Shoot.GetInfo().Name
 	)
 
-	// If the `ControlPlane` resource and the kube-apiserver deployment do no longer exist then we don't want to re-deploy it.
-	// The reason for the second condition is that some providers inject a cloud-provider-config into the kube-apiserver deployment
-	// which is needed for it to run.
+	// If the `ControlPlane` resource no longer exist then we don't want to re-deploy it.
 	exists, markedForDeletion, err := extensionResourceStillExists(ctx, o.SeedClientSet.APIReader(), &extensionsv1alpha1.ControlPlane{}, namespace, name)
 	if err != nil {
 		return false, err
@@ -1168,7 +1166,7 @@ func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, ku
 	// treat `ControlPlane` in deletion as if it is already gone. If it is marked for deletion, we also shouldn't wait
 	// for it to be reconciled, as it can potentially block the whole deletion flow (deletion depends on other control
 	// plane components like kcm and grm) which are scaled up later in the flow
-	case !exists && !kubeAPIServerDeploymentFound || markedForDeletion:
+	case !exists || markedForDeletion:
 		return false, nil
 	// The infrastructure resource has not been found, no need to redeploy the control plane
 	case infrastructure == nil:

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -124,7 +124,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			return nil
 		}),
 		errors.ToExecute("Check whether control plane deployment is needed", func() error {
-			controlPlaneDeploymentNeeded, err = needsControlPlaneDeployment(ctx, o, kubeAPIServerDeploymentFound, infrastructure)
+			controlPlaneDeploymentNeeded, err = needsControlPlaneDeployment(ctx, o, infrastructure)
 			return err
 		}),
 	)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
During Shoot deletion, `needsControlPlaneDeployment` could incorrectly decide to create a brand-new `ControlPlane` extension resource that never existed before. This happened when deletion was triggered while
  Shoot creation was still in progress, specifically after the kube-apiserver Deployment was created but before the `ControlPlane` resource was deployed.

  The root cause was the condition `!exists && !kubeAPIServerDeploymentFound` in the switch statement: when the `ControlPlane` didn't exist but the kube-apiserver Deployment was found, the function fell through to
  create the `ControlPlane`. The newly created `ControlPlane` could never be reconciled because required resources (like shoot access secrets) didn't exist, permanently blocking Shoot deletion.

  This fix simplifies the condition to `!exists` — if the `ControlPlane` resource doesn't exist during deletion, it should never be created. This is safe because:
  - If it was never created (deletion during incomplete creation), no CCM-managed cloud resources need cleanup
  - If it was already destroyed by a previous deletion attempt, that happens after the cleanup sync point, meaning cloud resource cleanup has already been completed.



**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14675

**Special notes for your reviewer**:
/cc @rfranzke @oliver-goetz @shafeeqes 

Regarding the concern mentioned in https://github.com/gardener/gardener/pull/8162#pullrequestreview-1500236005.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug where Shoot deletion could get permanently stuck if triggered while Shoot creation was still in progress. The delete flow incorrectly created a new `ControlPlane` extension resource that could never be reconciled due to missing shoot access secrets.
```
