### PR TITLE
[GEP-28] Node-level components of control plane nodes connect to `localhost`

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/gardeneruser"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/sshdensurer"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils"
@@ -724,7 +725,7 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		// Node-level components like gardener-node-agent and kubelet on control plane nodes should connect to the API
 		// server via localhost to avoid unnecessary network hops, i.e., they should not connect to the API server via the
 		// external exposure, which might not be available in a failure scenario.
-		apiServerURL = "https://localhost:443"
+		apiServerURL = fmt.Sprintf("https://localhost:%d", kubeapiserverconstants.Port)
 	}
 	setDefaultEvictionMemoryAvailable(kubeletConfigParameters.EvictionHard, kubeletConfigParameters.EvictionSoft, o.values.MachineTypes, worker.Machine.Type)
 

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -713,12 +713,18 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 
 	kubeletConfigParameters := components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(o.values.KubeletConfig)
 	kubeletCLIFlags := components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(o.values.KubeletConfig)
+	apiServerURL := o.values.APIServerURL
 	if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil {
 		kubeletConfigParameters = components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)
 		kubeletCLIFlags = components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)
 	}
 	if worker.ControlPlane != nil {
 		kubeletConfigParameters.WithStaticPodPath = true
+
+		// Node-level components like gardener-node-agent and kubelet on control plane nodes should connect to the API
+		// server via localhost to avoid unnecessary network hops, i.e., they should not connect to the API server via the
+		// external exposure, which might not be available in a failure scenario.
+		apiServerURL = "https://localhost:443"
 	}
 	setDefaultEvictionMemoryAvailable(kubeletConfigParameters.EvictionHard, kubeletConfigParameters.EvictionSoft, o.values.MachineTypes, worker.Machine.Type)
 
@@ -766,7 +772,7 @@ func (o *operatingSystemConfig) newDeployer(version int, osc *extensionsv1alpha1
 		worker:                                  worker,
 		purpose:                                 purpose,
 		key:                                     oscKey,
-		apiServerURL:                            o.values.APIServerURL,
+		apiServerURL:                            apiServerURL,
 		caBundle:                                caBundle,
 		clusterCASecretName:                     clusterCASecret.Name,
 		clusterCABundle:                         clusterCASecret.Data[secretsutils.DataKeyCertificateBundle],

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -189,11 +189,16 @@ var _ = Describe("OperatingSystemConfig", func() {
 				maps.Copy(imagesCopy, images)
 				imagesCopy["hyperkube"] = &imagevector.Image{Repository: ptr.To("europe-docker.pkg.dev/gardener-project/releases/hyperkube"), Tag: ptr.To("v" + k8sVersion.String())}
 
+				apiServerURLForWorker := apiServerURL
+				if worker.ControlPlane != nil {
+					apiServerURLForWorker = "https://localhost:443"
+				}
+
 				initUnits, initFiles, _ := initConfigFn(
 					worker,
 					imagesCopy["gardener-node-agent"].String(),
 					&nodeagentconfigv1alpha1.NodeAgentConfiguration{APIServer: nodeagentconfigv1alpha1.APIServer{
-						Server:   apiServerURL,
+						Server:   apiServerURLForWorker,
 						CABundle: []byte(caBundle),
 					}},
 				)

--- a/pkg/component/kubernetes/proxy/proxy.go
+++ b/pkg/component/kubernetes/proxy/proxy.go
@@ -115,6 +115,8 @@ type WorkerPool struct {
 	KubernetesVersion *semver.Version
 	// Image is the container image used for kube-proxy for this worker pool.
 	Image string
+	// ControlPlane is true for the control plane worker pool of a self-hosted shoot.
+	ControlPlane bool
 }
 
 func (k *kubeProxy) Deploy(ctx context.Context) error {

--- a/pkg/component/kubernetes/proxy/proxy_test.go
+++ b/pkg/component/kubernetes/proxy/proxy_test.go
@@ -572,6 +572,11 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 					kubeProxyContainerLogVerbosity = 1
 				}
 
+				baseCommand := []string{"/usr/local/bin/kube-proxy", "--config=/var/lib/kube-proxy-config/config.yaml"}
+				if pool.ControlPlane {
+					baseCommand = append(baseCommand, "--master=https://localhost:443")
+				}
+
 				ds := &appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        daemonSetNameFor(pool),
@@ -609,7 +614,7 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
 									{
-										Command:         []string{"/usr/local/bin/kube-proxy", "--config=/var/lib/kube-proxy-config/config.yaml", fmt.Sprintf("--v=%d", kubeProxyContainerLogVerbosity)},
+										Command:         append(baseCommand, fmt.Sprintf("--v=%d", kubeProxyContainerLogVerbosity)),
 										Image:           pool.Image,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Name:            "kube-proxy",
@@ -693,7 +698,7 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 										},
 									},
 									{
-										Command:         []string{"/usr/local/bin/kube-proxy", "--config=/var/lib/kube-proxy-config/config.yaml", "--v=2", "--init-only"},
+										Command:         append(baseCommand, "--v=2", "--init-only"),
 										Image:           pool.Image,
 										ImagePullPolicy: corev1.PullIfNotPresent,
 										Name:            "kube-proxy-init",
@@ -1235,6 +1240,95 @@ echo "${KUBE_PROXY_MODE}" >"$1"
 				Expect(managedResourceSecretForMajorMinorVersionOnly.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 				Expect(managedResourceForMajorMinorVersionOnly).To(consistOf(vpaFor(pool)))
 				Expect(managedResource).To(DeepEqual(expectedMr))
+			}
+		})
+
+		It("should successfully deploy all resources for a self-hosted shoot", func() {
+			values.WorkerPools[0].ControlPlane = true
+			component = New(c, namespace, values)
+
+			Expect(component.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
+			expectedMR := &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            managedResourceCentral.Name,
+					Namespace:       managedResourceCentral.Namespace,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"origin":    "gardener",
+						"component": "kube-proxy",
+					},
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+					KeepObjects:  ptr.To(false),
+				},
+			}
+			Expect(managedResourceCentral).To(contain(configMapFor(values.ProxyMode)))
+
+			managedResourceSecretCentral = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name:      managedResourceCentral.Spec.SecretRefs[0].Name,
+				Namespace: namespace,
+			}}
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
+			Expect(managedResourceSecretCentral.Type).To(Equal(corev1.SecretTypeOpaque))
+			Expect(managedResourceSecretCentral.Immutable).To(Equal(ptr.To(true)))
+			Expect(managedResourceSecretCentral.Labels).To(Equal(map[string]string{
+				"resources.gardener.cloud/garbage-collectable-reference": "true",
+				"component": "kube-proxy",
+				"origin":    "gardener",
+			}))
+			expectedMR.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecretCentral.Name}}
+			utilruntime.Must(references.InjectAnnotations(expectedMR))
+			Expect(managedResourceCentral).To(DeepEqual(expectedMR))
+
+			for _, pool := range values.WorkerPools {
+				By(pool.Name)
+
+				managedResource := managedResourceForPool(pool)
+
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				poolExpectedMr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            managedResource.Name,
+						Namespace:       managedResource.Namespace,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"origin":             "gardener",
+							"component":          "kube-proxy",
+							"role":               "pool",
+							"pool-name":          pool.Name,
+							"kubernetes-version": pool.KubernetesVersion.String(),
+						},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						KeepObjects:  ptr.To(false),
+					},
+				}
+
+				managedResourceSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+					Name:      managedResource.Spec.SecretRefs[0].Name,
+					Namespace: namespace,
+				}}
+				Expect(managedResource).To(consistOf(daemonSetFor(pool, values.ProxyMode, values.VPAEnabled)))
+
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecret.Labels).To(Equal(map[string]string{
+					"component":          "kube-proxy",
+					"kubernetes-version": pool.KubernetesVersion.String(),
+					"origin":             "gardener",
+					"pool-name":          pool.Name,
+					"resources.gardener.cloud/garbage-collectable-reference": "true",
+					"role": "pool",
+				}))
+				Expect(managedResourceSecret.Immutable).To(Equal(ptr.To(true)))
+				poolExpectedMr.Spec.SecretRefs = []corev1.LocalObjectReference{{Name: managedResourceSecret.Name}}
+				utilruntime.Must(references.InjectAnnotations(poolExpectedMr))
+				Expect(managedResource).To(DeepEqual(poolExpectedMr))
 			}
 		})
 	})

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -241,7 +241,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 							v1beta1constants.LabelWorkerPool:              pool.Name,
 							v1beta1constants.LabelWorkerKubernetesVersion: pool.KubernetesVersion.String(),
 						},
-						InitContainers:    k.getInitContainers(pool.Image, pool.KubernetesVersion),
+						InitContainers:    k.getInitContainers(pool.Image, pool.ControlPlane, pool.KubernetesVersion),
 						PriorityClassName: "system-node-critical",
 						SecurityContext: &corev1.PodSecurityContext{
 							SeccompProfile: &corev1.SeccompProfile{
@@ -261,7 +261,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 						HostNetwork:        true,
 						ServiceAccountName: k.serviceAccount.Name,
 						Containers: []corev1.Container{
-							k.getKubeProxyContainer(pool.Image, false, pool.KubernetesVersion),
+							k.getKubeProxyContainer(pool.Image, false, pool.ControlPlane, pool.KubernetesVersion),
 							{
 								// sidecar container with fix for conntrack
 								Name:            containerNameConntrackFix,
@@ -495,7 +495,7 @@ func (k *kubeProxy) getMode() kubeproxyconfigv1alpha1.ProxyMode {
 	}
 }
 
-func (k *kubeProxy) getInitContainers(image string, kubernetesVersion *semver.Version) []corev1.Container {
+func (k *kubeProxy) getInitContainers(image string, controlPlaneNode bool, kubernetesVersion *semver.Version) []corev1.Container {
 	initContainers := []corev1.Container{
 		{
 			Name:            "cleanup",
@@ -544,17 +544,17 @@ func (k *kubeProxy) getInitContainers(image string, kubernetesVersion *semver.Ve
 		},
 	}
 
-	initContainers = append(initContainers, k.getKubeProxyContainer(image, true, kubernetesVersion))
+	initContainers = append(initContainers, k.getKubeProxyContainer(image, true, controlPlaneNode, kubernetesVersion))
 
 	return initContainers
 }
 
-func (k *kubeProxy) getKubeProxyContainer(image string, init bool, kubernetesVersion *semver.Version) corev1.Container {
+func (k *kubeProxy) getKubeProxyContainer(image string, init, controlPlaneNode bool, kubernetesVersion *semver.Version) corev1.Container {
 	container := corev1.Container{
 		Name:            containerName,
 		Image:           image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         k.computeCommand(init, kubernetesVersion),
+		Command:         k.computeCommand(init, controlPlaneNode, kubernetesVersion),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("20m"),
@@ -623,10 +623,19 @@ func (k *kubeProxy) getKubeProxyContainer(image string, init bool, kubernetesVer
 	return container
 }
 
-func (k *kubeProxy) computeCommand(init bool, kubernetesVersion *semver.Version) []string {
+func (k *kubeProxy) computeCommand(init, controlPlaneNode bool, kubernetesVersion *semver.Version) []string {
 	command := []string{
 		"/usr/local/bin/kube-proxy",
 		fmt.Sprintf("--config=%s/%s", volumeMountPathConfig, dataKeyConfig),
+	}
+
+	if controlPlaneNode {
+		// kube-proxy pods on control plane nodes should connect to the API server via localhost to avoid unnecessary
+		// network hops, i.e., they should not connect to the API server via the external exposure, which might not be
+		// available in a failure scenario.
+		// The --master flag overwrites the address specified in the kubeconfig, so that all kube-proxy DaemonSets can keep
+		// using the same kubeconfig secret.
+		command = append(command, "--master=https://localhost:443")
 	}
 
 	// kube-proxy versions in the range [1.33.0, 1.33.6) are affected by https://github.com/kubernetes/kubernetes/issues/132678.

--- a/pkg/component/kubernetes/proxy/resources.go
+++ b/pkg/component/kubernetes/proxy/resources.go
@@ -25,6 +25,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kubeapiserverconstants "github.com/gardener/gardener/pkg/component/kubernetes/apiserver/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -635,7 +636,7 @@ func (k *kubeProxy) computeCommand(init, controlPlaneNode bool, kubernetesVersio
 		// available in a failure scenario.
 		// The --master flag overwrites the address specified in the kubeconfig, so that all kube-proxy DaemonSets can keep
 		// using the same kubeconfig secret.
-		command = append(command, "--master=https://localhost:443")
+		command = append(command, fmt.Sprintf("--master=https://localhost:%d", kubeapiserverconstants.Port))
 	}
 
 	// kube-proxy versions in the range [1.33.0, 1.33.6) are affected by https://github.com/kubernetes/kubernetes/issues/132678.

--- a/pkg/gardenlet/operation/botanist/kubeproxy.go
+++ b/pkg/gardenlet/operation/botanist/kubeproxy.go
@@ -98,6 +98,7 @@ func (b *Botanist) computeWorkerPoolsForKubeProxy(ctx context.Context) ([]kubepr
 			Name:              worker.Name,
 			KubernetesVersion: kubernetesVersion,
 			Image:             image.String(),
+			ControlPlane:      worker.ControlPlane != nil,
 		}
 	}
 
@@ -122,11 +123,13 @@ func (b *Botanist) computeWorkerPoolsForKubeProxy(ctx context.Context) ([]kubepr
 			return nil, err
 		}
 
+		_, isControlPlaneNode := node.Labels["node-role.kubernetes.io/control-plane"]
 		key := workerPoolKey(poolName, kubernetesVersionString)
 		poolKeyToPoolInfo[key] = kubeproxy.WorkerPool{
 			Name:              poolName,
 			KubernetesVersion: kubernetesVersion,
 			Image:             image.String(),
+			ControlPlane:      isControlPlaneNode,
 		}
 	}
 

--- a/pkg/gardenlet/operation/botanist/kubeproxy_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeproxy_test.go
@@ -193,6 +193,50 @@ users:
 				Expect(botanist.DeployKubeProxy(ctx)).To(Succeed())
 			})
 
+			It("with a control plane worker pool from worker spec", func() {
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: kubernetesVersionControlPlane.String(),
+						},
+						Provider: gardencorev1beta1.Provider{
+							Workers: []gardencorev1beta1.Worker{
+								{
+									Name:         poolName1,
+									ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+								},
+								{
+									Name: poolName2,
+									Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+										Version: ptr.To(kubernetesVersionPool2.String()),
+									},
+								},
+							},
+						},
+					},
+				})
+
+				kubeProxy.EXPECT().SetWorkerPools(gomock.AssignableToTypeOf([]kubeproxy.WorkerPool{})).DoAndReturn(func(actual []kubeproxy.WorkerPool) {
+					verifyWorkerPools(actual, []kubeproxy.WorkerPool{
+						{
+							Name:              poolName1,
+							KubernetesVersion: kubernetesVersionControlPlane,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane.String(),
+							ControlPlane:      true,
+						},
+						{
+							Name:              poolName2,
+							KubernetesVersion: kubernetesVersionPool2,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2.String(),
+							ControlPlane:      false,
+						},
+					})
+				})
+				kubeProxy.EXPECT().Deploy(ctx)
+
+				Expect(botanist.DeployKubeProxy(ctx)).To(Succeed())
+			})
+
 			It("with still existing worker pools", func() {
 				for _, node := range []*corev1.Node{
 					{
@@ -261,6 +305,57 @@ users:
 							Name:              "pool4",
 							KubernetesVersion: semver.MustParse("1.27.3"),
 							Image:             repositoryKubeProxyImage + ":v1.27.3",
+						},
+					})
+				})
+				kubeProxy.EXPECT().Deploy(ctx)
+
+				Expect(botanist.DeployKubeProxy(ctx)).To(Succeed())
+			})
+
+			It("with control plane nodes identified by node label", func() {
+				for _, node := range []*corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cp-node",
+							Labels: map[string]string{
+								"worker.gardener.cloud/pool":               poolName1,
+								"worker.gardener.cloud/kubernetes-version": kubernetesVersionControlPlane.String(),
+								"node-role.kubernetes.io/control-plane":    "",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-node",
+							Labels: map[string]string{
+								"worker.gardener.cloud/pool":               poolName2,
+								"worker.gardener.cloud/kubernetes-version": kubernetesVersionPool2.String(),
+							},
+						},
+					},
+				} {
+					Expect(fakeShootClient.Create(ctx, node)).To(Succeed())
+				}
+
+				kubeProxy.EXPECT().SetWorkerPools(gomock.AssignableToTypeOf([]kubeproxy.WorkerPool{})).DoAndReturn(func(actual []kubeproxy.WorkerPool) {
+					verifyWorkerPools(actual, []kubeproxy.WorkerPool{
+						{
+							Name:              poolName1,
+							KubernetesVersion: kubernetesVersionControlPlane,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionControlPlane.String(),
+							ControlPlane:      true,
+						},
+						{
+							Name:              poolName2,
+							KubernetesVersion: kubernetesVersionPool2,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool2.String(),
+							ControlPlane:      false,
+						},
+						{
+							Name:              poolName3,
+							KubernetesVersion: kubernetesVersionPool3,
+							Image:             repositoryKubeProxyImage + ":v" + kubernetesVersionPool3.String(),
 						},
 					})
 				})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ipcei robustness
/kind enhancement

**What this PR does / why we need it**:

For now, node-level components on control plane nodes of self-hosted shoots have connected to the API server via its external address. 
This PR reconfigures components deployed via the OperatingSystemConfig (e.g., gardener-node-agent, kubelet), and kube-proxy on control plane nodes to connect to `localhost` instead.

This is similar to static pods (e.g., kube-controller-manager, kube-scheduler) (see [006456d (#11701)](https://github.com/gardener/gardener/pull/11701/commits/006456d374f3dad73a6a6d210056722ff57dd52c)), which have `hostAliases` for `kubernetes.default.svc` pointing `127.0.0.1`/`::1`.
For coredns and extension pods, we don't need this as they talk to the IP injected by kubelet into the `KUBERNETES_SERVICE_HOST` env var (service link), which works as soon as the service network is up.

This is important for automatically recovering from certain network-related failure scenarios, like a meltdown of the external exposure mechanism (e.g., the external load balancer got deleted/replaced, and now the controllers need to reconcile the external exposure again), or a failure of one of the control plane nodes (or the only one).
In all of these cases, the listed node-level components on the control plane nodes must connect to the API server directly to recover from such failures.

Note that this doesn't help to recover from an outage of the majority of control plane nodes in HA setups. For this, we still need the "full" disaster recovery mechanism.
Furthermore, we also need to adapt the networking extensions to deploy a dedicated CNI DaemonSet for the control plane nodes that also connect to the API server via localhost. Without this, the recovery from the mentioned scenarios will not work fully.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

/cc @ScheererJ @hown3d 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
