### PR TITLE
Fix gardenadm build for, e.g., windows, by providing default signals.Info() implementation

### DIFF
--- a/pkg/utils/signals/signals.go
+++ b/pkg/utils/signals/signals.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux && !darwin
+
+package signals
+
+import "os"
+
+// Info returns the OS signals used for status dumping. Fallback for non-configured, e.g., Windows, which has no equivalent signal.
+func Info() []os.Signal {
+	return nil
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes failing gardenadm windows builds since https://github.com/gardener/gardener/pull/14755

**Special notes for your reviewer**:
/cc @rfranzke @maboehm 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
