### PR TITLE
fix discovery server ingress configuration with custom URL

### DIFF
--- a/pkg/api/operator/v1alpha1/helper/garden.go
+++ b/pkg/api/operator/v1alpha1/helper/garden.go
@@ -301,20 +301,28 @@ func DiscoveryServerDomain(garden *operatorv1alpha1.Garden) string {
 	return "discovery." + garden.Spec.RuntimeCluster.Ingress.Domains[0].Name
 }
 
-// GetAllIngressDomains returns all domains that are covered by the ingress controller. This includes:
-// - wildcard domains for all ingress domains (Garden.spec.runtimeCluster.ingress.domains[])
-// - the discovery server domain (Garden.spec.virtualCluster.gardener.gardenerDiscoveryServer.domain) if specified and not already covered by the wildcard domains
-func GetAllIngressDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSDomain {
+// GetIngressWildcardDomains returns all wildcarddomains that are covered by the ingress controller (Garden.spec.runtimeCluster.ingress.domains[]).
+func GetIngressWildcardDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSDomain {
 	runtimeDomains := garden.Spec.RuntimeCluster.Ingress.Domains
 
-	allIngressDomains := make([]operatorv1alpha1.DNSDomain, 0, len(runtimeDomains)+1)
+	ingressDomains := make([]operatorv1alpha1.DNSDomain, 0, len(runtimeDomains)+1)
 	for _, domain := range runtimeDomains {
-		allIngressDomains = append(allIngressDomains,
+		ingressDomains = append(ingressDomains,
 			operatorv1alpha1.DNSDomain{
 				Name:     "*." + domain.Name,
 				Provider: domain.Provider,
 			})
 	}
+
+	return ingressDomains
+}
+
+// GetAllIngressDomains returns all domains already covered by GetIngressWildcardDomains plus
+// the discovery server domain (Garden.spec.virtualCluster.gardener.gardenerDiscoveryServer.domain)
+// if specified and not already covered by the wildcard domains
+func GetAllIngressDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSDomain {
+	runtimeDomains := garden.Spec.RuntimeCluster.Ingress.Domains
+	allIngressDomains := GetIngressWildcardDomains(garden)
 
 	if discoveryServerConfig := garden.Spec.VirtualCluster.Gardener.DiscoveryServer; discoveryServerConfig != nil && discoveryServerConfig.Domain != nil {
 		// Cut the first segment of the discovery server domain to get the parent domain.

--- a/pkg/api/operator/v1alpha1/helper/garden.go
+++ b/pkg/api/operator/v1alpha1/helper/garden.go
@@ -321,7 +321,6 @@ func GetIngressWildcardDomains(garden *operatorv1alpha1.Garden) []operatorv1alph
 // the discovery server domain (Garden.spec.virtualCluster.gardener.gardenerDiscoveryServer.domain)
 // if specified and not already covered by the wildcard domains
 func GetAllIngressDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSDomain {
-	runtimeDomains := garden.Spec.RuntimeCluster.Ingress.Domains
 	allIngressDomains := GetIngressWildcardDomains(garden)
 
 	if discoveryServerConfig := garden.Spec.VirtualCluster.Gardener.DiscoveryServer; discoveryServerConfig != nil && discoveryServerConfig.Domain != nil {
@@ -333,7 +332,7 @@ func GetAllIngressDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DN
 
 		// Check if the discovery server's domain is a subdomain of the ingress domains, i.e., if the domain is already
 		// covered by the wildcard domains. If not, add the discovery server domain as well.
-		if !slices.ContainsFunc(runtimeDomains, func(domain operatorv1alpha1.DNSDomain) bool {
+		if !slices.ContainsFunc(garden.Spec.RuntimeCluster.Ingress.Domains, func(domain operatorv1alpha1.DNSDomain) bool {
 			return domain.Name == discoveryServerParentDomain
 		}) {
 			allIngressDomains = append(allIngressDomains, *discoveryServerConfig.Domain.DeepCopy())

--- a/pkg/api/operator/v1alpha1/helper/garden.go
+++ b/pkg/api/operator/v1alpha1/helper/garden.go
@@ -305,7 +305,7 @@ func DiscoveryServerDomain(garden *operatorv1alpha1.Garden) string {
 func GetIngressWildcardDomains(garden *operatorv1alpha1.Garden) []operatorv1alpha1.DNSDomain {
 	runtimeDomains := garden.Spec.RuntimeCluster.Ingress.Domains
 
-	ingressDomains := make([]operatorv1alpha1.DNSDomain, 0, len(runtimeDomains)+1)
+	ingressDomains := make([]operatorv1alpha1.DNSDomain, 0, len(runtimeDomains))
 	for _, domain := range runtimeDomains {
 		ingressDomains = append(ingressDomains,
 			operatorv1alpha1.DNSDomain{

--- a/pkg/api/operator/v1alpha1/helper/garden_test.go
+++ b/pkg/api/operator/v1alpha1/helper/garden_test.go
@@ -434,6 +434,44 @@ var _ = Describe("helper", func() {
 		}, []string{"reconcile", "rotate-credentials-start", "rotate-ssh-keypair", ""}),
 	)
 
+	Describe("#GetIngressWildcardDomains", func() {
+		var garden *operatorv1alpha1.Garden
+
+		BeforeEach(func() {
+			garden = &operatorv1alpha1.Garden{
+				Spec: operatorv1alpha1.GardenSpec{
+					RuntimeCluster: operatorv1alpha1.RuntimeCluster{
+						Ingress: operatorv1alpha1.Ingress{
+							Domains: []operatorv1alpha1.DNSDomain{
+								{
+									Name:     "ingress.local.gardener.cloud",
+									Provider: ptr.To("primary"),
+								},
+								{
+									Name:     "secondary.local.gardener.cloud",
+									Provider: ptr.To("secondary"),
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should return the ingress wildcard domains", func() {
+			Expect(GetIngressWildcardDomains(garden)).To(ConsistOf(
+				operatorv1alpha1.DNSDomain{
+					Name:     "*.ingress.local.gardener.cloud",
+					Provider: ptr.To("primary"),
+				},
+				operatorv1alpha1.DNSDomain{
+					Name:     "*.secondary.local.gardener.cloud",
+					Provider: ptr.To("secondary"),
+				},
+			))
+		})
+	})
+	// foo
 	Describe("#GetAllIngressDomains", func() {
 		var garden *operatorv1alpha1.Garden
 

--- a/pkg/api/operator/v1alpha1/helper/garden_test.go
+++ b/pkg/api/operator/v1alpha1/helper/garden_test.go
@@ -454,11 +454,21 @@ var _ = Describe("helper", func() {
 							},
 						},
 					},
+					VirtualCluster: operatorv1alpha1.VirtualCluster{
+						Gardener: operatorv1alpha1.Gardener{
+							DiscoveryServer: &operatorv1alpha1.GardenerDiscoveryServerConfig{
+								Domain: &operatorv1alpha1.DNSDomain{
+									Name:     "discovery.local.gardener.cloud",
+									Provider: ptr.To("primary"),
+								},
+							},
+						},
+					},
 				},
 			}
 		})
 
-		It("should return the ingress wildcard domains", func() {
+		It("should return the ingress wildcard domains only", func() {
 			Expect(GetIngressWildcardDomains(garden)).To(ConsistOf(
 				operatorv1alpha1.DNSDomain{
 					Name:     "*.ingress.local.gardener.cloud",
@@ -471,7 +481,7 @@ var _ = Describe("helper", func() {
 			))
 		})
 	})
-	// foo
+
 	Describe("#GetAllIngressDomains", func() {
 		var garden *operatorv1alpha1.Garden
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1036,7 +1036,7 @@ func (r *Reconciler) newNginxIngressController(garden *operatorv1alpha1.Garden, 
 		return nil, fmt.Errorf("exactly one Istio Ingress Gateway is required for the SNI config")
 	}
 
-	ingressDomains := toDomainNames(helper.GetAllIngressDomains(garden))
+	ingressDomains := toDomainNames(helper.GetIngressWildcardDomains(garden))
 
 	return sharedcomponent.NewNginxIngress(
 		r.RuntimeClientSet.Client(),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

The custom URL functionality for the [gardener-discovery-server](https://github.com/gardener/gardener-discovery-server) introduced in #14126 is broken since the discovery server is exposed via istio `gateway` instead of ingress nginx (#14587).

`istioctl analyze -n garden` returns:

```
Error [IST0145] (Gateway garden/gardener-discovery-server) Conflict with gateways garden/nginx-ingress-controller (workload selector istio=ingressgateway, port 443, hosts discovery.test.foo).
```

The conflict leads to undesired behaviour. The traffic for the discovery server is forwarded to the nginx-ingress. However, the nginx-ingress does not have a configuration for the discovery server anymore and serves the self-signed default cert from nginx (and a 404 if accepting the certificate). 

This happens because the custom configurable domain for the discovery server is still added to the nginx ingress `gateway` and is conflicting with the `gateway` specifically created for the discovery server. Therefore, the domain needs to be removed from the istio configuration for the ingress nginx.

However, if DNS entries are managed by gardener the discovery server domain still needs to be handled.

Since we require two different lists (one only with wildcards for the ingress-nginx) and one with all domains (wildcards + discovery server) I've split this into two functions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed unreachability of gardener-discovery server if a custom URL is configured
```
