### PR TITLE
dev setup: Update `europe-docker.pkg.dev/gardener-project/releases/3rd/registry` image tag to `3.1.0`

### DIFF
--- a/dev-setup/remote/registry/deploy-registry.sh
+++ b/dev-setup/remote/registry/deploy-registry.sh
@@ -108,9 +108,9 @@ stringData:
       ctr snapshot rm seed-registry-cache
     fi
     echo "Pulling registry-cache image"
-    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
+    ctr image pull europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.0
     echo "Starting registry-cache"
-    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0 seed-registry-cache
+    ctr run --detach --mount type=bind,src=/var/opt/docker/seed-registry-cache-config.yml,dst=/etc/distribution/config.yml,options=rbind:ro --net-host europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.0 seed-registry-cache
   stop-seed-registry-cache.sh: |
     #!/usr/bin/env bash
     echo "stopping seed-registry-cache"

--- a/dev-setup/remote/registry/registry/registry.yaml
+++ b/dev-setup/remote/registry/registry/registry.yaml
@@ -23,7 +23,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: registry
-        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.0.0
+        image: europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.0
         imagePullPolicy: IfNotPresent
         env:
         - name: REGISTRY_HTTP_TLS_CERTIFICATE
@@ -40,8 +40,6 @@ spec:
           value: ""
         - name: REGISTRY_LOG_LEVEL
           value: info
-        - name: OTEL_TRACES_EXPORTER
-          value: none
         ports:
         - name: registry
           containerPort: 5000


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Update to the new [distribution/distribution@v3.1.0](https://github.com/distribution/distribution/releases/tag/v3.1.0) release.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/558

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The images of the registry caches used in the dev setups are now updated to [distribution/distribution@v3.1.0](https://github.com/distribution/distribution/releases/tag/v3.1.0).
```
