### PR TITLE
[GEP-30] Promote `UseUnifiedHTTPProxyPort` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,8 +26,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CloudProfileCapabilities       | `false` | `Alpha` | `1.117` |         |
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
-| UseUnifiedHTTPProxyPort        | `false` | `Alpha` | `1.130` | `1.139` |
-| UseUnifiedHTTPProxyPort        | `true`  | `Beta`  | `1.140` |         |
 | VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |
 | VPAInPlaceUpdates              | `true`  | `Beta`  | `1.138` |         |
 | VictoriaLogsBackend            | `false` | `Alpha` | `1.137` |         |
@@ -224,6 +222,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | NewWorkerPoolHash                            | `true`  | `Beta`       | `1.126` | `1.140` |
 | NewWorkerPoolHash                            | `true`  | `GA`         | `1.141` | `1.142` |
 | NewWorkerPoolHash                            |         | `Removed`    | `1.143` |         |
+| UseUnifiedHTTPProxyPort                      | `false` | `Alpha`      | `1.130` | `1.139` |
+| UseUnifiedHTTPProxyPort                      | `true`  | `Beta`       | `1.140` | `1.143` |
+| UseUnifiedHTTPProxyPort                      | `true`  | `GA`         | `1.144` |         |
 
 ## Using a Feature
 

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/observability/monitoring/prometheus/shoot"
 	monitoringutils "github.com/gardener/gardener/pkg/component/observability/monitoring/utils"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -45,10 +44,8 @@ const (
 	configMapName       = "apiserver-proxy-config"
 	name                = "apiserver-proxy"
 
-	// TODO(hown3d): Drop with RemoveHTTPProxyLegacyPort feature gate
-	proxySeedServerPort = 8132
-	adminPort           = 16910
-	portNameMetrics     = "metrics"
+	adminPort       = 16910
+	portNameMetrics = "metrics"
 
 	volumeNameConfig   = "proxy-config"
 	volumeNameAdminUDS = "admin-uds"
@@ -211,20 +208,13 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 		gardenerDestinationHeaderValue = apiserverexposure.GetAPIServerProxyTargetClusterName(a.namespace)
 	}
 
-	seedServerPort := proxySeedServerPort
-	if features.DefaultFeatureGate.Enabled(features.UseUnifiedHTTPProxyPort) {
-		seedServerPort = vpnseedserver.HTTPProxyGatewayPort
-	}
-
 	if err := tplEnvoy.Execute(&envoyYAML, map[string]any{
 		"advertiseIPAddress":             a.values.advertiseIPAddress,
 		"dnsLookupFamily":                a.values.DNSLookupFamily,
 		"adminPort":                      adminPort,
 		"proxySeedServerHost":            a.values.ProxySeedServerHost,
-		"proxySeedServerPort":            seedServerPort,
+		"proxySeedServerPort":            vpnseedserver.HTTPProxyGatewayPort,
 		"gardenerDestinationHeaderValue": gardenerDestinationHeaderValue,
-		// TODO(hown3d): Drop with RemoveHTTPProxyLegacyPort feature gate
-		"reversedVPNHeaderValue": gardenerDestinationHeaderValue,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/networking/apiserverproxy/apiserver_proxy_test.go
@@ -50,7 +50,7 @@ var _ = Describe("APIServerProxy", func() {
 		values                 Values
 		component              Interface
 		advertiseIPAddress     string
-		reversedVPNHeaderValue string
+		destinationHeaderValue string
 
 		managedResourceName = "shoot-core-apiserver-proxy"
 		namespace           = "shoot--internal--internal"
@@ -187,7 +187,7 @@ var _ = Describe("APIServerProxy", func() {
 
 	BeforeEach(func() {
 		advertiseIPAddress = "10.2.170.21"
-		reversedVPNHeaderValue = "outbound|443||kube-apiserver.shoot--internal--internal.svc.cluster.local"
+		destinationHeaderValue = "outbound|443||kube-apiserver.shoot--internal--internal.svc.cluster.local"
 		values = Values{
 			Image:               image,
 			SidecarImage:        sidecarImage,
@@ -252,7 +252,7 @@ var _ = Describe("APIServerProxy", func() {
 			utilruntime.Must(references.InjectAnnotations(expectedMr))
 			Expect(managedResource).To(DeepEqual(expectedMr))
 			Expect(managedResource).To(consistOf(
-				getConfigYAML(hash, values.DNSLookupFamily, advertiseIPAddress, reversedVPNHeaderValue),
+				getConfigYAML(hash, values.DNSLookupFamily, advertiseIPAddress, destinationHeaderValue),
 				getDaemonSet(hash, advertiseIPAddress),
 				service,
 				serviceAccount,
@@ -272,7 +272,7 @@ var _ = Describe("APIServerProxy", func() {
 
 		Context("IPv4", func() {
 			It("should deploy the managed resource successfully", func() {
-				testFunc("00d55bbf") // hash of envoy config with V4_ONLY DNS + port 8443 (default: UseUnifiedHTTPProxyPort=true)
+				testFunc("ea6c7299") // hash of envoy config with V4_ONLY DNS + port 8443
 			})
 		})
 
@@ -283,18 +283,18 @@ var _ = Describe("APIServerProxy", func() {
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				testFunc("25408ef2") // hash of envoy config with V6_ONLY DNS + port 8443 (default: UseUnifiedHTTPProxyPort=true)
+				testFunc("b608555c") // hash of envoy config with V6_ONLY DNS + port 8443
 			})
 		})
 
 		Context("IstioTLSTermination", func() {
 			BeforeEach(func() {
 				values.IstioTLSTermination = true
-				reversedVPNHeaderValue = fmt.Sprintf("%s--kube-apiserver-socket", namespace)
+				destinationHeaderValue = fmt.Sprintf("%s--kube-apiserver-socket", namespace)
 			})
 
 			It("should deploy the managed resource successfully", func() {
-				testFunc("3b9cdaf4") // hash of envoy config with IstioTLSTermination + port 8443 (default: UseUnifiedHTTPProxyPort=true)
+				testFunc("7ff2f6b1") // hash of envoy config with IstioTLSTermination + port 8443
 			})
 		})
 	})
@@ -481,10 +481,6 @@ static_resources:
             # hostname is irrelevant as it will be dropped by envoy, we still need it for the configuration though
             hostname: "api.internal.local.:443"
             headers_to_add:
-            # TODO(hown3d): Drop with RemoveHTTPProxyLegacyPort feature gate
-            - header:
-                key: Reversed-VPN
-                value: "` + xGardenerDestination + `"
             - header:
                 key: X-Gardener-Destination
                 value: "` + xGardenerDestination + `"

--- a/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
+++ b/pkg/component/networking/apiserverproxy/templates/envoy.yaml.tpl
@@ -55,10 +55,6 @@ static_resources:
             # hostname is irrelevant as it will be dropped by envoy, we still need it for the configuration though
             hostname: "{{ .proxySeedServerHost }}:443"
             headers_to_add:
-            # TODO(hown3d): Drop with RemoveHTTPProxyLegacyPort feature gate
-            - header:
-                key: Reversed-VPN
-                value: "{{ .reversedVPNHeaderValue }}"
             - header:
                 key: X-Gardener-Destination
                 value: "{{ .gardenerDestinationHeaderValue }}"

--- a/pkg/component/networking/vpn/shoot/shoot.go
+++ b/pkg/component/networking/vpn/shoot/shoot.go
@@ -70,12 +70,8 @@ const (
 type ReversedVPNValues struct {
 	// Header is the header value for the ReversedVPN.
 	Header string
-	// HeaderKey is the actual header for the ReversedVPN.
-	HeaderKey string
 	// Endpoint is the endpoint for the ReversedVPN.
 	Endpoint string
-	// OpenVPNPort is the port for the ReversedVPN.
-	OpenVPNPort int32
 	// IPFamilies are the IPFamilies of the shoot.
 	IPFamilies []gardencorev1beta1.IPFamily
 }
@@ -774,11 +770,15 @@ func (v *vpnShoot) getEnvVars(index *int) []corev1.EnvVar {
 		},
 		corev1.EnvVar{
 			Name:  "OPENVPN_PORT",
-			Value: strconv.Itoa(int(v.values.ReversedVPN.OpenVPNPort)),
+			Value: strconv.Itoa(vpnseedserver.HTTPProxyGatewayPort),
 		},
 		corev1.EnvVar{
 			Name:  "REVERSED_VPN_HEADER",
 			Value: v.indexedReversedHeader(index),
+		},
+		corev1.EnvVar{
+			Name:  "REVERSED_VPN_HEADER_KEY",
+			Value: "X-Gardener-Destination",
 		},
 		corev1.EnvVar{
 			Name:  "IS_SHOOT_CLIENT",
@@ -801,13 +801,6 @@ func (v *vpnShoot) getEnvVars(index *int) []corev1.EnvVar {
 			Value: netutils.JoinByComma(v.values.Network.NodeCIDRs),
 		},
 	)
-
-	if headerKey := v.values.ReversedVPN.HeaderKey; headerKey != "" {
-		envVariables = append(envVariables, corev1.EnvVar{
-			Name:  "REVERSED_VPN_HEADER_KEY",
-			Value: headerKey,
-		})
-	}
 
 	if index != nil {
 		envVariables = append(envVariables,

--- a/pkg/component/networking/vpn/shoot/shoot_test.go
+++ b/pkg/component/networking/vpn/shoot/shoot_test.go
@@ -65,18 +65,16 @@ var _ = Describe("VPNShoot", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
-		endPoint                        = "10.0.0.1"
-		openVPNPort               int32 = 8132
-		reversedVPNHeader               = "outbound|1194||vpn-seed-server.shoot--project--shoot-name.svc.cluster.local"
-		reversedVPNHeaderTemplate       = "outbound|1194||vpn-seed-server-%d.shoot--project--shoot-name.svc.cluster.local"
+		endPoint                  = "10.0.0.1"
+		reversedVPNHeader         = "outbound|1194||vpn-seed-server.shoot--project--shoot-name.svc.cluster.local"
+		reversedVPNHeaderTemplate = "outbound|1194||vpn-seed-server-%d.shoot--project--shoot-name.svc.cluster.local"
 
 		values = Values{
 			Image: image,
 			ReversedVPN: ReversedVPNValues{
-				Endpoint:    endPoint,
-				OpenVPNPort: openVPNPort,
-				Header:      reversedVPNHeader,
-				IPFamilies:  []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				Endpoint:   endPoint,
+				Header:     reversedVPNHeader,
+				IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
 			},
 			SeedPodNetwork: "10.1.0.0/16",
 			Network: NetworkValues{
@@ -457,11 +455,15 @@ var _ = Describe("VPNShoot", func() {
 					},
 					corev1.EnvVar{
 						Name:  "OPENVPN_PORT",
-						Value: strconv.Itoa(int(openVPNPort)),
+						Value: strconv.Itoa(8443),
 					},
 					corev1.EnvVar{
 						Name:  "REVERSED_VPN_HEADER",
 						Value: header,
+					},
+					corev1.EnvVar{
+						Name:  "REVERSED_VPN_HEADER_KEY",
+						Value: "X-Gardener-Destination",
 					},
 					corev1.EnvVar{
 						Name:  "IS_SHOOT_CLIENT",
@@ -484,13 +486,6 @@ var _ = Describe("VPNShoot", func() {
 						Value: values.Network.NodeCIDRs[0].String(),
 					},
 				)
-
-				if headerKey := values.ReversedVPN.HeaderKey; headerKey != "" {
-					env = append(env, corev1.EnvVar{
-						Name:  "REVERSED_VPN_HEADER_KEY",
-						Value: headerKey,
-					})
-				}
 
 				volumeMounts = append(volumeMounts,
 					corev1.VolumeMount{
@@ -908,11 +903,7 @@ var _ = Describe("VPNShoot", func() {
 			})
 		})
 
-		Context("VPNShoot with header key", func() {
-			BeforeEach(func() {
-				values.ReversedVPN.HeaderKey = "X-Gardener-Destination"
-			})
-
+		Context("VPNShoot with X-Gardener-Destination header", func() {
 			It("should successfully deploy all resources", func() {
 				var (
 					secretNameClient  = expectVPNShootSecret(manifests)

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -72,6 +72,7 @@ const (
 	// owner: @hown3d
 	// alpha: v1.130.0
 	// beta: v1.140.0
+	// GA: v1.144.0
 	UseUnifiedHTTPProxyPort featuregate.Feature = "UseUnifiedHTTPProxyPort"
 
 	// VPAInPlaceUpdates enables the usage of in-place Pod resource updates in the Vertical Pod Autoscaler resources
@@ -171,7 +172,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DoNotCopyBackupCredentials:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	OpenTelemetryCollector:         {Default: true, PreRelease: featuregate.Beta},
 	VictoriaLogsBackend:            {Default: false, PreRelease: featuregate.Alpha},
-	UseUnifiedHTTPProxyPort:        {Default: true, PreRelease: featuregate.Beta},
+	UseUnifiedHTTPProxyPort:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	VPAInPlaceUpdates:              {Default: true, PreRelease: featuregate.Beta},
 	CustomDNSServerInNodeLocalDNS:  {Default: true, PreRelease: featuregate.Beta},
 	VPNBondingModeRoundRobin:       {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenlet/operation/botanist/vpnshoot.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot.go
@@ -13,7 +13,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	vpnseedserver "github.com/gardener/gardener/pkg/component/networking/vpn/seedserver"
 	vpnshoot "github.com/gardener/gardener/pkg/component/networking/vpn/shoot"
-	"github.com/gardener/gardener/pkg/features"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 )
 
@@ -25,25 +24,14 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 		return nil, err
 	}
 
-	var (
-		openvpnPort int32 = vpnseedserver.GatewayPort
-		headerKey   string
-	)
-
-	if features.DefaultFeatureGate.Enabled(features.UseUnifiedHTTPProxyPort) {
-		openvpnPort = vpnseedserver.HTTPProxyGatewayPort
-		headerKey = "X-Gardener-Destination"
-	}
 	values := vpnshoot.Values{
 		Image:             image.String(),
 		VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
 		VPAUpdateDisabled: b.Shoot.VPNVPAUpdateDisabled,
 		ReversedVPN: vpnshoot.ReversedVPNValues{
-			Header:      "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.ControlPlaneNamespace + ".svc.cluster.local",
-			HeaderKey:   headerKey,
-			Endpoint:    b.outOfClusterAPIServerFQDN(),
-			OpenVPNPort: openvpnPort,
-			IPFamilies:  b.Shoot.GetInfo().Spec.Networking.IPFamilies,
+			Header:     "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.ControlPlaneNamespace + ".svc.cluster.local",
+			Endpoint:   b.outOfClusterAPIServerFQDN(),
+			IPFamilies: b.Shoot.GetInfo().Spec.Networking.IPFamilies,
 		},
 		HighAvailabilityEnabled:              b.Shoot.VPNHighAvailabilityEnabled,
 		HighAvailabilityNumberOfSeedServers:  b.Shoot.VPNHighAvailabilityNumberOfSeedServers,
@@ -70,22 +58,10 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.UseUnifiedHTTPProxyPort) {
-		return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
-			condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort)
-			condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionTrue, "ShootUsesUnifiedHTTPProxyPort", fmt.Sprintf("Shoot uses http-proxy port %d for VPN", vpnseedserver.HTTPProxyGatewayPort))
-			shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
-			return nil
-		})
-	}
-
-	// in case the feature gate was previously enabled but now disabled, we need to remove the condition
-	if v1beta1helper.GetCondition(b.Shoot.GetInfo().Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort) == nil {
-		return nil
-	}
-
 	return b.Shoot.UpdateInfoStatus(ctx, b.GardenClient, true, false, func(shoot *gardencorev1beta1.Shoot) error {
-		shoot.Status.Constraints = v1beta1helper.RemoveConditions(shoot.Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort)
+		condition := v1beta1helper.GetOrInitConditionWithClock(b.Clock, shoot.Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort)
+		condition = v1beta1helper.UpdatedConditionWithClock(b.Clock, condition, gardencorev1beta1.ConditionTrue, "ShootUsesUnifiedHTTPProxyPort", fmt.Sprintf("Shoot uses http-proxy port %d for VPN", vpnseedserver.HTTPProxyGatewayPort))
+		shoot.Status.Constraints = v1beta1helper.MergeConditions(shoot.Status.Constraints, condition)
 		return nil
 	})
 }

--- a/pkg/gardenlet/operation/botanist/vpnshoot_test.go
+++ b/pkg/gardenlet/operation/botanist/vpnshoot_test.go
@@ -22,12 +22,10 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kubernetesmock "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockvpnshoot "github.com/gardener/gardener/pkg/component/networking/vpn/shoot/mock"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/operation"
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -129,14 +127,7 @@ var _ = Describe("VPNShoot", func() {
 			vpnShoot.EXPECT().SetPodNetworkCIDRs(botanist.Shoot.Networks.Pods)
 		})
 
-		It("should set the network ranges and deploy", func() {
-			vpnShoot.EXPECT().Deploy(ctx)
-			Expect(botanist.DeployVPNShoot(ctx)).To(Succeed())
-		})
-
-		It("should report a constraint if feature gate UseUnifiedHTTPProxyPort is enabled and remove it if disabled", func() {
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseUnifiedHTTPProxyPort, true))
-
+		It("should set the network ranges, deploy, and report the constraint", func() {
 			vpnShoot.EXPECT().Deploy(ctx)
 			Expect(botanist.DeployVPNShoot(ctx)).To(Succeed())
 			Expect(botanist.GardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
@@ -145,22 +136,6 @@ var _ = Describe("VPNShoot", func() {
 				OfType(gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort),
 				WithStatus(gardencorev1beta1.ConditionTrue),
 				WithReason("ShootUsesUnifiedHTTPProxyPort"),
-			))
-
-			By("disabling the feature gate again")
-			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.UseUnifiedHTTPProxyPort, false))
-
-			// Since we will call DeployVPNShoot again, we expect the calls to be made again
-			vpnShoot.EXPECT().SetNodeNetworkCIDRs(botanist.Shoot.Networks.Nodes)
-			vpnShoot.EXPECT().SetServiceNetworkCIDRs(botanist.Shoot.Networks.Services)
-			vpnShoot.EXPECT().SetPodNetworkCIDRs(botanist.Shoot.Networks.Pods)
-			vpnShoot.EXPECT().Deploy(ctx)
-
-			Expect(botanist.DeployVPNShoot(ctx)).To(Succeed())
-			Expect(botanist.GardenClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
-
-			Expect(shoot.Status.Constraints).NotTo(ContainCondition(
-				OfType(gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort),
 			))
 		})
 

--- a/test/e2e/gardener/shoot/create_authenticate_delete.go
+++ b/test/e2e/gardener/shoot/create_authenticate_delete.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component/kubernetes/apiserverexposure"
@@ -275,13 +274,7 @@ func copyRESTConfigAndInjectAuthorization(restConfig *rest.Config, authorization
 }
 
 func getAPIServerProxyClient(restConfig *rest.Config, targetShoot *gardencorev1beta1.Shoot) (client.Client, error) {
-	proxyPort := vpnseedserver.GatewayPort
-	newHTTPProxyPortConstraint := v1beta1helper.GetCondition(targetShoot.Status.Constraints, gardencorev1beta1.ShootUsesUnifiedHTTPProxyPort)
-	if newHTTPProxyPortConstraint != nil && newHTTPProxyPortConstraint.Status == gardencorev1beta1.ConditionTrue {
-		proxyPort = vpnseedserver.HTTPProxyGatewayPort
-	}
-
-	transport, err := newHTTPConnectTransport(restConfig, apiserverexposure.GetAPIServerProxyTargetClusterName(targetShoot.Status.TechnicalID), proxyPort)
+	transport, err := newHTTPConnectTransport(restConfig, apiserverexposure.GetAPIServerProxyTargetClusterName(targetShoot.Status.TechnicalID), vpnseedserver.HTTPProxyGatewayPort)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP connect transport: %w", err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind cleanup

**What this PR does / why we need it**:

Graduates the `UseUnifiedHTTPProxyPort` feature gate to GA and locks it to its default (`true`).
With this, gardenlet always configures `apiserver-proxy` and `vpn-shoot` to connect to the new unified proxy port (`8443`) on the Istio ingress gateway. The legacy proxy port (`8132`) on the ingress gateway is still available and will only be removed with the upcoming `RemoveHTTPProxyLegacyPort` feature gate.

The `UseUnifiedHTTPProxyPort` feature gate was introduced in v1.130.0 (alpha) and promoted to beta in v1.140.0. It is now stable and always enabled.
Support for this feature gate has been added in [gardener-extension-acl@v1.15.0](https://github.com/stackitcloud/gardener-extension-acl/releases/tag/v1.15.0) (released ~4 months ago).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11214

**Special notes for your reviewer**:

/cc @ScheererJ 

**Release note**:
```breaking operator
The `UseUnifiedHTTPProxyPort` feature gate has graduated to GA and cannot be disabled anymore. The feature gate can be removed from your component configuration. If you're using [gardener-extension-acl](https://github.com/stackitcloud/gardener-extension-acl), ensure that all shoots enabling the extension have been successfully reconciled with version [v1.15.0](https://github.com/stackitcloud/gardener-extension-acl/releases/tag/v1.15.0) or higher before upgrading to this Gardener version that enables the feature gate unconditionally.
```
