### PR TITLE
Fix release artifact file and archive names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,21 +179,27 @@ jobs:
         args:
           - os: linux
             arch: amd64
+            archive_suffix: .tar.gz
             runner: ubuntu-latest
           - os: linux
             arch: arm64
+            archive_suffix: .tar.gz
             runner: ubuntu-24.04-arm
           - os: darwin
             arch: amd64
+            archive_suffix: .tar.gz
             runner: ubuntu-latest
           - os: darwin
             arch: arm64
+            archive_suffix: .tar.gz
             runner: ubuntu-24.04-arm
           - os: windows
             arch: amd64
+            archive_suffix: .zip
             runner: ubuntu-latest
           - os: windows
             arch: arm64
+            archive_suffix: .zip
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.args.runner }}
     steps:
@@ -209,20 +215,19 @@ jobs:
           ld_flags="$(hack/get-build-ld-flags.sh)"
           os=${{ matrix.args.os }}
           arch=${{ matrix.args.arch }}
+          archive_suffix=${{ matrix.args.archive_suffix }}
 
           if [ ${os} == 'windows' ]; then
             exe_suffix='.exe'
-            archive_suffix='.zip'
           else
             exe_suffix=''
-            archive_suffix='.tar.gz'
           fi
 
           mkdir -p /tmp/blobs.d
           prefix=/tmp/blobs.d/gardenadm
           platform_suffix="-${os}-${arch}"
-          outpath="${prefix}${platform_suffix}${exe_suffix}${archive_suffix}"
-          archive="${prefix}${platform_suffix}.archive"
+          outpath="${prefix}${platform_suffix}${exe_suffix}"
+          archive="${prefix}${platform_suffix}${archive_suffix}.archive"
 
           GOOS=${os} \
           GOARCH=${arch} \
@@ -256,4 +261,4 @@ jobs:
             access:
               type: localBlob
               localReference: >-
-                gardenadm-${{ matrix.args.os }}-${{ matrix.args.arch }}.archive
+                gardenadm-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.archive_suffix }}.archive


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Currently, the release binary artifacts are wrongly named: They are archives (but without the archive suffix) that contain a binary that (wrongly) has the archive suffix.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The release binary artifact names have changed to include an archive suffix, which is removed from the contained binary.
```
