### PR TITLE
Increase SpecTimeout for "Wait for PersistentVolumes to be cleaned up" in the garden e2e test

### DIFF
--- a/test/e2e/operator/garden/garden.go
+++ b/test/e2e/operator/garden/garden.go
@@ -281,7 +281,7 @@ func itShouldCleanupVolumes(s *GardenContext) {
 
 			return true
 		}).WithPolling(2 * time.Second).Should(BeTrue())
-	}, SpecTimeout(time.Minute))
+	}, SpecTimeout(5*time.Minute))
 }
 
 func itShouldCleanupEtcdEncryptionConfig(s *GardenContext) {


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake


**What this PR does / why we need it**:
- Bumps the `SpecTimeout` of the `Wait for PersistentVolumes to be cleaned up` step in the operator e2e test from 1 minute to 5 minutes.
- This step polls (every 2s) for PVs in the `garden` namespace to be reclaimed by the kube-controller-manager after the preceding `DeleteAllOf` on the PVCs.
Over the past month it has been the dominant cause of `pull-gardener-e2e-kind-operator` flakes, hitting the 60s cap on **32 of the last ~40 sampled test failures (80%)** across 22 unrelated PRs (renovate bumps, MCM, istio, containerd, refactors).
- Every failure sits at exactly `60.001s` runtime — the work would complete shortly after if given more time. The PVC delete itself finishes in ~50ms; the rest is PV reclaim latency on the CI kind cluster.
- 5 minutes matches other long-running waits in the same file (`ManagedResource healthy` = 5m, `Garden deletion` = 15m). The 2s polling cadence is unchanged so a fast cleanup still exits quickly.

**Which issue(s) this PR fixes**:
Sample of recent failures of this exact test on unrelated PRs:

- [PR #14767 build 2057302009169580032](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14767/pull-gardener-e2e-kind-operator/2057302009169580032) (2026-05-21, MCM update)
- [PR #14880 build 2057296366278807552](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14880/pull-gardener-e2e-kind-operator/2057296366278807552) (2026-05-21, docker/cli renovate)
- [PR #14879 build 2057223097991303168](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14879/pull-gardener-e2e-kind-operator/2057223097991303168) (2026-05-20, skaffold renovate)
- [PR #14856 build 2057194698426028032](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14856/pull-gardener-e2e-kind-operator/2057194698426028032) (2026-05-20, containerd config v4)
- [PR #14690 build 2057192867989819392](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14690/pull-gardener-e2e-kind-operator/2057192867989819392) (2026-05-20, istio cluster config)

All five fail at the same line ([`garden.go:283`](https://github.com/gardener/gardener/blob/master/test/e2e/operator/garden/garden.go#L283)) with the same `60.001s` spec timeout signature.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
