### PR TITLE
Fix a potential `GRM` deployment error cycle

### DIFF
--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -380,14 +380,11 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		r.ensureRBAC,
 		r.ensureService,
 		func(ctx context.Context) error {
-			// The GRM deployment and webhook configs must be applied at the same step to avoid a situation
-			// where the GRM deployment is rolled out after a certificate (CA) rotation but the webhook configurations
-			// are not yet updated.
-			if err := r.ensureDeployment(ctx, configMap); err != nil {
-				return err
-			}
-			return r.ensureWebhookConfiguration(ctx)
+			return r.ensureDeployment(ctx, configMap)
 		},
+		// Webhook configs must be applied directly after the deployment to avoid a situation where the GRM deployment
+		// is rolled out after a certificate (CA) rotation but the webhook configurations are not yet updated.
+		r.ensureWebhookConfiguration,
 		r.ensurePodDisruptionBudget,
 		r.ensureVPA,
 		r.ensureServiceMonitor,

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -379,17 +379,18 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		},
 		r.ensureRBAC,
 		r.ensureService,
-		func(ctx context.Context) error { return r.ensureDeployment(ctx, configMap) },
+		func(ctx context.Context) error {
+			// The GRM deployment and webhook configs must be applied at the same step to avoid a situation
+			// where the GRM deployment is rolled out after a certificate (CA) rotation but the webhook configurations
+			// are not yet updated.
+			if err := r.ensureDeployment(ctx, configMap); err != nil {
+				return err
+			}
+			return r.ensureWebhookConfiguration(ctx)
+		},
 		r.ensurePodDisruptionBudget,
 		r.ensureVPA,
 		r.ensureServiceMonitor,
-	}
-
-	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
-		fns = append(fns, r.ensureShootResources)
-	} else {
-		fns = append(fns, r.ensureMutatingWebhookConfiguration)
-		fns = append(fns, r.ensureValidatingWebhookConfiguration)
 	}
 
 	return flow.Sequential(fns...)(ctx)
@@ -1205,6 +1206,17 @@ func (r *resourceManager) ensureServiceMonitor(ctx context.Context) error {
 
 func (r *resourceManager) emptyServiceMonitor() *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{ObjectMeta: monitoringutils.ConfigObjectMeta(r.values.NamePrefix+"gardener-resource-manager", r.namespace, r.getPrometheusLabel())}
+}
+
+func (r *resourceManager) ensureWebhookConfiguration(ctx context.Context) error {
+	if r.values.ResponsibilityMode == ForShootOrVirtualGarden {
+		return r.ensureShootResources(ctx)
+	}
+
+	if err := r.ensureMutatingWebhookConfiguration(ctx); err != nil {
+		return err
+	}
+	return r.ensureValidatingWebhookConfiguration(ctx)
 }
 
 func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context) error {

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -2554,7 +2554,7 @@ subjects:
 				Expect(fakeClient.Get(ctx, client.ObjectKey{Namespace: deployNamespace, Name: "shoot-core-gardener-resource-manager"}, actualManagedResource)).To(Succeed())
 				actualManagedResource.ResourceVersion = ""
 				managedResource.ResourceVersion = ""
-				Expect(actualManagedResource).To(Equal(managedResource))
+				Expect(actualManagedResource).To(DeepEqual(managedResource))
 			})
 		})
 

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -30,6 +30,7 @@ func init() {
 
 // DeepEqual returns a Gomega matcher which checks whether the expected object is deeply equal with the object it is
 // being compared against.
+// In contrast to gomega.Equal(), this matcher uses semantic equality for comparing objects.
 func DeepEqual(expected any) types.GomegaMatcher {
 	return newDeepEqualMatcher(expected)
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes a potential `gardener-resource-manager` deployment failure cycle by moving the `Deployment` and webhook configs closer together in the flow.

Earlier, we saw the flow breaking under the following circumstances:

1. GRM `Deployment` was created with a new (rotated) certificate signed by a new CA.
2. A `VPA` object deployment failure happened because of a broken VPN connection (involved Webhook was unreachable)
3. After the VPN connection was recovered, the `VPA` object deployment failed again, but this time due to a bad certificate. 4. The certificate from step 1 had reached the `Deployment`, but the corresponding CA update was still missing for GRM-related webhooks in the cluster. That CA update happens only after VPA deployment succeeds (see [here](https://github.com/gardener/gardener/blob/0025fc1765c6fdb9106249bb1754108acedb4362/pkg/component/gardener/resourcemanager/resource_manager.go#L391)).
4. The reconciliation flow became stuck and could not recover automatically. Only the rollback mentioned above brought GRM and the webhooks back into sync.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @etiennnr @marc1404

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `gardener-resource-manager` deployment procedure was hardened. In rare situations, the procedure became stuck indefinitely after the seed's CA rotation.
```
