### PR TITLE
Add containerd config file version 4 support (containerd 2.3)

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config.go
@@ -62,6 +62,13 @@ var (
 			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
 			cniPluginsPaths:    {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"},
 		},
+		4: {
+			registryConfigPath: {"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
+			sandboxImagePath:   {"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"},
+			cgroupDriverPath:   {"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
+			cniPluginPath:      {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
+			cniPluginsPaths:    {"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"},
+		},
 	}
 
 	// pluginPathReplacements is a map that contains replacements for paths brought in through an osc plugin config
@@ -84,7 +91,7 @@ func getContainerdConfigFileVersion(config map[string]any) (containerdConfigFile
 		return 0, fmt.Errorf("cannot assert containerd config file version \"%v\" as an int64", version)
 	}
 
-	if i < 1 || i > 3 {
+	if i < 1 || i > 4 {
 		return 0, fmt.Errorf("unsupported containerd config file version %d", i)
 	}
 
@@ -302,7 +309,7 @@ func replaceConfigPathPrefix(path, prefix, replace structuredmap.Path) structure
 }
 
 func replacePluginPath(path structuredmap.Path, replacementMap replacementMap, version containerdConfigFileVersion) structuredmap.Path {
-	if version != 3 {
+	if version < 3 {
 		return path
 	}
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/containerd_config_test.go
@@ -201,6 +201,12 @@ var _ = Describe("containerd configuration file tests", func() {
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
 			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
 		),
+		Entry("for containerd config file v4", "testfiles/containerd-config.toml-v4",
+			structuredmap.Path{"plugins", "io.containerd.cri.v1.images", "pinned_images", "sandbox"},
+			structuredmap.Path{"plugins", "io.containerd.cri.v1.images", "registry", "config_path"},
+			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "runc", "options", "SystemdCgroup"},
+			structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"},
+		),
 	)
 
 	It("should configure CNI plugin dirs as array at corresponding path for containerd >= 2.2", func() {
@@ -212,6 +218,29 @@ var _ = Describe("containerd configuration file tests", func() {
 		containerdClient.SetFakeContainerdVersion("2.2.1")
 
 		Expect(loadContainerdConfig("testfiles/containerd-config.toml-v3", r.FS)).To(Succeed())
+		Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+		pluginDirValue, err := getContainerdConfigValue(r.FS, cniPluginDirPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pluginDirValue).To(BeNil())
+
+		configValue, err := getContainerdConfigValue(r.FS, cniPluginDirsPath)
+		Expect(err).ToNot(HaveOccurred())
+		pluginDirsValue, ok := configValue.([]any)
+		Expect(ok).To(BeTrue())
+		Expect(pluginDirsValue).To(HaveLen(1))
+		Expect(pluginDirsValue).To(ContainElements("/opt/cni/bin"))
+	})
+
+	It("should configure CNI plugin dirs as array at corresponding path for containerd >= 2.2 with config v4", func() {
+		var (
+			cniPluginDirPath  = structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dir"}
+			cniPluginDirsPath = structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "cni", "bin_dirs"}
+		)
+
+		containerdClient.SetFakeContainerdVersion("2.3.0")
+
+		Expect(loadContainerdConfig("testfiles/containerd-config.toml-v4", r.FS)).To(Succeed())
 		Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
 
 		pluginDirValue, err := getContainerdConfigValue(r.FS, cniPluginDirPath)
@@ -309,6 +338,38 @@ var _ = Describe("containerd configuration file tests", func() {
 				Expect(err).To(HaveOccurred())
 
 				goodPath := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "foobar", "foo", "runtime_type"}
+				configValue, err := getContainerdConfigValue(r.FS, goodPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				v, ok := configValue.(string)
+				Expect(ok).To(BeTrue())
+				Expect(v).To(Equal("bar.123"))
+			})
+		})
+
+		When("containerd configuration file version is v4", func() {
+			BeforeEach(func() {
+				Expect(loadContainerdConfig("testfiles/containerd-config.toml-v4", r.FS)).To(Succeed())
+			})
+
+			It("should translate a v2 compliant runtime path to its v4 equivalent", func() {
+				osc.Spec.CRIConfig.Containerd.Plugins = []extensionsv1alpha1.PluginConfig{
+					{
+						Op:   ptr.To(extensionsv1alpha1.AddPluginPathOperation),
+						Path: []string{"io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo"},
+						Values: &apiextensionsv1.JSON{
+							Raw: []byte("{\"runtime_type\": \"bar.123\"}"),
+						},
+					},
+				}
+
+				Expect(r.ReconcileContainerdConfig(ctx, log, osc)).To(Succeed())
+
+				wrongPath := structuredmap.Path{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "foo", "runtime_type"}
+				_, err := getContainerdConfigValue(r.FS, wrongPath)
+				Expect(err).To(HaveOccurred())
+
+				goodPath := structuredmap.Path{"plugins", "io.containerd.cri.v1.runtime", "containerd", "runtimes", "foo", "runtime_type"}
 				configValue, err := getContainerdConfigValue(r.FS, goodPath)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v4
+++ b/pkg/nodeagent/controller/operatingsystemconfig/testfiles/containerd-config.toml-v4
@@ -1,0 +1,289 @@
+# obtained through containerd config default on containerd 2.3.0
+
+version = 4
+root = '/var/lib/containerd'
+state = '/run/containerd'
+temp = ''
+disabled_plugins = []
+required_plugins = []
+oom_score = 0
+imports = ['/etc/containerd/conf.d/*.toml']
+
+[debug]
+  level = ''
+  format = ''
+  log_trace_id = false
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'overlayfs'
+    disable_snapshot_annotations = true
+    discard_unpacked_layers = false
+    max_concurrent_downloads = 3
+    concurrent_layer_fetch_buffer = 0
+    image_pull_progress_timeout = '5m0s'
+    image_pull_with_sync_fs = false
+    stats_collect_period = 10
+    use_local_image_pull = false
+
+    [plugins.'io.containerd.cri.v1.images'.pinned_images]
+      sandbox = 'registry.k8s.io/pause:3.10.2'
+
+    [plugins.'io.containerd.cri.v1.images'.registry]
+      config_path = ''
+
+    [plugins.'io.containerd.cri.v1.images'.image_decryption]
+      key_model = 'node'
+
+  [plugins.'io.containerd.cri.v1.runtime']
+    enable_selinux = false
+    selinux_category_range = 1024
+    max_container_log_line_size = 16384
+    disable_apparmor = false
+    restrict_oom_score_adj = false
+    disable_proc_mount = false
+    unset_seccomp_profile = ''
+    tolerate_missing_hugetlb_controller = true
+    disable_hugetlb_controller = true
+    device_ownership_from_security_context = false
+    ignore_image_defined_volumes = false
+    netns_mounts_under_state_dir = false
+    enable_unprivileged_ports = true
+    enable_unprivileged_icmp = true
+    enable_cdi = true
+    cdi_spec_dirs = ['/etc/cdi', '/var/run/cdi']
+    drain_exec_sync_io_timeout = '0s'
+    ignore_deprecation_warnings = []
+    stats_collect_period = ''
+    stats_retention_period = ''
+
+    [plugins.'io.containerd.cri.v1.runtime'.containerd]
+      default_runtime_name = 'runc'
+      ignore_blockio_not_enabled_errors = false
+      ignore_rdt_not_enabled_errors = false
+
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]
+        [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
+          runtime_type = 'io.containerd.runc.v2'
+          runtime_path = ''
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          cgroup_writable = false
+          base_runtime_spec = ''
+          cni_conf_dir = ''
+          cni_max_conf_num = 0
+          snapshotter = ''
+          sandboxer = 'podsandbox'
+          io_type = ''
+
+          [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
+            BinaryName = ''
+            CriuImagePath = ''
+            CriuWorkPath = ''
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            Root = ''
+            ShimCgroup = ''
+            SystemdCgroup = false
+
+    [plugins.'io.containerd.cri.v1.runtime'.cni]
+      bin_dir = ''
+      bin_dirs = ['/opt/cni/bin']
+      conf_dir = '/etc/cni/net.d'
+      max_conf_num = 1
+      setup_serially = false
+      conf_template = ''
+      ip_pref = ''
+      use_internal_loopback = false
+
+  [plugins.'io.containerd.differ.v1.erofs']
+    mkfs_options = []
+    enable_tar_index = false
+    enable_dmverity = false
+
+  [plugins.'io.containerd.gc.v1.scheduler']
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = '0s'
+    startup_delay = '100ms'
+
+  [plugins.'io.containerd.grpc.v1.cri']
+    disable_tcp_service = true
+    stream_server_address = '127.0.0.1'
+    stream_server_port = '0'
+    stream_idle_timeout = '4h0m0s'
+    enable_tls_streaming = false
+
+    [plugins.'io.containerd.grpc.v1.cri'.x509_key_pair_streaming]
+      tls_cert_file = ''
+      tls_key_file = ''
+
+  [plugins.'io.containerd.image-verifier.v1.bindir']
+    bin_dir = '/opt/containerd/image-verifier/bin'
+    max_verifiers = 10
+    per_verifier_timeout = '10s'
+
+  [plugins.'io.containerd.internal.v1.opt']
+    path = '/opt/containerd'
+
+  [plugins.'io.containerd.internal.v1.tracing']
+
+  [plugins.'io.containerd.metadata.v1.bolt']
+    content_sharing_policy = 'shared'
+    no_sync = false
+
+  [plugins.'io.containerd.metrics.v1.grpc-prometheus']
+    grpc_histogram = false
+
+  [plugins.'io.containerd.monitor.container.v1.restart']
+    interval = '10s'
+
+  [plugins.'io.containerd.monitor.task.v1.cgroups']
+    no_prometheus = false
+
+  [plugins.'io.containerd.mount-handler.v1.erofs']
+
+  [plugins.'io.containerd.nri.v1.nri']
+    disable = false
+    socket_path = '/var/run/nri/nri.sock'
+    plugin_path = '/opt/nri/plugins'
+    plugin_config_path = '/etc/nri/conf.d'
+    plugin_registration_timeout = '5s'
+    plugin_request_timeout = '2s'
+    disable_connections = false
+
+    [plugins.'io.containerd.nri.v1.nri'.default_validator]
+      enable = false
+      reject_oci_hook_adjustment = false
+      reject_runtime_default_seccomp_adjustment = false
+      reject_unconfined_seccomp_adjustment = false
+      reject_custom_seccomp_adjustment = false
+      reject_namespace_adjustment = false
+      reject_sysctl_adjustment = false
+      required_plugins = []
+      tolerate_missing_plugins_annotation = ''
+
+  [plugins.'io.containerd.runtime.v2.task']
+    platforms = ['linux/amd64']
+
+  [plugins.'io.containerd.server.v1.debug']
+    address = ''
+    uid = 0
+    gid = 0
+
+  [plugins.'io.containerd.server.v1.grpc']
+    address = '/run/containerd/containerd.sock'
+    uid = 0
+    gid = 0
+    max_recv_message_size = 16777216
+    max_send_message_size = 16777216
+
+  [plugins.'io.containerd.server.v1.grpc-tcp']
+    address = ''
+    tls_ca = ''
+    tls_cert = ''
+    tls_key = ''
+    tls_common_name = ''
+    max_recv_message_size = 16777216
+    max_send_message_size = 16777216
+
+  [plugins.'io.containerd.server.v1.metrics']
+    address = ''
+
+  [plugins.'io.containerd.server.v1.ttrpc']
+    address = '/run/containerd/containerd.sock.ttrpc'
+    uid = 0
+    gid = 0
+
+  [plugins.'io.containerd.service.v1.diff-service']
+    default = ['walking']
+    sync_fs = false
+
+  [plugins.'io.containerd.service.v1.tasks-service']
+    blockio_config_file = ''
+    rdt_config_file = ''
+
+  [plugins.'io.containerd.shim.v1.manager']
+    env = []
+    socket_dir = ''
+
+  [plugins.'io.containerd.snapshotter.v1.blockfile']
+    root_path = ''
+    scratch_file = ''
+    fs_type = ''
+    mount_options = []
+    recreate_scratch = false
+
+  [plugins.'io.containerd.snapshotter.v1.btrfs']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.devmapper']
+    root_path = ''
+    pool_name = ''
+    base_image_size = ''
+    async_remove = false
+    discard_blocks = false
+    fs_type = ''
+    fs_options = ''
+
+  [plugins.'io.containerd.snapshotter.v1.erofs']
+    root_path = ''
+    ovl_mount_options = []
+    enable_fsverity = false
+    set_immutable = false
+    default_size = ''
+    dmverity_mode = ''
+
+  [plugins.'io.containerd.snapshotter.v1.native']
+    root_path = ''
+
+  [plugins.'io.containerd.snapshotter.v1.overlayfs']
+    root_path = ''
+    upperdir_label = false
+    sync_remove = false
+    slow_chown = false
+    mount_options = []
+
+  [plugins.'io.containerd.snapshotter.v1.zfs']
+    root_path = ''
+
+  [plugins.'io.containerd.tracing.processor.v1.otlp']
+
+  [plugins.'io.containerd.transfer.v1.local']
+    max_concurrent_downloads = 3
+    concurrent_layer_fetch_buffer = 0
+    max_concurrent_uploaded_layers = 3
+    check_platform_supported = false
+    config_path = ''
+    max_concurrent_unpacks = 1
+
+[cgroup]
+  path = ''
+
+[timeouts]
+  'io.containerd.timeout.bolt.open' = '0s'
+  'io.containerd.timeout.cri.defercleanup' = '1m0s'
+  'io.containerd.timeout.metrics.shimstats' = '2s'
+  'io.containerd.timeout.shim.cleanup' = '5s'
+  'io.containerd.timeout.shim.load' = '5s'
+  'io.containerd.timeout.shim.shutdown' = '3s'
+  'io.containerd.timeout.task.state' = '2s'
+
+[stream_processors]
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']
+
+  [stream_processors.'io.containerd.ocicrypt.decoder.v1.tar.gzip']
+    accepts = ['application/vnd.oci.image.layer.v1.tar+gzip+encrypted']
+    returns = 'application/vnd.oci.image.layer.v1.tar+gzip'
+    path = 'ctd-decoder'
+    args = ['--decryption-keys-path', '/etc/containerd/ocicrypt/keys']
+    env = ['OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf']


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind enhancement

**What this PR does / why we need it**:

With containerd 2.3, a new config file version v4 was introduced. Building on top of #11623 (which added v3 support), this PR extends the gardener-node-agent's `ensureContainerdConfiguration()` lookup logic to also handle v4.

In v4, the CRI plugin paths are unchanged compared to v3; only server-level fields (`grpc`, `ttrpc`, `debug`, `metrics`) were moved into plugin blocks. This PR adds a v4 path map, updates the version validation to accept v4, and applies the existing plugin path translation (originally introduced for v3) for all config file versions >= 3 so that any path inserted through an OSC `PluginConfiguration` matching a v2-compliant prefix is translated to the equivalent v3/v4-compliant prefix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Follow-up to #11623 which introduced v3 support. Tests cover the new v4 config file via a dedicated `containerd-config.toml-v4` testfile.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gardener-node-agent is now able to deal with version v4 of containerd's configuration file `/etc/containerd/config.toml` (introduced with containerd 2.3). CRI plugin paths in v4 are identical to v3; only server-level fields moved into plugin blocks. The plugin path translation that maps v2-compliant prefixes to their v3 equivalents is now applied for all config file versions >= 3.
```