### PR TITLE
Provider local does not properly set protocol in case of UDP

### DIFF
--- a/pkg/provider-local/cloud-provider/loadbalancer/envoy.go
+++ b/pkg/provider-local/cloud-provider/loadbalancer/envoy.go
@@ -171,6 +171,7 @@ func generateEnvoyDynamicConfig(service *corev1.Service, nodes []*corev1.Node) (
 			Listener: listener{
 				Port: port.Port,
 			},
+			Protocol: string(port.Protocol),
 		}
 
 		for _, nodeIP := range allNodeIPs {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
If in the garden local setup a service type loadbalancer for UDP is requested, the envoy configuration does not contain the required `protocol: UDP` configuration and defaults to TCP.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
@ScheererJ 