### PR TITLE
fix: Correct status message for nodes during scale-up

### DIFF
--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -898,9 +898,15 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 		}
 	}
 
-	if readyAndSchedulableNodes < desiredMachines {
+	if registeredNodes < desiredMachines {
 		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
 			return "NodesScalingUp", err
+		}
+	}
+
+	if readyAndSchedulableNodes < desiredMachines {
+		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
+			return "NodesRollOutScalingUp", err
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -904,6 +904,7 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 		}
 	}
 
+	// Report reason "NodesRollOutScalingUp" if enough nodes are registered and not enough are ready (still starting required pods, lost connection)
 	if readyAndSchedulableNodes < desiredMachines {
 		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
 			return "NodesRollOutScalingUp", err

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -898,7 +898,7 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 		}
 	}
 
-	if registeredNodes < desiredMachines {
+	if readyAndSchedulableNodes < desiredMachines {
 		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
 			return "NodesScalingUp", err
 		}
@@ -948,10 +948,6 @@ func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, d
 }
 
 func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList []*corev1.Node, registeredNodes, desiredMachines int) error {
-	if registeredNodes <= desiredMachines {
-		return nil
-	}
-
 	// Check if all nodes that are cordoned map to machines with a deletion timestamp. This might be the case during
 	// a rolling update.
 	nodeNameToMachine := map[string]machinev1alpha1.Machine{}

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -874,12 +874,8 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 		return "", err
 	}
 
-	// First check if the MachineDeployments report failed machines. If false then check if the MachineDeployments are
-	// "available". If false then check if there is a regular scale-up happening or if there are machines with an erroneous
-	// phase. Only then check the other MachineDeployment conditions. As last check, check if there is a scale-down happening
-	// (e.g., in case of a rolling-update).
-
-	checkScaleUp := false
+	// First check if the MachineDeployments report failed machines. If false then check if there is a rolling update
+	// in progress. Then use the node count to determine whether we are scaling up or down.
 	checkRollingUpdate := false
 	for _, deployment := range machineDeploymentList.Items {
 		if len(deployment.Status.FailedMachines) > 0 {
@@ -892,9 +888,6 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 				checkRollingUpdate = true
 				break
 			}
-			if condition.Type == machinev1alpha1.MachineDeploymentAvailable && condition.Status != machinev1alpha1.ConditionTrue {
-				checkScaleUp = true
-			}
 		}
 	}
 
@@ -905,21 +898,23 @@ func CheckNodesScaling(ctx context.Context, seedClient client.Client, nodeList [
 		}
 	}
 
-	if checkScaleUp {
+	if registeredNodes < desiredMachines {
 		if err := checkNodesScalingUp(machineList, readyAndSchedulableNodes, desiredMachines); err != nil {
 			return "NodesScalingUp", err
 		}
 	}
 
-	if err := checkNodesScalingDown(machineList, nodeList, registeredNodes, desiredMachines); err != nil {
-		return "NodesScalingDown", err
+	if registeredNodes > desiredMachines {
+		if err := checkNodesScalingDown(machineList, nodeList, registeredNodes, desiredMachines); err != nil {
+			return "NodesScalingDown", err
+		}
 	}
 
 	return "", nil
 }
 
 func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, desiredMachines int) error {
-	if readyNodes == desiredMachines {
+	if readyNodes >= desiredMachines {
 		return nil
 	}
 
@@ -953,7 +948,7 @@ func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, d
 }
 
 func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList []*corev1.Node, registeredNodes, desiredMachines int) error {
-	if registeredNodes == desiredMachines {
+	if registeredNodes <= desiredMachines {
 		return nil
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -740,7 +740,7 @@ var _ = Describe("health check", func() {
 				Expect(err).To(MatchError(ContainSubstring("is erroneous")))
 			})
 
-			It("should return an error when not enough ready nodes are registered", func() {
+			It("should return an error when not enough nodes are registered", func() {
 				machineList := &machinev1alpha1.MachineList{
 					Items: []machinev1alpha1.Machine{
 						{
@@ -766,6 +766,72 @@ var _ = Describe("health check", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
 							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(2)},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodesScalingUp"))
+				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
+			})
+
+			It("should return an error when not enough ready nodes are registered", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineRunning},
+							},
+						},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+				nodeList := []*corev1.Node{{}}
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
+						},
+					},
+				}
+				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
+				Expect(msg).To(Equal("NodesScalingUp"))
+				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
+			})
+
+			It("should return an error when the only registered node is ready but unschedulable (cordoned)", func() {
+				machineList := &machinev1alpha1.MachineList{
+					Items: []machinev1alpha1.Machine{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineRunning},
+							},
+						},
+					},
+				}
+				for _, machine := range machineList.Items {
+					Expect(fakeClient.Create(ctx, &machine)).To(Succeed())
+				}
+				// One node is registered and Ready but cordoned (unschedulable) - it must NOT count as ready+schedulable.
+				nodeList := []*corev1.Node{
+					{
+						Spec: corev1.NodeSpec{Unschedulable: true},
+						Status: corev1.NodeStatus{
+							Conditions: []corev1.NodeCondition{
+								{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+							},
+						},
+					},
+				}
+				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
+					Items: []machinev1alpha1.MachineDeployment{
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
 						},
 					},
 				}
@@ -834,21 +900,6 @@ var _ = Describe("health check", func() {
 		})
 
 		Describe("Scaling down", func() {
-			It("should return true if number of registered nodes equal number of desired machines", func() {
-				nodeList := []*corev1.Node{{}}
-				machineDeploymentList := &machinev1alpha1.MachineDeploymentList{
-					Items: []machinev1alpha1.MachineDeployment{
-						{
-							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
-							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-						},
-					},
-				}
-				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal(""))
-				Expect(err).ToNot(HaveOccurred())
-			})
-
 			It("should return an error if the machine for a cordoned node is not found", func() {
 				nodeList := []*corev1.Node{
 					{Spec: corev1.NodeSpec{Unschedulable: true}},

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -749,6 +749,12 @@ var _ = Describe("health check", func() {
 								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineRunning},
 							},
 						},
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachineRunning},
+							},
+						},
 					},
 				}
 				for _, machine := range machineList.Items {
@@ -759,10 +765,7 @@ var _ = Describe("health check", func() {
 					Items: []machinev1alpha1.MachineDeployment{
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
-							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
-								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
-							}},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(2)},
 						},
 					},
 				}
@@ -780,6 +783,12 @@ var _ = Describe("health check", func() {
 								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachinePending},
 							},
 						},
+						{
+							ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace},
+							Status: machinev1alpha1.MachineStatus{
+								CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachinePending},
+							},
+						},
 					},
 				}
 				for _, machine := range machineList.Items {
@@ -790,10 +799,7 @@ var _ = Describe("health check", func() {
 					Items: []machinev1alpha1.MachineDeployment{
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
-							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
-								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
-							}},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(2)},
 						},
 					},
 				}
@@ -806,6 +812,7 @@ var _ = Describe("health check", func() {
 				machineList := &machinev1alpha1.MachineList{
 					Items: []machinev1alpha1.Machine{
 						{ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace}},
+						{ObjectMeta: metav1.ObjectMeta{GenerateName: "obj-", Namespace: controlPlaneNamespace}},
 					},
 				}
 				for _, machine := range machineList.Items {
@@ -816,10 +823,7 @@ var _ = Describe("health check", func() {
 					Items: []machinev1alpha1.MachineDeployment{
 						{
 							ObjectMeta: metav1.ObjectMeta{GenerateName: "deploy", Namespace: controlPlaneNamespace},
-							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(1)},
-							Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
-								{Type: machinev1alpha1.MachineDeploymentAvailable, Status: machinev1alpha1.ConditionFalse}, {},
-							}},
+							Spec:       machinev1alpha1.MachineDeploymentSpec{Replicas: int32(2)},
 						},
 					},
 				}

--- a/pkg/gardenlet/controller/shoot/care/health_test.go
+++ b/pkg/gardenlet/controller/shoot/care/health_test.go
@@ -798,7 +798,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodesScalingUp"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
 			})
 
@@ -836,7 +836,7 @@ var _ = Describe("health check", func() {
 					},
 				}
 				msg, err := CheckNodesScaling(ctx, fakeClient, nodeList, machineDeploymentList, controlPlaneNamespace)
-				Expect(msg).To(Equal("NodesScalingUp"))
+				Expect(msg).To(Equal("NodesRollOutScalingUp"))
 				Expect(err).To(MatchError(ContainSubstring("not enough ready worker nodes registered in the cluster")))
 			})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug

**What this PR does / why we need it**:

Without this fix the node status was reported as `too many worker nodes are registered. Exceeding maximum desired machine count` under certain conditions while the cluster was still scaling up. 

The implementation was introduced in #11779 with a solution described here: https://github.com/gardener/gardener/pull/11084#issuecomment-2639137008

It has the following problematic edge cases:
- `checkNodesScalingDown` is called unconditionally, even if `registeredNodes < desiredMachines`, leading to the unexpected status message.
- `checkNodesScalingUp` is called only if the condition `MachineDeploymentAvailable` is not true for at least one `MachineDeployment`. However, a `MachineDeployment` can still be scaling up after the condition is true when `maxUnavailable > 0`.
  - MCM sets `MachineDeploymentAvailable` to `true` when `availableReplicas >= Spec.Replicas - maxUnavailable` ([Source](https://github.com/gardener/machine-controller-manager/blob/bd15a0127dce75ee533a6a917e664ffd0bab68c6/pkg/controller/deployment_sync.go#L655-L662))
  - As a result the node status was reporting `too many worker nodes` when `availableReplicas >= Spec.Replicas - maxUnavailable && availableReplicas < Spec.Replicas`.

The new logic ignores the the `MachineDeploymentAvailable` and relies purely on comparing `registeredNodes` with `desiredMachines` with a special case for rolling updates (not sure if this is even required). Tests had to be adjusted slightly because the test data for scale-up tests relied purely on the `MachineDeploymentAvailable` to be false

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix an edge case where node status was reported as "too many worker nodes" while the cluster was still scaling up.
```
