### PR TITLE
Fix `gardener-resource-manager` crash in `VirtualServicePredicate`

### DIFF
--- a/pkg/resourcemanager/controller/networkpolicy/add.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -234,9 +236,11 @@ func (r *Reconciler) VirtualServicePredicate() predicate.Predicate {
 
 			return !apiequality.Semantic.DeepEqual(oldVirtualService.Spec.Hosts, virtualService.Spec.Hosts) ||
 				!apiequality.Semantic.DeepEqual(oldVirtualService.Spec.Gateways, virtualService.Spec.Gateways) ||
-				!apiequality.Semantic.DeepEqual(oldVirtualService.Spec.Http, virtualService.Spec.Http) ||
-				!apiequality.Semantic.DeepEqual(oldVirtualService.Spec.Tls, virtualService.Spec.Tls) ||
-				!apiequality.Semantic.DeepEqual(oldVirtualService.Spec.Tcp, virtualService.Spec.Tcp)
+				// Http/Tls/Tcp contain nested proto-generated types with unexported fields (e.g. sizeCache int32 in StringMatch).
+				// apiequality.Semantic.DeepEqual panics on these via reflection; protocmp.Transform() handles them correctly.
+				!cmp.Equal(oldVirtualService.Spec.Http, virtualService.Spec.Http, protocmp.Transform()) ||
+				!cmp.Equal(oldVirtualService.Spec.Tls, virtualService.Spec.Tls, protocmp.Transform()) ||
+				!cmp.Equal(oldVirtualService.Spec.Tcp, virtualService.Spec.Tcp, protocmp.Transform())
 		},
 	}
 }

--- a/pkg/resourcemanager/controller/networkpolicy/add_test.go
+++ b/pkg/resourcemanager/controller/networkpolicy/add_test.go
@@ -238,6 +238,23 @@ var _ = Describe("Add", func() {
 				Expect(p.Update(event.UpdateEvent{ObjectOld: virtualService, ObjectNew: virtualService})).To(BeFalse())
 			})
 
+			It("should return false because nothing changed when http rules contain a StringMatch", func() {
+				virtualService.Spec.Http = append(virtualService.Spec.Http, &istioapinetworkingv1beta1.HTTPRoute{
+					Match: []*istioapinetworkingv1beta1.HTTPMatchRequest{
+						{
+							Uri: &istioapinetworkingv1beta1.StringMatch{
+								MatchType: &istioapinetworkingv1beta1.StringMatch_Prefix{
+									Prefix: "/api",
+								},
+							},
+						},
+					},
+				})
+				oldVirtualService := virtualService.DeepCopy()
+
+				Expect(p.Update(event.UpdateEvent{ObjectOld: oldVirtualService, ObjectNew: virtualService})).To(BeFalse())
+			})
+
 			It("should return true because the hosts were changed", func() {
 				oldVirtualService := virtualService.DeepCopy()
 				virtualService.Spec.Hosts = append(virtualService.Spec.Hosts, "new.host")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
The `gardener-resource-manager` panics with the following error whenever a `VirtualService` update event is processed and the `Http/Tls/Tcp` spec fields need element-by-element comparison:

```
\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/third_party/forked/golang/reflect/deep_equal.go:206\nk8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/third_party/forked/golang/reflect/deep_equal.go:203\nk8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepValueEqual\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/third_party/forked/golang/reflect/deep_equal.go:192\nk8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.deepEqual\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/third_party/forked/golang/reflect/deep_equal.go:289\nk8s.io/apimachinery/third_party/forked/golang/reflect.Equalities.DeepEqual\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/third_party/forked/golang/reflect/deep_equal.go:273\ngithub.com/gardener/gardener/pkg/resourcemanager/controller/networkpolicy.(*Reconciler).AddToManager.(*Reconciler).VirtualServicePredicate.func11\n\t/go/src/github.com/gardener/gardener/pkg/resourcemanager/controller/networkpolicy/add.go:237\nsigs.k8s.io/controller-runtime/pkg/predicate.TypedFuncs[...].Update\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/predicate/predicate.go:97\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler[...]).OnUpdate\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/source/event_handler.go:111\nk8s.io/client-go/tools/cache.(*processorListener).run.func1\n\t/go/pkg/mod/k8s.io/client-go@v0.35.5/tools/cache/shared_informer.go:1072\nk8s.io/client-go/tools/cache.(*processorListener).run\n\t/go/pkg/mod/k8s.io/client-go@v0.35.5/tools/cache/shared_informer.go:1084\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.5/pkg/util/wait/wait.go:72"}
panic: an unexported field was encountered, nested like this:  [recovered]
	panic: an unexported field was encountered, nested like this: int32 [recovered]
	panic: an unexported field was encountered, nested like this: v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: *v1alpha3.HTTPMatchRequest -> v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: []*v1alpha3.HTTPMatchRequest -> *v1alpha3.HTTPMatchRequest -> v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: v1alpha3.HTTPRoute -> []*v1alpha3.HTTPMatchRequest -> *v1alpha3.HTTPMatchRequest -> v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: *v1alpha3.HTTPRoute -> v1alpha3.HTTPRoute -> []*v1alpha3.HTTPMatchRequest -> *v1alpha3.HTTPMatchRequest -> v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered]
	panic: an unexported field was encountered, nested like this: []*v1alpha3.HTTPRoute -> *v1alpha3.HTTPRoute -> v1alpha3.HTTPRoute -> []*v1alpha3.HTTPMatchRequest -> *v1alpha3.HTTPMatchRequest -> v1alpha3.HTTPMatchRequest -> *v1alpha3.StringMatch -> v1alpha3.StringMatch -> int32 [recovered, repanicked]
```

The `VirtualServicePredicate` used `apiequality.Semantic.DeepEqual` to compare the `Http`, `Tls`, and `Tcp` route fields. These fields contain Istio proto-generated types (e.g. `StringMatch`) which have unexported fields (`sizeCache int32`, `state protoimpl.MessageState`). 

The panic only triggers when both the old and new VirtualService have the same number of routes (so the slice comparison cannot short-circuit on length), requiring a deep element-by-element comparison that eventually reaches `StringMatch`.


This PR fixes this by replacing `apiequality.Semantic.DeepEqual` with `cmp.Equal(..., protocmp.Transform())` for the three proto-typed fields (Http, Tls, Tcp). `protocmp.Transform()` instructs go-cmp to compare proto messages via their logical representation rather than raw struct reflection, correctly handling all unexported protobuf internal state.
Hosts and Gateways remain compared with apiequality as they are plain []string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with https://github.com/gardener/gardener/pull/14142
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing the `gardener-resource-manager` to panic whenever a `VirtualService` update event is processed and the Http/Tls/Tcp spec fields need element-by-element comparison is now fixed.
```
