### PR TITLE
Remove automated release for gardener/logging components until Vali is removed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -432,7 +432,7 @@
       ],
     },
     {
-      // Do not update gardener/logging images until Vali is removed.
+      // Do not update gardener/logging images until Vali is removed. See: https://github.com/gardener/gardener/issues/13709
       matchDatasources: [
         'github-releases',
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -441,7 +441,7 @@
       ],
       enabled: false,
       matchPackageNames: [
-        'github.com/gardener/logging',
+        'gardener/logging',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -432,6 +432,19 @@
       ],
     },
     {
+      // Do not update gardener/logging images until Vali is removed.
+      matchDatasources: [
+        'github-releases',
+      ],
+      matchFileNames: [
+        'imagevector/**',
+      ],
+      enabled: false,
+      matchPackageNames: [
+        'github.com/gardener/logging',
+      ],
+    },
+    {
       // Use Docker only for images from the Gardener registry that don't work with GitHub releases.
       matchDatasources: [
         'docker',


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Remove automated release for gardener/logging components until Vali is removed.

Follow-up to:
* https://github.com/gardener/gardener/pull/14782
