### PR TITLE
Disable reconcilers in `gardener-controller-manager` when `concurrentSyncs` is `0`

### DIFF
--- a/pkg/controllermanager/controller/bastion/add.go
+++ b/pkg/controllermanager/controller/bastion/add.go
@@ -33,6 +33,10 @@ const ControllerName = "bastion"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/certificatesigningrequest/add.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/add.go
@@ -20,6 +20,10 @@ const ControllerName = "csr-autoapprove"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/cloudprofile/add.go
+++ b/pkg/controllermanager/controller/cloudprofile/add.go
@@ -19,6 +19,10 @@ const ControllerName = "cloudprofile"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/controllerdeployment/add.go
+++ b/pkg/controllermanager/controller/controllerdeployment/add.go
@@ -24,6 +24,10 @@ const (
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/seed/add.go
@@ -37,6 +37,10 @@ const ControllerName = "controllerinstallation-seed"
 
 // AddToManager adds the ControllerInstallation Reconciler to the given manager.
 func AddToManager(mgr manager.Manager, config controllermanagerconfigv1alpha1.ControllerRegistrationControllerConfiguration) error {
+	if ptr.Deref(config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	var (
 		log = mgr.GetLogger().WithValues("controller", ControllerName)
 		r   = &controllerinstallation.Reconciler{

--- a/pkg/controllermanager/controller/controllerregistration/controllerinstallation/shoot/add.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerinstallation/shoot/add.go
@@ -33,6 +33,10 @@ const ControllerName = "controllerinstallation-shoot"
 
 // AddToManager adds the ControllerInstallation Reconciler to the given manager.
 func AddToManager(mgr manager.Manager, config controllermanagerconfigv1alpha1.ControllerRegistrationControllerConfiguration) error {
+	if ptr.Deref(config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	var (
 		log = mgr.GetLogger().WithValues("controller", ControllerName)
 		r   = &controllerinstallation.Reconciler{

--- a/pkg/controllermanager/controller/credentialsbinding/add.go
+++ b/pkg/controllermanager/controller/credentialsbinding/add.go
@@ -19,6 +19,10 @@ const ControllerName = "credentialsbinding"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/event/add.go
+++ b/pkg/controllermanager/controller/event/add.go
@@ -21,6 +21,10 @@ const ControllerName = "event"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/exposureclass/add.go
+++ b/pkg/controllermanager/controller/exposureclass/add.go
@@ -19,6 +19,10 @@ const ControllerName = "exposureclass"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/gardenletlifecycle/add.go
+++ b/pkg/controllermanager/controller/gardenletlifecycle/add.go
@@ -39,6 +39,10 @@ type Request struct {
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/managedseedset/add.go
+++ b/pkg/controllermanager/controller/managedseedset/add.go
@@ -33,6 +33,10 @@ const ControllerName = "managedseedset"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/namespacedcloudprofile/add.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/add.go
@@ -27,6 +27,10 @@ const ControllerName = "namespacedcloudprofile"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/project/activity/add.go
+++ b/pkg/controllermanager/controller/project/activity/add.go
@@ -35,6 +35,10 @@ const ControllerName = "project-activity"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/project/project/add.go
+++ b/pkg/controllermanager/controller/project/project/add.go
@@ -35,6 +35,10 @@ const ControllerName = "project"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/project/resourcequota/add.go
+++ b/pkg/controllermanager/controller/project/resourcequota/add.go
@@ -25,6 +25,10 @@ const ControllerName = "project-resourcequota"
 
 // AddToManager adds a controller with the given Options to the given manager.
 func (r *Reconciler) AddToManager(ctx context.Context, mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/project/stale/add.go
+++ b/pkg/controllermanager/controller/project/stale/add.go
@@ -23,6 +23,10 @@ const ControllerName = "project-stale"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/quota/add.go
+++ b/pkg/controllermanager/controller/quota/add.go
@@ -19,6 +19,10 @@ const ControllerName = "quota"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/secretbinding/add.go
+++ b/pkg/controllermanager/controller/secretbinding/add.go
@@ -19,6 +19,10 @@ const ControllerName = "secretbinding"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/add.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/add.go
@@ -27,6 +27,10 @@ const ControllerName = "seed-backupbuckets-check"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/seed/extensionscheck/add.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/add.go
@@ -26,6 +26,10 @@ const ControllerName = "seed-extensions-check"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/conditions/add.go
+++ b/pkg/controllermanager/controller/shoot/conditions/add.go
@@ -33,6 +33,10 @@ const ControllerName = "shoot-conditions"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/hibernation/add.go
+++ b/pkg/controllermanager/controller/shoot/hibernation/add.go
@@ -24,6 +24,10 @@ const ControllerName = "shoot-hibernation"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/maintenance/add.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/add.go
@@ -23,6 +23,10 @@ const ControllerName = "shoot-maintenance"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/migration/add.go
+++ b/pkg/controllermanager/controller/shoot/migration/add.go
@@ -22,6 +22,10 @@ const ControllerName = "shoot-migration"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/quota/add.go
+++ b/pkg/controllermanager/controller/shoot/quota/add.go
@@ -20,6 +20,10 @@ const ControllerName = "shoot-quota"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/retry/add.go
+++ b/pkg/controllermanager/controller/shoot/retry/add.go
@@ -22,6 +22,10 @@ const ControllerName = "shoot-retry"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shoot/statuslabel/add.go
+++ b/pkg/controllermanager/controller/shoot/statuslabel/add.go
@@ -23,6 +23,10 @@ const ControllerName = "shoot-statuslabel"
 
 // AddToManager adds Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}

--- a/pkg/controllermanager/controller/shootstate/add.go
+++ b/pkg/controllermanager/controller/shootstate/add.go
@@ -29,6 +29,10 @@ const ControllerName = "shootstate-finalizer"
 
 // AddToManager adds the Reconciler to the given manager.
 func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if ptr.Deref(r.Config.ConcurrentSyncs, -1) == 0 {
+		return nil
+	}
+
 	if r.Client == nil {
 		r.Client = mgr.GetClient()
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

When `concurrentSyncs` in component configurations is set to `0`, the respective reconcilers should not start.
This is a somewhat similar pattern to the `shoot/state` controller.

This is useful for development scenarios, where one explicitly wants to disable certain controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to disable controllers of the `gardener-controller-manager` by setting the respective `concurrentSyncs` to `0`.
```
