### PR TITLE
Fix empty `GroupVersionKind` during cleanup

### DIFF
--- a/pkg/gardenlet/operation/botanist/cleanup.go
+++ b/pkg/gardenlet/operation/botanist/cleanup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	utilclient "github.com/gardener/gardener/pkg/utils/kubernetes/client"
@@ -309,7 +310,7 @@ func (b *Botanist) addAdditionalCleanOptionsForKubernetesCleanup(
 	}
 
 	cleanOptions.IgnoreLeftovers = append(cleanOptions.IgnoreLeftovers,
-		utilclient.IgnoreUnknownNamespaces(namespaces),
+		utilclient.IgnoreUnknownNamespaces(namespaces, kubernetes.ShootScheme),
 	)
 
 	// Kubernetes objects created after the cleanup started + finalize time should be ignored.
@@ -323,7 +324,7 @@ func (b *Botanist) addAdditionalCleanOptionsForKubernetesCleanup(
 	}
 
 	cleanOptions.IgnoreLeftovers = append(cleanOptions.IgnoreLeftovers,
-		utilclient.IgnoreObjectsCreatedAfter(cleanupStartTime.Add(time.Duration(finalizeSeconds)*time.Second)),
+		utilclient.IgnoreObjectsCreatedAfter(cleanupStartTime.Add(time.Duration(finalizeSeconds)*time.Second), kubernetes.ShootScheme),
 	)
 
 	return nil

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -18,50 +18,51 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
 
-type objectsRemaining []client.Object
+type objectsRemaining struct {
+	scheme           *runtime.Scheme
+	remainingObjects []client.Object
+}
 
 // Error implements error.
 func (n objectsRemaining) Error() string {
-	out := make([]string, 0, len(n))
-	for _, obj := range n {
-		var typeID string
-		gvk := obj.GetObjectKind().GroupVersionKind()
-		if gvk.Empty() {
-			typeID = fmt.Sprintf("%T", obj)
-		} else {
-			typeID = gvk.String()
-		}
-
-		out = append(out, fmt.Sprintf("%s %s", typeID, client.ObjectKeyFromObject(obj).String()))
+	out := make([]string, 0, len(n.remainingObjects))
+	for _, obj := range n.remainingObjects {
+		out = append(out, fmt.Sprintf("%s %s", GVKStringForObject(obj, n.scheme), client.ObjectKeyFromObject(obj).String()))
 	}
 	return fmt.Sprintf("remaining objects are still present: %v", out)
 }
 
 // AreObjectsRemaining checks whether the given error is an 'objects remaining error'.
 func AreObjectsRemaining(err error) bool {
-	_, ok := err.(objectsRemaining)
-	return ok
+	objectsRemainingErr := &objectsRemaining{}
+	return errors.As(err, &objectsRemainingErr)
 }
 
 // NewObjectsRemaining returns a new error with the remaining objects.
-func NewObjectsRemaining(obj runtime.Object) error {
+func NewObjectsRemaining(obj runtime.Object, scheme *runtime.Scheme) error {
+	r := &objectsRemaining{
+		scheme: scheme,
+	}
+
 	switch remaining := obj.(type) {
 	case client.ObjectList:
-		r := make(objectsRemaining, 0, meta.LenList(remaining))
+		r.remainingObjects = make([]client.Object, 0, meta.LenList(remaining))
 		if err := meta.EachListItem(remaining, func(obj runtime.Object) error {
-			r = append(r, obj.(client.Object))
+			r.remainingObjects = append(r.remainingObjects, obj.(client.Object))
 			return nil
 		}); err != nil {
 			return err
 		}
 		return r
 	case client.Object:
-		return objectsRemaining{remaining}
+		r.remainingObjects = append(r.remainingObjects, remaining)
+		return r
 	}
 	return fmt.Errorf("type %T does neither implement client.Object nor client.ObjectList", obj)
 }
@@ -311,7 +312,7 @@ func ensureGone(ctx context.Context, c client.Client, log logr.Logger, obj clien
 		}
 	}
 
-	return NewObjectsRemaining(obj)
+	return NewObjectsRemaining(obj, c.Scheme())
 }
 
 func ensureCollectionGone(ctx context.Context, c client.Client, log logr.Logger, list client.ObjectList, listOpts []client.ListOption, ignoreFns []IgnoreLeftoverFunc) error {
@@ -341,7 +342,7 @@ func ensureCollectionGone(ctx context.Context, c client.Client, log logr.Logger,
 	}
 
 	if ignoredObjects < objectsInList {
-		return NewObjectsRemaining(list)
+		return NewObjectsRemaining(list, c.Scheme())
 	}
 	return nil
 }
@@ -470,4 +471,20 @@ func ForceDeleteObjects(c client.Client, namespace string, objectList client.Obj
 			return controllerutils.RemoveAllFinalizers(ctx, c, object)
 		})
 	}
+}
+
+// GVKStringForObject finds the GroupVersionKind associated with the given object.
+// Falls back to the object type if a distinct GVK couldn't be found.
+func GVKStringForObject(obj client.Object, scheme *runtime.Scheme) string {
+	var typeID string
+	// Generally use the scheme to find the GVK for the object, since list calls may strip the type meta.
+	// See https://github.com/kubernetes-sigs/controller-runtime/issues/3302#issuecomment-3237537512 for more information.
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil || gvk.Empty() {
+		typeID = fmt.Sprintf("%T", obj)
+	} else {
+		typeID = gvk.String()
+	}
+
+	return typeID
 }

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Cleaner", func() {
 			cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "n", Name: "foo"}}
 			Expect(fakeClient.Create(ctx, cm1)).To(Succeed())
 
-			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, cm1)).To(Equal(NewObjectsRemaining(cm1)))
+			Expect(EnsureGone(ctx, logr.Discard(), fakeClient, cm1)).To(Equal(NewObjectsRemaining(cm1, kubernetesscheme.Scheme)))
 		})
 
 		It("should ensure that the object is ignored", func() {
@@ -780,6 +780,89 @@ var _ = Describe("Cleaner", func() {
 
 			Expect(fakeClient.List(ctx, secretList)).To(Succeed())
 			Expect(secretList.Items).To(HaveLen(1))
+		})
+	})
+
+	Describe("#GVKStringForObject", func() {
+		var scheme *runtime.Scheme
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		})
+
+		It("should return GVK string when object has GVK set", func() {
+			pod := &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			}
+
+			result := GVKStringForObject(pod, scheme)
+			Expect(result).To(Equal("/v1, Kind=Pod"))
+		})
+
+		It("should return GVK string when object is registered in scheme but GVK not explicitly set", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			}
+
+			result := GVKStringForObject(pod, scheme)
+			Expect(result).To(Equal("/v1, Kind=Pod"))
+		})
+
+		It("should fall back to type name when object is not registered in scheme", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			}
+
+			// Use empty scheme where Pod is not registered
+			emptyScheme := runtime.NewScheme()
+
+			result := GVKStringForObject(pod, emptyScheme)
+			Expect(result).To(Equal("*v1.Pod"))
+		})
+
+		It("should fall back to type name when GVK is empty even if type is set", func() {
+			pod := &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "",
+					Kind:       "",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			}
+
+			// Use a scheme that doesn't have corev1 registered
+			emptyScheme := runtime.NewScheme()
+
+			result := GVKStringForObject(pod, emptyScheme)
+			Expect(result).To(Equal("*v1.Pod"))
+		})
+
+		It("should return GVK string for ConfigMap", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cm",
+					Namespace: "default",
+				},
+			}
+
+			result := GVKStringForObject(cm, scheme)
+			Expect(result).To(Equal("/v1, Kind=ConfigMap"))
 		})
 	})
 })

--- a/pkg/utils/kubernetes/client/options.go
+++ b/pkg/utils/kubernetes/client/options.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -98,22 +99,22 @@ func (m TolerateErrors) ApplyToClean(opts *CleanOptions) {
 }
 
 // IgnoreUnknownNamespaces returns an IgnoreLeftoverFunc that ignores objects in unknown namespaces.
-func IgnoreUnknownNamespaces(namespaces []string) IgnoreLeftoverFunc {
+func IgnoreUnknownNamespaces(namespaces []string, scheme *runtime.Scheme) IgnoreLeftoverFunc {
 	namespaceSet := sets.New(namespaces...)
 	return func(log logr.Logger, obj client.Object) bool {
 		ignore := obj.GetNamespace() != "" && !namespaceSet.Has(obj.GetNamespace())
 		if ignore {
-			log.Info("Ignoring leftover object in unknown namespace", "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind)
+			log.Info("Ignoring leftover object in unknown namespace", "obj", client.ObjectKeyFromObject(obj), "gvk", GVKStringForObject(obj, scheme))
 		}
 		return ignore
 	}
 }
 
 // IgnoreObjectsCreatedAfter returns an IgnoreLeftoverFunc that ignores objects created after the given time.
-func IgnoreObjectsCreatedAfter(timeStamp time.Time) IgnoreLeftoverFunc {
+func IgnoreObjectsCreatedAfter(timeStamp time.Time, scheme *runtime.Scheme) IgnoreLeftoverFunc {
 	return func(log logr.Logger, obj client.Object) bool {
 		if obj.GetCreationTimestamp().After(timeStamp) {
-			log.Info("Ignoring leftover object created after cleanup start time", "name", obj.GetName(), "kind", obj.GetObjectKind().GroupVersionKind().Kind, "creationTimestamp", obj.GetCreationTimestamp(), "cleanupStartTime", timeStamp.Format(time.RFC3339))
+			log.Info("Ignoring leftover object created after cleanup start time", "obj", client.ObjectKeyFromObject(obj), "gvk", GVKStringForObject(obj, scheme), "creationTimestamp", obj.GetCreationTimestamp(), "cleanupStartTime", timeStamp.Format(time.RFC3339))
 			return true
 		}
 		return false

--- a/pkg/utils/kubernetes/client/options_test.go
+++ b/pkg/utils/kubernetes/client/options_test.go
@@ -13,10 +13,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 )
 
@@ -80,7 +82,7 @@ var _ = Describe("Options", func() {
 		It("should ignore objects in unknown namespaces", func() {
 			namespaces := []string{"test1", "test2"}
 
-			ignore := IgnoreUnknownNamespaces(namespaces)
+			ignore := IgnoreUnknownNamespaces(namespaces, kubernetes.ShootScheme)
 
 			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test1"}})).To(BeFalse())
 			Expect(ignore(logr.Discard(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "test2"}})).To(BeFalse())
@@ -92,7 +94,7 @@ var _ = Describe("Options", func() {
 	Describe("#IgnoreObjectsCreatedAfter", func() {
 		It("should ignore objects create after configured time", func() {
 			clock := testclock.NewFakeClock(time.Now())
-			ignore := IgnoreObjectsCreatedAfter(clock.Now())
+			ignore := IgnoreObjectsCreatedAfter(clock.Now(), kubernetesscheme.Scheme)
 
 			createdBefore := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity usability
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug that caused log messages showing an empty `Kind` when objects were remaining in the shoot during cluster deletion. Esp. after list calls, the GVK information needs to be extracted via the scheme, since the type metadata is trimmed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
