### PR TITLE
Remove Perses Operator v1alpha1 to v1alpha2 CRD migration

### DIFF
--- a/pkg/component/observability/monitoring/persesoperator/crd.go
+++ b/pkg/component/observability/monitoring/persesoperator/crd.go
@@ -5,17 +5,12 @@
 package persesoperator
 
 import (
-	"context"
 	_ "embed"
-	"slices"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/crddeployer"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -27,13 +22,6 @@ var (
 	crdPersesDatasources string
 	//go:embed templates/crd-perses.dev_persesglobaldatasources.yaml
 	crdPersesGlobalDatasources string
-
-	// TODO(rickardsjp): Remove this variable after v1.141 has been released.
-	v1alpha1CRDNames = []string{
-		"perses.perses.dev",
-		"persesdashboards.perses.dev",
-		"persesdatasources.perses.dev",
-	}
 )
 
 // NewCRDs can be used to deploy perses-operator CRDs.
@@ -45,55 +33,5 @@ func NewCRDs(c client.Client) (component.DeployWaiter, error) {
 		crdPersesGlobalDatasources,
 	}
 
-	inner, err := crddeployer.New(c, resources, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return &crdDeployerWithCleanup{DeployWaiter: inner, client: c}, nil
-}
-
-// TODO(rickardsjp): Remove this struct after v1.141 has been released.
-type crdDeployerWithCleanup struct {
-	component.DeployWaiter
-
-	client client.Client
-}
-
-func (c *crdDeployerWithCleanup) Deploy(ctx context.Context) error {
-	// TODO(rickardsjp): Remove this code after v1.141 has been released.
-	var deletedCRDs []string
-
-	for _, name := range v1alpha1CRDNames {
-		crd := &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-		}
-
-		if err := c.client.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
-			if client.IgnoreNotFound(err) == nil {
-				continue
-			}
-			return err
-		}
-
-		if !slices.ContainsFunc(crd.Spec.Versions, func(v apiextensionsv1.CustomResourceDefinitionVersion) bool {
-			return v.Name == "v1alpha1"
-		}) {
-			continue
-		}
-
-		// Don't need to confirm deletion because Perses CRDs were created without deletion confirmation (and still are).
-
-		if err := c.client.Delete(ctx, crd); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-
-		deletedCRDs = append(deletedCRDs, name)
-	}
-
-	if err := kubernetesutils.WaitUntilCRDManifestsDestroyed(ctx, c.client, deletedCRDs...); err != nil {
-		return err
-	}
-
-	return c.DeployWaiter.Deploy(ctx)
+	return crddeployer.New(c, resources, false)
 }

--- a/pkg/component/observability/monitoring/persesoperator/crd_test.go
+++ b/pkg/component/observability/monitoring/persesoperator/crd_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -42,42 +41,6 @@ var _ = Describe("CRD", func() {
 			Expect(c.Get(ctx, client.ObjectKey{Name: "persesdashboards.perses.dev"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "persesdatasources.perses.dev"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: "persesglobaldatasources.perses.dev"}, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
-		})
-
-		// TODO(rickardsjp): Remove this test after v1.141 has been released.
-		It("should delete old v1alpha1 CRDs before deploying new ones", func() {
-			for _, name := range []string{
-				"perses.perses.dev",
-				"persesdashboards.perses.dev",
-				"persesdatasources.perses.dev",
-			} {
-				Expect(c.Create(ctx, &apiextensionsv1.CustomResourceDefinition{
-					ObjectMeta: metav1.ObjectMeta{Name: name},
-					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-						Group: "perses.dev",
-						Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: name[:len(name)-len(".perses.dev")], Kind: name[:len(name)-len(".perses.dev")]},
-						Scope: apiextensionsv1.NamespaceScoped,
-						Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-							{Name: "v1alpha1", Served: true, Storage: true, Schema: &apiextensionsv1.CustomResourceValidation{
-								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
-							}},
-						},
-					},
-				})).To(Succeed())
-			}
-
-			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
-
-			for _, name := range []string{
-				"perses.perses.dev",
-				"persesdashboards.perses.dev",
-				"persesdatasources.perses.dev",
-				"persesglobaldatasources.perses.dev",
-			} {
-				crd := &apiextensionsv1.CustomResourceDefinition{}
-				Expect(c.Get(ctx, client.ObjectKey{Name: name}, crd)).To(Succeed())
-				Expect(crd.Spec.Versions[0].Name).To(Equal("v1alpha2"))
-			}
 		})
 	})
 


### PR DESCRIPTION
/area monitoring
/kind cleanup

**What this PR does / why we need it**:
Removes the v1alpha1 perses CRD migration code from the perses-operator component. This code deleted old v1alpha1 CRDs before deploying the v1alpha2 replacements. Since v1.141 has been released a while ago, all clusters have already been migrated and the cleanup is no longer needed.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
The migration was introduced in v1.140 to handle the upstream perses CRD version bump from v1alpha1 to v1alpha2. Every supported Gardener version has now rolled through this, so the code is dead.

**Release note**:
```other operator
Removed v1alpha1 perses CRD migration code from the perses-operator component.
```
