### PR TITLE
[release-v1.142] Update dependency gardener/dashboard to v1.84.1 (#14759)

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -54,7 +54,7 @@ images:
   - name: gardener-dashboard
     sourceRepository: github.com/gardener/dashboard
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-    tag: "1.83.11"
+    tag: "1.84.1"
   - name: terminal-controller-manager
     sourceRepository: github.com/gardener/terminal-controller-manager
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

Manual cherry pick of: https://github.com/gardener/gardener/pull/14759#issuecomment-4388346618

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @rfranzke 
/cc @petersutter @grolu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The following dependencies have been updated:
- `gardener/dashboard` from `1.83.11` to `1.84.1`. [Release Notes](https://redirect.github.com/gardener/dashboard/releases/tag/1.84.1)
```
