### PR TITLE
Fix `make generate` skipping CRDs when only transitive deps change

### DIFF
--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -445,6 +445,12 @@ spec:
                             SerializeImagePulls describes whether the images are pulled one at a time.
                             Default: true
                           type: boolean
+                        singleProcessOOMKill:
+                          description: |-
+                            SingleProcessOOMKill, if true, will prevent the `memory.oom.group` flag from being set for container
+                            cgroups in cgroups v2. This causes processes in the container to be OOM killed individually instead of
+                            as a group. It means that if true, the behavior aligns with the behavior of cgroups v1.
+                          type: boolean
                         streamingConnectionIdleTimeout:
                           description: |-
                             StreamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -27,9 +27,16 @@ package_changed() {
     git diff --quiet master -- go.mod 2>/dev/null
     return $?
   else
-    # For internal packages, check if package directory changed
-    local pkg_path="${package#$current_module/}"
-    git diff --quiet master -- "$pkg_path" 2>/dev/null
+    # For internal packages, check if the package or any of its transitive
+    # internal dependencies changed (e.g. a referenced type in pkg/apis/core).
+    local dep_paths
+    dep_paths=$(go list -deps "$package" 2>/dev/null | grep "^${current_module}/" | sed "s|^${current_module}/||")
+    if [ -z "$dep_paths" ]; then
+      local pkg_path="${package#$current_module/}"
+      git diff --quiet master -- "$pkg_path" 2>/dev/null
+      return $?
+    fi
+    git diff --quiet master -- $dep_paths 2>/dev/null
     return $?
   fi
 }

--- a/hack/generate-parallel.sh
+++ b/hack/generate-parallel.sh
@@ -294,4 +294,4 @@ echo "$ROOTS" | while IFS= read -r dir; do
     echo "github.com/gardener/gardener/$dir"
   fi
   # TODO(rrhubenov): Revisit whether MAX_PARALLEL_WORKERS will be needed after prow cluster nodes start using coreutils >= 9.8. Ref: https://github.com/gardener/gardener/pull/13903#issuecomment-3835448178
-done | parallel --will-cite $([ "${MAX_PARALLEL_WORKERS}" != "" ] && echo "-j ${MAX_PARALLEL_WORKERS}") 'echo "Generate {}"; go generate {}'
+done | parallel --will-cite $([ "${MAX_PARALLEL_WORKERS:-}" != "" ] && echo "-j ${MAX_PARALLEL_WORKERS}") 'echo "Generate {}"; go generate {}'

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -91,7 +91,20 @@ run_target() {
       ;;
     manifests)
       local which=()
-      local mode="${MODE:-parallel}"
+      # In CI default to sequential mode so the package-changed optimization in
+      # generate-parallel.sh is bypassed. The optimization diffs against
+      # `master` and cannot detect drift that already exists on master itself
+      # (e.g. a CRD whose source type changed via a transitive dependency in a
+      # prior PR that did not regenerate it). Locally, prefer parallel for
+      # speed.
+      local mode="$MODE"
+      if [[ -z "$mode" ]]; then
+        if [[ -n "${CI:-}" ]]; then
+          mode="sequential"
+        else
+          mode="parallel"
+        fi
+      fi
 
       if [[ -z "$MANIFESTS_DIRS" ]]; then
         which=("${DEFAULT_MANIFESTS_DIRS[@]}")

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_workers.yaml
@@ -447,6 +447,12 @@ spec:
                             SerializeImagePulls describes whether the images are pulled one at a time.
                             Default: true
                           type: boolean
+                        singleProcessOOMKill:
+                          description: |-
+                            SingleProcessOOMKill, if true, will prevent the `memory.oom.group` flag from being set for container
+                            cgroups in cgroups v2. This causes processes in the container to be OOM killed individually instead of
+                            as a group. It means that if true, the behavior aligns with the behavior of cgroups v1.
+                          type: boolean
                         streamingConnectionIdleTimeout:
                           description: |-
                             StreamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/area quality
/kind bug

**What this PR does / why we need it**:

- `make generate` could silently leave CRDs stale on `master`. The `should_generate_crds` optimization in `hack/generate-parallel.sh` only diffs the **direct** package from a `//go:generate` directive against `master` — it does not follow transitive imports. So a PR that modifies a referenced type (e.g. `KubeletConfig` in `pkg/apis/core/v1beta1`) without touching the CRD's source package (`pkg/apis/extensions/v1alpha1`) skips regeneration. This is what happened in #14866: `SingleProcessOOMKill` was added to the core `KubeletConfig`, but the extensions `Worker` CRDs that embed it were never regenerated.

This PR addresses the issue in two layers:

1. `package_changed` now uses `go list -deps` to diff the full transitive closure of internal packages, so PRs touching a referenced type trigger regeneration.
2. `hack/generate.sh` defaults `manifests` `MODE` to `sequential` when `CI` is set (mirroring `codegen`). This bypasses the optimization in CI and catches drift that already exists on `master` — something (1) cannot detect because `git diff master` is empty there. Locally, `parallel` remains the default.

Also regenerates the stale workers CRDs and fixes a `MAX_PARALLEL_WORKERS:unbound variable` error under `set -o nounset`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @oliver-goetz @timuthy @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`make generate` no longer skips CRD regeneration when only a transitively-referenced type changed; CI runs manifest generation in sequential mode to catch any remaining drift.
```
