### PR TITLE
Use Kubernetes `v1.35` in e2e tests

### DIFF
--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -50,7 +50,7 @@ spec:
         storage:
           capacity: 10Gi
     kubernetes:
-      version: 1.34.2
+      version: 1.35.4
     gardener:
       clusterIdentity: gardener-local
       gardenerAPIServer:

--- a/dev-setup/gardenadm/resources/base/shoot.yaml
+++ b/dev-setup/gardenadm/resources/base/shoot.yaml
@@ -39,7 +39,7 @@ spec:
       systemComponents:
         allow: true
   kubernetes:
-    version: 1.34.3
+    version: 1.35.4
     kubelet:
       seccompDefault: true
       serializeImagePulls: false

--- a/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
+++ b/dev-setup/gardenconfig/components/cloudprofile/cloudprofile.yaml
@@ -10,7 +10,7 @@ spec:
     # We typically don't update the patch versions in the local cloud profile because this leads to failing upgrade tests.
     # When a specific patch version is needed for a bug fix or similar reason, keep the previous patch version for at least one more release.
     versions:
-    - version: 1.35.0
+    - version: 1.35.4
     - version: 1.34.3
     - version: 1.33.0
     - version: 1.32.0

--- a/test/e2e/gardener/common.go
+++ b/test/e2e/gardener/common.go
@@ -38,7 +38,7 @@ func baseShoot(name string) *gardencorev1beta1.Shoot {
 				Name: "local",
 			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:       "1.34",
+				Version:       "1.35",
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Provider: gardencorev1beta1.Provider{

--- a/test/e2e/operator/garden/common.go
+++ b/test/e2e/operator/garden/common.go
@@ -119,7 +119,7 @@ func defaultGarden(backupSecret *corev1.Secret, specifyBackupBucket bool) *opera
 					},
 				},
 				Kubernetes: operatorv1alpha1.Kubernetes{
-					Version: "1.34.2",
+					Version: "1.35.4",
 				},
 				Maintenance: operatorv1alpha1.Maintenance{
 					TimeWindow: gardencorev1beta1.MaintenanceTimeWindow{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13687

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
e2e tests are now running with Kubernetes `v1.35`.
```
