### PR TITLE
[GEP-28] Don't check VPN tunnel for self-hosted shoot clusters

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -614,7 +614,7 @@ func (h *Health) checkSystemComponents(
 		return exitCondition, nil
 	}
 
-	if !h.shoot.IsWorkerless {
+	if !h.shoot.IsWorkerless && !h.shoot.IsSelfHosted() {
 		podsList := &corev1.PodList{}
 		if err := shootClient.Client().List(ctx, podsList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"type": "tunnel"}); err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

Before this PR, even for self-hosted shoots, the `shoot-care` controller checked for a VPN tunnel, which is not present in the case of self-hosted shoots.

With this fix, the status looks like the following:

```yaml
status:
  conditions:
  - lastTransitionTime: "2026-05-11T13:38:33Z"
    lastUpdateTime: "2026-05-11T13:38:33Z"
    message: Gardenlet is posting ready status.
    reason: GardenletReady
    status: "True"
    type: GardenletReady
  - lastTransitionTime: "2026-05-11T13:38:34Z"
    lastUpdateTime: "2026-05-11T13:38:34Z"
    message: API server /healthz endpoint responded with success status code.
    reason: HealthzRequestSucceeded
    status: "True"
    type: APIServerAvailable
  - lastTransitionTime: "2026-05-11T13:42:01Z"
    lastUpdateTime: "2026-05-11T13:38:34Z"
    message: 'Etcd extension resource "etcd-main" is unhealthy: etcd "etcd-main" is
      not ready yet'
    reason: EtcdUnhealthy
    status: Progressing
    type: ControlPlaneHealthy
  - lastTransitionTime: "2026-05-11T13:42:01Z"
    lastUpdateTime: "2026-05-11T13:38:34Z"
    message: 'Missing required deployments: [kube-state-metrics]'
    reason: DeploymentMissing
    status: Progressing
    type: ObservabilityComponentsHealthy
  - lastTransitionTime: "2026-05-11T13:40:01Z"
    lastUpdateTime: "2026-05-11T13:40:01Z"
    message: All nodes are ready.
    reason: EveryNodeReady
    status: "True"
    type: EveryNodeReady
  - lastTransitionTime: "2026-05-11T13:40:31Z"
    lastUpdateTime: "2026-05-11T13:40:31Z"
    message: All system components are healthy.
    reason: SystemComponentsRunning
    status: "True"
    type: SystemComponentsHealthy
  - lastTransitionTime: "2026-05-11T13:38:34Z"
    lastUpdateTime: "2026-05-11T13:38:34Z"
    message: Backup Buckets are available.
    reason: BackupBucketsAvailable
    status: "True"
    type: BackupBucketsReady
  constraints:
  - codes:
    - ERR_PROBLEMATIC_WEBHOOK
    lastTransitionTime: "2026-05-11T13:42:31Z"
    lastUpdateTime: "2026-05-11T13:38:33Z"
    message: 'MutatingWebhookConfiguration "gardener-extension-provider-local" is
      problematic: webhook "shoot.local.extensions.gardener.cloud" with failurePolicy
      "Fail" and 10s timeout might prevent worker nodes from properly joining the
      shoot cluster'
    reason: ProblematicWebhooks
    status: Progressing
    type: HibernationPossible
  - codes:
    - ERR_PROBLEMATIC_WEBHOOK
    lastTransitionTime: "2026-05-11T13:42:31Z"
    lastUpdateTime: "2026-05-11T13:38:33Z"
    message: 'MutatingWebhookConfiguration "gardener-extension-provider-local" is
      problematic: webhook "shoot.local.extensions.gardener.cloud" with failurePolicy
      "Fail" and 10s timeout might prevent worker nodes from properly joining the
      shoot cluster'
    reason: ProblematicWebhooks
    status: Progressing
    type: MaintenancePreconditionsSatisfied
...
```

## conditions / constraints not reporting "healthy"

### EtcdUnhealthy

In self-hosted shoot case, `etcd-druid` does not seem do report as much, as in the hosted case.

However, it _does_ report it was reconciled successfully.
```yaml
status:
  lastOperation:
    description: Etcd cluster has been successfully reconciled
    lastUpdateTime: "2026-05-11T13:30:30Z"
    runID: 9aef4bae-2d67-407f-accd-ae142e14bed5
    state: Succeeded
    type: Reconcile
```

I don't know, if `etcd-druid` will report more in the future, or if we should adapt the health-check to just the `lastOperation` in the self-hosted shoot case.

### ObservabilityComponentsHealthy

We currently do not deploy any observability components, so this is a valid failure, as of now.

### ProblematicWebhooks

These two problematic webhooks are also valid findings, as we install `provider-local` into the self-hosted shoot, which validates these rules.

We need to either live with that or explicitly disable this check for self-hosted shoots (unmanaged infra).



**Which issue(s) this PR fixes**:
Part of #2906 

**Special notes for your reviewer**:

/cc @rfranzke @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed where the `SystemComponentsRunning` was showing and error for self-hosted shoots on unmanaged infrastructure.
```
