### PR TITLE
[GEP-36]  Implement `SelfHostedShootExposure` in `provider-local`

### DIFF
--- a/charts/gardener/provider-local/templates/rbac.yaml
+++ b/charts/gardener/provider-local/templates/rbac.yaml
@@ -94,6 +94,7 @@ rules:
   - admissionregistration.k8s.io
   - apiextensions.k8s.io
   - networking.k8s.io
+  - discovery.k8s.io
   - crd.projectcalico.org
   resources:
   - namespaces
@@ -102,6 +103,7 @@ rules:
   - secrets
   - configmaps
   - endpoints
+  - endpointslices
   - deployments
   - deployments/scale
   - services

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -45,6 +45,7 @@ import (
 	localhealthcheck "github.com/gardener/gardener/pkg/provider-local/controller/healthcheck"
 	localinfrastructure "github.com/gardener/gardener/pkg/provider-local/controller/infrastructure"
 	localoperatingsystemconfig "github.com/gardener/gardener/pkg/provider-local/controller/operatingsystemconfig"
+	localselfhostedshootexposure "github.com/gardener/gardener/pkg/provider-local/controller/selfhostedshootexposure"
 	localworker "github.com/gardener/gardener/pkg/provider-local/controller/worker"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 	prometheuswebhook "github.com/gardener/gardener/pkg/provider-local/webhook/prometheus"
@@ -310,6 +311,7 @@ func applyReconcileOptions(reconcileOpts *extensionscmdcontroller.ReconcilerOpti
 	localdnsrecord.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localinfrastructure.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localoperatingsystemconfig.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
+	localselfhostedshootexposure.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 	localworker.DefaultAddOptions.IgnoreOperationAnnotation = config.IgnoreOperationAnnotation
 }
 
@@ -327,6 +329,7 @@ func applyGeneralOptions(generalOpts *extensionscmdcontroller.GeneralOptions) {
 	localdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localoperatingsystemconfig.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
+	localselfhostedshootexposure.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localworker.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 	localhealthcheck.DefaultAddOptions.ExtensionClasses = slices.Clone(config.ExtensionClasses)
 }

--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -13,6 +13,7 @@ import (
 	extensionsheartbeatcontroller "github.com/gardener/gardener/extensions/pkg/controller/heartbeat"
 	extensionsinfrastructurecontroller "github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsoperatingsystemconfigcontroller "github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig"
+	extensionsselfhostedshootexposurecontroller "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	extensionscmdwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	extensionscontrolplanewebhook "github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
@@ -29,6 +30,7 @@ import (
 	infrastructurecontroller "github.com/gardener/gardener/pkg/provider-local/controller/infrastructure"
 	networkpolicycontroller "github.com/gardener/gardener/pkg/provider-local/controller/networkpolicy"
 	operatingsystemconfigcontroller "github.com/gardener/gardener/pkg/provider-local/controller/operatingsystemconfig"
+	selfhostedshootexposurecontroller "github.com/gardener/gardener/pkg/provider-local/controller/selfhostedshootexposure"
 	workercontroller "github.com/gardener/gardener/pkg/provider-local/controller/worker"
 	controlplanewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/controlplane"
 	networkpolicywebhook "github.com/gardener/gardener/pkg/provider-local/webhook/networkpolicy"
@@ -50,6 +52,7 @@ func ControllerSwitchOptions() *extensionscmdcontroller.SwitchOptions {
 		extensionscmdcontroller.Switch(extensionsworkercontroller.ControllerName, workercontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionshealthcheckcontroller.ControllerName, healthcheckcontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionsoperatingsystemconfigcontroller.ControllerName, operatingsystemconfigcontroller.AddToManager),
+		extensionscmdcontroller.Switch(extensionsselfhostedshootexposurecontroller.ControllerName, selfhostedshootexposurecontroller.AddToManager),
 		extensionscmdcontroller.Switch(extensionsheartbeatcontroller.ControllerName, extensionsheartbeatcontroller.AddToManager),
 		extensionscmdcontroller.Switch(localextensionseedcontroller.ControllerName, localextensionseedcontroller.AddToManager),
 		extensionscmdcontroller.Switch(localextensionshootcontroller.ControllerName, localextensionshootcontroller.AddToManager),

--- a/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
+++ b/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
@@ -24,6 +24,8 @@ spec:
       type: local
     - kind: OperatingSystemConfig
       type: local
+    - kind: SelfHostedShootExposure
+      type: local
     - kind: Worker
       type: local
     - kind: Extension

--- a/dev-setup/extensions/provider-local/components/extension/extension.yaml
+++ b/dev-setup/extensions/provider-local/components/extension/extension.yaml
@@ -35,3 +35,5 @@ spec:
     type: local
   - kind: OperatingSystemConfig
     type: local
+  - kind: SelfHostedShootExposure
+    type: local

--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -879,6 +879,7 @@ build:
             - extensions/pkg/controller/heartbeat/cmd
             - extensions/pkg/controller/infrastructure
             - extensions/pkg/controller/operatingsystemconfig
+            - extensions/pkg/controller/selfhostedshootexposure
             - extensions/pkg/controller/worker
             - extensions/pkg/controller/worker/genericactuator
             - extensions/pkg/controller/worker/helper
@@ -975,6 +976,7 @@ build:
             - pkg/provider-local/controller/infrastructure
             - pkg/provider-local/controller/networkpolicy
             - pkg/provider-local/controller/operatingsystemconfig
+            - pkg/provider-local/controller/selfhostedshootexposure
             - pkg/provider-local/controller/worker
             - pkg/provider-local/imagevector
             - pkg/provider-local/local

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -1004,6 +1004,7 @@ build:
             - extensions/pkg/controller/heartbeat/cmd
             - extensions/pkg/controller/infrastructure
             - extensions/pkg/controller/operatingsystemconfig
+            - extensions/pkg/controller/selfhostedshootexposure
             - extensions/pkg/controller/worker
             - extensions/pkg/controller/worker/genericactuator
             - extensions/pkg/controller/worker/helper
@@ -1100,6 +1101,7 @@ build:
             - pkg/provider-local/controller/infrastructure
             - pkg/provider-local/controller/networkpolicy
             - pkg/provider-local/controller/operatingsystemconfig
+            - pkg/provider-local/controller/selfhostedshootexposure
             - pkg/provider-local/controller/worker
             - pkg/provider-local/imagevector
             - pkg/provider-local/local

--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -122,6 +122,18 @@ This controller implements the `Bastion.extensions.gardener.cloud` resource by d
 
 Note that this controller does not respect the `Bastion.spec.ingress` configuration as there is no way to perform client IP restrictions in the local setup.
 
+#### `SelfHostedShootExposure`
+
+This controller implements the `SelfHostedShootExposure.extensions.gardener.cloud` resource for [self-hosted shoots with managed infrastructure](https://github.com/gardener/enhancements/tree/main/geps/0036-self-hosted-shoot-exposure).
+Its purpose is to expose the self-hosted shoot's API server via a `LoadBalancer` Service backed by the control plane node addresses.
+
+This controller runs inside the self-hosted shoot and creates two resources in the kind cluster (see [Credentials](#credentials)):
+
+- A `Service` of type `LoadBalancer`, which causes `cloud-controller-manager-local` to provision an Envoy Proxy based load balancer in the kind network (see [cloud-controller-manager-local](#cloud-controller-manager-local)).
+- One `EndpointSlice` per IP family configured in `Shoot.spec.networking.ipFamilies`, backed by the `InternalIP` addresses of the control plane nodes from `SelfHostedShootExposure.spec.endpoints`.
+
+The controller waits until the `LoadBalancer` Service is assigned ingress IPs by `cloud-controller-manager-local` before reporting the `SelfHostedShootExposure` as ready and populating `.status.ingress`.
+
 #### ETCD Backups
 
 This controller reconciles the `BackupBucket` and `BackupEntry` of the shoot allowing the `etcd-backup-restore` to create and copy backups using the `local` provider functionality. The backups are stored on the host file system. This is achieved by mounting that directory to the `etcd-backup-restore` container.

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -15,8 +15,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
-	discoveryv1ac "k8s.io/client-go/applyconfigurations/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -25,6 +23,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/provider-local/local"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 type actuator struct {
@@ -36,31 +35,27 @@ func newActuator(mgr manager.Manager) selfhostedshootexposure.Actuator {
 }
 
 func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
-	if err := a.client.Apply(ctx, serviceForExposure(exposure), local.FieldOwner, client.ForceOwnership); err != nil {
+	service := serviceForExposure(exposure)
+	if err := a.client.Patch(ctx, service, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 		return nil, fmt.Errorf("could not apply Service: %w", err)
 	}
 
 	for _, family := range endpointSliceFamilies {
-		if err := a.client.Apply(ctx, endpointSliceForExposure(exposure, family), local.FieldOwner, client.ForceOwnership); err != nil {
+		if err := a.client.Patch(ctx, endpointSliceForExposure(exposure, family), client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 			return nil, fmt.Errorf("could not apply %s EndpointSlice: %w", family, err)
 		}
 	}
 
-	liveService := &corev1.Service{}
-	if err := a.client.Get(ctx, client.ObjectKey{Name: serviceName(exposure), Namespace: exposure.Namespace}, liveService); err != nil {
-		return nil, fmt.Errorf("could not get Service: %w", err)
-	}
-
-	if len(liveService.Status.LoadBalancer.Ingress) == 0 {
-		log.Info("Waiting for LoadBalancer to get an external address")
+	// wait for LoadBalancer to be ready
+	if err := health.CheckService(service); err != nil {
 		return nil, &reconcilerutils.RequeueAfterError{
 			RequeueAfter: 5 * time.Second,
 			Cause:        fmt.Errorf("LoadBalancer not yet ready"),
 		}
 	}
 
+	return service.Status.LoadBalancer.Ingress, nil
 	log.Info("LoadBalancer ready", "ingress", liveService.Status.LoadBalancer.Ingress)
-	return liveService.Status.LoadBalancer.Ingress, nil
 }
 
 func (a *actuator) Delete(ctx context.Context, _ logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
@@ -86,22 +81,31 @@ func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, exposure *e
 // On single-stack clusters the non-matching slice is empty and ignored.
 var endpointSliceFamilies = []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6}
 
-func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *corev1ac.ServiceApplyConfiguration {
-	return corev1ac.Service(serviceName(exposure), exposure.Namespace).
-		WithSpec(corev1ac.ServiceSpec().
-			WithType(corev1.ServiceTypeLoadBalancer).
-			WithIPFamilyPolicy(corev1.IPFamilyPolicyPreferDualStack).
-			WithPorts(corev1ac.ServicePort().
-				WithName("https").
-				WithPort(exposure.Spec.Port).
-				WithTargetPort(intstr.FromInt32(exposure.Spec.Port)).
-				WithProtocol(corev1.ProtocolTCP),
-			),
-		)
+func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName(exposure),
+			Namespace: exposure.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:           corev1.ServiceTypeLoadBalancer,
+			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
+			Ports: []corev1.ServicePort{{
+				Name:       "https",
+				Port:       exposure.Spec.Port,
+				TargetPort: intstr.FromInt32(exposure.Spec.Port),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
 }
 
-func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) *discoveryv1ac.EndpointSliceApplyConfiguration {
-	var endpoints []*discoveryv1ac.EndpointApplyConfiguration
+func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) *discoveryv1.EndpointSlice {
+	var endpoints []discoveryv1.Endpoint
 	for _, endpoint := range exposure.Spec.Endpoints {
 		for _, address := range endpoint.Addresses {
 			if address.Type != corev1.NodeInternalIP {
@@ -111,23 +115,34 @@ func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposu
 			if isIPv6 != (family == discoveryv1.AddressTypeIPv6) {
 				continue
 			}
-			endpoints = append(endpoints, discoveryv1ac.Endpoint().
-				WithAddresses(address.Address).
-				WithNodeName(endpoint.NodeName).
-				WithConditions(discoveryv1ac.EndpointConditions().WithReady(true)),
-			)
+			endpoints = append(endpoints, discoveryv1.Endpoint{
+				Addresses: []string{address.Address},
+				NodeName:  ptr.To(endpoint.NodeName),
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
+			})
 		}
 	}
 
-	return discoveryv1ac.EndpointSlice(endpointSliceName(exposure, family), exposure.Namespace).
-		WithLabels(map[string]string{discoveryv1.LabelServiceName: serviceName(exposure)}).
-		WithAddressType(family).
-		WithEndpoints(endpoints...).
-		WithPorts(discoveryv1ac.EndpointPort().
-			WithName("https").
-			WithPort(exposure.Spec.Port).
-			WithProtocol(corev1.ProtocolTCP),
-		)
+	return &discoveryv1.EndpointSlice{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "discovery.k8s.io/v1",
+			Kind:       "EndpointSlice",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      endpointSliceName(exposure, family),
+			Namespace: exposure.Namespace,
+			Labels:    map[string]string{discoveryv1.LabelServiceName: serviceName(exposure)},
+		},
+		AddressType: family,
+		Endpoints:   endpoints,
+		Ports: []discoveryv1.EndpointPort{{
+			Name:     ptr.To("https"),
+			Port:     ptr.To(exposure.Spec.Port),
+			Protocol: ptr.To(corev1.ProtocolTCP),
+		}},
+	}
 }
 
 func serviceName(exposure *extensionsv1alpha1.SelfHostedShootExposure) string {

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -7,6 +7,7 @@ package selfhostedshootexposure
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -15,34 +16,49 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	"github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionselfhostedshootexposure "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
+const portName = "https"
+
 type actuator struct {
 	client client.Client
 }
 
-func newActuator(mgr manager.Manager) selfhostedshootexposure.Actuator {
+func newActuator(mgr manager.Manager) extensionselfhostedshootexposure.Actuator {
 	return &actuator{client: mgr.GetClient()}
 }
 
-func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
+func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
 	service := serviceForExposure(exposure)
+	if err := controllerutil.SetControllerReference(exposure, service, a.client.Scheme()); err != nil {
+		return nil, fmt.Errorf("could not set controller reference on Service: %w", err)
+	}
 	if err := a.client.Patch(ctx, service, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
-		return nil, fmt.Errorf("could not apply Service: %w", err)
+		return nil, fmt.Errorf("could not patch Service: %w", err)
 	}
 
-	for _, family := range endpointSliceFamilies {
-		if err := a.client.Patch(ctx, endpointSliceForExposure(exposure, family), client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
-			return nil, fmt.Errorf("could not apply %s EndpointSlice: %w", family, err)
+	for _, family := range endpointSliceFamiliesForCluster(cluster) {
+		slice, err := endpointSliceForExposure(exposure, family)
+		if err != nil {
+			return nil, fmt.Errorf("could not build %s EndpointSlice: %w", family, err)
+		}
+		if err := controllerutil.SetControllerReference(exposure, slice, a.client.Scheme()); err != nil {
+			return nil, fmt.Errorf("could not set controller reference on %s EndpointSlice: %w", family, err)
+		}
+		if err := a.client.Patch(ctx, slice, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+			return nil, fmt.Errorf("could not patch %s EndpointSlice: %w", family, err)
 		}
 	}
 
@@ -55,31 +71,31 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *ext
 	}
 
 	return service.Status.LoadBalancer.Ingress, nil
-	log.Info("LoadBalancer ready", "ingress", liveService.Status.LoadBalancer.Ingress)
 }
 
-func (a *actuator) Delete(ctx context.Context, _ logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
-	objects := []client.Object{
-		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName(exposure), Namespace: exposure.Namespace}},
-	}
-	for _, family := range endpointSliceFamilies {
-		objects = append(objects, &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Name: endpointSliceName(exposure, family), Namespace: exposure.Namespace}})
-	}
-	for _, obj := range objects {
-		if err := client.IgnoreNotFound(a.client.Delete(ctx, obj)); err != nil {
-			return fmt.Errorf("could not delete %T %q: %w", obj, client.ObjectKeyFromObject(obj), err)
-		}
-	}
+func (a *actuator) Delete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
 	return nil
 }
 
-func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) error {
-	return a.Delete(ctx, log, exposure, cluster)
+func (a *actuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
+	return nil
 }
 
-// endpointSliceFamilies are the address families for which an EndpointSlice is created.
-// On single-stack clusters the non-matching slice is empty and ignored.
-var endpointSliceFamilies = []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6}
+func endpointSliceFamiliesForCluster(cluster *extensionscontroller.Cluster) []discoveryv1.AddressType {
+	if cluster == nil || cluster.Shoot == nil || cluster.Shoot.Spec.Networking == nil {
+		return nil
+	}
+	families := make([]discoveryv1.AddressType, 0, len(cluster.Shoot.Spec.Networking.IPFamilies))
+	for _, f := range cluster.Shoot.Spec.Networking.IPFamilies {
+		switch f {
+		case gardencorev1beta1.IPFamilyIPv4:
+			families = append(families, discoveryv1.AddressTypeIPv4)
+		case gardencorev1beta1.IPFamilyIPv6:
+			families = append(families, discoveryv1.AddressTypeIPv6)
+		}
+	}
+	return families
+}
 
 func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *corev1.Service {
 	return &corev1.Service{
@@ -95,7 +111,7 @@ func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *c
 			Type:           corev1.ServiceTypeLoadBalancer,
 			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 			Ports: []corev1.ServicePort{{
-				Name:       "https",
+				Name:       portName,
 				Port:       exposure.Spec.Port,
 				TargetPort: intstr.FromInt32(exposure.Spec.Port),
 				Protocol:   corev1.ProtocolTCP,
@@ -104,25 +120,33 @@ func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *c
 	}
 }
 
-func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) *discoveryv1.EndpointSlice {
+func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) (*discoveryv1.EndpointSlice, error) {
 	var endpoints []discoveryv1.Endpoint
 	for _, endpoint := range exposure.Spec.Endpoints {
 		for _, address := range endpoint.Addresses {
+			// Use InternalIPs as the Service backends since they are directly reachable
+			// within the cluster network.
 			if address.Type != corev1.NodeInternalIP {
 				continue
 			}
-			isIPv6 := strings.Contains(address.Address, ":")
-			if isIPv6 != (family == discoveryv1.AddressTypeIPv6) {
+			ip, err := netip.ParseAddr(address.Address)
+			if err != nil {
+				continue
+			}
+			// Using ip.Is4() here excludes IPv4-mapped IPv6 addresses (like ::ffff:192.0.2.1)
+			if ip.Is4() != (family == discoveryv1.AddressTypeIPv4) {
 				continue
 			}
 			endpoints = append(endpoints, discoveryv1.Endpoint{
 				Addresses: []string{address.Address},
-				NodeName:  ptr.To(endpoint.NodeName),
 				Conditions: discoveryv1.EndpointConditions{
 					Ready: ptr.To(true),
 				},
 			})
 		}
+	}
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("no %s endpoints found for exposure %q", family, exposure.Name)
 	}
 
 	return &discoveryv1.EndpointSlice{
@@ -138,15 +162,15 @@ func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposu
 		AddressType: family,
 		Endpoints:   endpoints,
 		Ports: []discoveryv1.EndpointPort{{
-			Name:     ptr.To("https"),
+			Name:     ptr.To(portName),
 			Port:     ptr.To(exposure.Spec.Port),
 			Protocol: ptr.To(corev1.ProtocolTCP),
 		}},
-	}
+	}, nil
 }
 
 func serviceName(exposure *extensionsv1alpha1.SelfHostedShootExposure) string {
-	return exposure.Name + "-exposure"
+	return "exposure-" + exposure.Name
 }
 
 func endpointSliceName(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) string {

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -14,11 +14,11 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -33,19 +33,27 @@ import (
 const portName = "https"
 
 type actuator struct {
-	client client.Client
+	// runtimeClient uses provider-local's in-cluster config, e.g., for the seed/bootstrap cluster it runs in.
+	// It's used to interact with extension objects. By default, it's also used as the provider runtimeClient to interact with
+	// infrastructure resources, unless a kubeconfig is specified in the cloudprovider secret.
+	runtimeClient client.Client
 }
 
 func newActuator(mgr manager.Manager) extensionselfhostedshootexposure.Actuator {
-	return &actuator{client: mgr.GetClient()}
+	return &actuator{runtimeClient: mgr.GetClient()}
 }
 
 func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
-	service := serviceForExposure(exposure)
-	if err := controllerutil.SetControllerReference(exposure, service, a.client.Scheme()); err != nil {
-		return nil, fmt.Errorf("could not set controller reference on Service: %w", err)
+	providerClient, err := local.GetProviderClient(ctx, log, a.runtimeClient, corev1.SecretReference{
+		Name:      exposure.Spec.CredentialsRef.Name,
+		Namespace: exposure.Spec.CredentialsRef.Namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create ProviderClient: %w", err)
 	}
-	if err := a.client.Patch(ctx, service, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+
+	service := serviceForExposure(exposure)
+	if err := providerClient.Patch(ctx, service, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 		return nil, fmt.Errorf("could not patch Service: %w", err)
 	}
 
@@ -54,10 +62,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *ext
 		if err != nil {
 			return nil, fmt.Errorf("could not build %s EndpointSlice: %w", family, err)
 		}
-		if err := controllerutil.SetControllerReference(exposure, slice, a.client.Scheme()); err != nil {
-			return nil, fmt.Errorf("could not set controller reference on %s EndpointSlice: %w", family, err)
-		}
-		if err := a.client.Patch(ctx, slice, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
+		if err := providerClient.Patch(ctx, slice, client.Apply, local.FieldOwner, client.ForceOwnership); err != nil {
 			return nil, fmt.Errorf("could not patch %s EndpointSlice: %w", family, err)
 		}
 	}
@@ -73,8 +78,41 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *ext
 	return service.Status.LoadBalancer.Ingress, nil
 }
 
-func (a *actuator) Delete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
-	return nil
+func (a *actuator) Delete(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
+	providerClient, err := local.GetProviderClient(ctx, log, a.runtimeClient, corev1.SecretReference{
+		Name:      exposure.Spec.CredentialsRef.Name,
+		Namespace: exposure.Spec.CredentialsRef.Namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("could not create ProviderClient: %w", err)
+	}
+
+	// Explicitly delete the Service and wait for it to be gone so the LoadBalancer is deprovisioned before
+	// releasing the SelfHostedShootExposure.
+	if err := providerClient.Delete(ctx, serviceForExposure(exposure)); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Service is gone, delete the EndpointSlices. They have no owner references in the provider
+			// cluster so they won't be garbage collected automatically.
+			for _, family := range []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6} {
+				if err := providerClient.Delete(ctx, &discoveryv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      endpointSliceName(exposure, family),
+						Namespace: exposure.Namespace,
+					},
+				}); client.IgnoreNotFound(err) != nil {
+					return fmt.Errorf("could not delete %s EndpointSlice: %w", family, err)
+				}
+			}
+			log.Info("Service gone, releasing SelfHostedShootExposure")
+			return nil
+		}
+		return err
+	}
+
+	return &reconcilerutils.RequeueAfterError{
+		RequeueAfter: 5 * time.Second,
+		Cause:        fmt.Errorf("waiting for Service to be deleted"),
+	}
 }
 
 func (a *actuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -44,12 +44,9 @@ func newActuator(mgr manager.Manager) extensionselfhostedshootexposure.Actuator 
 }
 
 func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
-	providerClient, err := local.GetProviderClient(ctx, log, a.runtimeClient, corev1.SecretReference{
-		Name:      exposure.Spec.CredentialsRef.Name,
-		Namespace: exposure.Spec.CredentialsRef.Namespace,
-	})
+	providerClient, err := a.providerClient(ctx, log, exposure)
 	if err != nil {
-		return nil, fmt.Errorf("could not create ProviderClient: %w", err)
+		return nil, err
 	}
 
 	service := serviceForExposure(exposure)
@@ -78,41 +75,53 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *ext
 	return service.Status.LoadBalancer.Ingress, nil
 }
 
-func (a *actuator) Delete(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
-	providerClient, err := local.GetProviderClient(ctx, log, a.runtimeClient, corev1.SecretReference{
-		Name:      exposure.Spec.CredentialsRef.Name,
-		Namespace: exposure.Spec.CredentialsRef.Namespace,
-	})
+func (a *actuator) Delete(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) error {
+	providerClient, err := a.providerClient(ctx, log, exposure)
 	if err != nil {
-		return fmt.Errorf("could not create ProviderClient: %w", err)
+		return err
 	}
 
 	// Explicitly delete the Service and wait for it to be gone so the LoadBalancer is deprovisioned before
 	// releasing the SelfHostedShootExposure.
 	if err := providerClient.Delete(ctx, serviceForExposure(exposure)); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Service is gone, delete the EndpointSlices. They have no owner references in the provider
-			// cluster so they won't be garbage collected automatically.
-			for _, family := range []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6} {
-				if err := providerClient.Delete(ctx, &discoveryv1.EndpointSlice{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      endpointSliceName(exposure, family),
-						Namespace: exposure.Namespace,
-					},
-				}); client.IgnoreNotFound(err) != nil {
-					return fmt.Errorf("could not delete %s EndpointSlice: %w", family, err)
-				}
-			}
-			log.Info("Service gone, releasing SelfHostedShootExposure")
-			return nil
+		if !apierrors.IsNotFound(err) {
+			return err
 		}
-		return err
+	} else {
+		return &reconcilerutils.RequeueAfterError{
+			RequeueAfter: 5 * time.Second,
+			Cause:        fmt.Errorf("waiting for Service to be deleted"),
+		}
 	}
 
-	return &reconcilerutils.RequeueAfterError{
-		RequeueAfter: 5 * time.Second,
-		Cause:        fmt.Errorf("waiting for Service to be deleted"),
+	// Service is gone; delete the EndpointSlices. They have no owner references in the provider
+	// cluster so they won't be garbage collected automatically.
+	for _, family := range endpointSliceFamiliesForCluster(cluster) {
+		if err := providerClient.Delete(ctx, &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      endpointSliceName(exposure, family),
+				Namespace: exposure.Namespace,
+			},
+		}); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("could not delete %s EndpointSlice: %w", family, err)
+		}
 	}
+	log.Info("Service and EndpointSlices gone, releasing SelfHostedShootExposure")
+	return nil
+}
+
+func (a *actuator) providerClient(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure) (client.Client, error) {
+	if exposure.Spec.CredentialsRef == nil {
+		return nil, fmt.Errorf("credentialsRef is required for the provider-local SelfHostedShootExposure implementation but is not set")
+	}
+	providerClient, err := local.GetProviderClient(ctx, log, a.runtimeClient, corev1.SecretReference{
+		Name:      exposure.Spec.CredentialsRef.Name,
+		Namespace: exposure.Spec.CredentialsRef.Namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create provider client: %w", err)
+	}
+	return providerClient, nil
 }
 
 func (a *actuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -120,12 +120,9 @@ func (a *actuator) ForceDelete(_ context.Context, _ logr.Logger, _ *extensionsv1
 }
 
 func endpointSliceFamiliesForCluster(cluster *extensionscontroller.Cluster) []discoveryv1.AddressType {
-	if cluster == nil || cluster.Shoot == nil || cluster.Shoot.Spec.Networking == nil {
-		return nil
-	}
 	families := make([]discoveryv1.AddressType, 0, len(cluster.Shoot.Spec.Networking.IPFamilies))
-	for _, f := range cluster.Shoot.Spec.Networking.IPFamilies {
-		switch f {
+	for _, family := range cluster.Shoot.Spec.Networking.IPFamilies {
+		switch family {
 		case gardencorev1beta1.IPFamilyIPv4:
 			families = append(families, discoveryv1.AddressTypeIPv4)
 		case gardencorev1beta1.IPFamilyIPv6:
@@ -169,7 +166,7 @@ func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposu
 			}
 			ip, err := netip.ParseAddr(address.Address)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("could not parse address %q for endpoint %q: %w", address.Address, endpoint.NodeName, err)
 			}
 			// Using ip.Is4() here excludes IPv4-mapped IPv6 addresses (like ::ffff:192.0.2.1)
 			if ip.Is4() != (family == discoveryv1.AddressTypeIPv4) {

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	extensionselfhostedshootexposure "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionsselfhostedshootexposurecontroller "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
@@ -39,7 +39,7 @@ type actuator struct {
 	runtimeClient client.Client
 }
 
-func newActuator(mgr manager.Manager) extensionselfhostedshootexposure.Actuator {
+func newActuator(mgr manager.Manager) extensionsselfhostedshootexposurecontroller.Actuator {
 	return &actuator{runtimeClient: mgr.GetClient()}
 }
 
@@ -83,15 +83,15 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, exposure *extens
 
 	// Explicitly delete the Service and wait for it to be gone so the LoadBalancer is deprovisioned before
 	// releasing the SelfHostedShootExposure.
-	if err := providerClient.Delete(ctx, serviceForExposure(exposure)); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-	} else {
+	err = providerClient.Delete(ctx, serviceForExposure(exposure))
+	if err == nil {
 		return &reconcilerutils.RequeueAfterError{
 			RequeueAfter: 5 * time.Second,
 			Cause:        fmt.Errorf("waiting for Service to be deleted"),
 		}
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
 	}
 
 	// Service is gone; delete the EndpointSlices. They have no owner references in the provider

--- a/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/actuator.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	discoveryv1ac "k8s.io/client-go/applyconfigurations/discovery/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+type actuator struct {
+	client client.Client
+}
+
+func newActuator(mgr manager.Manager) selfhostedshootexposure.Actuator {
+	return &actuator{client: mgr.GetClient()}
+}
+
+func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) ([]corev1.LoadBalancerIngress, error) {
+	if err := a.client.Apply(ctx, serviceForExposure(exposure), local.FieldOwner, client.ForceOwnership); err != nil {
+		return nil, fmt.Errorf("could not apply Service: %w", err)
+	}
+
+	for _, family := range endpointSliceFamilies {
+		if err := a.client.Apply(ctx, endpointSliceForExposure(exposure, family), local.FieldOwner, client.ForceOwnership); err != nil {
+			return nil, fmt.Errorf("could not apply %s EndpointSlice: %w", family, err)
+		}
+	}
+
+	liveService := &corev1.Service{}
+	if err := a.client.Get(ctx, client.ObjectKey{Name: serviceName(exposure), Namespace: exposure.Namespace}, liveService); err != nil {
+		return nil, fmt.Errorf("could not get Service: %w", err)
+	}
+
+	if len(liveService.Status.LoadBalancer.Ingress) == 0 {
+		log.Info("Waiting for LoadBalancer to get an external address")
+		return nil, &reconcilerutils.RequeueAfterError{
+			RequeueAfter: 5 * time.Second,
+			Cause:        fmt.Errorf("LoadBalancer not yet ready"),
+		}
+	}
+
+	log.Info("LoadBalancer ready", "ingress", liveService.Status.LoadBalancer.Ingress)
+	return liveService.Status.LoadBalancer.Ingress, nil
+}
+
+func (a *actuator) Delete(ctx context.Context, _ logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, _ *extensionscontroller.Cluster) error {
+	objects := []client.Object{
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName(exposure), Namespace: exposure.Namespace}},
+	}
+	for _, family := range endpointSliceFamilies {
+		objects = append(objects, &discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Name: endpointSliceName(exposure, family), Namespace: exposure.Namespace}})
+	}
+	for _, obj := range objects {
+		if err := client.IgnoreNotFound(a.client.Delete(ctx, obj)); err != nil {
+			return fmt.Errorf("could not delete %T %q: %w", obj, client.ObjectKeyFromObject(obj), err)
+		}
+	}
+	return nil
+}
+
+func (a *actuator) ForceDelete(ctx context.Context, log logr.Logger, exposure *extensionsv1alpha1.SelfHostedShootExposure, cluster *extensionscontroller.Cluster) error {
+	return a.Delete(ctx, log, exposure, cluster)
+}
+
+// endpointSliceFamilies are the address families for which an EndpointSlice is created.
+// On single-stack clusters the non-matching slice is empty and ignored.
+var endpointSliceFamilies = []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6}
+
+func serviceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure) *corev1ac.ServiceApplyConfiguration {
+	return corev1ac.Service(serviceName(exposure), exposure.Namespace).
+		WithSpec(corev1ac.ServiceSpec().
+			WithType(corev1.ServiceTypeLoadBalancer).
+			WithIPFamilyPolicy(corev1.IPFamilyPolicyPreferDualStack).
+			WithPorts(corev1ac.ServicePort().
+				WithName("https").
+				WithPort(exposure.Spec.Port).
+				WithTargetPort(intstr.FromInt32(exposure.Spec.Port)).
+				WithProtocol(corev1.ProtocolTCP),
+			),
+		)
+}
+
+func endpointSliceForExposure(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) *discoveryv1ac.EndpointSliceApplyConfiguration {
+	var endpoints []*discoveryv1ac.EndpointApplyConfiguration
+	for _, endpoint := range exposure.Spec.Endpoints {
+		for _, address := range endpoint.Addresses {
+			if address.Type != corev1.NodeInternalIP {
+				continue
+			}
+			isIPv6 := strings.Contains(address.Address, ":")
+			if isIPv6 != (family == discoveryv1.AddressTypeIPv6) {
+				continue
+			}
+			endpoints = append(endpoints, discoveryv1ac.Endpoint().
+				WithAddresses(address.Address).
+				WithNodeName(endpoint.NodeName).
+				WithConditions(discoveryv1ac.EndpointConditions().WithReady(true)),
+			)
+		}
+	}
+
+	return discoveryv1ac.EndpointSlice(endpointSliceName(exposure, family), exposure.Namespace).
+		WithLabels(map[string]string{discoveryv1.LabelServiceName: serviceName(exposure)}).
+		WithAddressType(family).
+		WithEndpoints(endpoints...).
+		WithPorts(discoveryv1ac.EndpointPort().
+			WithName("https").
+			WithPort(exposure.Spec.Port).
+			WithProtocol(corev1.ProtocolTCP),
+		)
+}
+
+func serviceName(exposure *extensionsv1alpha1.SelfHostedShootExposure) string {
+	return exposure.Name + "-exposure"
+}
+
+func endpointSliceName(exposure *extensionsv1alpha1.SelfHostedShootExposure, family discoveryv1.AddressType) string {
+	return serviceName(exposure) + "-" + strings.ToLower(string(family))
+}

--- a/pkg/provider-local/controller/selfhostedshootexposure/add.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/add.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure
+
+import (
+	"context"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+var (
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+
+	// supportedExtensionClasses are the extension classes supported by the SelfHostedShootExposure controller.
+	supportedExtensionClasses = sets.New(extensionsv1alpha1.ExtensionClassShoot)
+)
+
+// AddOptions are options to apply when adding the SelfHostedShootExposure controller to the manager.
+type AddOptions struct {
+	// Controller are the controller.Options.
+	Controller controller.Options
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	IgnoreOperationAnnotation bool
+	// ExtensionClasses are the configured extension classes for this extension deployment.
+	ExtensionClasses []extensionsv1alpha1.ExtensionClass
+}
+
+// AddToManagerWithOptions adds a controller with the given Options to the given manager.
+func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
+	classes := slices.DeleteFunc(opts.ExtensionClasses, func(class extensionsv1alpha1.ExtensionClass) bool {
+		return !supportedExtensionClasses.Has(class)
+	})
+
+	return selfhostedshootexposure.Add(mgr, selfhostedshootexposure.AddArgs{
+		Actuator:          newActuator(mgr),
+		ControllerOptions: opts.Controller,
+		Predicates:        selfhostedshootexposure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Type:              local.Type,
+		ExtensionClasses:  classes,
+	})
+}
+
+// AddToManager adds a controller with the default Options.
+func AddToManager(_ context.Context, mgr manager.Manager) error {
+	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+}

--- a/pkg/provider-local/controller/selfhostedshootexposure/add.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/add.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionselfhostedshootexposure "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
@@ -41,10 +41,10 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		return !supportedExtensionClasses.Has(class)
 	})
 
-	return selfhostedshootexposure.Add(mgr, selfhostedshootexposure.AddArgs{
+	return extensionselfhostedshootexposure.Add(mgr, extensionselfhostedshootexposure.AddArgs{
 		Actuator:          newActuator(mgr),
 		ControllerOptions: opts.Controller,
-		Predicates:        selfhostedshootexposure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        extensionselfhostedshootexposure.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              local.Type,
 		ExtensionClasses:  classes,
 	})

--- a/pkg/provider-local/controller/selfhostedshootexposure/add.go
+++ b/pkg/provider-local/controller/selfhostedshootexposure/add.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	extensionselfhostedshootexposure "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
+	extensionsselfhostedshootexposurecontroller "github.com/gardener/gardener/extensions/pkg/controller/selfhostedshootexposure"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 )
@@ -41,10 +41,10 @@ func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 		return !supportedExtensionClasses.Has(class)
 	})
 
-	return extensionselfhostedshootexposure.Add(mgr, extensionselfhostedshootexposure.AddArgs{
+	return extensionsselfhostedshootexposurecontroller.Add(mgr, extensionsselfhostedshootexposurecontroller.AddArgs{
 		Actuator:          newActuator(mgr),
 		ControllerOptions: opts.Controller,
-		Predicates:        extensionselfhostedshootexposure.DefaultPredicates(opts.IgnoreOperationAnnotation),
+		Predicates:        extensionsselfhostedshootexposurecontroller.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              local.Type,
 		ExtensionClasses:  classes,
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

/area ipcei networking
/kind enhancement

**What this PR does / why we need it**:

This PR adds a `SelfHostedShootExposure` controller to `provider-local`. For each `SelfHostedShootExposure` the actuator reconciles a `LoadBalancer` Service with one corresponding `EndpointSlice` per IP address family. The Service does not specify a selector, the `EndpointSlices` are fully managed by the extension controller.

All control plane endpoints are published via the `EndpointSlice` objects and the IP address of the provisioned load balancer is exposed in the status of the `SelfHostedShootExposure` object.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13602

**Special notes for your reviewer**:

I have added support for dual-stack setups even though `gardenadm` currently only works with IPv4. If it does not make sense to handle IPv6 or dual-stack setup at the moment, I can remove the corresponding parts in the code.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `provider-local` now implements the `SelfHostedShootExposure` extension.
```
