### PR TITLE
Add validation for auth-token file for valitail and otel-col systemd units

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -117,6 +117,7 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 Environment=KUBECONFIG=` + openTelemetryCollectorKubeconfigPath + `
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=` + goMemLimit + `"
+ExecStartPre=/bin/sh -c "test -e ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentelemetry-collector --config=` + PathConfig),
 		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -117,7 +117,7 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 Environment=KUBECONFIG=` + openTelemetryCollectorKubeconfigPath + `
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=` + goMemLimit + `"
-ExecStartPre=/bin/sh -c "test -e ` + PathAuthToken + `"
+ExecStartPre=/bin/sh -c "test -s ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentelemetry-collector --config=` + PathConfig),
 		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -67,6 +67,7 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 Environment=KUBECONFIG=/var/lib/opentelemetry-collector/kubeconfig
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=1600MiB"
+ExecStartPre=/bin/sh -c "test -e /var/lib/opentelemetry-collector/auth-token"
 ExecStart=/opt/bin/opentelemetry-collector --config=` + PathConfig
 
 			otelDaemonUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -67,7 +67,7 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 Environment=KUBECONFIG=/var/lib/opentelemetry-collector/kubeconfig
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=1600MiB"
-ExecStartPre=/bin/sh -c "test -e /var/lib/opentelemetry-collector/auth-token"
+ExecStartPre=/bin/sh -c "test -s /var/lib/opentelemetry-collector/auth-token"
 ExecStart=/opt/bin/opentelemetry-collector --config=` + PathConfig
 
 			otelDaemonUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -107,7 +107,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
-ExecStartPre=/bin/sh -c "test -e ` + PathAuthToken + `"
+ExecStartPre=/bin/sh -c "test -s ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/valitail -config.file=` + PathConfig),
 		FilePaths: []string{PathConfig, PathCACert, valitailBinaryPath},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -107,6 +107,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
+ExecStartPre=/bin/sh -c "test -e ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/valitail -config.file=` + PathConfig),
 		FilePaths: []string{PathConfig, PathCACert, valitailBinaryPath},
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -69,7 +69,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
-ExecStartPre=/bin/sh -c "test -e /var/lib/valitail/auth-token"
+ExecStartPre=/bin/sh -c "test -s /var/lib/valitail/auth-token"
 ExecStart=/opt/bin/valitail -config.file=` + PathConfig
 
 				valitailDaemonUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -69,6 +69,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
+ExecStartPre=/bin/sh -c "test -e /var/lib/valitail/auth-token"
 ExecStart=/opt/bin/valitail -config.file=` + PathConfig
 
 				valitailDaemonUnit := extensionsv1alpha1.Unit{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Add `ExecStartPre=/bin/sh -c "test -e PATH_TO_AUTH_TOKEN_FILE"` to the unit files of valitail and otel-col.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix an issue where shoot node logging is broken when the `valitail` and `opentelemetry-collector` systemd units start before their auth-token file is written to disk. The units now wait for the token file to exist before starting, ensuring logs and telemetry from worker nodes are reliably shipped
```
