### PR TITLE
Next attempt to deflake `e2e-kind-operator` test

### DIFF
--- a/charts/gardener/provider-local/templates/deployment.yaml
+++ b/charts/gardener/provider-local/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - --heartbeat-namespace={{ .Release.Namespace }}
         - --heartbeat-renew-interval-seconds={{ .Values.controllers.heartbeat.renewIntervalSeconds }}
         {{- if .Values.gardener.runtimeCluster.enabled }}
-        - --disable-webhooks=controlplane,networkpolicy,prometheus,shoot
+        - --disable-webhooks=controlplane,networkpolicy,shoot
         - --controllers=backupbucket,backupentry,dnsrecord,local-ext-shoot
         - --extension-classes=garden
         {{- else }}

--- a/pkg/provider-local/webhook/prometheus/mutator.go
+++ b/pkg/provider-local/webhook/prometheus/mutator.go
@@ -10,13 +10,22 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-var handledPrometheusNames = sets.New("seed")
+var (
+	// runtimeGardenPrometheuses are managed by gardener-operator in the runtime garden cluster.
+	runtimeGardenPrometheuses = sets.New("garden", "longterm")
+	// seedPrometheuses are managed by gardenlet in the seed cluster.
+	seedPrometheuses = sets.New("seed")
+
+	// handledPrometheusNames are the Prometheus instances this webhook reconciles.
+	handledPrometheusNames = runtimeGardenPrometheuses.Union(seedPrometheuses)
+)
 
 type mutator struct {
 	client          client.Client
@@ -35,6 +44,16 @@ func (m *mutator) Mutate(_ context.Context, newObj, _ client.Object) error {
 	}
 
 	if !handledPrometheusNames.Has(prometheus.Name) {
+		return nil
+	}
+
+	// prometheus-operator defaults TerminationGracePeriodSeconds to 600s. In e2e the
+	// `Wait for PersistentVolumes to be cleaned up` step waits for PV reclaim, which
+	// is gated on the pod releasing the PVC. Shrink the grace period so cleanup waits
+	// stay short and PV reclaim is what we're actually measuring.
+	prometheus.Spec.TerminationGracePeriodSeconds = ptr.To[int64](60)
+
+	if !seedPrometheuses.Has(prometheus.Name) {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
`prometheus-operator` defaults `TerminationGracePeriodSeconds` to 600s on the `StatefulSet`s it manages. In the operator e2e flow, the Wait for `PersistentVolumes` to be cleaned up step waits for PV reclaim, which is blocked by the `kubernetes.io/pvc-protection` finalizer until the consuming pod exits.

With a 600s grace period, the test still flaked even after #14882 raised its cap to 5m — observed on [this flake](prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/14878/pull-gardener-e2e-kind-operator/2057388447768776704#1:build-log.txt%3A1178) where the `prometheus-garden-1` pod was still serving readiness probes 5m after `SIGTERM`, leaving its PV bound and the test timing out at exactly 5m00s.

Enable the prometheus webhook in provider-local runtime mode (it was previously disabled via `--disable-webhooks`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
