### PR TITLE
Fix data race and flaky stress test in `CommandLineProgressReporter`

### DIFF
--- a/pkg/utils/flow/progress_reporter_commandline.go
+++ b/pkg/utils/flow/progress_reporter_commandline.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/signal"
 	"sync"
@@ -33,7 +34,7 @@ Running Tasks:
 
 var infoTpl = template.Must(template.New("").
 	Option("missingkey=zero").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"red":   color.RedString,
 		"green": color.GreenString,
 	}).
@@ -116,9 +117,15 @@ func (p *progressReporterCommandline) ReportRetry(_ context.Context, id TaskID, 
 }
 
 func (p *progressReporterCommandline) printInfo() {
-	if err := infoTpl.Execute(p.out, map[string]interface{}{
-		"stat":     p.lastStats,
-		"lastErrs": p.lastErrs,
+	p.lock.Lock()
+	stat := p.lastStats
+	lastErrs := make(map[TaskID]error, len(p.lastErrs))
+	maps.Copy(lastErrs, p.lastErrs)
+	p.lock.Unlock()
+
+	if err := infoTpl.Execute(p.out, map[string]any{
+		"stat":     stat,
+		"lastErrs": lastErrs,
 	}); err != nil {
 		fmt.Fprintf(p.out, "Failed to print progress: %v", err)
 	}

--- a/pkg/utils/flow/progress_reporter_commandline_test.go
+++ b/pkg/utils/flow/progress_reporter_commandline_test.go
@@ -60,23 +60,17 @@ var _ = Describe("CommandLineProgressReporter", func() {
 
 		debugChan <- os.Interrupt
 
-		Eventually(outBuf).Should(And(
-			gbytes.Say("Flow: Test-Flow"),
-			gbytes.Say("Succeeded: 2"),
-			gbytes.Say("Failed: 1"),
-		))
+		Eventually(outBuf).Should(gbytes.Say("Flow: Test-Flow"))
+		Eventually(outBuf).Should(gbytes.Say("Succeeded: 2"))
+		Eventually(outBuf).Should(gbytes.Say("Failed: 1"))
 
 		// Verify Running tasks section
-		Eventually(outBuf).Should(And(
-			gbytes.Say("Running Tasks:"),
-			gbytes.Say("== task_running_1"),
-		))
+		Eventually(outBuf).Should(gbytes.Say("Running Tasks:"))
+		Eventually(outBuf).Should(gbytes.Say("== task_running_1"))
 
 		// Verify Error reporting
-		Eventually(outBuf).Should(And(
-			gbytes.Say("Last Error:"),
-			gbytes.Say("connection timeout"),
-		))
+		Eventually(outBuf).Should(gbytes.Say("Last Error:"))
+		Eventually(outBuf).Should(gbytes.Say("connection timeout"))
 	})
 
 	It("should capture retry errors end-to-end when running a flow with RetryUntilTimeout", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind flake

**What this PR does / why we need it**:
**1. Data race in printInfo**

`printInfo` read `lastStats` and `lastErrs` without holding the lock, while `Report` and `ReportRetry` write those fields under it. Under concurrent execution the Go race detector flags this, and in practice, it can cause the template to render against a partially-written or nil `lastStats`.

This PR takes a snapshot of `lastStats` and `lastErrs` under the lock, then renders the template from the snapshot outside the lock.

**2. Flaky test using And(gbytes.Say(...), gbytes.Say(...)) inside Eventually**

`gbytes.Say` is stateful — it advances the buffer's read cursor on every match, including within a failing `And`. If `gbytes.Say("Running Tasks:")` matched and advanced the cursor but `gbytes.Say("== task_running_1")` failed (the template hadn't finished writing yet), `Eventually` would retry. On the next attempt, `"Running Tasks:"` was already consumed, so the assertion timed out permanently.

This PR replaces each `And(gbytes.Say(...), gbytes.Say(...))` with a separate `Eventually` per `gbytes.Say`. Each assertion then retries independently without risking consuming output that a later assertion still needs.

**Which issue(s) this PR fixes**:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14690/pull-gardener-unit/2053949069239259136
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14806/pull-gardener-unit/2053878367547035648
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14806/pull-gardener-unit/2054084308108316672

**Special notes for your reviewer**:
Before:
```
stress -p 8 ./pkg/utils/flow/flow.test

10s: 125 runs so far, 17 failures (13.60%), 8 active
```
After:
```
stress -p 32 ./pkg/utils/flow/flow.test

1m40s: 7310 runs so far, 0 failures, 32 active
1m45s: 7690 runs so far, 0 failures, 32 active
1m50s: 8053 runs so far, 0 failures, 32 active
1m55s: 8432 runs so far, 0 failures, 32 active
2m0s: 8795 runs so far, 0 failures, 32 active
2m5s: 9172 runs so far, 0 failures, 32 active
2m10s: 9536 runs so far, 0 failures, 32 active
2m15s: 9914 runs so far, 0 failures, 32 active
```

/cc @maboehm 
Follow up after #14755 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
