### PR TITLE
[GEP-28] `gardenadm bootstrap`: download `gardenadm` binary explicitly

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap.go
@@ -47,8 +47,6 @@ type ControlPlaneBootstrapValues struct {
 
 	// Worker is the control plane worker pool.
 	Worker *gardencorev1beta1.Worker
-	// GardenadmImage is the gardenadm image reference that should be pulled.
-	GardenadmImage string
 }
 
 // NewControlPlaneBootstrap creates a new instance of Interface for deploying OperatingSystemConfigs during gardenadm bootstrap.
@@ -95,7 +93,7 @@ func (c *controlPlaneBootstrap) Deploy(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameSSHKeyPair)
 	}
 
-	units, files, err := nodeinit.GardenadmConfig(c.values.GardenadmImage, string(sshKeypairSecret.Data[secretsutils.DataKeySSHAuthorizedKeys]))
+	units, files, err := nodeinit.GardenadmConfig(string(sshKeypairSecret.Data[secretsutils.DataKeySSHAuthorizedKeys]))
 	if err != nil {
 		return err
 	}

--- a/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/controlplanebootstrap_test.go
@@ -90,8 +90,7 @@ var _ = Describe("controlPlaneBootstrap", func() {
 				Namespace:         namespace,
 				KubernetesVersion: semver.MustParse("1.34.0"),
 			},
-			Worker:         worker,
-			GardenadmImage: "gardenadm-image",
+			Worker: worker,
 		}
 		deployer = NewControlPlaneBootstrap(logr.Discard(), c, sm, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
 	})
@@ -112,7 +111,6 @@ var _ = Describe("controlPlaneBootstrap", func() {
 			Expect(actual.Spec.Units).To(ConsistOf(
 				HaveField("Name", "gardener-user.service"),
 				HaveField("Name", "gardener-user.path"),
-				HaveField("Name", "gardenadm-download.service"),
 			))
 			Expect(actual.Spec.Files).To(ConsistOf(
 				HaveField("Path", "/var/lib/gardener-user/run.sh"),

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm.go
@@ -35,26 +35,24 @@ var (
 	GardenadmBinaryPath = filepath.Join(GardenadmBinaryDir, GardenadmBinaryName)
 )
 
-// GardenadmConfig returns the init units and the files for the OperatingSystemConfig for downloading gardenadm.
+// GardenadmConfig returns the init units and the files for the OperatingSystemConfig for the first control plane node
+// of a self-hosted shoot cluster.
 // ### !CAUTION! ###
 // Most cloud providers have a limit of 16 KB regarding the user-data that may be sent during VM creation.
 // The result of this operating system config is exactly the user-data that will be sent to the providers.
 // We must not exceed the 16 KB, so be careful when extending/changing anything in here.
 // ### !CAUTION! ###
-func GardenadmConfig(gardenadmImage, sshPublicKey string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
+func GardenadmConfig(sshPublicKey string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	units, files, err := gardeneruser.New().Config(components.Context{SSHPublicKeys: []string{sshPublicKey}})
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating gardener user component contents: %w", err)
 	}
 
-	downloadScript, err := generateGardenadmDownloadScript(gardenadmImage)
+	downloadScript, err := generateGardenadmDownloadScript()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed generating download script: %w", err)
 	}
 
-	units = append(units,
-		generateInitScriptUnit("gardenadm-download.service", "gardenadm", GardenadmPathDownloadScript),
-	)
 	files = append(files, []extensionsv1alpha1.File{
 		{
 			Path:        GardenadmPathDownloadScript,
@@ -84,10 +82,9 @@ func GardenadmConfig(gardenadmImage, sshPublicKey string) ([]extensionsv1alpha1.
 	return units, files, nil
 }
 
-func generateGardenadmDownloadScript(gardenadmImage string) ([]byte, error) {
+func generateGardenadmDownloadScript() ([]byte, error) {
 	var script bytes.Buffer
 	if err := initScriptTpl.Execute(&script, map[string]any{
-		"image":           gardenadmImage,
 		"binaryName":      GardenadmBinaryName,
 		"binaryDirectory": GardenadmBinaryDir,
 	}); err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/gardenadm_test.go
@@ -15,14 +15,11 @@ import (
 )
 
 var _ = Describe("Init", func() {
-	const (
-		image        = "gardenadm:tag"
-		sshPublicKey = "ssh-rsa foobar"
-	)
+	const sshPublicKey = "ssh-rsa foobar"
 
 	Describe("#GardenadmConfig", func() {
 		It("should return the correct units and files", func() {
-			units, files, err := GardenadmConfig(image, sshPublicKey)
+			units, files, err := GardenadmConfig(sshPublicKey)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(units).To(ConsistOf(
@@ -34,29 +31,6 @@ var _ = Describe("Init", func() {
 					HaveField("Name", "gardener-user.path"),
 					HaveField("Enable", HaveValue(BeTrue())),
 				),
-				extensionsv1alpha1.Unit{
-					Name:    "gardenadm-download.service",
-					Command: ptr.To(extensionsv1alpha1.CommandStart),
-					Enable:  ptr.To(true),
-					Content: ptr.To(`[Unit]
-Description=Downloads the gardenadm binary from the container registry and bootstraps it.
-Requires=containerd.service
-After=containerd.service
-After=network-online.target
-Wants=network-online.target
-[Service]
-Type=oneshot
-Restart=on-failure
-RestartSec=5
-StartLimitBurst=0
-EnvironmentFile=/etc/environment
-ExecStart=/var/lib/gardenadm/download.sh
-StandardOutput=journal+console
-StandardError=journal+console
-[Install]
-WantedBy=multi-user.target`),
-					FilePaths: []string{"/var/lib/gardenadm/download.sh"},
-				},
 			))
 
 			Expect(files).To(ConsistOf(
@@ -77,6 +51,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ -z "$1" ]; then
+  echo "Usage: $0 <image-ref>"
+  exit 1
+fi
+image="$1"
+
 echo "> Prepare temporary directory for image pull and mount"
 tmp_dir="$(mktemp -d)"
 unmount() {
@@ -90,8 +70,8 @@ CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"
 fi
-ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "` + image + `"
-ctr images mount "` + image + `" "$tmp_dir"
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "$image"
+ctr images mount "$image" "$tmp_dir"
 
 echo "> Copy gardenadm binary to host (/opt/bin) and make it executable"
 mkdir -p "/opt/bin"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -120,6 +120,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+image="` + image + `"
+
 echo "> Prepare temporary directory for image pull and mount"
 tmp_dir="$(mktemp -d)"
 unmount() {
@@ -133,8 +135,8 @@ CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"
 fi
-ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "` + image + `"
-ctr images mount "` + image + `" "$tmp_dir"
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "$image"
+ctr images mount "$image" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
 mkdir -p "/opt/bin"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -4,6 +4,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+{{ if .image -}}
+image="{{ .image }}"
+{{- else -}}
+if [ -z "$1" ]; then
+  echo "Usage: $0 <image-ref>"
+  exit 1
+fi
+image="$1"
+{{- end }}
+
 echo "> Prepare temporary directory for image pull and mount"
 tmp_dir="$(mktemp -d)"
 unmount() {
@@ -22,8 +32,8 @@ CTR_EXTRA_ARGS=""
 if [ "$CTR_MAJOR" -gt 1 ]; then
     CTR_EXTRA_ARGS="--skip-metadata"
 fi
-ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "{{ .image }}"
-ctr images mount "{{ .image }}" "$tmp_dir"
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "$image"
+ctr images mount "$image" "$tmp_dir"
 
 echo "> Copy {{ .binaryName }} binary to host ({{ .binaryDirectory }}) and make it executable"
 mkdir -p "{{ .binaryDirectory }}"

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -221,12 +221,6 @@ func (b *GardenadmBotanist) generateGardenerNodeInitOperatingSystemConfig(secret
 // ControlPlaneBootstrapOperatingSystemConfig creates the deployer for the OperatingSystemConfig custom resource that is
 // used for bootstrapping control plane nodes in `gardenadm bootstrap`.
 func (b *GardenadmBotanist) ControlPlaneBootstrapOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
-	image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenadm)
-	if err != nil {
-		return nil, fmt.Errorf("failed finding image %q: %w", imagevector.ContainerImageNameGardenadm, err)
-	}
-	image.WithOptionalTag(version.Get().GitVersion)
-
 	worker := v1beta1helper.ControlPlaneWorkerPoolForShoot(b.Shoot.GetInfo().Spec.Provider.Workers)
 	if worker == nil {
 		return nil, fmt.Errorf("did not find the control plane worker pool of the shoot")
@@ -242,9 +236,8 @@ func (b *GardenadmBotanist) ControlPlaneBootstrapOperatingSystemConfig() (operat
 		b.SeedClientSet.Client(),
 		b.SecretsManager,
 		&operatingsystemconfig.ControlPlaneBootstrapValues{
-			Values:         values,
-			Worker:         worker,
-			GardenadmImage: image.String(),
+			Values: values,
+			Worker: worker,
 		},
 		operatingsystemconfig.DefaultInterval,
 		operatingsystemconfig.DefaultSevereThreshold,

--- a/pkg/gardenadm/cmd/bootstrap/bootstrap.go
+++ b/pkg/gardenadm/cmd/bootstrap/bootstrap.go
@@ -15,8 +15,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/imagevector"
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -289,6 +291,21 @@ func run(ctx context.Context, opts *Options) error {
 			Dependencies: flow.NewTaskIDs(connectToMachine, compileShootState),
 		})
 
+		downloadGardenadm = g.Add(flow.Task{
+			Name: "Downloading gardenadm binary on the first control plane machine",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				image, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameGardenadm)
+				if err != nil {
+					return fmt.Errorf("failed finding image %q: %w", imagevector.ContainerImageNameGardenadm, err)
+				}
+				image.WithOptionalTag(version.Get().GitVersion)
+
+				return b.SSHConnection().RunWithStreams(ctx, nil, opts.Out, opts.ErrOut,
+					fmt.Sprintf("%s %q", nodeinit.GardenadmPathDownloadScript, image.String()),
+				)
+			}).Timeout(5 * time.Minute),
+			Dependencies: flow.NewTaskIDs(deployDNSRecord, copyManifests),
+		})
 		bootstrapControlPlane = g.Add(flow.Task{
 			Name: "Bootstrapping control plane on the first control plane machine",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -299,7 +316,7 @@ func run(ctx context.Context, opts *Options) error {
 					),
 				)
 			}).Timeout(30 * time.Minute),
-			Dependencies: flow.NewTaskIDs(deployDNSRecord, copyManifests),
+			Dependencies: flow.NewTaskIDs(downloadGardenadm),
 		})
 
 		fetchKubeconfig = g.Add(flow.Task{

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -122,14 +122,6 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 				Should(HaveField("Items", ConsistOf(HaveField("Status.Phase", corev1.PodRunning))))
 		}, SpecTimeout(time.Minute))
 
-		It("should download gardenadm in the control plane machine", func(ctx SpecContext) {
-			Eventually(ctx, func(g Gomega) {
-				stdOut, _, err := RunInMachine(ctx, technicalID, 0, "/opt/bin/gardenadm", "version")
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Eventually(ctx, stdOut).Should(gbytes.Say("gardenadm version"))
-			}).Should(Succeed())
-		}, SpecTimeout(time.Minute))
-
 		It("should stop machine-controller-manager", func(ctx SpecContext) {
 			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameMachineControllerManager, Namespace: technicalID}}
 			Eventually(ctx, Object(deployment)).Should(HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Instead of adding a systemd unit to the provision OSC that downloads the gardenadm binary on the control plane machine, we explicitly call the download script from `gardenadm bootstrap` before executing `gardenadm init`. This simplifies the development loop as you can now run `gardenadm bootstrap` again after changing the `gardenadm init` logic and it will ensure to fetch the latest binary from the registry.
Before this change, you could only tear down the control plane machine and let a new one be created. However, this also required some nasty patching of the `Worker` and `DNSRecord` resources.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906 https://github.com/gardener/hackathon/issues/54

**Special notes for your reviewer**:

/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
