### PR TITLE
provider-local: Disable IPIP encapsulation for IPv6 IP pools

### DIFF
--- a/pkg/provider-local/controller/infrastructure/actuator.go
+++ b/pkg/provider-local/controller/infrastructure/actuator.go
@@ -213,6 +213,10 @@ func IPPoolName(shootNamespace, ipFamily string) string {
 }
 
 func ipPool(clusterMeta metav1.ObjectMeta, ipFamily, nodeCIDR string) (client.Object, error) {
+	ipipMode := "Always"
+	if ipFamily == string(gardencorev1beta1.IPFamilyIPv6) {
+		ipipMode = "Never"
+	}
 	return kubernetes.NewManifestReader([]byte(`apiVersion: crd.projectcalico.org/v1
 kind: IPPool
 metadata:
@@ -224,7 +228,7 @@ metadata:
     uid: ` + string(clusterMeta.UID) + `
 spec:
   cidr: ` + nodeCIDR + `
-  ipipMode: Always
+  ipipMode: ` + ipipMode + `
   natOutgoing: true
   nodeSelector: "!all()" # Without this, calico defaults nodeSelector to "all()" and can randomly pick this pool for
                          # IPAM for pods even if the pod does not explicitly request an IP from this pool via the


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
IPIP is not supported for IPv6 traffic in Calico.

This change conditionally sets `ipipMode` based on the IP family:

IPv4 pools: `ipipMode: Always` (existing behavior, unchanged)
IPv6 pools: `ipipMode: Never` (new — IPIP is not applicable for IPv6)

Leaving `ipipMode: Always` on an IPv6 pool is either a no-op or causes misconfiguration depending on the Calico version.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Required for:
* https://github.com/gardener/gardener/pull/14740

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable IPIP encapsulation for IPv6 IP pools for local setup.
```
