### PR TITLE
Clean up `TODO` for `cloud-controller-manager-local`

### DIFF
--- a/hack/ci-e2e-kind-upgrade.sh
+++ b/hack/ci-e2e-kind-upgrade.sh
@@ -66,19 +66,9 @@ function copy_virtual_garden_kubeconfig_from_old_gardener_version_folder() {
 function install_previous_release() {
   pushd "$GARDENER_RELEASE_DOWNLOAD_PATH/gardener-releases/$GARDENER_PREVIOUS_RELEASE" >/dev/null
   copy_kubeconfig_files_to_old_gardener_version_folder
-  remove_provider_local_service_controller
   make gardener-up
   copy_virtual_garden_kubeconfig_from_old_gardener_version_folder
   popd >/dev/null
-}
-
-# TODO(timebertt): remove this after v1.141 has been released.
-# In the upgrade tests, `make kind-up` is executed with the new version of Gardener, which includes deploying cloud-controller-manager-local to the kind cluster.
-# However, `make gardener-up` is executed with the old version of Gardener, which still includes the service controller in gardener-extension-provider-local.
-# This leads to a conflict between cloud-controller-manager-local and service controller, as they both try to reconcile LoadBalancer services.
-# This function removes the service controller from the previous version of Gardener to rely on cloud-controller-manager-local throughout the upgrade test.
-function remove_provider_local_service_controller() {
-  sed -i '/servicecontroller/d' cmd/gardener-extension-provider-local/app/options.go
 }
 
 function upgrade_to_next_release() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Clean up the migration code added in [`f1f7440` (#14415)](https://github.com/gardener/gardener/pull/14415/commits/f1f74400ec2b793b02ecdf7e040974264f7ae531) for making the upgrade tests succeed.

**Which issue(s) this PR fixes**:
Follow-up to https://github.com/gardener/gardener/pull/14415

**Special notes for your reviewer**:

/cc @RadaBDimitrova 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
