### PR TITLE
Add `events.k8s.io` RBAC for `{opentelemtery,prometheus}-operator`

### DIFF
--- a/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/prometheus_operator_test.go
@@ -286,7 +286,7 @@ var _ = Describe("PrometheusOperator", func() {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
-					APIGroups: []string{""},
+					APIGroups: []string{"", "events.k8s.io"},
 					Resources: []string{"events"},
 					Verbs:     []string{"patch", "create"},
 				},

--- a/pkg/component/observability/monitoring/prometheusoperator/rbac.go
+++ b/pkg/component/observability/monitoring/prometheusoperator/rbac.go
@@ -7,6 +7,7 @@ package prometheusoperator
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -84,7 +85,7 @@ func (p *prometheusOperator) clusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{corev1.GroupName},
+				APIGroups: []string{corev1.GroupName, eventsv1.GroupName},
 				Resources: []string{"events"},
 				Verbs:     []string{"patch", "create"},
 			},

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -148,7 +148,7 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{"", "events.k8s.io"},
 				Resources: []string{"events"},
 				Verbs:     []string{"create", "patch"},
 			},
@@ -259,7 +259,7 @@ func (o *openTelemetryOperator) role() *rbacv1.Role {
 				Verbs:     []string{"list", "patch", "create", "get", "watch"},
 			},
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{"", "events.k8s.io"},
 				Resources: []string{"events"},
 				Verbs:     []string{"create", "patch"},
 			},

--- a/pkg/component/observability/opentelemetry/operator/operator.go
+++ b/pkg/component/observability/opentelemetry/operator/operator.go
@@ -10,7 +10,12 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,42 +148,42 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{corev1.GroupName},
 				Resources: []string{"configmaps", "pods", "serviceaccounts", "services"},
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{"", "events.k8s.io"},
+				APIGroups: []string{corev1.GroupName, eventsv1.GroupName},
 				Resources: []string{"events"},
 				Verbs:     []string{"create", "patch"},
 			},
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{corev1.GroupName},
 				Resources: []string{"namespaces", "secrets"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{"apps"},
+				APIGroups: []string{appsv1.GroupName},
 				Resources: []string{"daemonsets", "deployments", "statefulsets"},
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{"apps"},
+				APIGroups: []string{appsv1.GroupName},
 				Resources: []string{"replicasets"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{"autoscaling"},
+				APIGroups: []string{autoscalingv1.GroupName},
 				Resources: []string{"horizontalpodautoscalers"},
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{"batch"},
+				APIGroups: []string{batchv1.GroupName},
 				Resources: []string{"jobs"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
-				APIGroups: []string{"coordination.k8s.io"},
+				APIGroups: []string{coordinationv1.GroupName},
 				Resources: []string{"leases"},
 				Verbs:     []string{"create", "get", "list", "update"},
 			},
@@ -188,12 +193,12 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{"networking.k8s.io"},
+				APIGroups: []string{networkingv1.GroupName},
 				Resources: []string{"ingresses"},
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			{
-				APIGroups: []string{"networking.k8s.io"},
+				APIGroups: []string{networkingv1.GroupName},
 				Resources: []string{"networkpolicies"},
 				Verbs:     []string{"list", "watch"},
 			},
@@ -218,7 +223,7 @@ func (*openTelemetryOperator) clusterRole() *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "patch", "update"},
 			},
 			{
-				APIGroups: []string{"policy"},
+				APIGroups: []string{policyv1.GroupName},
 				Resources: []string{"poddisruptionbudgets"},
 				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
@@ -254,12 +259,12 @@ func (o *openTelemetryOperator) role() *rbacv1.Role {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{""},
+				APIGroups: []string{corev1.GroupName},
 				Resources: []string{"configmaps"},
 				Verbs:     []string{"list", "patch", "create", "get", "watch"},
 			},
 			{
-				APIGroups: []string{"", "events.k8s.io"},
+				APIGroups: []string{corev1.GroupName, eventsv1.GroupName},
 				Resources: []string{"events"},
 				Verbs:     []string{"create", "patch"},
 			},

--- a/pkg/component/observability/opentelemetry/operator/operator_test.go
+++ b/pkg/component/observability/opentelemetry/operator/operator_test.go
@@ -93,7 +93,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 					Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 				},
 				{
-					APIGroups: []string{""},
+					APIGroups: []string{"", "events.k8s.io"},
 					Resources: []string{"events"},
 					Verbs:     []string{"create", "patch"},
 				},
@@ -198,7 +198,7 @@ var _ = Describe("OpenTelemetry Operator", func() {
 					Verbs:     []string{"list", "patch", "create", "get", "watch"},
 				},
 				{
-					APIGroups: []string{""},
+					APIGroups: []string{"", "events.k8s.io"},
 					Resources: []string{"events"},
 					Verbs:     []string{"create", "patch"},
 				},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/area logging
/kind bug

**What this PR does / why we need it**:
This PR adds necessary RBAC for the `events.k8s.io` API group for `prometheus-operator` and `opentelemetry-operator` components.

For `prometheus-operator` check https://github.com/prometheus-operator/prometheus-operator/pull/8077
For `opentelemetry-operator` - `GetEventRecorder` was added with https://github.com/open-telemetry/opentelemetry-operator/pull/4880, and then the RBAC they use fixed with https://github.com/open-telemetry/opentelemetry-operator/pull/4950

So far, other components do not seem to work with events from the `events.k8s.io` API group. This is the case even for leader election events when `controller-runtime` is used, as there still the core API group is used, [ref](https://github.com/kubernetes-sigs/controller-runtime/blob/f9589b9f2b9dddf8532b432bb8315f2820ab9971/pkg/leaderelection/leader_election.go#L128-L130)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `opentelemetry-operator` and `prometheus-operator` deployed by Gardener now have the required RBAC for Events in the `events.k8s.io` API group.
```
