### PR TITLE
set exposed ports for local load balancer container

### DIFF
--- a/dev-setup/kind.sh
+++ b/dev-setup/kind.sh
@@ -118,10 +118,10 @@ EOF
       # backend on macOS, without requiring users to explicitly configure the socket path.
       socket=$(docker context inspect "$(docker context show)" -f json | jq -r '.[].Endpoints.docker.Host' | sed 's|unix://||')
 
-      # If the socket path contains .lima or .colima, we assume that Lima/Colima is used as Docker backend.
+      # If the socket path contains lima or colima, we assume that Lima/Colima is used as Docker backend.
       # In this case, the socket on the host is a forward to /var/run/docker.sock in the guest VM.
       # Instead of mounting the socket on the host back into the VM, we directly use /var/run/docker.sock in the VM.
-      if [[ "$socket" == *"/.lima/"* || "$socket" == *"/.colima/"* ]]; then
+      if [[ "$socket" == *"/.lima/"* || "$socket" == *"/.colima/"* || "$socket" == *"/lima/"* || "$socket" == *"/colima/"* ]]; then
         socket="/var/run/docker.sock"
       fi
 

--- a/pkg/provider-local/cloud-provider/loadbalancer/container.go
+++ b/pkg/provider-local/cloud-provider/loadbalancer/container.go
@@ -42,7 +42,12 @@ func (p *Provider) createLoadBalancerContainer(ctx context.Context, name string,
 		return nil, fmt.Errorf("failed to determine port bindings for service: %w", err)
 	}
 
-	exposedPorts := make(nat.PortSet)
+	// ExposedPorts is technically redundant with HostConfig.PortBindings on Docker Engine >= 29.0.0, but populating
+	// it (a) ensures correct `docker inspect` output and (b) avoids inconsistent behavior with older daemons (the
+	// libnetwork sandbox on Engine <29 only exposed ports declared in Config.ExposedPorts).
+	// See: https://github.com/moby/moby/pull/50710 and https://github.com/moby/moby/commit/cb3abacc52.
+	// TODO(marc1404): Drop this once we require Docker Engine >= 29.0.0.
+	exposedPorts := make(nat.PortSet, len(portBindings))
 	for port := range portBindings {
 		exposedPorts[port] = struct{}{}
 	}

--- a/pkg/provider-local/cloud-provider/loadbalancer/container.go
+++ b/pkg/provider-local/cloud-provider/loadbalancer/container.go
@@ -42,6 +42,11 @@ func (p *Provider) createLoadBalancerContainer(ctx context.Context, name string,
 		return nil, fmt.Errorf("failed to determine port bindings for service: %w", err)
 	}
 
+	exposedPorts := make(nat.PortSet)
+	for port := range portBindings {
+		exposedPorts[port] = struct{}{}
+	}
+
 	_, err = p.DockerClient.ContainerCreate(
 		ctx,
 		&container.Config{
@@ -54,6 +59,7 @@ func (p *Provider) createLoadBalancerContainer(ctx context.Context, name string,
 				Timeout:  time.Second,
 				Retries:  3,
 			},
+			ExposedPorts: exposedPorts,
 			Labels: map[string]string{
 				"gardener.cloud/role":    "loadbalancer",
 				"gardener.cloud/service": client.ObjectKeyFromObject(service).String(),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
area: local gardener setup
kind: enhancement

**What this PR does / why we need it**:

When starting the gardener locally on mac os with colima I faced the following issue:

service/istio-ingressgateway did not become ready because of the error: Error syncing load balancer: failed to ensure load balancer: envoy proxy container gardener-lb-66e41455 is in status: starting

k logs deploy/cloud-controller-manager -n kube-system shows:
"Container has outdated port bindings, recreating container" container="gardener-lb-e54f5fce" service="istio-ingress/istio-ingressgateway" ports={"10000/tcp":null}

So, the ports were not assigned to the gardener-lb-* service, however, the portBindings were set.

The related code was introduced by the PR: https://github.com/gardener/gardener/pull/14415

I was able to fix the issue by adding the ExposedPorts parameter to the p.DockerClient.ContainerCreate

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/14772
