### PR TITLE
Fix Garden Plutono `prometheus-longterm` datasource

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -379,7 +379,7 @@ datasources:
 		datasource += `- name: prometheus-longterm
   type: prometheus
   access: proxy
-  url: http://prometheus-longterm:80
+  url: http://prometheus-longterm:81
   basicAuth: false
   isDefault: false
   jsonData:

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -212,7 +212,7 @@ metadata:
 					configMapData += `    - name: prometheus-longterm
       type: prometheus
       access: proxy
-      url: http://prometheus-longterm:80
+      url: http://prometheus-longterm:81
       basicAuth: false
       isDefault: false
       jsonData:


### PR DESCRIPTION
**How to categorize this PR?**
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fixes the `prometheus-longterm` datasource URL in Plutono. The URL was `:80` (Prometheus's own API, target port 9090), but the egress NetworkPolicy on the Plutono pod only opens port 9091 (Cortex query frontend at service port `:81`). As a result, longterm queries from Plutono dashboards time out. Updates the URL to `:81` so traffic actually goes through Cortex.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
Plutono's `prometheus-longterm` datasource now correctly targets the Cortex query frontend (port 81) instead of Prometheus's local API (port 80), fixing timed-out longterm queries.
```
