### PR TITLE
Add handling of HTTP/2 connection coalescing.

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
@@ -19,6 +19,7 @@ spec:
     match:
       context: GATEWAY
       listener:
+        portNumber: 9443
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
@@ -34,11 +35,18 @@ spec:
             function envoy_on_request(request_handle)
               local streamInfo = request_handle:streamInfo()
               if streamInfo:requestedServerName() ~= "" then
-                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 3), 1, true)) then
+                -- Handle wildcard in the requested server name
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2), 1, true)) then
                   request_handle:respond({[":status"] = "421"}, "Misdirected Request")
                 end
+                -- Handle mismatch between requested server name and :authority header
                 if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then
-                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                  -- Check if the difference is just the port (443) as suffix in the :authority header
+                  local portSuffix = ":443"
+                  local portSuffixLen = string.len(portSuffix)
+                  if (not(string.find(string.sub(request_handle:headers():get(":authority"), -portSuffixLen), portSuffix, 1, true) and streamInfo:requestedServerName() == string.sub(request_handle:headers():get(":authority"), 1, -portSuffixLen - 1))) then
+                    request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                  end
                 end
               end
             end

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
@@ -1,0 +1,44 @@
+# Envoy proxy and istio do not support HTTP/2 client connection coalescing natively.
+# Clients, especially web browsers, may open a single HTTP/2 connection and send requests
+# targeted at different hosts all backed by the same IP address and wildcard certificate.
+# Returning 421 for requests where the server name and the authority header do not match
+# indicates to the client that it should open a new connection for the request.
+# Issues:
+# - https://github.com/envoyproxy/envoy/issues/6767
+# - https://github.com/istio/istio/issues/13589
+# Documentation:
+# - https://istio.io/latest/docs/ops/common-problems/network-issues/#404-errors-occur-when-multiple-gateways-configured-with-same-tls-certificate
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: misdirected-requests
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.lua
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              local streamInfo = request_handle:streamInfo()
+              if streamInfo:requestedServerName() ~= "" then
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2))) then
+                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                end
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then
+                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                end
+              end
+            end

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/misdirected-requests-envoy-filter.yaml
@@ -34,7 +34,7 @@ spec:
             function envoy_on_request(request_handle)
               local streamInfo = request_handle:streamInfo()
               if streamInfo:requestedServerName() ~= "" then
-                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2))) then
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 3), 1, true)) then
                   request_handle:respond({[":status"] = "421"}, "Misdirected Request")
                 end
                 if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -169,6 +169,11 @@ var _ = Describe("istiod", func() {
 			return string(data)
 		}
 
+		istioIngressMisdirectedRequestsEnvoyFilter = func() string {
+			data, _ := os.ReadFile("./test_charts/ingress_misdirected_requests_envoyfilter.yaml")
+			return string(data)
+		}
+
 		istioIngressHTTPConnectGateway = func() string {
 			data, _ := os.ReadFile("./test_charts/ingress_http_connect_gateway.yaml")
 			return string(data)
@@ -413,6 +418,7 @@ var _ = Describe("istiod", func() {
 				istioIngressServiceAccount(),
 				istioIngressDeployment(minReplicas),
 				istioIngressEnvoyFilter(),
+				istioIngressMisdirectedRequestsEnvoyFilter(),
 				istioIngressServiceMonitor(),
 				istioIngressTelemetry(),
 			}

--- a/pkg/component/networking/istio/test_charts/ingress_misdirected_requests_envoyfilter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_misdirected_requests_envoyfilter.yaml
@@ -1,0 +1,44 @@
+# Envoy proxy and istio do not support HTTP/2 client connection coalescing natively.
+# Clients, especially web browsers, may open a single HTTP/2 connection and send requests
+# targeted at different hosts all backed by the same IP address and wildcard certificate.
+# Returning 421 for requests where the server name and the authority header do not match
+# indicates to the client that it should open a new connection for the request.
+# Issues:
+# - https://github.com/envoyproxy/envoy/issues/6767
+# - https://github.com/istio/istio/issues/13589
+# Documentation:
+# - https://istio.io/latest/docs/ops/common-problems/network-issues/#404-errors-occur-when-multiple-gateways-configured-with-same-tls-certificate
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: misdirected-requests
+  namespace: test-ingress
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+            subFilter:
+              name: envoy.filters.http.router
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.lua
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+              local streamInfo = request_handle:streamInfo()
+              if streamInfo:requestedServerName() ~= "" then
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2))) then
+                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                end
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then
+                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                end
+              end
+            end

--- a/pkg/component/networking/istio/test_charts/ingress_misdirected_requests_envoyfilter.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_misdirected_requests_envoyfilter.yaml
@@ -19,6 +19,7 @@ spec:
     match:
       context: GATEWAY
       listener:
+        portNumber: 9443
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
@@ -34,11 +35,18 @@ spec:
             function envoy_on_request(request_handle)
               local streamInfo = request_handle:streamInfo()
               if streamInfo:requestedServerName() ~= "" then
-                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2))) then
+                -- Handle wildcard in the requested server name
+                if (string.sub(streamInfo:requestedServerName(), 1, 2) == "*." and not string.find(request_handle:headers():get(":authority"), string.sub(streamInfo:requestedServerName(), 2), 1, true)) then
                   request_handle:respond({[":status"] = "421"}, "Misdirected Request")
                 end
+                -- Handle mismatch between requested server name and :authority header
                 if (string.sub(streamInfo:requestedServerName(), 1, 2) ~= "*." and streamInfo:requestedServerName() ~= request_handle:headers():get(":authority")) then
-                  request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                  -- Check if the difference is just the port (443) as suffix in the :authority header
+                  local portSuffix = ":443"
+                  local portSuffixLen = string.len(portSuffix)
+                  if (not(string.find(string.sub(request_handle:headers():get(":authority"), -portSuffixLen), portSuffix, 1, true) and streamInfo:requestedServerName() == string.sub(request_handle:headers():get(":authority"), 1, -portSuffixLen - 1))) then
+                    request_handle:respond({[":status"] = "421"}, "Misdirected Request")
+                  end
                 end
               end
             end


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area monitoring
/area logging
/kind enhancement

**What this PR does / why we need it**:

Add handling of HTTP/2 connection coalescing.

HTTP/2 clients, especially web browsers, may coalesce requests into a single connection. This might have surprising consequences if wildcard certificates and a shared reverse proxy are used. In such a scenario, clients may believe that a connection to `a.example.com` with a wildcard certificate `*.example.com` may also be usable for requests to `b.example.com`.

Envoy proxy and istio do not support this scenario. Hence, client requests may lead to unexpected `404` errors. This is documented in issues, e.g. https://github.com/envoyproxy/envoy/issues/6767 and https://github.com/istio/istio/issues/13589. It even made it into FAQs (https://istio.io/latest/docs/ops/common-problems/network-issues/#404-errors-occur-when-multiple-gateways-configured-with-same-tls-certificate).

As we do not want change our gateway/virtual service architecture, we use the simple approach of sending `421` in case a mismatch between requested server name and host/authority header is detected. Clients should take this as a hint to create a new connection for the corresponding request. Current web browsers support this by now.

**Which issue(s) this PR fixes**:
Part of #13448 

**Special notes for your reviewer**:

The corresponding issue previous to this fix is easy to reproduce if a wildcard certificate is used in a gardener landscape (see [garden runtime](https://github.com/gardener/gardener/blob/master/docs/operations/trusted-tls-for-garden-runtime.md) or [seed cluster](https://github.com/gardener/gardener/blob/master/docs/operations/trusted-tls-for-control-planes.md)). The first connection usually works as expected, e.g. to plutono, but the second connection, e.g. to prometheus, will fail with `404` as the first connection is reused.

Please note that this does not seem to be reproducible in the local gardener setup. Furthermore, web browsers differ in their handling, e.g. safari private browsing does not reuse connections while others do.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener observability components are accessible even if web browsers try to coalesce connections.
```

/cc @oliver-goetz @timuthy 