### PR TITLE
extensions/healthcheck: improve log structure of SetLoggerSuffix across all checkers

### DIFF
--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -74,7 +74,7 @@ func (h *ShootDaemonSetHealthChecker) InjectTargetClient(targetClient client.Cli
 
 // SetLoggerSuffix injects the logger
 func (h *daemonSetHealthChecker) SetLoggerSuffix(provider, extension string) {
-	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-daemonset", provider, extension))
+	h.logger = log.Log.WithName("healthcheck-daemonset").WithValues("provider", provider, "extension", extension)
 }
 
 // Check executes the health check

--- a/extensions/pkg/controller/healthcheck/general/deployment.go
+++ b/extensions/pkg/controller/healthcheck/general/deployment.go
@@ -74,7 +74,7 @@ func (h *ShootDeploymentHealthChecker) InjectTargetClient(targetClient client.Cl
 
 // SetLoggerSuffix injects the logger
 func (h *deploymentHealthChecker) SetLoggerSuffix(provider, extension string) {
-	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-deployment", provider, extension))
+	h.logger = log.Log.WithName("healthcheck-deployment").WithValues("provider", provider, "extension", extension)
 }
 
 // Check executes the health check

--- a/extensions/pkg/controller/healthcheck/general/managed_resource.go
+++ b/extensions/pkg/controller/healthcheck/general/managed_resource.go
@@ -47,7 +47,7 @@ func (healthChecker *ManagedResourceHealthChecker) InjectSourceClient(client cli
 
 // SetLoggerSuffix injects the logger
 func (healthChecker *ManagedResourceHealthChecker) SetLoggerSuffix(provider, extension string) {
-	healthChecker.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-managed-resource", provider, extension))
+	healthChecker.logger = log.Log.WithName("healthcheck-managed-resource").WithValues("provider", provider, "extension", extension)
 }
 
 // configurationProblemRegex is used to check if a not healthy managed resource has a configuration problem.

--- a/extensions/pkg/controller/healthcheck/general/statefulsets.go
+++ b/extensions/pkg/controller/healthcheck/general/statefulsets.go
@@ -74,7 +74,7 @@ func (h *ShootStatefulSetHealthChecker) InjectTargetClient(targetClient client.C
 
 // SetLoggerSuffix injects the logger
 func (h *statefulSetHealthChecker) SetLoggerSuffix(provider, extension string) {
-	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-statefulset", provider, extension))
+	h.logger = log.Log.WithName("healthcheck-statefulset").WithValues("provider", provider, "extension", extension)
 }
 
 // Check executes the health check

--- a/extensions/pkg/controller/healthcheck/worker/nodes.go
+++ b/extensions/pkg/controller/healthcheck/worker/nodes.go
@@ -84,7 +84,7 @@ func (h *DefaultHealthChecker) InjectTargetClient(targetClient client.Client) {
 
 // SetLoggerSuffix injects the logger.
 func (h *DefaultHealthChecker) SetLoggerSuffix(provider, extension string) {
-	h.logger = log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-nodes", provider, extension))
+	h.logger = log.Log.WithName("healthcheck-nodes").WithValues("provider", provider, "extension", extension)
 }
 
 // Check executes the health check.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area logging
/area quality
/kind enhancement

**What this PR does / why we need it**:

All five `SetLoggerSuffix` implementations in the extension healthcheck package (`general/deployment.go`, `general/daemonset.go`, `general/statefulsets.go`, `general/managed_resource.go`, and `worker/nodes.go`) previously embedded `provider` and `extension` into the logger name using `fmt.Sprintf`, e.g.:

```json
{
    "logger": "gcp-ControlPlane-healthcheck-deployment",
    "level": "error",
    "msg": "Health check failed"
}
```

This makes logs harder to filter programmatically since the values are fused into an opaque string rather than being queryable fields.

This PR changes each `SetLoggerSuffix` to use a stable logger name and attach `provider` and `extension` as structured fields via `WithValues`:

```json
{
    "logger": "healthcheck-deployment",
    "provider": "gcp",
    "extension": "ControlPlane",
    "level": "error",
    "msg": "Health check failed"
}
```

The `HealthCheck` interface (`SetLoggerSuffix(string, string)`) and all callers are untouched. No behaviour changes — only the structure of the log output.

**Which issue(s) this PR fixes**:
Fixes #13373

**Special notes for your reviewer**:

The change is one line per file across five files — only `SetLoggerSuffix` is touched in each case. `fmt` remains imported in all files since it is still used in the `Check` functions for error formatting.

**Release note**:
```other developer
The `SetLoggerSuffix` implementations in the extension healthcheck package now emit `provider` and `extension` as independent structured log fields instead of embedding them in the logger name.
```