### PR TITLE
fix: ignore unusable machines for bastion

### DIFF
--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -221,6 +221,10 @@ func findMostSuitableMachineType(profile *gardencorev1beta1.CloudProfile) (machi
 			continue
 		}
 
+		if !ptr.Deref(machine.Usable, true) {
+			continue
+		}
+
 		if minCpu == nil || machine.CPU.Value() < *minCpu &&
 			(supportedArchitectures == nil || slices.Contains(supportedArchitectures, arch)) {
 			minCpu = ptr.To(machine.CPU.Value())

--- a/extensions/pkg/bastion/machine_test.go
+++ b/extensions/pkg/bastion/machine_test.go
@@ -184,6 +184,23 @@ var _ = Describe("Bastion VM Details", func() {
 			Expect(details.MachineTypeName).To(DeepEqual("smallerMachine"))
 		})
 
+		It("should ignore unusable machines", func() {
+			cloudProfile.Spec.Bastion.MachineType = nil
+			cloudProfile.Spec.MachineTypes = append(cloudProfile.Spec.MachineTypes, gardencorev1beta1.MachineType{
+				CPU:          resource.MustParse("1"),
+				GPU:          resource.MustParse("1"),
+				Name:         "smallerMachine",
+				Usable:       ptr.To(false),
+				Architecture: ptr.To(desired.Architecture),
+				Capabilities: gardencorev1beta1.Capabilities{
+					"architecture": []string{v1beta1constants.ArchitectureAMD64},
+				},
+			})
+			details, err := GetMachineSpecFromCloudProfile(cloudProfile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(details).To(DeepEqual(desired))
+		})
+
 		It("should only use supported version", func() {
 			addImageToCloudProfile(desired.ImageBaseName, "1.2.4", gardencorev1beta1.ClassificationPreview, []string{"amd64"}, gardencorev1beta1.Capabilities{"architecture": []string{v1beta1constants.ArchitectureAMD64}})
 			details, err := GetMachineSpecFromCloudProfile(cloudProfile)


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

The logic searched for the smallest machine type in the CloudProfile even if it has `usable: false`. This could result in provisioning errors if the smallest machine type cannot be created. Unusable machine types are now skipped when looking for the type with lowest CPU.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Skip unusable machine types in search for suitable bastion host image
```
