### PR TITLE
Add OPENVPN_AUTO_MTU support via shoot annotation

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -162,7 +162,7 @@ images:
   - name: vpn-server
     sourceRepository: github.com/gardener/vpn2
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-server
-    tag: "0.48.0"
+    tag: "0.49.0"
   # OpenTelemetry
   - name: opentelemetry-operator
     sourceRepository: github.com/open-telemetry/opentelemetry-operator
@@ -452,7 +452,7 @@ images:
   - name: vpn-client
     sourceRepository: github.com/gardener/vpn2
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-client
-    tag: "0.48.0"
+    tag: "0.49.0"
   - name: coredns
     sourceRepository: github.com/coredns/coredns
     repository: registry.k8s.io/coredns/coredns

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -365,6 +365,11 @@ const (
 	// ShootAlphaControlPlaneVPNVPAUpdateDisabled is a constant for an annotation on the Shoot resource to enforce
 	// disabling the vertical pod autoscaler update resources related to the VPN connection.
 	ShootAlphaControlPlaneVPNVPAUpdateDisabled = "alpha.control-plane.shoot.gardener.cloud/vpn-vpa-update-disabled"
+	// ShootAlphaControlPlaneVPNAutoMTU is a constant for an annotation on the Shoot resource to enable
+	// automatic MTU configuration for the VPN connection.
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaControlPlaneVPNAutoMTU = "alpha.control-plane.shoot.gardener.cloud/vpn-auto-mtu"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/component/kubernetes/apiserver/apiserver.go
+++ b/pkg/component/kubernetes/apiserver/apiserver.go
@@ -206,6 +206,9 @@ type VPNConfig struct {
 	HighAvailabilityNumberOfShootClients int
 	// IPFamilies are the IPFamilies of the shoot.
 	IPFamilies []gardencorev1beta1.IPFamily
+	// AutoMTU enables automatic MTU configuration for the VPN connection.
+	// When nil, the OPENVPN_AUTO_MTU environment variable is not set.
+	AutoMTU *bool
 }
 
 // ServerCertificateConfig contains configuration for the server certificate.

--- a/pkg/component/kubernetes/apiserver/deployment.go
+++ b/pkg/component/kubernetes/apiserver/deployment.go
@@ -885,6 +885,12 @@ func (k *kubeAPIServer) vpnSeedClientInitContainer() *corev1.Container {
 			Value: "balance-rr",
 		})
 	}
+	if k.values.VPN.AutoMTU != nil {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "OPENVPN_AUTO_MTU",
+			Value: strconv.FormatBool(*k.values.VPN.AutoMTU),
+		})
+	}
 	// may need to enable IPv6 in pod network (e.g. for GKE clusters)
 	container.SecurityContext.Privileged = ptr.To(true)
 
@@ -980,6 +986,13 @@ func (k *kubeAPIServer) vpnSeedClientContainer(index int) *corev1.Container {
 			// IP_FAMILIES of seed
 			Name:  "IP_FAMILIES",
 			Value: string(k.values.VPN.IPFamilies[0]),
+		})
+	}
+
+	if k.values.VPN.AutoMTU != nil {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "OPENVPN_AUTO_MTU",
+			Value: strconv.FormatBool(*k.values.VPN.AutoMTU),
 		})
 	}
 

--- a/pkg/component/networking/vpn/seedserver/seedserver.go
+++ b/pkg/component/networking/vpn/seedserver/seedserver.go
@@ -134,6 +134,9 @@ type Values struct {
 	HighAvailabilityNumberOfShootClients int
 	// VPAUpdateDisabled indicates whether the vertical pod autoscaler update should be disabled.
 	VPAUpdateDisabled bool
+	// AutoMTU enables automatic MTU configuration for the VPN connection.
+	// When nil, the OPENVPN_AUTO_MTU environment variable is not set.
+	AutoMTU *bool
 }
 
 // New creates a new instance of DeployWaiter for the vpn-seed-server.
@@ -555,6 +558,13 @@ func (v *vpnSeedServer) podTemplate(configMap *corev1.ConfigMap, secretCAVPN, se
 		}
 
 		template.Spec.Containers = append(template.Spec.Containers, exporterContainer)
+	}
+
+	if v.values.AutoMTU != nil {
+		template.Spec.Containers[0].Env = append(template.Spec.Containers[0].Env, corev1.EnvVar{
+			Name:  "OPENVPN_AUTO_MTU",
+			Value: strconv.FormatBool(*v.values.AutoMTU),
+		})
 	}
 
 	return template

--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -112,6 +112,9 @@ type Values struct {
 	HighAvailabilityNumberOfSeedServers int
 	// HighAvailabilityNumberOfShootClients is the number of VPN shoot clients used for HA.
 	HighAvailabilityNumberOfShootClients int
+	// AutoMTU enables automatic MTU configuration for the VPN connection.
+	// When nil, the OPENVPN_AUTO_MTU environment variable is not set.
+	AutoMTU *bool
 }
 
 // Interface contains functions for a VPNShoot deployer.
@@ -828,6 +831,13 @@ func (v *vpnShoot) getEnvVars(index *int) []corev1.EnvVar {
 			}...)
 	}
 
+	if v.values.AutoMTU != nil {
+		envVariables = append(envVariables, corev1.EnvVar{
+			Name:  "OPENVPN_AUTO_MTU",
+			Value: strconv.FormatBool(*v.values.AutoMTU),
+		})
+	}
+
 	return envVariables
 }
 
@@ -977,6 +987,13 @@ func (v *vpnShoot) getInitContainers() []corev1.Container {
 				Value: "balance-rr",
 			})
 		}
+	}
+
+	if v.values.AutoMTU != nil {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "OPENVPN_AUTO_MTU",
+			Value: strconv.FormatBool(*v.values.AutoMTU),
+		})
 	}
 
 	return []corev1.Container{container}

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -47,6 +47,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		vpnConfig.HighAvailabilityNumberOfShootClients = b.Shoot.VPNHighAvailabilityNumberOfShootClients
 		// Pod/service/node network CIDRs are set on deployment to handle dynamic network CIDRs
 		vpnConfig.IPFamilies = b.Seed.GetInfo().Spec.Networks.IPFamilies
+		vpnConfig.AutoMTU = b.Shoot.VPNAutoMTU
 	}
 
 	return shared.NewKubeAPIServer(

--- a/pkg/gardenlet/operation/botanist/vpnseedserver.go
+++ b/pkg/gardenlet/operation/botanist/vpnseedserver.go
@@ -40,6 +40,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 		HighAvailabilityNumberOfShootClients: b.Shoot.VPNHighAvailabilityNumberOfShootClients,
 		VPAUpdateDisabled:                    b.Shoot.VPNVPAUpdateDisabled,
 		SeedPodNetwork:                       b.Seed.GetInfo().Spec.Networks.Pods,
+		AutoMTU:                              b.Shoot.VPNAutoMTU,
 	}
 
 	if b.ShootUsesDNS() {

--- a/pkg/gardenlet/operation/botanist/vpnshoot.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot.go
@@ -49,6 +49,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,
 		HighAvailabilityNumberOfShootClients: b.Shoot.VPNHighAvailabilityNumberOfShootClients,
 		SeedPodNetwork:                       b.Seed.GetInfo().Spec.Networks.Pods,
+		AutoMTU:                              b.Shoot.VPNAutoMTU,
 	}
 
 	return vpnshoot.New(

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -282,10 +282,8 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	if vpnVPAUpdateDisabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateDisabled]); err == nil {
 		shoot.VPNVPAUpdateDisabled = vpnVPAUpdateDisabled
 	}
-	if autoMTUStr, ok := shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNAutoMTU]; ok {
-		if autoMTU, err := strconv.ParseBool(autoMTUStr); err == nil {
-			shoot.VPNAutoMTU = &autoMTU
-		}
+	if autoMTU, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNAutoMTU]); err == nil {
+		shoot.VPNAutoMTU = &autoMTU
 	}
 
 	shoot.WantsClusterAutoscaler = v1beta1helper.ShootWantsClusterAutoscaler(shootObject)

--- a/pkg/gardenlet/operation/shoot/shoot.go
+++ b/pkg/gardenlet/operation/shoot/shoot.go
@@ -282,6 +282,11 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	if vpnVPAUpdateDisabled, err := strconv.ParseBool(shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateDisabled]); err == nil {
 		shoot.VPNVPAUpdateDisabled = vpnVPAUpdateDisabled
 	}
+	if autoMTUStr, ok := shoot.GetInfo().GetAnnotations()[v1beta1constants.ShootAlphaControlPlaneVPNAutoMTU]; ok {
+		if autoMTU, err := strconv.ParseBool(autoMTUStr); err == nil {
+			shoot.VPNAutoMTU = &autoMTU
+		}
+	}
 
 	shoot.WantsClusterAutoscaler = v1beta1helper.ShootWantsClusterAutoscaler(shootObject)
 

--- a/pkg/gardenlet/operation/shoot/types.go
+++ b/pkg/gardenlet/operation/shoot/types.go
@@ -98,6 +98,7 @@ type Shoot struct {
 	VPNHighAvailabilityNumberOfSeedServers  int
 	VPNHighAvailabilityNumberOfShootClients int
 	VPNVPAUpdateDisabled                    bool
+	VPNAutoMTU                              *bool
 	NodeLocalDNSEnabled                     bool
 	TopologyAwareRoutingEnabled             bool
 	Networks                                *Networks


### PR DESCRIPTION
Add the `alpha.control-plane.shoot.gardener.cloud/vpn-auto-mtu` annotation to enable automatic MTU configuration for the VPN connection. When set, the `OPENVPN_AUTO_MTU` env variable is injected into the vpn-seed-server, the vpn-shoot init and main containers, and the kube-apiserver VPN sidecar and init containers.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Needs a release of https://github.com/gardener/vpn2/pull/265
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `alpha.control-plane.shoot.gardener.cloud/vpn-auto-mtu` annotation to enable automatic MTU configuration for VPN connections. When set to `true`, the `OPENVPN_AUTO_MTU` flag is propagated to all VPN components (seed server, shoot client, kube-apiserver sidecars).`
```
