### PR TITLE
Add missing RBAC for CA v1.35

### DIFF
--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -42,6 +42,7 @@ import (
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 const (
@@ -76,6 +77,7 @@ func New(
 	config *gardencorev1beta1.ClusterAutoscaler,
 	workerConfig []gardencorev1beta1.Worker,
 	runtimeVersion *semver.Version,
+	targetVersion *semver.Version,
 ) Interface {
 	return &clusterAutoscaler{
 		client:         client,
@@ -86,6 +88,7 @@ func New(
 		config:         config,
 		workerConfig:   workerConfig,
 		runtimeVersion: runtimeVersion,
+		targetVersion:  targetVersion,
 	}
 }
 
@@ -99,6 +102,7 @@ type clusterAutoscaler struct {
 	workerConfig   []gardencorev1beta1.Worker
 	maxNodesTotal  int64
 	runtimeVersion *semver.Version
+	targetVersion  *semver.Version
 
 	namespaceUID       types.UID
 	machineDeployments []extensionsv1alpha1.MachineDeployment
@@ -596,11 +600,6 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string,
 					Verbs:     []string{"watch", "list", "get"},
 				},
 				{
-					APIGroups: []string{"resource.k8s.io"},
-					Resources: []string{"resourceslices", "resourceclaims", "deviceclasses"},
-					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
 					APIGroups: []string{"coordination.k8s.io"},
 					Resources: []string{"leases"},
 					Verbs:     []string{"create"},
@@ -677,6 +676,15 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string,
 			},
 		}
 	)
+
+	if versionutils.ConstraintK8sGreaterEqual135.Check(c.targetVersion) {
+		clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"resource.k8s.io"},
+			Resources: []string{"resourceslices", "resourceclaims", "deviceclasses"},
+			Verbs:     []string{"watch", "list", "get"},
+		})
+	}
+
 	objects := []client.Object{clusterRole, clusterRoleBinding, role, rolebinding}
 
 	if workersHavePrioritiesConfigured {

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler.go
@@ -596,6 +596,11 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string,
 					Verbs:     []string{"watch", "list", "get"},
 				},
 				{
+					APIGroups: []string{"resource.k8s.io"},
+					Resources: []string{"resourceslices", "resourceclaims", "deviceclasses"},
+					Verbs:     []string{"watch", "list", "get"},
+				},
+				{
 					APIGroups: []string{"coordination.k8s.io"},
 					Resources: []string{"leases"},
 					Verbs:     []string{"create"},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -566,6 +566,11 @@ var _ = Describe("ClusterAutoscaler", func() {
 					Verbs:     []string{"watch", "list", "get"},
 				},
 				{
+					APIGroups: []string{"resource.k8s.io"},
+					Resources: []string{"resourceslices", "resourceclaims", "deviceclasses"},
+					Verbs:     []string{"watch", "list", "get"},
+				},
+				{
 					APIGroups: []string{"coordination.k8s.io"},
 					Resources: []string{"leases"},
 					Verbs:     []string{"create"},

--- a/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/component/autoscaling/clusterautoscaler/cluster_autoscaler_test.go
@@ -514,84 +514,91 @@ var _ = Describe("ClusterAutoscaler", func() {
 			},
 		}
 
-		clusterRoleShoot = &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gardener.cloud:target:cluster-autoscaler",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events", "endpoints"},
-					Verbs:     []string{"create", "patch"},
+		clusterRoleShootFor = func(k8sVersionGreaterEqual135 bool) *rbacv1.ClusterRole {
+			clusterRole := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gardener.cloud:target:cluster-autoscaler",
 				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods/eviction"},
-					Verbs:     []string{"create"},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events", "endpoints"},
+						Verbs:     []string{"create", "patch"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"pods/eviction"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"pods/status"},
+						Verbs:     []string{"update"},
+					},
+					{
+						APIGroups:     []string{""},
+						Resources:     []string{"endpoints"},
+						ResourceNames: []string{"cluster-autoscaler"},
+						Verbs:         []string{"get", "update"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"nodes"},
+						Verbs:     []string{"watch", "list", "get", "update"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"},
+						Verbs:     []string{"watch", "list", "get"},
+					},
+					{
+						APIGroups: []string{"apps", "extensions"},
+						Resources: []string{"daemonsets", "replicasets", "statefulsets"},
+						Verbs:     []string{"watch", "list", "get"},
+					},
+					{
+						APIGroups: []string{"policy"},
+						Resources: []string{"poddisruptionbudgets"},
+						Verbs:     []string{"watch", "list"},
+					},
+					{
+						APIGroups: []string{"storage.k8s.io"},
+						Resources: []string{"storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"},
+						Verbs:     []string{"watch", "list", "get"},
+					},
+					{
+						APIGroups: []string{"coordination.k8s.io"},
+						Resources: []string{"leases"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups:     []string{"coordination.k8s.io"},
+						ResourceNames: []string{"cluster-autoscaler"},
+						Resources:     []string{"leases"},
+						Verbs:         []string{"get", "update"},
+					},
+					{
+						APIGroups: []string{"batch", "extensions"},
+						Resources: []string{"jobs"},
+						Verbs:     []string{"get", "list", "patch", "watch"},
+					},
+					{
+						APIGroups: []string{"batch"},
+						Resources: []string{"jobs", "cronjobs"},
+						Verbs:     []string{"get", "list", "watch"},
+					},
 				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods/status"},
-					Verbs:     []string{"update"},
-				},
-				{
-					APIGroups:     []string{""},
-					Resources:     []string{"endpoints"},
-					ResourceNames: []string{"cluster-autoscaler"},
-					Verbs:         []string{"get", "update"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"nodes"},
-					Verbs:     []string{"watch", "list", "get", "update"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"},
-					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
-					APIGroups: []string{"apps", "extensions"},
-					Resources: []string{"daemonsets", "replicasets", "statefulsets"},
-					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
-					APIGroups: []string{"policy"},
-					Resources: []string{"poddisruptionbudgets"},
-					Verbs:     []string{"watch", "list"},
-				},
-				{
-					APIGroups: []string{"storage.k8s.io"},
-					Resources: []string{"storageclasses", "csinodes", "csidrivers", "csistoragecapacities", "volumeattachments"},
-					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
+			}
+
+			if k8sVersionGreaterEqual135 {
+				clusterRole.Rules = append(clusterRole.Rules, rbacv1.PolicyRule{
 					APIGroups: []string{"resource.k8s.io"},
 					Resources: []string{"resourceslices", "resourceclaims", "deviceclasses"},
 					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
-					APIGroups: []string{"coordination.k8s.io"},
-					Resources: []string{"leases"},
-					Verbs:     []string{"create"},
-				},
-				{
-					APIGroups:     []string{"coordination.k8s.io"},
-					ResourceNames: []string{"cluster-autoscaler"},
-					Resources:     []string{"leases"},
-					Verbs:         []string{"get", "update"},
-				},
-				{
-					APIGroups: []string{"batch", "extensions"},
-					Resources: []string{"jobs"},
-					Verbs:     []string{"get", "list", "patch", "watch"},
-				},
-				{
-					APIGroups: []string{"batch"},
-					Resources: []string{"jobs", "cronjobs"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-			},
+				})
+			}
+
+			return clusterRole
 		}
 
 		clusterRoleBindingShoot = &rbacv1.ClusterRoleBinding{
@@ -683,14 +690,14 @@ var _ = Describe("ClusterAutoscaler", func() {
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
 
-		clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil)
+		clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil, semver.MustParse("1.35.0"))
 		clusterAutoscaler.SetNamespaceUID(namespaceUID)
 		clusterAutoscaler.SetMachineDeployments(machineDeployments)
 	})
 
 	Describe("#Deploy", func() {
 		Context("should successfully deploy all the resources", func() {
-			test := func(withConfig bool, withWorkerConfig bool, withPriorityExpander bool) {
+			test := func(withConfig bool, withWorkerConfig bool, withPriorityExpander bool, k8sVersionGreaterEqual135 bool) {
 				var config *gardencorev1beta1.ClusterAutoscaler
 				var shootWorkerConfig []gardencorev1beta1.Worker
 				if withConfig {
@@ -705,7 +712,12 @@ var _ = Describe("ClusterAutoscaler", func() {
 					shootWorkerConfig = workerConfig
 				}
 
-				clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, config, shootWorkerConfig, semver.MustParse("1.33.1"))
+				shootVersion := "1.33.1"
+				if k8sVersionGreaterEqual135 {
+					shootVersion = "1.35.0"
+				}
+
+				clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, config, shootWorkerConfig, semver.MustParse("1.33.1"), semver.MustParse(shootVersion))
 				clusterAutoscaler.SetNamespaceUID(namespaceUID)
 				clusterAutoscaler.SetMachineDeployments(machineDeployments)
 
@@ -717,11 +729,10 @@ var _ = Describe("ClusterAutoscaler", func() {
 
 				utilruntime.Must(references.InjectAnnotations(managedResource))
 				Expect(actualMr).To(DeepEqual(managedResource))
-
 				if withWorkerConfig {
-					Expect(managedResource).To(consistOf(clusterRoleShoot, clusterRoleBindingShoot, roleShoot, roleBindingShoot, priorityExpanderConfigMap))
+					Expect(managedResource).To(consistOf(clusterRoleShootFor(k8sVersionGreaterEqual135), clusterRoleBindingShoot, roleShoot, roleBindingShoot, priorityExpanderConfigMap))
 				} else {
-					Expect(managedResource).To(consistOf(clusterRoleShoot, clusterRoleBindingShoot, roleShoot, roleBindingShoot))
+					Expect(managedResource).To(consistOf(clusterRoleShootFor(k8sVersionGreaterEqual135), clusterRoleBindingShoot, roleShoot, roleBindingShoot))
 				}
 
 				actualServiceAccount := &corev1.ServiceAccount{}
@@ -762,16 +773,18 @@ var _ = Describe("ClusterAutoscaler", func() {
 				Expect(actualServiceMonitor).To(DeepEqual(serviceMonitor))
 			}
 
-			It("w/o config", func() { test(false, false, false) })
-			It("w/ config", func() { test(true, false, false) })
-			It("w/ config, w/ workerConfig", func() { test(true, true, false) })
-			It("w/ config, w/ workerConfig, w/ 'priority' expander already configured", func() { test(true, true, true) })
+			It("w/o config", func() { test(false, false, false, false) })
+			It("w/o config, k8s v1.35", func() { test(false, false, false, true) })
+			It("w/ config", func() { test(true, false, false, false) })
+			It("w/ config, k8s v1.35", func() { test(true, false, false, true) })
+			It("w/ config, w/ workerConfig", func() { test(true, true, false, false) })
+			It("w/ config, w/ workerConfig, w/ 'priority' expander already configured", func() { test(true, true, true, false) })
 		})
 	})
 
 	Describe("#Destroy", func() {
 		BeforeEach(func() {
-			clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil)
+			clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil, semver.MustParse("1.35.0"))
 			clusterAutoscaler.SetNamespaceUID(namespaceUID)
 			clusterAutoscaler.SetMachineDeployments(machineDeployments)
 			Expect(clusterAutoscaler.Deploy(ctx)).To(Succeed())
@@ -798,7 +811,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				},
 			}).Build()
 
-			clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil)
+			clusterAutoscaler = New(fakeClient, namespace, sm, image, replicas, nil, workerConfig, nil, semver.MustParse("1.35.0"))
 			clusterAutoscaler.SetNamespaceUID(namespaceUID)
 			clusterAutoscaler.SetMachineDeployments(machineDeployments)
 

--- a/pkg/gardenlet/operation/botanist/clusterautoscaler.go
+++ b/pkg/gardenlet/operation/botanist/clusterautoscaler.go
@@ -39,6 +39,7 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 		b.Shoot.GetInfo().Spec.Kubernetes.ClusterAutoscaler,
 		b.Shoot.GetInfo().Spec.Provider.Workers,
 		b.Seed.KubernetesVersion,
+		b.Shoot.KubernetesVersion,
 	), nil
 }
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Without this PR, CA v1.35 errors with:
```
E0522 12:45:35.171271       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
E0522 12:45:38.373082       1 reflector.go:204] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.DeviceClass"
E0522 12:45:38.942796       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceClaim: resourceclaims.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceclaims\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceClaim"
E0522 12:45:39.861685       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
E0522 12:45:44.927320       1 reflector.go:204] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.DeviceClass"
E0522 12:45:49.125932       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceClaim: resourceclaims.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceclaims\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceClaim"
E0522 12:45:51.994887       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
E0522 12:46:06.463268       1 reflector.go:204] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.DeviceClass"
E0522 12:46:12.163583       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
E0522 12:46:14.226144       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceClaim: resourceclaims.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceclaims\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceClaim"
E0522 12:46:33.393509       1 reflector.go:204] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.DeviceClass"
E0522 12:46:43.713307       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceSlice: resourceslices.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceslices\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceSlice"
E0522 12:46:44.467180       1 reflector.go:204] "Failed to watch" err="failed to list *v1.ResourceClaim: resourceclaims.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"resourceclaims\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.ResourceClaim"
E0522 12:47:10.334786       1 reflector.go:204] "Failed to watch" err="failed to list *v1.DeviceClass: deviceclasses.resource.k8s.io is forbidden: User \"system:serviceaccount:kube-system:cluster-autoscaler\" cannot list resource \"deviceclasses\" in API group \"resource.k8s.io\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289" type="*v1.DeviceClass"
I0522 12:47:20.271202       1 reflector.go:446] "Caches populated" type="*v1.ResourceClaim" reflector="pkg/mod/k8s.io/client-go@v0.35.0/tools/cache/reflector.go:289"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow up after https://github.com/gardener/gardener/pull/14857
/cc @timuthy 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
