### PR TITLE
Fix gRPC upstream protocol for otel-collector DestinationRule

### DIFF
--- a/pkg/component/observability/opentelemetry/collector/collector.go
+++ b/pkg/component/observability/opentelemetry/collector/collector.go
@@ -728,6 +728,9 @@ func (o *otelCollector) getIstioResources(tlsSecret *corev1.Secret) ([]client.Ob
 	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, getLabels(), destinationHost)(); err != nil {
 		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
 	}
+	destinationRule.Spec.TrafficPolicy.ConnectionPool.Http = &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+		UseClientProtocol: true,
+	}
 
 	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -947,6 +947,9 @@ func getDestinationRule() *istionetworkingv1beta1.DestinationRule {
 						},
 						MaxConnectionDuration: &durationpb.Duration{Seconds: 86400},
 					},
+					Http: &istioapinetworkingv1beta1.ConnectionPoolSettings_HTTPSettings{
+						UseClientProtocol: true,
+					},
 				},
 				OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{},
 				Tls:              &istioapinetworkingv1beta1.ClientTLSSettings{},


### PR DESCRIPTION
/area logging
/kind bug

**What this PR does / why we need it**:

The logging `DestinationRule` for the otel-collector did not specify HTTP connection pool settings, causing the istio-ingress gateway to default to HTTP/1.1 when connecting upstream to the otel-collector on port 8080. Since gRPC requires HTTP/2 for proper trailer handling, this caused intermittent `"server closed the stream without sending trailers"` errors on the shoot-node otel-collector exporter.

This PR sets `useClientProtocol: true` in the DestinationRule's HTTP connection pool settings so the istio-ingress preserves the client's HTTP/2 protocol when connecting to the backend.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The `DestinationRuleWithLocalityPreference` helper passes `nil` for the HTTP connection pool settings. Without explicit HTTP settings, Istio defaults to HTTP/1.1 for upstream connections. This is fine for HTTP/1.1 services but breaks gRPC which requires HTTP/2 end-to-end for trailer propagation.

The fix mutates the DestinationRule spec after creation rather than changing the shared helper's signature, keeping the change minimal and non-breaking for other callers.

**Release note**:
```bugfix operator
Fixed intermittent gRPC "server closed the stream without sending trailers" errors for shoot-node log collection by setting `useClientProtocol: true` on the otel-collector DestinationRule to ensure HTTP/2 is used for upstream connections.
```