### PR TITLE
Loop sshd-ensurer service instead of restart

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component.go
@@ -92,7 +92,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Restart=always
-RestartSec=15
+RestartSec=5
 ExecStart=` + pathScript + `
 [Install]
 WantedBy=multi-user.target`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/component_test.go
@@ -42,7 +42,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Restart=always
-RestartSec=15
+RestartSec=5
 ExecStart=/var/lib/sshd-ensurer/run.sh
 [Install]
 WantedBy=multi-user.target`),
@@ -79,7 +79,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Restart=always
-RestartSec=15
+RestartSec=5
 ExecStart=/var/lib/sshd-ensurer/run.sh
 [Install]
 WantedBy=multi-user.target`),
@@ -107,34 +107,42 @@ const (
 	enableScript = `#!/bin/bash -eu
 set -e
 
-# Unmask and enable sshd service if not enabled
-if ! systemctl is-enabled --quiet sshd.service ; then
-    systemctl unmask sshd.service
-    # When sshd.service is disabled on gardenlinux the service is deleted
-    # On gardenlinux sshd.service is enabled by enabling ssh.service
-    if ! systemctl enable sshd.service ; then
-        systemctl enable ssh.service
+while true; do
+    # Unmask and enable sshd service if not enabled
+    if ! systemctl is-enabled --quiet sshd.service ; then
+        systemctl unmask sshd.service
+        # When sshd.service is disabled on gardenlinux the service is deleted
+        # On gardenlinux sshd.service is enabled by enabling ssh.service
+        if ! systemctl enable sshd.service ; then
+            systemctl enable ssh.service
+        fi
     fi
-fi
 
-# Start sshd service if not active
-if ! systemctl is-active --quiet sshd.service ; then
-    systemctl start sshd.service
-fi
+    # Start sshd service if not active
+    if ! systemctl is-active --quiet sshd.service ; then
+        systemctl start sshd.service
+    fi
+
+    sleep 15
+done
 `
 	disableScript = `#!/bin/bash -eu
 set -e
 
-# Disable and mask sshd service if not masked
-if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
-    systemctl disable sshd.service || true
-    # Using the --now flag stops the selected service
-    systemctl mask --now sshd.service
-fi
+while true; do
+    # Disable and mask sshd service if not masked
+    if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
+        systemctl disable sshd.service || true
+        # Using the --now flag stops the selected service
+        systemctl mask --now sshd.service
+    fi
 
-# Stopping the sshd service with the --now flag does
-# not terminate already established connections
-# Kill all currently established orphaned ssh connections on the host
-pkill -P 1 -x sshd || true
+    # Stopping the sshd service with the --now flag does
+    # not terminate already established connections
+    # Kill all currently established orphaned ssh connections on the host
+    pkill -P 1 -x sshd || true
+
+    sleep 15
+done
 `
 )

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/disable-sshd.tpl.sh
@@ -1,14 +1,18 @@
 #!/bin/bash -eu
 set -e
 
-# Disable and mask sshd service if not masked
-if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
-    systemctl disable sshd.service || true
-    # Using the --now flag stops the selected service
-    systemctl mask --now sshd.service
-fi
+while true; do
+    # Disable and mask sshd service if not masked
+    if [ "$(systemctl is-enabled sshd.service)" != "masked" ] ; then
+        systemctl disable sshd.service || true
+        # Using the --now flag stops the selected service
+        systemctl mask --now sshd.service
+    fi
 
-# Stopping the sshd service with the --now flag does
-# not terminate already established connections
-# Kill all currently established orphaned ssh connections on the host
-pkill -P 1 -x sshd || true
+    # Stopping the sshd service with the --now flag does
+    # not terminate already established connections
+    # Kill all currently established orphaned ssh connections on the host
+    pkill -P 1 -x sshd || true
+
+    sleep 15
+done

--- a/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/enable-sshd.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer/templates/scripts/enable-sshd.tpl.sh
@@ -1,17 +1,21 @@
 #!/bin/bash -eu
 set -e
 
-# Unmask and enable sshd service if not enabled
-if ! systemctl is-enabled --quiet sshd.service ; then
-    systemctl unmask sshd.service
-    # When sshd.service is disabled on gardenlinux the service is deleted
-    # On gardenlinux sshd.service is enabled by enabling ssh.service
-    if ! systemctl enable sshd.service ; then
-        systemctl enable ssh.service
+while true; do
+    # Unmask and enable sshd service if not enabled
+    if ! systemctl is-enabled --quiet sshd.service ; then
+        systemctl unmask sshd.service
+        # When sshd.service is disabled on gardenlinux the service is deleted
+        # On gardenlinux sshd.service is enabled by enabling ssh.service
+        if ! systemctl enable sshd.service ; then
+            systemctl enable ssh.service
+        fi
     fi
-fi
 
-# Start sshd service if not active
-if ! systemctl is-active --quiet sshd.service ; then
-    systemctl start sshd.service
-fi
+    # Start sshd service if not active
+    if ! systemctl is-active --quiet sshd.service ; then
+        systemctl start sshd.service
+    fi
+
+    sleep 15
+done


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #14310 

**Special notes for your reviewer**:
This PR changes the `sshd-ensurer` services to use a loop instead of restart every 15 seconds to reduce `syslog` entries.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `sshd-ensurer` service is changed to use a loop instead of restart every 15 seconds to prevent spamming journalctl with noisy logs.
```
