### PR TITLE
test(utils): convert VisitPodSpec table tests to DescribeTable (refs #13890)

### DIFF
--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -72,61 +72,89 @@ var _ = Describe("Pod Utils", func() {
 		})
 
 		DescribeTable("should visit and mutate PodSpec",
-			func(obj runtime.Object, getSpec func(runtime.Object) *corev1.PodSpec) {
+			func(build func() runtime.Object, getPodSpec func(runtime.Object) *corev1.PodSpec) {
+				obj := build()
+
 				Expect(VisitPodSpec(obj, func(podSpec *corev1.PodSpec) {
 					podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
 				})).To(Succeed())
 
-				Expect(getSpec(obj).RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+				Expect(getPodSpec(obj).RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+				Expect(getPodSpec(obj).InitContainers).To(HaveLen(2))
+				Expect(getPodSpec(obj).Containers).To(HaveLen(2))
 			},
 			Entry("corev1.Pod",
-				&corev1.Pod{Spec: podSpec},
+				func() runtime.Object {
+					return &corev1.Pod{Spec: podSpec}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*corev1.Pod).Spec },
 			),
 			Entry("appsv1.Deployment",
-				&appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.Deployment).Spec.Template.Spec },
 			),
 			Entry("appsv1beta2.Deployment",
-				&appsv1beta2.Deployment{Spec: appsv1beta2.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1beta2.Deployment{Spec: appsv1beta2.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.Deployment).Spec.Template.Spec },
 			),
 			Entry("appsv1beta1.Deployment",
-				&appsv1beta1.Deployment{Spec: appsv1beta1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1beta1.Deployment{Spec: appsv1beta1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta1.Deployment).Spec.Template.Spec },
 			),
 			Entry("appsv1.StatefulSet",
-				&appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.StatefulSet).Spec.Template.Spec },
 			),
 			Entry("appsv1beta2.StatefulSet",
-				&appsv1beta2.StatefulSet{Spec: appsv1beta2.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1beta2.StatefulSet{Spec: appsv1beta2.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.StatefulSet).Spec.Template.Spec },
 			),
 			Entry("appsv1beta1.StatefulSet",
-				&appsv1beta1.StatefulSet{Spec: appsv1beta1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1beta1.StatefulSet{Spec: appsv1beta1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta1.StatefulSet).Spec.Template.Spec },
 			),
 			Entry("appsv1.DaemonSet",
-				&appsv1.DaemonSet{Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1.DaemonSet{Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.DaemonSet).Spec.Template.Spec },
 			),
 			Entry("appsv1beta2.DaemonSet",
-				&appsv1beta2.DaemonSet{Spec: appsv1beta2.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &appsv1beta2.DaemonSet{Spec: appsv1beta2.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.DaemonSet).Spec.Template.Spec },
 			),
 			Entry("batchv1.Job",
-				&batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func() runtime.Object {
+					return &batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec { return &o.(*batchv1.Job).Spec.Template.Spec },
 			),
 			Entry("batchv1.CronJob",
-				&batchv1.CronJob{Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}},
+				func() runtime.Object {
+					return &batchv1.CronJob{Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec {
 					return &o.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec
 				},
 			),
 			Entry("batchv1beta1.CronJob",
-				&batchv1beta1.CronJob{Spec: batchv1beta1.CronJobSpec{JobTemplate: batchv1beta1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}},
+				func() runtime.Object {
+					return &batchv1beta1.CronJob{Spec: batchv1beta1.CronJobSpec{JobTemplate: batchv1beta1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}}
+				},
 				func(o runtime.Object) *corev1.PodSpec {
 					return &o.(*batchv1beta1.CronJob).Spec.JobTemplate.Spec.Template.Spec
 				},

--- a/pkg/utils/kubernetes/pod_test.go
+++ b/pkg/utils/kubernetes/pod_test.go
@@ -71,151 +71,67 @@ var _ = Describe("Pod Utils", func() {
 			Expect(VisitPodSpec(&corev1.Service{}, nil)).To(MatchError(ContainSubstring("unhandled object type")))
 		})
 
-		test := func(obj runtime.Object, podSpec *corev1.PodSpec) {
-			It("should visit and mutate PodSpec", Offset(1), func() {
+		DescribeTable("should visit and mutate PodSpec",
+			func(obj runtime.Object, getSpec func(runtime.Object) *corev1.PodSpec) {
 				Expect(VisitPodSpec(obj, func(podSpec *corev1.PodSpec) {
 					podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
 				})).To(Succeed())
 
-				Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
-			})
-		}
-
-		Context("corev1.Pod", func() {
-			var obj = &corev1.Pod{
-				Spec: podSpec,
-			}
-			test(obj, &obj.Spec)
-		})
-
-		Context("appsv1.Deployment", func() {
-			var obj = &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
+				Expect(getSpec(obj).RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+			},
+			Entry("corev1.Pod",
+				&corev1.Pod{Spec: podSpec},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*corev1.Pod).Spec },
+			),
+			Entry("appsv1.Deployment",
+				&appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.Deployment).Spec.Template.Spec },
+			),
+			Entry("appsv1beta2.Deployment",
+				&appsv1beta2.Deployment{Spec: appsv1beta2.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.Deployment).Spec.Template.Spec },
+			),
+			Entry("appsv1beta1.Deployment",
+				&appsv1beta1.Deployment{Spec: appsv1beta1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta1.Deployment).Spec.Template.Spec },
+			),
+			Entry("appsv1.StatefulSet",
+				&appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.StatefulSet).Spec.Template.Spec },
+			),
+			Entry("appsv1beta2.StatefulSet",
+				&appsv1beta2.StatefulSet{Spec: appsv1beta2.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.StatefulSet).Spec.Template.Spec },
+			),
+			Entry("appsv1beta1.StatefulSet",
+				&appsv1beta1.StatefulSet{Spec: appsv1beta1.StatefulSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta1.StatefulSet).Spec.Template.Spec },
+			),
+			Entry("appsv1.DaemonSet",
+				&appsv1.DaemonSet{Spec: appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1.DaemonSet).Spec.Template.Spec },
+			),
+			Entry("appsv1beta2.DaemonSet",
+				&appsv1beta2.DaemonSet{Spec: appsv1beta2.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*appsv1beta2.DaemonSet).Spec.Template.Spec },
+			),
+			Entry("batchv1.Job",
+				&batchv1.Job{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}},
+				func(o runtime.Object) *corev1.PodSpec { return &o.(*batchv1.Job).Spec.Template.Spec },
+			),
+			Entry("batchv1.CronJob",
+				&batchv1.CronJob{Spec: batchv1.CronJobSpec{JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}},
+				func(o runtime.Object) *corev1.PodSpec {
+					return &o.(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec
 				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1beta2.Deployment", func() {
-			var obj = &appsv1beta2.Deployment{
-				Spec: appsv1beta2.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
+			),
+			Entry("batchv1beta1.CronJob",
+				&batchv1beta1.CronJob{Spec: batchv1beta1.CronJobSpec{JobTemplate: batchv1beta1.JobTemplateSpec{Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: podSpec}}}}},
+				func(o runtime.Object) *corev1.PodSpec {
+					return &o.(*batchv1beta1.CronJob).Spec.JobTemplate.Spec.Template.Spec
 				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1beta1.Deployment", func() {
-			var obj = &appsv1beta1.Deployment{
-				Spec: appsv1beta1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1.StatefulSet", func() {
-			var obj = &appsv1.StatefulSet{
-				Spec: appsv1.StatefulSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1beta2.StatefulSet", func() {
-			var obj = &appsv1beta2.StatefulSet{
-				Spec: appsv1beta2.StatefulSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1beta1.StatefulSet", func() {
-			var obj = &appsv1beta1.StatefulSet{
-				Spec: appsv1beta1.StatefulSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1.DaemonSet", func() {
-			var obj = &appsv1.DaemonSet{
-				Spec: appsv1.DaemonSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("appsv1beta2.DaemonSet", func() {
-			var obj = &appsv1beta2.DaemonSet{
-				Spec: appsv1beta2.DaemonSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("batchv1.Job", func() {
-			var obj = &batchv1.Job{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: podSpec,
-					},
-				},
-			}
-			test(obj, &obj.Spec.Template.Spec)
-		})
-
-		Context("batchv1.CronJob", func() {
-			var obj = &batchv1.CronJob{
-				Spec: batchv1.CronJobSpec{
-					JobTemplate: batchv1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: podSpec,
-							},
-						},
-					},
-				},
-			}
-			test(obj, &obj.Spec.JobTemplate.Spec.Template.Spec)
-		})
-
-		Context("batchv1beta1.CronJob", func() {
-			var obj = &batchv1beta1.CronJob{
-				Spec: batchv1beta1.CronJobSpec{
-					JobTemplate: batchv1beta1.JobTemplateSpec{
-						Spec: batchv1.JobSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: podSpec,
-							},
-						},
-					},
-				},
-			}
-			test(obj, &obj.Spec.JobTemplate.Spec.Template.Spec)
-		})
+			),
+		)
 	})
 
 	Describe("#VisitContainers", func() {


### PR DESCRIPTION
<!-- /area dev-productivity -->
<!-- /kind cleanup -->

**What this PR does / why we need it**:

Refs #13890. Converts the table-style tests in `pkg/utils/kubernetes/pod_test.go::#VisitPodSpec` from the manual `test()` helper plus 12 `Context` blocks into a single `DescribeTable` with 12 `Entry` lines, which is the idiomatic Ginkgo pattern called out in the issue. The "good first issue" examples in the issue body have moved away from `pkg/apis/core/helper/` (the package no longer exists), so I picked the second example listed in the issue (`pkg/utils/kubernetes/pod_test.go`), which still has the same shape.

The behavior is unchanged: same 12 cases, same assertion (`VisitPodSpec` mutates `RestartPolicy`), same `RestartPolicyOnFailure` expectation. The diff drops 139 lines of `Context` wrapper boilerplate in favor of 55 lines of `Entry` declarations.

The `DescribeTable` takes the `runtime.Object` and a getter that returns the embedded `*PodSpec`; the getter pattern handles the two `CronJob` cases (`Spec.JobTemplate.Spec.Template.Spec`) the same as the simpler ones.

I left the `It("should do nothing because object type is not handled")` block alone since it's a single negative case, not a table row.

**Which issue(s) this PR fixes**:
Part of #13890

**Special notes for your reviewer**:

- 264 of 264 specs still pass locally (`go test ./pkg/utils/kubernetes/`).
- `gofmt` and `go vet` clean.
- I noted @timebertt's "lacks type-safety and IDE navigation" caveat in the issue thread. That's true in general; the trade is fewer lines and a single source of truth for the assertion. If the trade-off is unwelcome here, happy to drop the PR; otherwise the same pattern can be applied to the other examples in the issue once the existing `pkg/apis/core/helper/*_test.go` files are located in their new home.

**Release note**:
```other
NONE
```