### PR TITLE
admission-local: Assume the virtual cluster always exists

### DIFF
--- a/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/admission-local/charts/runtime/templates/deployment.yaml
@@ -55,8 +55,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: SOURCE_CLUSTER
-          value: enabled
         ports:
         - name: webhook-server
           containerPort: {{ .Values.webhookConfig.serverPort }}

--- a/cmd/gardener-extension-admission-local/app/app.go
+++ b/cmd/gardener-extension-admission-local/app/app.go
@@ -10,14 +10,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -96,29 +93,12 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 
 			managerOptions := mgrOpts.Completed().Options()
 
-			// Operators can enable the source cluster option via SOURCE_CLUSTER environment variable.
-			// In-cluster config will be used if no SOURCE_KUBECONFIG is specified.
-			//
-			// The source cluster is for instance used by Gardener's certificate controller, to maintain certificate
-			// secrets in a different cluster ('runtime-garden') than the cluster where the webhook configurations
-			// are maintained ('virtual-garden').
-			var sourceClusterConfig *rest.Config
-			if sourceClusterEnabled := os.Getenv("SOURCE_CLUSTER"); sourceClusterEnabled != "" {
-				log.Info("Configuring source cluster option")
-				var err error
-				sourceClusterConfig, err = clientcmd.BuildConfigFromFlags("", os.Getenv("SOURCE_KUBECONFIG"))
-				if err != nil {
-					return err
-				}
-				managerOptions.LeaderElectionConfig = sourceClusterConfig
-			} else {
-				// Restrict the cache for secrets to the configured namespace to avoid the need for cluster-wide list/watch permissions.
-				managerOptions.Cache = cache.Options{
-					ByObject: map[client.Object]cache.ByObject{
-						&corev1.Secret{}: {Namespaces: map[string]cache.Config{webhookOptions.Server.Completed().Namespace: {}}},
-					},
-				}
+			log.Info("Configuring source cluster option")
+			inClusterConfig, err := rest.InClusterConfig()
+			if err != nil {
+				return fmt.Errorf("could not get in-cluster config: %w", err)
 			}
+			managerOptions.LeaderElectionConfig = inClusterConfig
 
 			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
 			if err != nil {
@@ -132,26 +112,23 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 
-			var sourceCluster cluster.Cluster
-			if sourceClusterConfig != nil {
-				sourceCluster, err = cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
-					opts.Logger = log
-					opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
-				})
-				if err != nil {
-					return err
-				}
+			sourceCluster, err := cluster.New(inClusterConfig, func(opts *cluster.Options) {
+				opts.Logger = log
+				opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
+			})
+			if err != nil {
+				return err
+			}
 
-				if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, sourceCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
-					return err
-				}
-				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
-					return err
-				}
+			if err := mgr.AddHealthzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthzWithDeadline(mgr.GetLogger(), clock.RealClock{}, sourceCluster.GetCache(), gardenerhealthz.DefaultCacheSyncDeadline)); err != nil {
+				return err
+			}
+			if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
+				return err
+			}
 
-				if err = mgr.Add(sourceCluster); err != nil {
-					return err
-				}
+			if err = mgr.Add(sourceCluster); err != nil {
+				return err
 			}
 
 			log.Info("Setting up webhook server")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity quality
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-registry-cache/issues/578 and https://github.com/gardener/gardener-extension-registry-cache/pull/581 for context.
The admission-local's `SOURCE_CLUSTER` environment variable was used to denote if the virtual cluster is enabled or not. 
From the above-referenced issue:
> With Gardener [v1.142.0](https://github.com/gardener/gardener/releases/tag/v1.142.0) the local setup that was using the `gardener/controlplane` chart is dropped. The related PR is https://github.com/gardener/gardener/pull/14614. 
This means that all local setups are based on the gardener-operator and the Garden resource. Hence, we can now always rely that the virtual cluster exists and the runtime and virtual clusters are not the same.

The `SOURCE_CLUSTER` environment variable is unconditionally enabled. It does not make sense to support in the admission code branches where it is not enabled or in general the scenario where the virtual cluster is not enabled.

**Which issue(s) this PR fixes**:
Similar to https://github.com/gardener/gardener-extension-registry-cache/pull/581
Follow-up after https://github.com/gardener/gardener/pull/14614

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
