### PR TITLE
Build gardenadm images and oci-images in PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,17 +10,22 @@ on:
         description: |
           the mode to use. either `snapshot` or `release`. Will affect effective version, as well
           as target-oci-registry.
+  pull_request:
+    branches:
+      - master
+      - 'release-v*'
 
 jobs:
   prepare:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
     with:
-      mode: ${{ inputs.mode }}
+      mode: ${{ inputs.mode || 'snapshot' }}
     permissions:
       id-token: write
 
   tests:
     runs-on: ${{ github.repository_owner == 'gardener' && 'ubuntu-latest-large' || 'ubuntu-latest' }}
+    if: github.event_name != 'pull_request'
     steps:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
@@ -57,6 +62,7 @@ jobs:
 
   sast-lint:
     uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
     with:
@@ -74,6 +80,7 @@ jobs:
 
   oci-images:
     name: Build OCI-Images
+    if: ${{ always() && needs.prepare.result == 'success' && needs.tests.result != 'failure' && needs.sast-lint.result != 'failure' }}
     needs:
       - prepare
       - tests
@@ -123,9 +130,11 @@ jobs:
       oci-platforms: linux/amd64,linux/arm64
       ocm-labels:
       extra-tags: latest
+      push: ${{ github.event_name != 'pull_request' && 'if-possible' || 'never' }}
 
   helmcharts:
     name: Build Helmcharts
+    if: github.event_name != 'pull_request'
     needs:
       - prepare
       - oci-images
@@ -169,6 +178,7 @@ jobs:
       ocm-mappings: ${{ toJSON(matrix.args.ocm-mappings) }}
 
   gardenadm:
+    if: ${{ always() && needs.tests.result != 'failure' && needs.sast-lint.result != 'failure' }}
     permissions:
       contents: read
     needs:
@@ -249,6 +259,7 @@ jobs:
 
           unlink ${outpath}
       - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+        if: github.event_name != 'pull_request'
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Following up on https://github.com/gardener/gardener/pull/14816, we might want to build the gardenadm binaries and oci-images for other platforms within a PR already.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
