### PR TITLE
Skip PVC cleanup in garden-down for non-remote scenarios

### DIFF
--- a/dev-setup/garden.sh
+++ b/dev-setup/garden.sh
@@ -84,9 +84,11 @@ case "$COMMAND" in
     # cleanup the remaining resources required for successful deletion of the garden
     kubectl delete -k "$(dirname "$0")/garden/overlays/$SCENARIO" --ignore-not-found
 
-    # cleanup all PVCs in the garden namespace
-    echo "Cleaning up PVCs in garden namespace..."
-    kubectl delete pvc --all -n garden --ignore-not-found --timeout=120s
+    # cleanup all PVCs in the garden namespace (only needed for remote scenario where real infrastructure exists)
+    if [[ "$SCENARIO" == "remote" ]]; then
+      echo "Cleaning up PVCs in garden namespace..."
+      kubectl delete pvc --all -n garden --ignore-not-found --timeout=120s
+    fi
 
     # cleanup virtual garden kubconfig
     if [[ -f "$KUBECONFIG_VIRTUAL_GARDEN_CLUSTER" ]]; then


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

The `pull-gardener-e2e-kind-gardenadm-unmanaged-infra` CI job fails intermittently during teardown when `kubectl delete pvc --all -n garden --timeout=120s` times out. 

In non-remote scenarios (local, CI), the entire cluster is destroyed after teardown, making PVC cleanup unnecessary. This change restricts PVC cleanup to the `remote` scenario where real persistent infrastructure exists and cleanup is actually needed.

**Which issue(s) this PR fixes**:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14750/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2052651687406997504
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14419/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2052639387480494080
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14780/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2052377255610421248
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14419/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2052405813686833152
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14760/pull-gardener-e2e-kind-gardenadm-unmanaged-infra/2052320499563761664


**Special notes for your reviewer**:
Followup after https://github.com/gardener/gardener/pull/14547
/cc @matthias-horne 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
