### PR TITLE
Allow changing encryption provider type for `Shoot` and `Garden`

### DIFF
--- a/docs/usage/security/etcd_encryption_config.md
+++ b/docs/usage/security/etcd_encryption_config.md
@@ -19,7 +19,7 @@ The `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot API allo
     - `aesgcm`
     - `secretbox`
   - The default encryption provider is `aescbc`.
-  - Only newly created `Shoots` can specify the `aesgcm` and `secretbox` encryption providers.
+  - Changing the encryption provider type triggers an encryption key rotation.
   - **Important for `aesgcm`**: The `aesgcm` provider uses 96-bit IVs (nonces), and per [NIST SP 800-38D](https://csrc.nist.gov/pubs/sp/800/38/d/final), the total number of encryption invocations with a given key should not exceed 2³². To mitigate the risk of nonce collisions, Gardener defaults and requires ETCD encryption key auto-rotation to be enabled. By default, the rotation period is set to **28 days** for newly created Shoots. The maximum allowed rotation period for `aesgcm` is **90 days**.
 
 ## Example Usage in a `Shoot`

--- a/docs/usage/security/etcd_encryption_config.md
+++ b/docs/usage/security/etcd_encryption_config.md
@@ -19,7 +19,6 @@ The `spec.kubernetes.kubeAPIServer.encryptionConfig` field in the Shoot API allo
     - `aesgcm`
     - `secretbox`
   - The default encryption provider is `aescbc`.
-  - This field is immutable.
   - Only newly created `Shoots` can specify the `aesgcm` and `secretbox` encryption providers.
   - **Important for `aesgcm`**: The `aesgcm` provider uses 96-bit IVs (nonces), and per [NIST SP 800-38D](https://csrc.nist.gov/pubs/sp/800/38/d/final), the total number of encryption invocations with a given key should not exceed 2³². To mitigate the risk of nonce collisions, Gardener defaults and requires ETCD encryption key auto-rotation to be enabled. By default, the rotation period is set to **28 days** for newly created Shoots. The maximum allowed rotation period for `aesgcm` is **90 days**.
 

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -776,8 +776,25 @@ func ValidateEncryptionConfigUpdate(newConfig, oldConfig *core.EncryptionConfig,
 		}
 	}
 
-	// TODO(AleksandarSavchev): Remove this validation once we have added a gardenlet feature gate to allow changing the encryption provider type.
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newEncryptionProviderType, oldEncryptionProviderType, fldPath.Child("provider", "type"))...)
+	if newEncryptionProviderType != oldEncryptionProviderType {
+		providerTypeFldPath := fldPath.Child("provider", "type")
+
+		if etcdEncryptionKeyRotation != nil && etcdEncryptionKeyRotation.Phase != core.RotationCompleted && etcdEncryptionKeyRotation.Phase != "" {
+			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, fmt.Sprintf("provider type cannot be changed when .status.credentials.rotation.etcdEncryptionKey.phase is not %q", string(core.RotationCompleted))))
+		}
+
+		if !oldEncryptedResources.Equal(currentEncryptedResources) || oldEncryptionProviderType != currentEncryptionProviderType {
+			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, "provider type cannot be changed because a previous encryption configuration change is currently being rolled out"))
+		}
+
+		if isClusterInHibernation {
+			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, "provider type cannot be changed when shoot is in hibernation"))
+		}
+
+		if !newEncryptedResources.Equal(oldEncryptedResources) {
+			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, "provider type and resources cannot be changed simultaneously"))
+		}
+	}
 
 	return allErrs
 }

--- a/pkg/api/core/validation/shoot.go
+++ b/pkg/api/core/validation/shoot.go
@@ -274,7 +274,7 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 		}
 	}
 
-	allErrs = append(allErrs, ValidateEncryptionConfigUpdate(newEncryptionConfig, oldEncryptionConfig, encryptedResources, encryptionProviderType, etcdEncryptionKeyRotation, hibernationEnabled, field.NewPath("spec", "kubernetes", "kubeAPIServer", "encryptionConfig"))...)
+	allErrs = append(allErrs, ValidateEncryptionConfigUpdate(newEncryptionConfig, oldEncryptionConfig, encryptedResources, encryptionProviderType, etcdEncryptionKeyRotation, hibernationEnabled, newShoot.Status.LastOperation, field.NewPath("spec", "kubernetes", "kubeAPIServer", "encryptionConfig"))...)
 	allErrs = append(allErrs, ValidateShootWithOpts(newShoot, opts)...)
 	allErrs = append(allErrs, ValidateShootHAConfigUpdate(newShoot, oldShoot)...)
 	allErrs = append(allErrs, validateHibernationUpdate(newShoot, oldShoot)...)
@@ -739,7 +739,7 @@ func ValidateNodeCIDRMaskWithMaxPod(maxPod int32, nodeCIDRMaskSize int32, networ
 }
 
 // ValidateEncryptionConfigUpdate validates the updates to the KubeAPIServer encryption configuration.
-func ValidateEncryptionConfigUpdate(newConfig, oldConfig *core.EncryptionConfig, currentEncryptedResources sets.Set[schema.GroupResource], currentEncryptionProviderType core.EncryptionProviderType, etcdEncryptionKeyRotation *core.ETCDEncryptionKeyRotation, isClusterInHibernation bool, fldPath *field.Path) field.ErrorList {
+func ValidateEncryptionConfigUpdate(newConfig, oldConfig *core.EncryptionConfig, currentEncryptedResources sets.Set[schema.GroupResource], currentEncryptionProviderType core.EncryptionProviderType, etcdEncryptionKeyRotation *core.ETCDEncryptionKeyRotation, isClusterInHibernation bool, lastOperation *core.LastOperation, fldPath *field.Path) field.ErrorList {
 	var (
 		allErrs                   = field.ErrorList{}
 		oldEncryptedResources     = sets.New[schema.GroupResource]()
@@ -778,6 +778,10 @@ func ValidateEncryptionConfigUpdate(newConfig, oldConfig *core.EncryptionConfig,
 
 	if newEncryptionProviderType != oldEncryptionProviderType {
 		providerTypeFldPath := fldPath.Child("provider", "type")
+
+		if !isShootReadyForRotationStart(lastOperation) {
+			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, "provider type cannot be changed if resource was not yet created successfully or is not ready for reconciliation"))
+		}
 
 		if etcdEncryptionKeyRotation != nil && etcdEncryptionKeyRotation.Phase != core.RotationCompleted && etcdEncryptionKeyRotation.Phase != "" {
 			allErrs = append(allErrs, field.Forbidden(providerTypeFldPath, fmt.Sprintf("provider type cannot be changed when .status.credentials.rotation.etcdEncryptionKey.phase is not %q", string(core.RotationCompleted))))

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -3016,7 +3016,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: resources,
 						Provider: core.EncryptionProvider{
-							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
@@ -3024,7 +3024,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeCreate, State: core.LastOperationStateProcessing}
 
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
@@ -3040,7 +3040,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: resources,
 						Provider: core.EncryptionProvider{
-							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
@@ -3048,7 +3048,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 					newShoot.Status.Credentials.Rotation = &core.ShootCredentialsRotation{
 						ETCDEncryptionKey: &core.ETCDEncryptionKeyRotation{
 							Phase: core.RotationPreparing,
@@ -3069,7 +3069,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: resources,
 						Provider: core.EncryptionProvider{
-							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
@@ -3077,7 +3077,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
@@ -3093,16 +3093,16 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: resources,
 						Provider: core.EncryptionProvider{
-							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
 					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
-					shoot.Spec.Hibernation = &core.Hibernation{Enabled: ptr.To(true)}
+					shoot.Spec.Hibernation = &core.Hibernation{Enabled: new(true)}
 
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
 						PointTo(MatchFields(IgnoreExtras, Fields{
@@ -3118,7 +3118,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
 						Resources: resources,
 						Provider: core.EncryptionProvider{
-							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
@@ -3126,7 +3126,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
-					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Resources = []string{"configmaps", "new.fancyresource.io"}
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -3003,11 +3003,36 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 
 					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
+				})
+
+				It("should deny changing provider type when shoot is not ready for reconciliation", func() {
+					resources := []string{"configmaps", "deployments.apps"}
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
+						Provider: core.EncryptionProvider{
+							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+						},
+					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeCreate, State: core.LastOperationStateProcessing}
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+							"Detail": Equal("provider type cannot be changed if resource was not yet created successfully or is not ready for reconciliation"),
+						})),
+					))
 				})
 
 				It("should deny changing provider type during ETCD encryption key rotation", func() {
@@ -3020,6 +3045,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
@@ -3048,6 +3074,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeSecretbox
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
@@ -3071,6 +3098,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 					shoot.Spec.Hibernation = &core.Hibernation{Enabled: ptr.To(true)}
 
 					newShoot := prepareShootForUpdate(shoot)
@@ -3095,6 +3123,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}
 					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
 					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Status.LastOperation = &core.LastOperation{Type: core.LastOperationTypeReconcile}
 
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)

--- a/pkg/api/core/validation/shoot_test.go
+++ b/pkg/api/core/validation/shoot_test.go
@@ -2993,23 +2993,120 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))
 				})
 
-				It("should fail updating immutable provider type field", func() {
+				It("should allow changing provider type", func() {
+					resources := []string{"configmaps", "deployments.apps"}
 					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
 						Provider: core.EncryptionProvider{
 							Type: new(core.EncryptionProviderTypeAESCBC),
 						},
 					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
 
 					newShoot := prepareShootForUpdate(shoot)
 					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = new(core.EncryptionProviderTypeSecretbox)
 
-					errorList := ValidateShootUpdate(newShoot, shoot)
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
+				})
 
-					Expect(errorList).To(ConsistOfFields(Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
-						"Detail": ContainSubstring(`field is immutable`),
-					}))
+				It("should deny changing provider type during ETCD encryption key rotation", func() {
+					resources := []string{"configmaps", "deployments.apps"}
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
+						Provider: core.EncryptionProvider{
+							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+						},
+					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Status.Credentials.Rotation = &core.ShootCredentialsRotation{
+						ETCDEncryptionKey: &core.ETCDEncryptionKeyRotation{
+							Phase: core.RotationPreparing,
+						},
+					}
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+							"Detail": Equal(`provider type cannot be changed when .status.credentials.rotation.etcdEncryptionKey.phase is not "Completed"`),
+						})),
+					))
+				})
+
+				It("should deny changing provider type when a previous encryption configuration change is being rolled out", func() {
+					resources := []string{"configmaps", "deployments.apps"}
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
+						Provider: core.EncryptionProvider{
+							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+						},
+					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeSecretbox
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+							"Detail": Equal("provider type cannot be changed because a previous encryption configuration change is currently being rolled out"),
+						})),
+					))
+				})
+
+				It("should deny changing provider type when shoot is in hibernation", func() {
+					resources := []string{"configmaps", "deployments.apps"}
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
+						Provider: core.EncryptionProvider{
+							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+						},
+					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+					shoot.Spec.Hibernation = &core.Hibernation{Enabled: ptr.To(true)}
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+							"Detail": Equal("provider type cannot be changed when shoot is in hibernation"),
+						})),
+					))
+				})
+
+				It("should deny changing provider type and resources simultaneously", func() {
+					resources := []string{"configmaps", "deployments.apps"}
+					shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &core.EncryptionConfig{
+						Resources: resources,
+						Provider: core.EncryptionProvider{
+							Type: ptr.To(core.EncryptionProviderTypeAESCBC),
+						},
+					}
+					shoot.Status.Credentials.EncryptionAtRest.Resources = resources
+					shoot.Status.Credentials.EncryptionAtRest.Provider.Type = core.EncryptionProviderTypeAESCBC
+
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type = ptr.To(core.EncryptionProviderTypeSecretbox)
+					newShoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig.Resources = []string{"configmaps", "new.fancyresource.io"}
+
+					Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+						PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeForbidden),
+							"Field":  Equal("spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+							"Detail": Equal("provider type and resources cannot be changed simultaneously"),
+						})),
+					))
 				})
 			})
 

--- a/pkg/api/operator/v1alpha1/validation/garden.go
+++ b/pkg/api/operator/v1alpha1/validation/garden.go
@@ -891,6 +891,7 @@ func validateEncryptionConfigUpdate(oldGarden, newGarden *operatorv1alpha1.Garde
 		newKubeAPIServerEncryptionConfig     = &gardencore.EncryptionConfig{}
 		oldGAPIServerEncryptionConfig        = &gardencore.EncryptionConfig{}
 		newGAPIServerEncryptionConfig        = &gardencore.EncryptionConfig{}
+		newLastOperation                     = &gardencore.LastOperation{}
 		etcdEncryptionKeyRotation            = &gardencore.ETCDEncryptionKeyRotation{}
 		kubeAPIServerEncryptionConfigFldPath = field.NewPath("spec", "virtualCluster", "kubernetes", "kubeAPIServer", "encryptionConfig")
 		gAPIServerEncryptionConfigFldPath    = field.NewPath("spec", "virtualCluster", "gardener", "gardenerAPIServer", "encryptionConfig")
@@ -926,16 +927,22 @@ func validateEncryptionConfigUpdate(oldGarden, newGarden *operatorv1alpha1.Garde
 			return allErrs
 		}
 	}
+	if newGarden.Status.LastOperation != nil {
+		if err := gardenCoreScheme.Convert(newGarden.Status.LastOperation, newLastOperation, nil); err != nil {
+			allErrs = append(allErrs, field.InternalError(field.NewPath("status", "lastOperation"), err))
+			return allErrs
+		}
+	}
 
 	for _, r := range utils.FilterEntriesByFilterFn(helper.GetEncryptedResourcesInStatus(newGarden.Status), operator.IsServedByKubeAPIServer) {
 		currentEncryptedKubernetesResources.Insert(schema.ParseGroupResource(r))
 	}
-	allErrs = append(allErrs, gardencorevalidation.ValidateEncryptionConfigUpdate(newKubeAPIServerEncryptionConfig, oldKubeAPIServerEncryptionConfig, currentEncryptedKubernetesResources, gardencore.EncryptionProviderType(currentEncryptionProviderType), etcdEncryptionKeyRotation, false, kubeAPIServerEncryptionConfigFldPath)...)
+	allErrs = append(allErrs, gardencorevalidation.ValidateEncryptionConfigUpdate(newKubeAPIServerEncryptionConfig, oldKubeAPIServerEncryptionConfig, currentEncryptedKubernetesResources, gardencore.EncryptionProviderType(currentEncryptionProviderType), etcdEncryptionKeyRotation, false, newLastOperation, kubeAPIServerEncryptionConfigFldPath)...)
 
 	for _, r := range utils.FilterEntriesByFilterFn(helper.GetEncryptedResourcesInStatus(newGarden.Status), operator.IsServedByGardenerAPIServer) {
 		currentEncryptedGardenerResources.Insert(schema.ParseGroupResource(r))
 	}
-	allErrs = append(allErrs, gardencorevalidation.ValidateEncryptionConfigUpdate(newGAPIServerEncryptionConfig, oldGAPIServerEncryptionConfig, currentEncryptedGardenerResources, gardencore.EncryptionProviderType(currentEncryptionProviderType), etcdEncryptionKeyRotation, false, gAPIServerEncryptionConfigFldPath)...)
+	allErrs = append(allErrs, gardencorevalidation.ValidateEncryptionConfigUpdate(newGAPIServerEncryptionConfig, oldGAPIServerEncryptionConfig, currentEncryptedGardenerResources, gardencore.EncryptionProviderType(currentEncryptionProviderType), etcdEncryptionKeyRotation, false, newLastOperation, gAPIServerEncryptionConfigFldPath)...)
 
 	return allErrs
 }

--- a/pkg/api/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/api/operator/v1alpha1/validation/garden_test.go
@@ -3367,6 +3367,100 @@ var _ = Describe("Validation Tests", func() {
 
 						Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(BeEmpty())
 					})
+
+					It("should allow changing provider type when garden is ready for reconciliation", func() {
+						oldResources := []string{"resource.custom.io", "deployments.apps"}
+						oldGardenerResources := []string{"shoots.core.gardener.cloud", "bastions.operations.gardener.cloud"}
+						oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+							},
+						}
+						oldGarden.Spec.VirtualCluster.Gardener = operatorv1alpha1.Gardener{
+							APIServer: &operatorv1alpha1.GardenerAPIServerConfig{
+								EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
+									Resources: oldGardenerResources,
+									Provider: gardencorev1beta1.EncryptionProvider{
+										Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+									},
+								},
+							},
+						}
+						newGarden.Status.Credentials.EncryptionAtRest.Resources = append(oldResources, oldGardenerResources...)
+						newGarden.Status.Credentials.EncryptionAtRest.Provider.Type = gardencorev1beta1.EncryptionProviderTypeAESCBC
+						newGarden.Status.LastOperation = &gardencorev1beta1.LastOperation{
+							Type: gardencorev1beta1.LastOperationTypeReconcile,
+						}
+
+						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+							},
+						}
+						newGarden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldGardenerResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+							},
+						}
+
+						Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(BeEmpty())
+					})
+
+					It("should deny changing provider type when garden is not ready for reconciliation", func() {
+						oldResources := []string{"resource.custom.io", "deployments.apps"}
+						oldGardenerResources := []string{"shoots.core.gardener.cloud", "bastions.operations.gardener.cloud"}
+						oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+							},
+						}
+						oldGarden.Spec.VirtualCluster.Gardener = operatorv1alpha1.Gardener{
+							APIServer: &operatorv1alpha1.GardenerAPIServerConfig{
+								EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
+									Resources: oldGardenerResources,
+									Provider: gardencorev1beta1.EncryptionProvider{
+										Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+									},
+								},
+							},
+						}
+						newGarden.Status.Credentials.EncryptionAtRest.Resources = append(oldResources, oldGardenerResources...)
+						newGarden.Status.Credentials.EncryptionAtRest.Provider.Type = gardencorev1beta1.EncryptionProviderTypeAESCBC
+						newGarden.Status.LastOperation = &gardencorev1beta1.LastOperation{
+							Type:  gardencorev1beta1.LastOperationTypeCreate,
+							State: gardencorev1beta1.LastOperationStateProcessing,
+						}
+
+						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+							},
+						}
+						newGarden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+							Resources: oldGardenerResources,
+							Provider: gardencorev1beta1.EncryptionProvider{
+								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+							},
+						}
+
+						Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(ConsistOf(
+							PointTo(MatchFields(IgnoreExtras, Fields{
+								"Type":   Equal(field.ErrorTypeForbidden),
+								"Field":  Equal("spec.virtualCluster.kubernetes.kubeAPIServer.encryptionConfig.provider.type"),
+								"Detail": Equal("provider type cannot be changed if resource was not yet created successfully or is not ready for reconciliation"),
+							})),
+							PointTo(MatchFields(IgnoreExtras, Fields{
+								"Type":   Equal(field.ErrorTypeForbidden),
+								"Field":  Equal("spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.provider.type"),
+								"Detail": Equal("provider type cannot be changed if resource was not yet created successfully or is not ready for reconciliation"),
+							})),
+						))
+					})
 				})
 
 				It("should allow invalid accepted issuer URLs on update if they are unchanged", func() {

--- a/pkg/api/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/api/operator/v1alpha1/validation/garden_test.go
@@ -3374,7 +3374,7 @@ var _ = Describe("Validation Tests", func() {
 						oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeAESCBC),
 							},
 						}
 						oldGarden.Spec.VirtualCluster.Gardener = operatorv1alpha1.Gardener{
@@ -3382,7 +3382,7 @@ var _ = Describe("Validation Tests", func() {
 								EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
 									Resources: oldGardenerResources,
 									Provider: gardencorev1beta1.EncryptionProvider{
-										Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+										Type: new(gardencorev1beta1.EncryptionProviderTypeAESCBC),
 									},
 								},
 							},
@@ -3396,13 +3396,13 @@ var _ = Describe("Validation Tests", func() {
 						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeSecretbox),
 							},
 						}
 						newGarden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldGardenerResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeSecretbox),
 							},
 						}
 
@@ -3415,7 +3415,7 @@ var _ = Describe("Validation Tests", func() {
 						oldGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeAESCBC),
 							},
 						}
 						oldGarden.Spec.VirtualCluster.Gardener = operatorv1alpha1.Gardener{
@@ -3423,7 +3423,7 @@ var _ = Describe("Validation Tests", func() {
 								EncryptionConfig: &gardencorev1beta1.EncryptionConfig{
 									Resources: oldGardenerResources,
 									Provider: gardencorev1beta1.EncryptionProvider{
-										Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+										Type: new(gardencorev1beta1.EncryptionProviderTypeAESCBC),
 									},
 								},
 							},
@@ -3438,13 +3438,13 @@ var _ = Describe("Validation Tests", func() {
 						newGarden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeSecretbox),
 							},
 						}
 						newGarden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
 							Resources: oldGardenerResources,
 							Provider: gardencorev1beta1.EncryptionProvider{
-								Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeSecretbox),
+								Type: new(gardencorev1beta1.EncryptionProviderTypeSecretbox),
 							},
 						}
 

--- a/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
+++ b/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
@@ -59,70 +59,50 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 			seed.ItShouldInitializeSeedClient(&s.SeedContext)
 
 			It("Verify initial encryption config uses AESCBC", func(ctx SpecContext) {
-				verifyEncryptionConfigProvider(ctx, s, true, false)
+				verifyEncryptionConfigProvider(ctx, s, gardencorev1beta1.EncryptionProviderTypeAESCBC)
 			}, SpecTimeout(2*time.Minute))
 
 			It("Verify encrypted data can be created and read before provider change", func(ctx SpecContext) {
 				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
 			}, SpecTimeout(2*time.Minute))
 
-			It("Update Shoot encryption provider type to AESGCM", func(ctx SpecContext) {
-				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
-					s.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
-						Provider: gardencorev1beta1.EncryptionProvider{
-							Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESGCM),
-						},
-					}
-				})).Should(Succeed())
-			}, SpecTimeout(time.Minute))
-
-			ItShouldWaitForShootToBeReconciledAndHealthy(s)
-
-			It("Verify shoot status reflects AESGCM encryption provider", func(ctx SpecContext) {
-				verifyShootEncryptionStatus(ctx, s, gardencorev1beta1.EncryptionProviderTypeAESGCM)
-			}, SpecTimeout(2*time.Minute))
-
-			It("Verify encryption config uses AESGCM after rotation", func(ctx SpecContext) {
-				verifyEncryptionConfigProvider(ctx, s, false, true)
-			}, SpecTimeout(2*time.Minute))
-
-			It("Verify secret created before provider change can still be read", func(ctx SpecContext) {
-				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
-			}, SpecTimeout(2*time.Minute))
-
-			It("Verify encrypted data can be created and read before second provider change", func(ctx SpecContext) {
-				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
-			}, SpecTimeout(2*time.Minute))
-
-			It("Update Shoot encryption provider type back to AESCBC", func(ctx SpecContext) {
-				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
-					s.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
-						Provider: gardencorev1beta1.EncryptionProvider{
-							Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
-						},
-					}
-				})).Should(Succeed())
-			}, SpecTimeout(time.Minute))
-
-			ItShouldWaitForShootToBeReconciledAndHealthy(s)
-
-			It("Verify shoot status reflects AESCBC encryption provider", func(ctx SpecContext) {
-				verifyShootEncryptionStatus(ctx, s, gardencorev1beta1.EncryptionProviderTypeAESCBC)
-			}, SpecTimeout(2*time.Minute))
-
-			It("Verify encryption config uses AESCBC after second rotation", func(ctx SpecContext) {
-				verifyEncryptionConfigProvider(ctx, s, true, false)
-			}, SpecTimeout(2*time.Minute))
-
-			It("Verify encrypted data can still be read after second provider change", func(ctx SpecContext) {
-				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
-			}, SpecTimeout(2*time.Minute))
+			itShouldChangeEncryptionProviderAndVerify(s, gardencorev1beta1.EncryptionProviderTypeAESGCM)
+			itShouldChangeEncryptionProviderAndVerify(s, gardencorev1beta1.EncryptionProviderTypeSecretbox)
+			itShouldChangeEncryptionProviderAndVerify(s, gardencorev1beta1.EncryptionProviderTypeAESCBC)
 
 			ItShouldDeleteShoot(s)
 			ItShouldWaitForShootToBeDeleted(s)
 		})
 	})
 })
+
+func itShouldChangeEncryptionProviderAndVerify(s *ShootContext, providerType gardencorev1beta1.EncryptionProviderType) {
+	GinkgoHelper()
+
+	It("Update Shoot encryption provider type to "+string(providerType), func(ctx SpecContext) {
+		Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+			s.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+				Provider: gardencorev1beta1.EncryptionProvider{
+					Type: ptr.To(providerType),
+				},
+			}
+		})).Should(Succeed())
+	}, SpecTimeout(time.Minute))
+
+	ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+	It("Verify shoot status reflects "+string(providerType)+" encryption provider", func(ctx SpecContext) {
+		verifyShootEncryptionStatus(ctx, s, providerType)
+	}, SpecTimeout(2*time.Minute))
+
+	It("Verify encryption config uses "+string(providerType), func(ctx SpecContext) {
+		verifyEncryptionConfigProvider(ctx, s, providerType)
+	}, SpecTimeout(2*time.Minute))
+
+	It("Verify encrypted data can still be read after provider change to "+string(providerType), func(ctx SpecContext) {
+		rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
+	}, SpecTimeout(2*time.Minute))
+}
 
 func getEncryptionConfiguration(ctx context.Context, g Gomega, s *ShootContext) *apiserverconfigv1.EncryptionConfiguration {
 	secretList := &corev1.SecretList{}
@@ -150,20 +130,27 @@ func verifyShootEncryptionStatus(ctx context.Context, s *ShootContext, expectedT
 	Expect(s.Shoot.Status.Credentials.EncryptionAtRest.Provider.Type).To(Equal(expectedType))
 }
 
-func verifyEncryptionConfigProvider(ctx context.Context, s *ShootContext, expectAESCBC, expectAESGCM bool) {
+func verifyEncryptionConfigProvider(ctx context.Context, s *ShootContext, expectedProvider gardencorev1beta1.EncryptionProviderType) {
 	encryptionConfiguration := getEncryptionConfiguration(ctx, Default, s)
 	Expect(encryptionConfiguration.Resources).To(HaveLen(1))
 	Expect(encryptionConfiguration.Resources[0].Providers).To(HaveLen(2))
-	if expectAESCBC {
-		Expect(encryptionConfiguration.Resources[0].Providers[0].AESCBC).NotTo(BeNil(), "provider should be AESCBC")
-	} else {
-		Expect(encryptionConfiguration.Resources[0].Providers[0].AESCBC).To(BeNil(), "provider should not be AESCBC")
+
+	provider := encryptionConfiguration.Resources[0].Providers[0]
+	switch expectedProvider {
+	case gardencorev1beta1.EncryptionProviderTypeAESCBC:
+		Expect(provider.AESCBC).NotTo(BeNil())
+		Expect(provider.AESGCM).To(BeNil())
+		Expect(provider.Secretbox).To(BeNil())
+	case gardencorev1beta1.EncryptionProviderTypeAESGCM:
+		Expect(provider.AESCBC).To(BeNil())
+		Expect(provider.AESGCM).NotTo(BeNil())
+		Expect(provider.Secretbox).To(BeNil())
+	case gardencorev1beta1.EncryptionProviderTypeSecretbox:
+		Expect(provider.AESCBC).To(BeNil())
+		Expect(provider.AESGCM).To(BeNil())
+		Expect(provider.Secretbox).NotTo(BeNil())
 	}
-	if expectAESGCM {
-		Expect(encryptionConfiguration.Resources[0].Providers[0].AESGCM).NotTo(BeNil(), "provider should be AESGCM")
-	} else {
-		Expect(encryptionConfiguration.Resources[0].Providers[0].AESGCM).To(BeNil(), "provider should not be AESGCM")
-	}
+
 	Expect(encryptionConfiguration.Resources[0].Providers[1].Identity).NotTo(BeNil())
 }
 

--- a/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
+++ b/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shoot
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/test/e2e"
+	. "github.com/gardener/gardener/test/e2e/gardener"
+	"github.com/gardener/gardener/test/e2e/gardener/seed"
+	rotationutils "github.com/gardener/gardener/test/utils/rotation"
+)
+
+var encryptionConfigDecoder runtime.Decoder
+
+func init() {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(apiserverconfigv1.AddToScheme(scheme))
+	encryptionConfigDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
+}
+
+var _ = FDescribe("Shoot Tests", Label("Shoot", "default"), func() {
+	FDescribe("Create Shoot, Change Encryption Provider Type and Delete Shoot", Label("encryption-provider-change"), func() {
+		Context("Shoot with workers", Ordered, func() {
+			var s *ShootContext
+
+			BeforeTestSetup(func() {
+				shoot := DefaultShoot("e2e-encr-chg")
+				shoot.Spec.Maintenance.AutoRotation = &gardencorev1beta1.MaintenanceAutoRotation{
+					Credentials: &gardencorev1beta1.MaintenanceCredentialsAutoRotation{
+						ETCDEncryptionKey: &gardencorev1beta1.MaintenanceRotationConfig{
+							RotationPeriod: &metav1.Duration{Duration: v1beta1constants.ETCDEncryptionKeyAutoRotationPeriod},
+						},
+					},
+				}
+				s = NewTestContext().ForShoot(shoot)
+			})
+			ItShouldCreateShoot(s)
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+			ItShouldInitializeShootClient(s)
+			ItShouldGetResponsibleSeed(s)
+			seed.ItShouldInitializeSeedClient(&s.SeedContext)
+
+			It("Verify initial encryption config uses AESCBC", func(ctx SpecContext) {
+				verifyEncryptionConfigProvider(ctx, s, true, false)
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify encrypted data can be created and read before provider change", func(ctx SpecContext) {
+				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
+			}, SpecTimeout(2*time.Minute))
+
+			It("Update Shoot encryption provider type to AESGCM", func(ctx SpecContext) {
+				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+					s.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+						Provider: gardencorev1beta1.EncryptionProvider{
+							Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESGCM),
+						},
+					}
+				})).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+			It("Verify shoot status reflects AESGCM encryption provider", func(ctx SpecContext) {
+				verifyShootEncryptionStatus(ctx, s, gardencorev1beta1.EncryptionProviderTypeAESGCM)
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify encryption config uses AESGCM after rotation", func(ctx SpecContext) {
+				verifyEncryptionConfigProvider(ctx, s, false, true)
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify secret created before provider change can still be read", func(ctx SpecContext) {
+				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify encrypted data can be created and read before second provider change", func(ctx SpecContext) {
+				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
+			}, SpecTimeout(2*time.Minute))
+
+			It("Update Shoot encryption provider type back to AESCBC", func(ctx SpecContext) {
+				Eventually(ctx, s.GardenKomega.Update(s.Shoot, func() {
+					s.Shoot.Spec.Kubernetes.KubeAPIServer.EncryptionConfig = &gardencorev1beta1.EncryptionConfig{
+						Provider: gardencorev1beta1.EncryptionProvider{
+							Type: ptr.To(gardencorev1beta1.EncryptionProviderTypeAESCBC),
+						},
+					}
+				})).Should(Succeed())
+			}, SpecTimeout(time.Minute))
+
+			ItShouldWaitForShootToBeReconciledAndHealthy(s)
+
+			It("Verify shoot status reflects AESCBC encryption provider", func(ctx SpecContext) {
+				verifyShootEncryptionStatus(ctx, s, gardencorev1beta1.EncryptionProviderTypeAESCBC)
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify encryption config uses AESCBC after second rotation", func(ctx SpecContext) {
+				verifyEncryptionConfigProvider(ctx, s, true, false)
+			}, SpecTimeout(2*time.Minute))
+
+			It("Verify encrypted data can still be read after second provider change", func(ctx SpecContext) {
+				rotationutils.VerifyEncryptedData(ctx, s.ShootClient, defaultEncryptedResources())
+			}, SpecTimeout(2*time.Minute))
+
+			ItShouldDeleteShoot(s)
+			ItShouldWaitForShootToBeDeleted(s)
+		})
+	})
+})
+
+func getEncryptionConfiguration(ctx context.Context, g Gomega, s *ShootContext) *apiserverconfigv1.EncryptionConfiguration {
+	secretList := &corev1.SecretList{}
+	g.Expect(s.SeedClient.List(
+		ctx,
+		secretList,
+		client.InNamespace(s.Shoot.Status.TechnicalID),
+		client.MatchingLabels{v1beta1constants.LabelRole: v1beta1constants.SecretNamePrefixETCDEncryptionConfiguration},
+	)).To(Succeed())
+	g.Expect(secretList.Items).NotTo(BeEmpty())
+	sort.Sort(sort.Reverse(rotationutils.AgeSorter(secretList.Items)))
+
+	encryptionConfiguration := &apiserverconfigv1.EncryptionConfiguration{}
+	g.Expect(runtime.DecodeInto(encryptionConfigDecoder, secretList.Items[0].Data["encryption-configuration.yaml"], encryptionConfiguration)).To(Succeed())
+	return encryptionConfiguration
+}
+
+func verifyShootEncryptionStatus(ctx context.Context, s *ShootContext, expectedType gardencorev1beta1.EncryptionProviderType) {
+	Expect(s.GardenClient.Get(ctx, client.ObjectKeyFromObject(s.Shoot), s.Shoot)).To(Succeed())
+	Expect(s.Shoot.Status.Credentials).NotTo(BeNil())
+	Expect(s.Shoot.Status.Credentials.Rotation).NotTo(BeNil())
+	Expect(s.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey).NotTo(BeNil())
+	Expect(s.Shoot.Status.Credentials.Rotation.ETCDEncryptionKey.Phase).To(Equal(gardencorev1beta1.RotationCompleted))
+	Expect(s.Shoot.Status.Credentials.EncryptionAtRest).NotTo(BeNil())
+	Expect(s.Shoot.Status.Credentials.EncryptionAtRest.Provider.Type).To(Equal(expectedType))
+}
+
+func verifyEncryptionConfigProvider(ctx context.Context, s *ShootContext, expectAESCBC, expectAESGCM bool) {
+	encryptionConfiguration := getEncryptionConfiguration(ctx, Default, s)
+	Expect(encryptionConfiguration.Resources).To(HaveLen(1))
+	Expect(encryptionConfiguration.Resources[0].Providers).To(HaveLen(2))
+	if expectAESCBC {
+		Expect(encryptionConfiguration.Resources[0].Providers[0].AESCBC).NotTo(BeNil(), "provider should be AESCBC")
+	} else {
+		Expect(encryptionConfiguration.Resources[0].Providers[0].AESCBC).To(BeNil(), "provider should not be AESCBC")
+	}
+	if expectAESGCM {
+		Expect(encryptionConfiguration.Resources[0].Providers[0].AESGCM).NotTo(BeNil(), "provider should be AESGCM")
+	} else {
+		Expect(encryptionConfiguration.Resources[0].Providers[0].AESGCM).To(BeNil(), "provider should not be AESGCM")
+	}
+	Expect(encryptionConfiguration.Resources[0].Providers[1].Identity).NotTo(BeNil())
+}
+
+func defaultEncryptedResources() []rotationutils.EncryptedResource {
+	return []rotationutils.EncryptedResource{
+		{
+			NewObject: func() client.Object {
+				return &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{GenerateName: "test-encr-", Namespace: "default"},
+					StringData: map[string]string{"content": "foo"},
+				}
+			},
+			NewEmptyList: func() client.ObjectList { return &corev1.SecretList{} },
+		},
+	}
+}

--- a/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
+++ b/test/e2e/gardener/shoot/create_encr_provider_change_delete.go
@@ -36,8 +36,8 @@ func init() {
 	encryptionConfigDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
 }
 
-var _ = FDescribe("Shoot Tests", Label("Shoot", "default"), func() {
-	FDescribe("Create Shoot, Change Encryption Provider Type and Delete Shoot", Label("encryption-provider-change"), func() {
+var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
+	Describe("Create Shoot, Change Encryption Provider Type and Delete Shoot", Label("encryption-provider-change"), func() {
 		Context("Shoot with workers", Ordered, func() {
 			var s *ShootContext
 

--- a/test/utils/rotation/encrypted_data.go
+++ b/test/utils/rotation/encrypted_data.go
@@ -29,7 +29,9 @@ type EncryptedDataVerifier struct {
 // Before is called before the rotation is started.
 func (v *EncryptedDataVerifier) Before(ctx context.Context) {
 	By("Verify encrypted data before credentials rotation")
-	v.verifyEncryptedData(ctx)
+	targetClient, err := v.NewTargetClientFunc(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
@@ -44,7 +46,9 @@ func (v *EncryptedDataVerifier) ExpectWaitingForWorkersRolloutStatus(_ Gomega) {
 // AfterPrepared is called when the Shoot is in Prepared status.
 func (v *EncryptedDataVerifier) AfterPrepared(ctx context.Context) {
 	By("Verify encrypted data after preparing credentials rotation")
-	v.verifyEncryptedData(ctx)
+	targetClient, err := v.NewTargetClientFunc(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
@@ -53,28 +57,7 @@ func (v *EncryptedDataVerifier) ExpectCompletingStatus(_ Gomega) {}
 // AfterCompleted is called when the Shoot is in Completed status.
 func (v *EncryptedDataVerifier) AfterCompleted(ctx context.Context) {
 	By("Verify encrypted data after credentials rotation")
-	v.verifyEncryptedData(ctx)
-}
-
-func (v *EncryptedDataVerifier) verifyEncryptedData(ctx context.Context) {
-	var (
-		targetClient kubernetes.Interface
-		err          error
-	)
-
-	Eventually(func(g Gomega) {
-		targetClient, err = v.NewTargetClientFunc(ctx)
-		g.Expect(err).NotTo(HaveOccurred())
-	}).Should(Succeed())
-
-	for _, resource := range v.Resources {
-		obj := resource.NewObject()
-		Eventually(func(g Gomega) {
-			g.Expect(targetClient.Client().Create(ctx, obj)).To(Succeed())
-		}).Should(Succeed(), "creating resource should succeed for "+client.ObjectKeyFromObject(obj).String())
-
-		Eventually(func(g Gomega) {
-			g.Expect(targetClient.Client().List(ctx, resource.NewEmptyList())).To(Succeed())
-		}).Should(Succeed(), "reading all encrypted resources should succeed")
-	}
+	targetClient, err := v.NewTargetClientFunc(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
 }

--- a/test/utils/rotation/encrypted_data.go
+++ b/test/utils/rotation/encrypted_data.go
@@ -29,8 +29,17 @@ type EncryptedDataVerifier struct {
 // Before is called before the rotation is started.
 func (v *EncryptedDataVerifier) Before(ctx context.Context) {
 	By("Verify encrypted data before credentials rotation")
-	targetClient, err := v.NewTargetClientFunc(ctx)
-	Expect(err).NotTo(HaveOccurred())
+
+	var (
+		targetClient kubernetes.Interface
+		err          error
+	)
+
+	Eventually(func(g Gomega) {
+		targetClient, err = v.NewTargetClientFunc(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	}).Should(Succeed())
+
 	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
 }
 
@@ -46,8 +55,17 @@ func (v *EncryptedDataVerifier) ExpectWaitingForWorkersRolloutStatus(_ Gomega) {
 // AfterPrepared is called when the Shoot is in Prepared status.
 func (v *EncryptedDataVerifier) AfterPrepared(ctx context.Context) {
 	By("Verify encrypted data after preparing credentials rotation")
-	targetClient, err := v.NewTargetClientFunc(ctx)
-	Expect(err).NotTo(HaveOccurred())
+
+	var (
+		targetClient kubernetes.Interface
+		err          error
+	)
+
+	Eventually(func(g Gomega) {
+		targetClient, err = v.NewTargetClientFunc(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	}).Should(Succeed())
+
 	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
 }
 
@@ -57,7 +75,30 @@ func (v *EncryptedDataVerifier) ExpectCompletingStatus(_ Gomega) {}
 // AfterCompleted is called when the Shoot is in Completed status.
 func (v *EncryptedDataVerifier) AfterCompleted(ctx context.Context) {
 	By("Verify encrypted data after credentials rotation")
-	targetClient, err := v.NewTargetClientFunc(ctx)
-	Expect(err).NotTo(HaveOccurred())
+
+	var (
+		targetClient kubernetes.Interface
+		err          error
+	)
+
+	Eventually(func(g Gomega) {
+		targetClient, err = v.NewTargetClientFunc(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	}).Should(Succeed())
+
 	VerifyEncryptedData(ctx, targetClient.Client(), v.Resources)
+}
+
+// VerifyEncryptedData creates and reads encrypted resources in the target cluster to verify encryption is working.
+func VerifyEncryptedData(ctx context.Context, c client.Client, resources []EncryptedResource) {
+	for _, resource := range resources {
+		obj := resource.NewObject()
+		Eventually(func(g Gomega) {
+			g.Expect(c.Create(ctx, obj)).To(Succeed())
+		}).Should(Succeed(), "creating resource should succeed for "+client.ObjectKeyFromObject(obj).String())
+
+		Eventually(func(g Gomega) {
+			g.Expect(c.List(ctx, resource.NewEmptyList())).To(Succeed())
+		}).Should(Succeed(), "reading all encrypted resources should succeed")
+	}
 }

--- a/test/utils/rotation/utils.go
+++ b/test/utils/rotation/utils.go
@@ -5,9 +5,12 @@
 package rotation
 
 import (
+	"context"
 	"sort"
 
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SecretConfigNamesToSecrets is a map for secret config names to a list of corev1.Secret objects.
@@ -32,3 +35,17 @@ type AgeSorter []corev1.Secret
 func (x AgeSorter) Len() int           { return len(x) }
 func (x AgeSorter) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 func (x AgeSorter) Less(i, j int) bool { return x[i].CreationTimestamp.Before(&x[j].CreationTimestamp) }
+
+// VerifyEncryptedData creates and reads encrypted resources in the target cluster to verify encryption is working.
+func VerifyEncryptedData(ctx context.Context, c client.Client, resources []EncryptedResource) {
+	for _, resource := range resources {
+		obj := resource.NewObject()
+		Eventually(func(g Gomega) {
+			g.Expect(c.Create(ctx, obj)).To(Succeed())
+		}).Should(Succeed(), "creating resource should succeed for "+client.ObjectKeyFromObject(obj).String())
+
+		Eventually(func(g Gomega) {
+			g.Expect(c.List(ctx, resource.NewEmptyList())).To(Succeed())
+		}).Should(Succeed(), "reading all encrypted resources should succeed")
+	}
+}

--- a/test/utils/rotation/utils.go
+++ b/test/utils/rotation/utils.go
@@ -5,12 +5,9 @@
 package rotation
 
 import (
-	"context"
 	"sort"
 
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SecretConfigNamesToSecrets is a map for secret config names to a list of corev1.Secret objects.
@@ -35,17 +32,3 @@ type AgeSorter []corev1.Secret
 func (x AgeSorter) Len() int           { return len(x) }
 func (x AgeSorter) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 func (x AgeSorter) Less(i, j int) bool { return x[i].CreationTimestamp.Before(&x[j].CreationTimestamp) }
-
-// VerifyEncryptedData creates and reads encrypted resources in the target cluster to verify encryption is working.
-func VerifyEncryptedData(ctx context.Context, c client.Client, resources []EncryptedResource) {
-	for _, resource := range resources {
-		obj := resource.NewObject()
-		Eventually(func(g Gomega) {
-			g.Expect(c.Create(ctx, obj)).To(Succeed())
-		}).Should(Succeed(), "creating resource should succeed for "+client.ObjectKeyFromObject(obj).String())
-
-		Eventually(func(g Gomega) {
-			g.Expect(c.List(ctx, resource.NewEmptyList())).To(Succeed())
-		}).Should(Succeed(), "reading all encrypted resources should succeed")
-	}
-}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR allow the ETCD encryption provider type to be changed for `Shoot` and `Garden` resources. The required operations for changing the provider type were added with https://github.com/gardener/gardener/pull/14034.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11276

**Special notes for your reviewer**:
/cc @dimityrmirchev @plkokanov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `Shoot` spec field `spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type` is no longer immutable.
```
```feature user
The `Garden` spec fields `spec.virtualCluster.kubernetes.kubeAPIServer.encryptionConfig.provider.type` and `spec.virtualCluster.gardener.gardenerAPIServer.encryptionConfig.provider.type` are no longer immutable.
```
