### PR TITLE
Clean up the "ratcheting" validation for the `eventTTL` fields

### DIFF
--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -119,10 +119,6 @@ func GetKubeAPIServerWarnings(kubeAPIServer *core.KubeAPIServerConfig, fldPath *
 	if kubeAPIServer.WatchCacheSizes != nil && kubeAPIServer.WatchCacheSizes.Default != nil {
 		warnings = append(warnings, fmt.Sprintf("you are setting the %s field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.", fldPath.Child("watchCacheSizes", "default").String()))
 	}
-	// TODO(ialidzhikov): Remove this in Gardener v1.142.0 when invalid event ttl values for existing Shoots are no longer accepted.
-	if kubeAPIServer.EventTTL != nil && kubeAPIServer.EventTTL.Duration > time.Hour*24 {
-		warnings = append(warnings, fmt.Sprintf("you are setting the %s field to an invalid value. Invalid value: '%s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825", fldPath.Child("eventTTL").String(), kubeAPIServer.EventTTL.Duration))
-	}
 
 	return warnings
 }

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -398,30 +398,6 @@ var _ = Describe("Warnings", func() {
 			),
 		)
 
-		DescribeTable("spec.kubernetes.kubeAPIServer.eventTTL",
-			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
-				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
-			},
-
-			Entry("should not return a warning when kubeAPIServerConfig is nil",
-				nil,
-				BeEmpty(),
-			),
-			Entry("should not return a warning when eventTTL is nil",
-				&core.KubeAPIServerConfig{EventTTL: nil},
-				BeEmpty(),
-			),
-			Entry("should not return a warning for valid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}},
-				BeEmpty(),
-			),
-			Entry("should return a warning for invalid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
-				ContainElement(Equal("you are setting the spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
-			),
-		)
-
 		DescribeTable("spec.dns.providers[].secretName",
 			func(dns *core.DNS, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.DNS = dns
@@ -486,29 +462,6 @@ var _ = Describe("Warnings", func() {
 			Entry("should return a warning when watchCacheSizes.default is set",
 				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: ptr.To[int32](50)}},
 				ContainElement(Equal("you are setting the kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
-			),
-		)
-
-		DescribeTable("eventTTL",
-			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
-				Expect(GetKubeAPIServerWarnings(kubeAPIServerConfig, field.NewPath("kubeAPIServer"))).To(matcher)
-			},
-
-			Entry("should not return a warning when kubeAPIServerConfig is nil",
-				nil,
-				BeEmpty(),
-			),
-			Entry("should not return a warning when eventTTL is nil",
-				&core.KubeAPIServerConfig{EventTTL: nil},
-				BeEmpty(),
-			),
-			Entry("should not return a warning for valid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}},
-				BeEmpty(),
-			),
-			Entry("should return a warning for invalid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
-				ContainElement(Equal("you are setting the kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
 	})

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -179,10 +179,6 @@ type shootValidationOptions struct {
 type KubeAPIServerValidationOptions struct {
 	// AllowInvalidAcceptedIssuers specifies whether invalid accepted issuers are allowed.
 	AllowInvalidAcceptedIssuers bool
-	// AllowInvalidEventTTL specifies whether invalid event ttl is allowed.
-	//
-	// TODO(ialidzhikov): Stop accepting invalid event ttl values for existing Shoots in Gardener v1.142.0.
-	AllowInvalidEventTTL bool
 	// ETCDEncryptionConfigValidationOptions are validation options for the encryption configuration fields.
 	ETCDEncryptionConfigValidationOptions ETCDEncryptionConfigValidationOptions
 }
@@ -205,7 +201,6 @@ func ValidateShoot(shoot *core.Shoot) field.ErrorList {
 	opts := shootValidationOptions{
 		KubeAPIServerValidationOptions: KubeAPIServerValidationOptions{
 			AllowInvalidAcceptedIssuers: false,
-			AllowInvalidEventTTL:        false,
 			ETCDEncryptionConfigValidationOptions: ETCDEncryptionConfigValidationOptions{
 				AutoRotationEnabled: helper.IsETCDEncryptionKeyAutoRotationEnabled(shoot.Spec.Maintenance),
 			},
@@ -239,8 +234,6 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 			AllowInvalidAcceptedIssuers: oldShoot.Spec.Kubernetes.KubeAPIServer != nil && newShoot.Spec.Kubernetes.KubeAPIServer != nil &&
 				oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 				apiequality.Semantic.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
-			AllowInvalidEventTTL: oldShoot.Spec.Kubernetes.KubeAPIServer != nil && newShoot.Spec.Kubernetes.KubeAPIServer != nil &&
-				apiequality.Semantic.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.EventTTL, newShoot.Spec.Kubernetes.KubeAPIServer.EventTTL),
 			ETCDEncryptionConfigValidationOptions: ETCDEncryptionConfigValidationOptions{
 				AutoRotationEnabled: helper.IsETCDEncryptionKeyAutoRotationEnabled(newShoot.Spec.Maintenance),
 			},
@@ -1855,7 +1848,7 @@ func ValidateKubeAPIServer(kubeAPIServer *core.KubeAPIServerConfig, kubernetesVe
 		}
 	}
 
-	if kubeAPIServer.EventTTL != nil && !opts.AllowInvalidEventTTL {
+	if kubeAPIServer.EventTTL != nil {
 		if kubeAPIServer.EventTTL.Duration < 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("eventTTL"), *kubeAPIServer.EventTTL, "can not be negative"))
 		}

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -3457,37 +3457,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
-			It("should allow invalid event ttl on shoot update if it is unchanged", func() {
-				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-				newShoot := prepareShootForUpdate(shoot)
-
-				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
-			})
-
-			It("should not allow invalid event ttl on shoot update if it is changed", func() {
-				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-
-				newShoot := prepareShootForUpdate(shoot)
-				newShoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 42}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.kubernetes.kubeAPIServer.eventTTL"),
-					"Detail": Equal("can not be longer than 24h"),
-				}))))
-			})
-
-			It("should allow invalid event ttl to be updated with valid one on shoot update", func() {
-				shoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-
-				newShoot := prepareShootForUpdate(shoot)
-				newShoot.Spec.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24}
-
-				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
-			})
-
 			It("should not allow to specify a negative defaultNotReadyTolerationSeconds", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.DefaultNotReadyTolerationSeconds = ptr.To(int64(-1))
 

--- a/pkg/api/operator/v1alpha1/validation/garden.go
+++ b/pkg/api/operator/v1alpha1/validation/garden.go
@@ -73,7 +73,6 @@ func init() {
 func ValidateGarden(garden *operatorv1alpha1.Garden, extensions []operatorv1alpha1.Extension) field.ErrorList {
 	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
-		AllowInvalidEventTTL:        false,
 		// Skip validation for auto rotation of etcd encryption key, since the rotation cannot be automated for the Garden API.
 		// Unlike Shoots, the Garden resource does not have a maintenance controller
 		// that can automatically trigger key rotations when the rotation period has passed.
@@ -121,8 +120,6 @@ func ValidateGardenUpdate(oldGarden, newGarden *operatorv1alpha1.Garden, extensi
 		AllowInvalidAcceptedIssuers: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
 			oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
-		AllowInvalidEventTTL: oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil && newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer != nil &&
-			apiequality.Semantic.DeepEqual(oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL, newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL),
 		// Skip validation for auto rotation of etcd encryption key, since the rotation cannot be automated for the Garden API.
 		// Unlike Shoots, the Garden resource does not have a maintenance controller
 		// that can automatically trigger key rotations when the rotation period has passed.

--- a/pkg/api/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/api/operator/v1alpha1/validation/garden_test.go
@@ -3407,32 +3407,6 @@ var _ = Describe("Validation Tests", func() {
 
 					Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(BeEmpty())
 				})
-
-				It("should allow invalid event ttl on update if it is unchanged", func() {
-					oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-					newGarden := oldGarden.DeepCopy()
-
-					Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(BeEmpty())
-				})
-
-				It("should not allow invalid event ttl on update if it is changed", func() {
-					oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-					newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 42}
-
-					errorList := ValidateGardenUpdate(oldGarden, newGarden, extensions)
-					Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL"),
-						"Detail": Equal("can not be longer than 24h"),
-					}))))
-				})
-
-				It("should allow invalid event ttl to be updated with valid ones", func() {
-					oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24 * 10}
-					newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EventTTL = &metav1.Duration{Duration: time.Hour * 24}
-
-					Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(BeEmpty())
-				})
 			})
 		})
 	})

--- a/pkg/api/seedmanagement/managedseedset/warnings_test.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings_test.go
@@ -5,12 +5,9 @@
 package managedseedset_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/api/seedmanagement/managedseedset"
@@ -67,30 +64,6 @@ var _ = Describe("Warnings", func() {
 			Entry("should return a warning when watchCacheSizes.default is set",
 				&core.KubeAPIServerConfig{WatchCacheSizes: &core.WatchCacheSizes{Default: ptr.To[int32](50)}},
 				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
-			),
-		)
-
-		DescribeTable("spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL",
-			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
-				managedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
-				Expect(GetWarnings(managedSeedSet)).To(matcher)
-			},
-
-			Entry("should not return a warning when kubeAPIServerConfig is nil",
-				nil,
-				BeEmpty(),
-			),
-			Entry("should not return a warning when eventTTL is nil",
-				&core.KubeAPIServerConfig{EventTTL: nil},
-				BeEmpty(),
-			),
-			Entry("should not return a warning for valid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}},
-				BeEmpty(),
-			),
-			Entry("should return a warning for invalid eventTTL duration",
-				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}},
-				ContainElement(Equal("you are setting the spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
 

--- a/pkg/api/seedmanagement/validation/managedseedset.go
+++ b/pkg/api/seedmanagement/validation/managedseedset.go
@@ -30,7 +30,6 @@ import (
 func ValidateManagedSeedSet(managedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	opts := gardencorevalidation.KubeAPIServerValidationOptions{
 		AllowInvalidAcceptedIssuers: false,
-		AllowInvalidEventTTL:        false,
 		ETCDEncryptionConfigValidationOptions: gardencorevalidation.ETCDEncryptionConfigValidationOptions{
 			AutoRotationEnabled: helper.IsETCDEncryptionKeyAutoRotationEnabled(managedSeedSet.Spec.ShootTemplate.Spec.Maintenance),
 		},
@@ -61,8 +60,6 @@ func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmana
 		AllowInvalidAcceptedIssuers: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
 			oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.AcceptedIssuers),
-		AllowInvalidEventTTL: oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil && newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer != nil &&
-			apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.EventTTL, newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer.EventTTL),
 		ETCDEncryptionConfigValidationOptions: gardencorevalidation.ETCDEncryptionConfigValidationOptions{
 			AutoRotationEnabled: helper.IsETCDEncryptionKeyAutoRotationEnabled(newManagedSeedSet.Spec.ShootTemplate.Spec.Maintenance),
 		},

--- a/pkg/api/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/api/seedmanagement/validation/managedseedset_test.go
@@ -5,8 +5,6 @@
 package validation_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -469,56 +467,6 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 			newShoot := shootCopy.DeepCopy()
 			newShoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
 				AcceptedIssuers: []string{"https://issuer.com"},
-			}
-			newManagedSeedSet.Spec.ShootTemplate.Spec = newShoot.Spec
-
-			Expect(ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)).To(BeEmpty())
-		})
-
-		It("should allow invalid event ttl in shootTemplate on update if it is unchanged", func() {
-			shootCopy := shoot.DeepCopy()
-			shootCopy.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-				EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10},
-			}
-
-			managedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
-			newManagedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
-
-			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
-			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should not allow invalid invalid ttl in shootTemplate on update if it is changed", func() {
-			shootCopy := shoot.DeepCopy()
-			shootCopy.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-				EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10},
-			}
-			managedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
-
-			newShoot := shootCopy.DeepCopy()
-			newShoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-				EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 42},
-			}
-			newManagedSeedSet.Spec.ShootTemplate.Spec = newShoot.Spec
-
-			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
-			Expect(errorList).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL"),
-				"Detail": Equal("can not be longer than 24h"),
-			}))))
-		})
-
-		It("should allow invalid event ttl in shootTemplate to be updated with valid one", func() {
-			shootCopy := shoot.DeepCopy()
-			shootCopy.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-				EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10},
-			}
-			managedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
-
-			newShoot := shootCopy.DeepCopy()
-			newShoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-				EventTTL: &metav1.Duration{Duration: time.Hour * 24},
 			}
 			newManagedSeedSet.Spec.ShootTemplate.Spec = newShoot.Spec
 

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -90,6 +90,8 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 
 	// Ensure that encrypted provider type is set in `status.credentials.encryptionAtRest.providerType`.
 	SyncEncryptedProviderStatus(newShoot)
+
+	capEventTTL(newShoot.Spec.Kubernetes.KubeAPIServer)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -213,6 +215,20 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 	}
 
 	return !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec)
+}
+
+// capEventTTL caps the eventTTL to 24h for already persisted Shoots with a value exceeding the allowed maximum.
+//
+// TODO(ialidzhikov): Remove this function after v1.145 has been released.
+func capEventTTL(kubeAPIServer *core.KubeAPIServerConfig) {
+	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
+		return
+	}
+
+	const maxEventTTL = 24 * time.Hour
+	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
+		kubeAPIServer.EventTTL.Duration = maxEventTTL
+	}
 }
 
 func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -7,6 +7,7 @@ package shoot_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -302,6 +303,42 @@ var _ = Describe("Strategy", func() {
 			),
 			Entry("do not sync when encryption provider is nil", nil, core.ShootStatus{}, core.ShootStatus{}),
 			Entry("do not sync when encryption provider is empty", ptr.To(core.EncryptionProviderType("")), core.ShootStatus{}, core.ShootStatus{}),
+		)
+
+		DescribeTable("should cap eventTTL to the allowed maximum",
+			func(kubeAPIServer *core.KubeAPIServerConfig, expectedKubeAPIServer *core.KubeAPIServerConfig) {
+				oldShoot = &core.Shoot{
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{
+							KubeAPIServer: kubeAPIServer,
+						},
+					},
+				}
+				newShoot = oldShoot.DeepCopy()
+
+				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
+				Expect(newShoot.Spec.Kubernetes.KubeAPIServer).To(Equal(expectedKubeAPIServer))
+			},
+			Entry("should not modify when kubeAPIServer is nil",
+				nil,
+				nil,
+			),
+			Entry("should not modify when eventTTL is nil",
+				&core.KubeAPIServerConfig{},
+				&core.KubeAPIServerConfig{},
+			),
+			Entry("should not modify when within valid range",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
+			),
+			Entry("should not modify when exactly 24h",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+			),
+			Entry("cap to 24h when exceeding maximum",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 48 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+			),
 		)
 
 		Context("seedName change", func() {

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/strategy.go
@@ -7,6 +7,7 @@ package managedseedset
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
@@ -20,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/api/seedmanagement/managedseedset"
 	"github.com/gardener/gardener/pkg/api/seedmanagement/validation"
+	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -61,6 +63,8 @@ func (s Strategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	if mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet) {
 		newManagedSeedSet.Generation = oldManagedSeedSet.Generation + 1
 	}
+
+	capEventTTL(newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer)
 }
 
 func mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet *seedmanagement.ManagedSeedSet) bool {
@@ -81,6 +85,20 @@ func mustIncreaseGeneration(oldManagedSeedSet, newManagedSeedSet *seedmanagement
 	}
 
 	return false
+}
+
+// capEventTTL caps the eventTTL to 24h for already persisted ManagedSeedSets with a value exceeding the allowed maximum.
+//
+// TODO(ialidzhikov): Remove this function after v1.145 has been released.
+func capEventTTL(kubeAPIServer *core.KubeAPIServerConfig) {
+	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
+		return
+	}
+
+	const maxEventTTL = 24 * time.Hour
+	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
+		kubeAPIServer.EventTTL.Duration = maxEventTTL
+	}
 }
 
 // Validate validates the given object.

--- a/pkg/apiserver/registry/seedmanagement/managedseedset/strategy_test.go
+++ b/pkg/apiserver/registry/seedmanagement/managedseedset/strategy_test.go
@@ -6,6 +6,7 @@ package managedseedset_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,46 @@ var _ = Describe("Strategy", func() {
 			strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
 			Expect(newManagedSeedSet.Generation).To(Equal(oldManagedSeedSet.Generation))
 		})
+
+		DescribeTable("should cap eventTTL to the allowed maximum",
+			func(kubeAPIServer *core.KubeAPIServerConfig, expectedKubeAPIServer *core.KubeAPIServerConfig) {
+				oldManagedSeedSet = &seedmanagement.ManagedSeedSet{
+					Spec: seedmanagement.ManagedSeedSetSpec{
+						ShootTemplate: core.ShootTemplate{
+							Spec: core.ShootSpec{
+								Kubernetes: core.Kubernetes{
+									KubeAPIServer: kubeAPIServer,
+								},
+							},
+						},
+					},
+				}
+				newManagedSeedSet = oldManagedSeedSet.DeepCopy()
+
+				strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
+				Expect(newManagedSeedSet.Spec.ShootTemplate.Spec.Kubernetes.KubeAPIServer).To(Equal(expectedKubeAPIServer))
+			},
+			Entry("should not modify when kubeAPIServer is nil",
+				nil,
+				nil,
+			),
+			Entry("should not modify when eventTTL is nil",
+				&core.KubeAPIServerConfig{},
+				&core.KubeAPIServerConfig{},
+			),
+			Entry("should not modify when within valid range",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 12 * time.Hour}},
+			),
+			Entry("should not modify when exactly 24h",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+			),
+			Entry("cap to 24h when exceeding maximum",
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 48 * time.Hour}},
+				&core.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: 24 * time.Hour}},
+			),
+		)
 	})
 })
 

--- a/pkg/operator/webhook/defaulting/garden/handler.go
+++ b/pkg/operator/webhook/defaulting/garden/handler.go
@@ -7,6 +7,7 @@ package garden
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -66,5 +67,21 @@ func (h *Handler) Default(_ context.Context, obj runtime.Object) error {
 		garden.Status.Credentials.EncryptionAtRest.Provider.Type = operatorv1alpha1helper.GetKubeAPIServerEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer)
 	}
 
+	capEventTTL(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig)
+
 	return nil
+}
+
+// capEventTTL caps the eventTTL to 24h for already persisted Gardens with a value exceeding the allowed maximum.
+//
+// TODO(ialidzhikov): Remove this function after v1.145 has been released.
+func capEventTTL(kubeAPIServer *gardencorev1beta1.KubeAPIServerConfig) {
+	if kubeAPIServer == nil || kubeAPIServer.EventTTL == nil {
+		return
+	}
+
+	const maxEventTTL = 24 * time.Hour
+	if kubeAPIServer.EventTTL.Duration > maxEventTTL {
+		kubeAPIServer.EventTTL.Duration = maxEventTTL
+	}
 }

--- a/pkg/operator/webhook/defaulting/garden/handler_test.go
+++ b/pkg/operator/webhook/defaulting/garden/handler_test.go
@@ -171,5 +171,33 @@ var _ = Describe("Handler", func() {
 			Expect(garden.Spec.RuntimeCluster.Networking.IPFamilies).To(Equal([]gardencorev1beta1.IPFamily{"foo"}))
 		})
 
+		DescribeTable("should cap eventTTL to the allowed maximum",
+			func(eventTTL *metav1.Duration, expectedEventTTL *metav1.Duration) {
+				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = &operatorv1alpha1.KubeAPIServerConfig{
+					KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{
+						EventTTL: eventTTL,
+					},
+				}
+
+				Expect(handler.Default(ctx, garden)).To(Succeed())
+				Expect(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.KubeAPIServerConfig.EventTTL).To(Equal(expectedEventTTL))
+			},
+			Entry("should not modify when eventTTL is nil",
+				nil,
+				&metav1.Duration{Duration: 1 * time.Hour},
+			),
+			Entry("should not modify when within valid range",
+				&metav1.Duration{Duration: 12 * time.Hour},
+				&metav1.Duration{Duration: 12 * time.Hour},
+			),
+			Entry("should not modify when exactly 24h",
+				&metav1.Duration{Duration: 24 * time.Hour},
+				&metav1.Duration{Duration: 24 * time.Hour},
+			),
+			Entry("cap to 24h when exceeding maximum",
+				&metav1.Duration{Duration: 48 * time.Hour},
+				&metav1.Duration{Duration: 24 * time.Hour},
+			),
+		)
 	})
 })

--- a/pkg/operator/webhook/validation/garden/warnings_test.go
+++ b/pkg/operator/webhook/validation/garden/warnings_test.go
@@ -5,12 +5,9 @@
 package garden_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -67,30 +64,6 @@ var _ = Describe("Warnings", func() {
 			Entry("should return a warning when watchCacheSizes.default is set",
 				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{WatchCacheSizes: &gardencorev1beta1.WatchCacheSizes{Default: ptr.To[int32](50)}}},
 				ContainElement(Equal("you are setting the spec.virtualCluster.kubernetes.kubeAPIServer.watchCacheSizes.default field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.35. The cache size is automatically sized by the kube-apiserver.")),
-			),
-		)
-
-		DescribeTable("spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL",
-			func(kubeAPIServerConfig *operatorv1alpha1.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
-				garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer = kubeAPIServerConfig
-				Expect(GetWarnings(garden)).To(matcher)
-			},
-
-			Entry("should not return a warning when kubeAPIServerConfig is nil",
-				nil,
-				BeEmpty(),
-			),
-			Entry("should not return a warning when eventTTL is nil",
-				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: nil}},
-				BeEmpty(),
-			),
-			Entry("should not return a warning for valid eventTTL duration",
-				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24}}},
-				BeEmpty(),
-			),
-			Entry("should return a warning for invalid eventTTL duration",
-				&operatorv1alpha1.KubeAPIServerConfig{KubeAPIServerConfig: &gardencorev1beta1.KubeAPIServerConfig{EventTTL: &metav1.Duration{Duration: time.Hour * 24 * 10}}},
-				ContainElement(Equal("you are setting the spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL field to an invalid value. Invalid value: '240h0m0s', valid values: [0, 24h]. Invalid values for existing resources will be no longer allowed in Gardener v1.142.0. See: https://github.com/gardener/gardener/issues/13825")),
 			),
 		)
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity ops-productivity
/kind cleanup

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/13830 forbid with "ratcheting" validation `eventTTL` > 24h for **new** Shoot, Garden, ManagedSeedSet resources.
For **existing** resources in the system, previously set invalid `eventTTL` values were still accepted due to backwards-compatibility reasons.
~~With this PR, previously set invalid `eventTTL` values are no longer accepted even for **existing** resources in the system.~~
With this PR, we cap an `eventTTL` to 24h for already persisted Shoot, ManagedSeedSet and Garden with a value exceeding the allowed maximum.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/13830
Part of https://github.com/gardener/gardener/issues/13825

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
gardener-apiserver no longer accepts invalid values for the Shoot's `.spec.kubernetes.kubeAPIServer.eventTTL` field even for existing Shoot resources with already invalid values. Invalid values are values outside of the range `[0, 24h]`. gardener-apiserver caps the `eventTTL` to `24h` for already persisted Shoots with a value exceeding the allowed maximum.
```

```breaking operator
gardener-operator's ValidatingWebhookConfiguration no longer accepts invalid values for the Garden's `.spec.virtualCluster.kubernetes.kubeAPIServer.eventTTL` field even for existing Garden resources with already invalid values. Invalid values are values outside of the range `[0, 24h]`. The gardener-operator webhook caps the `eventTTL` to `24h` for already persisted Gardens with a value exceeding the allowed maximum.
```

```breaking operator
gardener-apiserver no longer accepts invalid values for ManagedSeedSet's `.spec.shootTemplate.spec.kubernetes.kubeAPIServer.eventTTL` field even for existing ManagedSeedSet resources with already invalid values. Invalid values are values outside of the range `[0, 24h]`. gardener-apiserver caps the `eventTTL` to `24h` for already persisted ManagedSeedSets with a value exceeding the allowed maximum.
```