### PR TITLE
systemdunitcheck: Do not report unhealthy status for a disabled unit that is in failed state

### DIFF
--- a/pkg/nodeagent/controller/systemdunitcheck/reconciler.go
+++ b/pkg/nodeagent/controller/systemdunitcheck/reconciler.go
@@ -168,7 +168,10 @@ func (r *Reconciler) checkUnits(ctx context.Context, units []unitInfo) (unhealth
 			}
 
 		case "failed":
-			unhealthyMessages = append(unhealthyMessages, fmt.Sprintf("%s: failed", unit.name))
+			// Only enabled units should be marked as erroring in case they are in a failed state.
+			if unit.enabled {
+				unhealthyMessages = append(unhealthyMessages, fmt.Sprintf("%s: failed", unit.name))
+			}
 
 		case "activating", "deactivating":
 			// Services configured with Restart=always/on-success cycle through "activating (auto-restart)"

--- a/test/integration/nodeagent/systemdunitcheck/systemdunitcheck_test.go
+++ b/test/integration/nodeagent/systemdunitcheck/systemdunitcheck_test.go
@@ -302,6 +302,28 @@ var _ = Describe("SystemdUnitCheck controller tests", func() {
 		})))
 	})
 
+	It("should not report unhealthy for a disabled unit that is in a failed state", func() {
+		writeOSC(&extensionsv1alpha1.OperatingSystemConfig{
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				Units: []extensionsv1alpha1.Unit{
+					{Name: "optional.service", Enable: ptr.To(false)},
+				},
+			},
+		})
+
+		fakeDBus.AddUnitsToList(
+			systemddbus.UnitStatus{Name: "optional.service", ActiveState: "failed"},
+		)
+
+		Eventually(func(g Gomega) *corev1.NodeCondition {
+			return getNodeCondition(g)
+		}).Should(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":   Equal(nodeagentconfigv1alpha1.ConditionTypeSystemdUnitsReady),
+			"Status": Equal(corev1.ConditionTrue),
+			"Reason": Equal("AllUnitsHealthy"),
+		})))
+	})
+
 	It("should also monitor gardener-node-agent's own units", func() {
 		writeOSC(&extensionsv1alpha1.OperatingSystemConfig{
 			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area robustness
/area os
/kind bug

**What this PR does / why we need it**:

Disabled `systemd units` in a `failed` state are currently reported as `unhealthy` by the `systemdunitcheck` controller introduced in https://github.com/gardener/gardener/pull/14496. This affects units that are explicitly disabled, for example in the CoreOS extension (see https://github.com/gardener/gardener-extension-os-coreos/blob/0f3c67a060fa90771c10e9322fa09d5757e37b55/pkg/controller/operatingsystemconfig/actuator.go#L191-L194).

Such units may remain in a failed state from a previous run, which is expected. Disabled units should not be considered when evaluating node health, regardless of their last active state.

As a result, Shoots are incorrectly marked as unhealthy.

Example of the error that is displayed for the Shoot in the Gardener Dashboard:
`systemd units are not healthy on node "...": update-engine.service: failed`

Example unit status on the node:
```
× update-engine.service - Update Engine
     Loaded: loaded (/usr/lib/systemd/system/update-engine.service; disabled; preset: disabled)
     Active: failed (Result: exit-code) since Tue 2026-04-21 13:25:48 UTC; 1 week 1 day ago
```

**Which issue(s) this PR fixes**:
Fixes: #

**Special notes for your reviewer**:
To solve the issue I have added a simple check that ensures a failed unit is only being reported as `unhealthy` when it is not explicitly disabled.

I have also added a test to check for this special case. 

/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `systemdunitcheck` controller now correctly treats systemd units that are in a failed state but explicitly disabled as healthy.
```
