### PR TITLE
[GEP-28] `gardenadm discover`: Export BackupEntry and BackupBucket resources for already existing self-hosted Shoot

### DIFF
--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
@@ -93,7 +94,7 @@ func run(ctx context.Context, opts *Options) error {
 	if err != nil {
 		return fmt.Errorf("failed reading binding for shoot: %w", err)
 	}
-	backupBucket, backupEntry, err := backupResourcesForShoot(ctx, clientSet.Client(), shoot)
+	backupEntry, backupBucket, err := backupResourcesForShoot(ctx, clientSet.Client(), shoot)
 	if err != nil {
 		return fmt.Errorf("failed reading backup resources for shoot: %w", err)
 	}
@@ -228,43 +229,39 @@ func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev
 	return botanist.ComputeExtensions(resources, true, managedInfrastructure)
 }
 
-func backupResourcesForShoot(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.BackupBucket, *gardencorev1beta1.BackupEntry, error) {
+func backupResourcesForShoot(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.BackupEntry, *gardencorev1beta1.BackupBucket, error) {
+	var (
+		backupEntry  *gardencorev1beta1.BackupEntry
+		backupBucket *gardencorev1beta1.BackupBucket
+	)
+
 	backupEntryList := &gardencorev1beta1.BackupEntryList{}
-	if err := c.List(ctx, backupEntryList, client.InNamespace(shoot.Namespace)); err != nil {
-		return nil, nil, fmt.Errorf("failed listing BackupEntries in namespace %q: %w", shoot.Namespace, err)
+	if err := c.List(ctx, backupEntryList, client.InNamespace(shoot.Namespace),
+		client.MatchingFields{gardencore.BackupEntryShootRefName: shoot.Name, gardencore.BackupEntryShootRefNamespace: shoot.Namespace}); err != nil {
+		return nil, nil, fmt.Errorf("failed listing BackupEntries for Shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
 
-	var backupEntry *gardencorev1beta1.BackupEntry
-	for i := range backupEntryList.Items {
-		current := &backupEntryList.Items[i]
-
-		if current.Spec.ShootRef == nil {
-			continue
-		}
-		if current.Spec.ShootRef.Name != shoot.Name || current.Spec.ShootRef.Namespace != shoot.Namespace {
-			continue
-		}
-
-		if backupEntry != nil {
-			return nil, nil, fmt.Errorf("found more than one BackupEntry for Shoot %s", client.ObjectKeyFromObject(shoot))
-		}
-
-		backupEntry = current
+	if len(backupEntryList.Items) > 1 {
+		return nil, nil, fmt.Errorf("found more than one BackupEntry for Shoot %s", client.ObjectKeyFromObject(shoot))
+	}
+	if len(backupEntryList.Items) == 1 {
+		backupEntry = &backupEntryList.Items[0]
 	}
 
-	if backupEntry == nil {
-		return nil, nil, nil
+	backupBucketList := &gardencorev1beta1.BackupBucketList{}
+	if err := c.List(ctx, backupBucketList,
+		client.MatchingFields{gardencore.BackupBucketShootRefName: shoot.Name, gardencore.BackupBucketShootRefNamespace: shoot.Namespace}); err != nil {
+		return nil, nil, fmt.Errorf("failed listing BackupBuckets for Shoot %s: %w", client.ObjectKeyFromObject(shoot), err)
 	}
 
-	backupBucket := &gardencorev1beta1.BackupBucket{}
-	if err := c.Get(ctx, client.ObjectKey{Name: backupEntry.Spec.BucketName}, backupBucket); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, backupEntry, nil
-		}
-		return nil, nil, fmt.Errorf("failed getting BackupBucket %q: %w", backupEntry.Spec.BucketName, err)
+	if len(backupBucketList.Items) > 1 {
+		return nil, nil, fmt.Errorf("found more than one BackupBucket for Shoot %s", client.ObjectKeyFromObject(shoot))
+	}
+	if len(backupBucketList.Items) == 1 {
+		backupBucket = &backupBucketList.Items[0]
 	}
 
-	return backupBucket, backupEntry, nil
+	return backupEntry, backupBucket, nil
 }
 
 func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, opts *Options, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -93,6 +93,10 @@ func run(ctx context.Context, opts *Options) error {
 	if err != nil {
 		return fmt.Errorf("failed reading binding for shoot: %w", err)
 	}
+	backupBucket, backupEntry, err := backupResourcesForShoot(ctx, clientSet.Client(), shoot)
+	if err != nil {
+		return fmt.Errorf("failed reading backup resources for shoot: %w", err)
+	}
 
 	fmt.Fprintf(opts.Out, "Computing required resources for Shoot...\n")
 
@@ -105,6 +109,12 @@ func run(ctx context.Context, opts *Options) error {
 		case *securityv1alpha1.CredentialsBinding:
 			g.HandleCredentialsBindingCreateOrUpdate(b)
 		}
+	}
+	if backupEntry != nil {
+		g.HandleBackupEntryCreateOrUpdate(backupEntry)
+	}
+	if backupBucket != nil {
+		g.HandleBackupBucketCreateOrUpdate(backupBucket)
 	}
 
 	var taskFns []flow.TaskFn
@@ -216,6 +226,45 @@ func requiredExtensions(ctx context.Context, c client.Client, shoot *gardencorev
 	}
 
 	return botanist.ComputeExtensions(resources, true, managedInfrastructure)
+}
+
+func backupResourcesForShoot(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.BackupBucket, *gardencorev1beta1.BackupEntry, error) {
+	backupEntryList := &gardencorev1beta1.BackupEntryList{}
+	if err := c.List(ctx, backupEntryList, client.InNamespace(shoot.Namespace)); err != nil {
+		return nil, nil, fmt.Errorf("failed listing BackupEntries in namespace %q: %w", shoot.Namespace, err)
+	}
+
+	var backupEntry *gardencorev1beta1.BackupEntry
+	for i := range backupEntryList.Items {
+		current := &backupEntryList.Items[i]
+
+		if current.Spec.ShootRef == nil {
+			continue
+		}
+		if current.Spec.ShootRef.Name != shoot.Name || current.Spec.ShootRef.Namespace != shoot.Namespace {
+			continue
+		}
+
+		if backupEntry != nil {
+			return nil, nil, fmt.Errorf("found more than one BackupEntry for Shoot %s", client.ObjectKeyFromObject(shoot))
+		}
+
+		backupEntry = current
+	}
+
+	if backupEntry == nil {
+		return nil, nil, nil
+	}
+
+	backupBucket := &gardencorev1beta1.BackupBucket{}
+	if err := c.Get(ctx, client.ObjectKey{Name: backupEntry.Spec.BucketName}, backupBucket); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, backupEntry, nil
+		}
+		return nil, nil, fmt.Errorf("failed getting BackupBucket %q: %w", backupEntry.Spec.BucketName, err)
+	}
+
+	return backupBucket, backupEntry, nil
 }
 
 func getAndExportObject(ctx context.Context, c client.Client, fs afero.Afero, opts *Options, kind string, obj client.Object) error {

--- a/pkg/gardenadm/cmd/discover/discover.go
+++ b/pkg/gardenadm/cmd/discover/discover.go
@@ -98,6 +98,9 @@ func run(ctx context.Context, opts *Options) error {
 	if err != nil {
 		return fmt.Errorf("failed reading backup resources for shoot: %w", err)
 	}
+	if backupBucket != nil && backupEntry == nil {
+		fmt.Fprintf(opts.Out, "WARNING: found BackupBucket without a corresponding BackupEntry for Shoot %s - backup restoration may not be possible\n", client.ObjectKeyFromObject(shoot))
+	}
 
 	fmt.Fprintf(opts.Out, "Computing required resources for Shoot...\n")
 

--- a/pkg/gardenadm/cmd/discover/discover_test.go
+++ b/pkg/gardenadm/cmd/discover/discover_test.go
@@ -88,6 +88,8 @@ var _ = Describe("Discover", func() {
 			shoot             *gardencorev1beta1.Shoot
 			shootRaw          []byte
 			shootManifestPath = "some-path-to-shoot-manifest-file"
+
+			expectCommonExports func()
 		)
 
 		BeforeEach(func() {
@@ -247,47 +249,129 @@ var _ = Describe("Discover", func() {
 			shootRaw, err = runtime.Encode(&json.Serializer{}, shoot)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fs.WriteFile(shootManifestPath, shootRaw, 0600)).To(Succeed())
+
+			expectCommonExports = func() {
+				GinkgoHelper()
+
+				Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
+					ContainSubstring("Computing required resources for Shoot..."),
+					ContainSubstring("Fetching required resources for from garden cluster..."),
+					ContainSubstring("Exported Namespace/"+namespace.Name),
+					ContainSubstring("Exported Project/"+project.Name),
+					ContainSubstring("Exported Secret/"+secret.Name),
+					ContainSubstring("Exported Secret/"+secretDNS.Name),
+					ContainSubstring("Exported SecretBinding/"+secretBinding.Name),
+					ContainSubstring("Exported CloudProfile/"+cloudProfile.Name),
+					ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentProvider.Name),
+					ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationProvider.Name),
+					ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentNetwork.Name),
+					ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationNetwork.Name),
+					ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentDNS.Name),
+					ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationDNS.Name),
+				))
+
+				for _, path := range []string{
+					fmt.Sprintf("namespace-%s.yaml", namespace.Name),
+					fmt.Sprintf("project-%s.yaml", project.Name),
+					fmt.Sprintf("secret-%s.yaml", secret.Name),
+					fmt.Sprintf("secret-%s.yaml", secretDNS.Name),
+					fmt.Sprintf("secretbinding-%s.yaml", secretBinding.Name),
+					fmt.Sprintf("cloudprofile-%s.yaml", cloudProfile.Name),
+					fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentProvider.Name),
+					fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationProvider.Name),
+					fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentNetwork.Name),
+					fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationNetwork.Name),
+					fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentDNS.Name),
+					fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationDNS.Name),
+				} {
+					exists, err := fs.Exists(path)
+					Expect(err).NotTo(HaveOccurred(), "for path "+path)
+					Expect(exists).To(BeTrue(), "for path "+path)
+				}
+			}
 		})
 
-		It("should return the expected output", func() {
-			Expect(command.Flags().Set("kubeconfig", "some-path-to-kubeconfig")).To(Succeed())
-			Expect(command.RunE(command, []string{shootManifestPath})).To(Succeed())
+		Context("for new Shoot", func() {
+			It("should return the expected output", func() {
+				Expect(command.Flags().Set("kubeconfig", "some-path-to-kubeconfig")).To(Succeed())
+				Expect(command.RunE(command, []string{shootManifestPath})).To(Succeed())
 
-			Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
-				ContainSubstring("Computing required resources for Shoot..."),
-				ContainSubstring("Fetching required resources for from garden cluster..."),
-				ContainSubstring("Exported Namespace/"+namespace.Name),
-				ContainSubstring("Exported Project/"+project.Name),
-				ContainSubstring("Exported Secret/"+secret.Name),
-				ContainSubstring("Exported Secret/"+secretDNS.Name),
-				ContainSubstring("Exported SecretBinding/"+secretBinding.Name),
-				ContainSubstring("Exported CloudProfile/"+cloudProfile.Name),
-				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentProvider.Name),
-				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationProvider.Name),
-				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentNetwork.Name),
-				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationNetwork.Name),
-				ContainSubstring("Exported ControllerDeployment/"+controllerDeploymentDNS.Name),
-				ContainSubstring("Exported ControllerRegistration/"+controllerRegistrationDNS.Name),
-			))
+				expectCommonExports()
+			})
+		})
 
-			for _, path := range []string{
-				fmt.Sprintf("namespace-%s.yaml", namespace.Name),
-				fmt.Sprintf("project-%s.yaml", project.Name),
-				fmt.Sprintf("secret-%s.yaml", secret.Name),
-				fmt.Sprintf("secret-%s.yaml", secretDNS.Name),
-				fmt.Sprintf("secretbinding-%s.yaml", secretBinding.Name),
-				fmt.Sprintf("cloudprofile-%s.yaml", cloudProfile.Name),
-				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentProvider.Name),
-				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationProvider.Name),
-				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentNetwork.Name),
-				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationNetwork.Name),
-				fmt.Sprintf("controllerdeployment-%s.yaml", controllerDeploymentDNS.Name),
-				fmt.Sprintf("controllerregistration-%s.yaml", controllerRegistrationDNS.Name),
-			} {
-				exists, err := fs.Exists(path)
-				Expect(err).NotTo(HaveOccurred(), "for path "+path)
-				Expect(exists).To(BeTrue(), "for path "+path)
-			}
+		Context("for already existing Shoot", func() {
+			var (
+				backupBucketSecret *corev1.Secret
+				backupBucket       *gardencorev1beta1.BackupBucket
+				backupEntry        *gardencorev1beta1.BackupEntry
+			)
+
+			BeforeEach(func() {
+				backupBucketSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-backup-secret",
+						Namespace: "garden",
+					},
+				}
+				backupBucket = &gardencorev1beta1.BackupBucket{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-backup-bucket",
+					},
+					Spec: gardencorev1beta1.BackupBucketSpec{
+						CredentialsRef: &corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "Secret",
+							Name:       backupBucketSecret.Name,
+							Namespace:  backupBucketSecret.Namespace,
+						},
+					},
+				}
+				backupEntry = &gardencorev1beta1.BackupEntry{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-backup-entry",
+						Namespace: namespaceName,
+					},
+					Spec: gardencorev1beta1.BackupEntrySpec{
+						BucketName: backupBucket.Name,
+						ShootRef: &corev1.ObjectReference{
+							APIVersion: "core.gardener.cloud/v1beta1",
+							Kind:       "Shoot",
+							Name:       shoot.Name,
+							Namespace:  shoot.Namespace,
+						},
+					},
+				}
+
+				Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
+
+				Expect(fakeClient.Create(ctx, backupBucketSecret)).To(Succeed())
+				Expect(fakeClient.Create(ctx, backupBucket)).To(Succeed())
+				Expect(fakeClient.Create(ctx, backupEntry)).To(Succeed())
+			})
+
+			It("should return the expected output", func() {
+				Expect(command.Flags().Set("kubeconfig", "some-path-to-kubeconfig")).To(Succeed())
+				Expect(command.RunE(command, []string{shootManifestPath})).To(Succeed())
+
+				expectCommonExports()
+
+				Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
+					ContainSubstring("Exported Secret/"+backupBucketSecret.Name),
+					ContainSubstring("Exported BackupBucket/"+backupBucket.Name),
+					ContainSubstring("Exported BackupEntry/"+backupEntry.Name),
+				))
+
+				for _, path := range []string{
+					fmt.Sprintf("secret-%s.yaml", backupBucketSecret.Name),
+					fmt.Sprintf("backupbucket-%s.yaml", backupBucket.Name),
+					fmt.Sprintf("backupentry-%s.yaml", backupEntry.Name),
+				} {
+					exists, err := fs.Exists(path)
+					Expect(err).NotTo(HaveOccurred(), "for path "+path)
+					Expect(exists).To(BeTrue(), "for path "+path)
+				}
+			})
 		})
 	})
 })

--- a/pkg/gardenadm/cmd/discover/discover_test.go
+++ b/pkg/gardenadm/cmd/discover/discover_test.go
@@ -54,6 +54,11 @@ var _ = Describe("Discover", func() {
 
 		fakeClient = fakeclient.NewClientBuilder().
 			WithScheme(kubernetes.GardenScheme).
+			WithStatusSubresource(&gardencorev1beta1.BackupBucket{}).
+			WithIndex(&gardencorev1beta1.BackupEntry{}, core.BackupEntryShootRefName, indexer.BackupEntryShootRefNameIndexerFunc).
+			WithIndex(&gardencorev1beta1.BackupEntry{}, core.BackupEntryShootRefNamespace, indexer.BackupEntryShootRefNamespaceIndexerFunc).
+			WithIndex(&gardencorev1beta1.BackupBucket{}, core.BackupBucketShootRefName, indexer.BackupBucketShootRefNameIndexerFunc).
+			WithIndex(&gardencorev1beta1.BackupBucket{}, core.BackupBucketShootRefNamespace, indexer.BackupBucketShootRefNamespaceIndexerFunc).
 			WithIndex(&gardencorev1beta1.Project{}, core.ProjectNamespace, indexer.ProjectNamespaceIndexerFunc).
 			Build()
 		clientSet = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
@@ -302,15 +307,22 @@ var _ = Describe("Discover", func() {
 
 		Context("for already existing Shoot", func() {
 			var (
-				backupBucketSecret *corev1.Secret
-				backupBucket       *gardencorev1beta1.BackupBucket
-				backupEntry        *gardencorev1beta1.BackupEntry
+				backupBucketSecret          *corev1.Secret
+				backupBucketGeneratedSecret *corev1.Secret
+				backupBucket                *gardencorev1beta1.BackupBucket
+				backupEntry                 *gardencorev1beta1.BackupEntry
 			)
 
 			BeforeEach(func() {
 				backupBucketSecret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-backup-secret",
+						Namespace: "garden",
+					},
+				}
+				backupBucketGeneratedSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-backup-bucket-generated-secret",
 						Namespace: "garden",
 					},
 				}
@@ -324,6 +336,12 @@ var _ = Describe("Discover", func() {
 							Kind:       "Secret",
 							Name:       backupBucketSecret.Name,
 							Namespace:  backupBucketSecret.Namespace,
+						},
+						ShootRef: &corev1.ObjectReference{
+							APIVersion: "core.gardener.cloud/v1beta1",
+							Kind:       "Shoot",
+							Name:       shoot.Name,
+							Namespace:  shoot.Namespace,
 						},
 					},
 				}
@@ -346,7 +364,16 @@ var _ = Describe("Discover", func() {
 				Expect(fakeClient.Create(ctx, shoot)).To(Succeed())
 
 				Expect(fakeClient.Create(ctx, backupBucketSecret)).To(Succeed())
+				Expect(fakeClient.Create(ctx, backupBucketGeneratedSecret)).To(Succeed())
 				Expect(fakeClient.Create(ctx, backupBucket)).To(Succeed())
+
+				patch := client.MergeFrom(backupBucket.DeepCopy())
+				backupBucket.Status.GeneratedSecretRef = &corev1.SecretReference{
+					Name:      backupBucketGeneratedSecret.Name,
+					Namespace: backupBucketGeneratedSecret.Namespace,
+				}
+				Expect(fakeClient.Status().Patch(ctx, backupBucket, patch)).To(Succeed())
+
 				Expect(fakeClient.Create(ctx, backupEntry)).To(Succeed())
 			})
 
@@ -358,12 +385,14 @@ var _ = Describe("Discover", func() {
 
 				Eventually(func() string { return string(stdOut.Contents()) }).Should(SatisfyAll(
 					ContainSubstring("Exported Secret/"+backupBucketSecret.Name),
+					ContainSubstring("Exported Secret/"+backupBucketGeneratedSecret.Name),
 					ContainSubstring("Exported BackupBucket/"+backupBucket.Name),
 					ContainSubstring("Exported BackupEntry/"+backupEntry.Name),
 				))
 
 				for _, path := range []string{
 					fmt.Sprintf("secret-%s.yaml", backupBucketSecret.Name),
+					fmt.Sprintf("secret-%s.yaml", backupBucketGeneratedSecret.Name),
 					fmt.Sprintf("backupbucket-%s.yaml", backupBucket.Name),
 					fmt.Sprintf("backupentry-%s.yaml", backupEntry.Name),
 				} {

--- a/pkg/utils/graph/eventhandler_backupbucket.go
+++ b/pkg/utils/graph/eventhandler_backupbucket.go
@@ -24,7 +24,7 @@ func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informe
 			if !ok {
 				return
 			}
-			g.handleBackupBucketCreateOrUpdate(backupBucket)
+			g.HandleBackupBucketCreateOrUpdate(backupBucket)
 		},
 
 		UpdateFunc: func(oldObj, newObj any) {
@@ -41,7 +41,7 @@ func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informe
 			if !apiequality.Semantic.DeepEqual(oldBackupBucket.Spec.SeedName, newBackupBucket.Spec.SeedName) ||
 				!apiequality.Semantic.DeepEqual(oldBackupBucket.Spec.CredentialsRef, newBackupBucket.Spec.CredentialsRef) ||
 				!apiequality.Semantic.DeepEqual(oldBackupBucket.Status.GeneratedSecretRef, newBackupBucket.Status.GeneratedSecretRef) {
-				g.handleBackupBucketCreateOrUpdate(newBackupBucket)
+				g.HandleBackupBucketCreateOrUpdate(newBackupBucket)
 			}
 		},
 
@@ -59,7 +59,7 @@ func (g *graph) setupBackupBucketWatch(_ context.Context, informer cache.Informe
 	return err
 }
 
-func (g *graph) handleBackupBucketCreateOrUpdate(backupBucket *gardencorev1beta1.BackupBucket) {
+func (g *graph) HandleBackupBucketCreateOrUpdate(backupBucket *gardencorev1beta1.BackupBucket) {
 	start := time.Now()
 	defer func() {
 		metricUpdateDuration.WithLabelValues("BackupBucket", "CreateOrUpdate").Observe(time.Since(start).Seconds())

--- a/pkg/utils/graph/eventhandler_backupentry.go
+++ b/pkg/utils/graph/eventhandler_backupentry.go
@@ -23,7 +23,7 @@ func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer
 			if !ok {
 				return
 			}
-			g.handleBackupEntryCreateOrUpdate(backupEntry)
+			g.HandleBackupEntryCreateOrUpdate(backupEntry)
 		},
 
 		UpdateFunc: func(oldObj, newObj any) {
@@ -41,7 +41,7 @@ func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer
 				!apiequality.Semantic.DeepEqual(oldBackupEntry.Status.SeedName, newBackupEntry.Status.SeedName) ||
 				!apiequality.Semantic.DeepEqual(oldBackupEntry.OwnerReferences, newBackupEntry.OwnerReferences) ||
 				oldBackupEntry.Spec.BucketName != newBackupEntry.Spec.BucketName {
-				g.handleBackupEntryCreateOrUpdate(newBackupEntry)
+				g.HandleBackupEntryCreateOrUpdate(newBackupEntry)
 			}
 		},
 
@@ -59,7 +59,7 @@ func (g *graph) setupBackupEntryWatch(_ context.Context, informer cache.Informer
 	return err
 }
 
-func (g *graph) handleBackupEntryCreateOrUpdate(backupEntry *gardencorev1beta1.BackupEntry) {
+func (g *graph) HandleBackupEntryCreateOrUpdate(backupEntry *gardencorev1beta1.BackupEntry) {
 	start := time.Now()
 	defer func() {
 		metricUpdateDuration.WithLabelValues("BackupEntry", "CreateOrUpdate").Observe(time.Since(start).Seconds())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery ipcei control-plane
/kind enhancement

**What this PR does / why we need it**:
`gardenadm discover` was originally designed to download Gardener configuration resources for a new Shoot that is about to be created. With this PR, we extend it to also support existing Shoots by discovering their associated BackupBucket and BackupEntry resources (along with the BackupBucket's credential secret). This enables using `gardenadm discover` for disaster recovery purposes — exporting all resources needed to re-bootstrap a control plane Node of existing self-hosted Shoot cluster.

For disaster recovery of a control plane Node, we need the BackupBucket and BackupEntry resources to restore the etcd data of the control plane Node from the backup. We decided to use `gardenadm discover` for this purpose. 

When the the Gardener API server is up and running and a disaster event happens for the SHSC's control plane Node, in order to restore it an operator needs to first run `gardenadm discover` against the Gardener API server to fetch all the required Shoot resources for the restore. Then, the operator would need to run `gardenadm init`/`gardenadm restore`. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/15264

**Special notes for your reviewer**:
Now, when running `gardenadm discover` for existing Shoot it additionally returns the BackupBucket and BackupEntry resources and their associated Secrets:
```diff
 % gardenadm discover shoot.yaml
 Computing required resources for Shoot...
 Fetching required resources for from garden cluster...

+Exported Secret/generated-bucket-cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c to secret-generated-bucket-cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c.yaml
 Exported ConfigMap/cluster-identity to configmap-cluster-identity.yaml
 Exported ControllerRegistration/networking-calico to controllerregistration-networking-calico.yaml
 Exported Namespace/garden to namespace-garden.yaml
+Exported Secret/backup-local to secret-backup-local.yaml
 Exported ControllerDeployment/provider-local to controllerdeployment-provider-local.yaml
 Exported Lease/self-hosted-shoot-root to lease-self-hosted-shoot-root.yaml
 Exported ControllerDeployment/networking-calico to controllerdeployment-networking-calico.yaml
 Exported ControllerRegistration/provider-local to controllerregistration-provider-local.yaml
+Exported BackupEntry/kube-system--cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c to backupentry-kube-system--cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c.yaml
+Exported BackupBucket/cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c to backupbucket-cfe4ad4b-f3f1-4542-8983-6cb56c9c9c0c.yaml
 Exported Project/garden to project-garden.yaml
 Exported CloudProfile/local to cloudprofile-local.yaml
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardenadm discover` now exports `BackupBucket` and `BackupEntry` resources for existing Shoots, which are needed for disaster recovery scenarios.
```
