### PR TITLE
Use the new "istio-role" label in all selectors

### DIFF
--- a/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -27,9 +27,6 @@ spec:
       labels:
 {{ toYaml .Values.labels | indent 8 }}
 {{ toYaml .Values.networkPolicyLabels | indent 8 }}
-{{- with .Values.podLabels }}
-{{ toYaml . | indent 8 }}
-{{- end }}
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
+++ b/pkg/component/networking/istio/charts/istio/istio-ingress/values.yaml
@@ -1,6 +1,5 @@
 labels:
   app: istio-ingressgateway
-podLabels: {}
 networkPolicyLabels:
   to-target: allowed
 annotations: {}

--- a/pkg/component/networking/istio/ingress_gateway.go
+++ b/pkg/component/networking/istio/ingress_gateway.go
@@ -34,7 +34,6 @@ var (
 type IngressGatewayValues struct {
 	Annotations                        map[string]string
 	Labels                             map[string]string
-	PodLabels                          map[string]string // TODO(maboehm): Remove this parameter after one release (v1.143)
 	NetworkPolicyLabels                map[string]string
 	LoadBalancerClass                  *string
 	ExternalTrafficPolicy              *corev1.ServiceExternalTrafficPolicy
@@ -103,7 +102,6 @@ func (i *istiod) generateIstioIngressGatewayChart(ctx context.Context) (*chartre
 		values := map[string]any{
 			"trustDomain":                        istioIngressGateway.TrustDomain,
 			"labels":                             istioIngressGateway.Labels,
-			"podLabels":                          istioIngressGateway.PodLabels,
 			"networkPolicyLabels":                istioIngressGateway.NetworkPolicyLabels,
 			"annotations":                        istioIngressGateway.Annotations,
 			"loadBalancerClass":                  istioIngressGateway.LoadBalancerClass,

--- a/pkg/component/networking/istio/istio_test.go
+++ b/pkg/component/networking/istio/istio_test.go
@@ -1040,7 +1040,6 @@ func makeIngressGateway(namespace string, annotations, labels map[string]string,
 			IstiodNamespace:     "istio-test-system",
 			Annotations:         annotations,
 			Labels:              labels,
-			PodLabels:           map[string]string{"pod-label": "foo"},
 			NetworkPolicyLabels: networkPolicyLabels,
 			Ports: []corev1.ServicePort{
 				{Name: "foo", Port: 999, TargetPort: intstr.FromInt32(999)},

--- a/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
+++ b/pkg/component/networking/istio/test_charts/ingress_deployment.yaml
@@ -27,7 +27,6 @@ spec:
         app: istio-ingressgateway
         foo: bar
         to-target: allowed
-        pod-label: foo
         service.istio.io/canonical-name: "istio-ingressgateway"
         service.istio.io/canonical-revision: "1.29"
       annotations:

--- a/pkg/component/shared/istio.go
+++ b/pkg/component/shared/istio.go
@@ -52,7 +52,6 @@ func NewIstio(
 	priorityClassName string,
 	istiodEnabled bool,
 	labels map[string]string,
-	podLabels map[string]string, // TODO(maboehm): Remove this parameter after one release (v1.143)
 	networkPolicyLabels []string,
 	lbAnnotations map[string]string,
 	loadBalancerClass *string,
@@ -103,7 +102,6 @@ func NewIstio(
 		Ports:                              servicePorts,
 		LoadBalancerIP:                     serviceExternalIP,
 		Labels:                             labels,
-		PodLabels:                          podLabels,
 		NetworkPolicyLabels:                policyLabels,
 		Namespace:                          namePrefix + ingressNamespace,
 		PriorityClassName:                  priorityClassName,
@@ -238,7 +236,10 @@ func GetIstioZoneLabels(labels map[string]string, zone *string) map[string]strin
 	if zone != nil {
 		zoneValue = fmt.Sprintf("%s%s%s", zoneValue, zoneInfix, *zone)
 	}
-	return utils.MergeStringMaps(labels, map[string]string{zonekey: zoneValue})
+	return utils.MergeStringMaps(labels, map[string]string{
+		istio.RoleKey: istio.RoleSeed,
+		zonekey:       zoneValue,
+	})
 }
 
 // IsZonalIstioExtension indicates whether the namespace related to the given labels is a zonal istio extension.

--- a/pkg/component/shared/istio_test.go
+++ b/pkg/component/shared/istio_test.go
@@ -72,7 +72,6 @@ func createIstio(testValues istioTestValues) istio.Interface {
 		testValues.priorityClassName,
 		testValues.istiodEnabled,
 		testValues.labels,
-		testValues.podLabels,
 		[]string{testValues.kubeAPIServerPolicyLabel},
 		testValues.lbAnnotations,
 		testValues.loadBalancerClass,
@@ -131,7 +130,6 @@ func checkIstio(istioDeploy istio.Interface, testValues istioTestValues) {
 				Ports:                              testValues.servicePorts,
 				LoadBalancerIP:                     testValues.serviceExternalIP,
 				Labels:                             testValues.labels,
-				PodLabels:                          testValues.podLabels,
 				NetworkPolicyLabels:                networkPolicyLabels,
 				Namespace:                          "shared-istio-test-some-istio-ingress",
 				PriorityClassName:                  testValues.priorityClassName,
@@ -547,12 +545,12 @@ var _ = Describe("Istio", func() {
 			Expect(GetIstioZoneLabels(labels, zone)).To(matcher)
 		},
 
-		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value"})),
-		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role"})),
-		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway"})),
-		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone"})),
-		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone"})),
-		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone"})),
+		Entry("no zone, but istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, nil, Equal(map[string]string{istio.DefaultZoneKey: "istio-value", istio.RoleKey: istio.RoleSeed})),
+		Entry("no zone, but gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, nil, Equal(map[string]string{"gardener.cloud/role": "gardener-role", istio.RoleKey: istio.RoleSeed})),
+		Entry("no zone, other labels", map[string]string{"key1": "value1", "key2": "value2"}, nil, Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and istio label", map[string]string{istio.DefaultZoneKey: "istio-value"}, ptr.To("my-zone"), Equal(map[string]string{istio.DefaultZoneKey: "istio-value--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and gardener.cloud/role label", map[string]string{"gardener.cloud/role": "gardener-role"}, ptr.To("my-zone"), Equal(map[string]string{"gardener.cloud/role": "gardener-role--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
+		Entry("zone and other labels", map[string]string{"key1": "value1", "key2": "value2"}, ptr.To("my-zone"), Equal(map[string]string{"key1": "value1", "key2": "value2", istio.DefaultZoneKey: "ingressgateway--zone--my-zone", istio.RoleKey: istio.RoleSeed})),
 	)
 
 	DescribeTable("#IsZonalIstioExtension",

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -360,10 +360,6 @@ func (r *Reconciler) newIstio(ctx context.Context, seed *seedpkg.Seed, seedIsGar
 		v1beta1constants.PriorityClassNameSeedSystemCritical,
 		!seedIsGarden,
 		labels,
-		// TODO(maboehm): Always set this label in sharedcomponent.GetIstioZoneLabels() after on release (v1.143)
-		map[string]string{
-			istio.RoleKey: istio.RoleSeed,
-		},
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),
 		},

--- a/pkg/gardenlet/operation/istio_config_test.go
+++ b/pkg/gardenlet/operation/istio_config_test.go
@@ -14,6 +14,7 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/istio"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
@@ -27,6 +28,7 @@ var _ = Describe("istioconfig", func() {
 			defaultServiceName         = "default-service"
 			defaultNamespaceName       = "default-namespace"
 			defaultLabels              = map[string]string{"default": "label", "istio": "gateway"}
+			defaultLabelsWithRole      = utils.MergeStringMaps(defaultLabels, map[string]string{istio.RoleKey: istio.RoleSeed})
 			exposureClassName          = "my-exposureclass"
 			exposureClassHandlerName   = "my-handler"
 			exposureClassServiceName   = "exposure-service"
@@ -120,38 +122,38 @@ var _ = Describe("istioconfig", func() {
 			Entry("non-pinned control plane without exposure class", nil, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName),
-				Equal(defaultLabels),
-				Equal(defaultLabels),
+				Equal(defaultLabelsWithRole),
+				Equal(defaultLabelsWithRole),
 			),
 			Entry("pinned control plane (single zone) without exposure class", &zoneName, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName+"--"+zoneName),
-				Equal(utils.MergeStringMaps(defaultLabels, map[string]string{"istio": defaultLabels["istio"] + "--zone--" + zoneName})),
-				Equal(defaultLabels),
+				Equal(utils.MergeStringMaps(defaultLabelsWithRole, map[string]string{"istio": defaultLabels["istio"] + "--zone--" + zoneName})),
+				Equal(defaultLabelsWithRole),
 			),
 			Entry("pinned control plane (multi zone) without exposure class", &multiZone, false,
 				Equal(defaultServiceName),
 				Equal(defaultNamespaceName),
-				Equal(defaultLabels),
-				Equal(defaultLabels),
+				Equal(defaultLabelsWithRole),
+				Equal(defaultLabelsWithRole),
 			),
 			Entry("non-pinned control plane with exposure class", nil, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
-				Equal(defaultLabels),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{istio.RoleKey: istio.RoleSeed})),
+				Equal(defaultLabelsWithRole),
 			),
 			Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName+"--"+zoneName),
-				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName})),
-				Equal(defaultLabels),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler--zone--" + zoneName, istio.RoleKey: istio.RoleSeed})),
+				Equal(defaultLabelsWithRole),
 			),
 			Entry("pinned control plane (multi zone) with exposure class", &multiZone, true,
 				Equal(exposureClassServiceName),
 				Equal(exposureClassNamespaceName),
-				Equal(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName)),
-				Equal(defaultLabels),
+				Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{istio.RoleKey: istio.RoleSeed})),
+				Equal(defaultLabelsWithRole),
 			),
 		)
 
@@ -183,14 +185,14 @@ var _ = Describe("istioconfig", func() {
 				Entry("pinned control plane (single zone) without exposure class", &zoneName, false,
 					Equal(defaultServiceName),
 					Equal(defaultNamespaceName),
-					Equal(utils.MergeStringMaps(defaultLabels, map[string]string{"istio": defaultLabels["istio"]})),
-					Equal(defaultLabels),
+					Equal(utils.MergeStringMaps(defaultLabelsWithRole, map[string]string{"istio": defaultLabels["istio"]})),
+					Equal(defaultLabelsWithRole),
 				),
 				Entry("pinned control plane (single zone) with exposure class", &zoneName, true,
 					Equal(exposureClassServiceName),
 					Equal(exposureClassNamespaceName),
-					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler"})),
-					Equal(defaultLabels),
+					Equal(utils.MergeStringMaps(gardenerutils.GetMandatoryExposureClassHandlerSNILabels(exposureClassLabels, exposureClassHandlerName), map[string]string{"gardener.cloud/role": "exposureclass-handler", istio.RoleKey: istio.RoleSeed})),
+					Equal(defaultLabelsWithRole),
 				),
 			)
 		})

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -911,10 +911,7 @@ func (r *Reconciler) newIstio(ctx context.Context, garden *operatorv1alpha1.Gard
 		true,
 		map[string]string{
 			istio.DefaultZoneKey: "ingressgateway",
-		},
-		// TODO(maboehm): Merge the podLabels into labels after on release (v1.143)
-		map[string]string{
-			istio.RoleKey: istio.RoleGarden,
+			istio.RoleKey:        istio.RoleGarden,
 		},
 		[]string{
 			gardenerutils.NetworkPolicyLabel(v1beta1constants.GardenNamespace+"-"+operatorv1alpha1.VirtualGardenNamePrefix+v1beta1constants.DeploymentNameIstioBasicAuthServer, istiobasicauthserver.Port),


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind bug

**What this PR does / why we need it**:
Cleanup the temporary `podLabels` fields and use the `istio-role` label now in all selectors. This causes the `istio-ingressgateway` deployments to be recreated, adopting the existing pods. With this, the overlapping label issue is resolved.

**Which issue(s) this PR fixes**:
Follow up to https://github.com/gardener/gardener/pull/14663
Fixes https://github.com/gardener/gardener/issues/14424

**Special notes for your reviewer**:
/hold cannot be in the same gardener release as https://github.com/gardener/gardener/pull/14663

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug was resolved that caused some Istio configuration to be applied to all `istio-ingressgateway` deployments when the runtime cluster is also a seed. A new label `istio-role=seed|garden` is now used to distinguish the two ingressgateways.
```
