### PR TITLE
Add `resourceId` for image `istio-basic-auth-server` to fix overwrite image lookup

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -888,6 +888,8 @@ images:
     sourceRepository: github.com/gardener/ext-authz-server
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/ext-authz-server
     tag: "v0.2.0"
+    resourceId:
+      name: ext-authz-server
   # API Server SNI, VPN-SeedServer and Kube-ApiServer Proxy
   - name: envoy-proxy
     sourceRepository: github.com/envoyproxy/envoy


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
A new image `istio-basic-auth-server` was introduced in the image vector with [Replace Ingress exposure of Plutono with Istio-native exposure #14142](https://github.com/gardener/gardener/pull/14142).
But the image is named `ext-authz-server` in the referenced component. A resource ID must be specified in this case to make imagevector overwrite working. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `resourceId` for image `istio-basic-auth-server` to fix overwrite image lookup
```

/cc @ScheererJ 