### PR TITLE
Improve ETCD Cluster Details dashboard

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
@@ -59,7 +59,7 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
+        "w": 8,
         "x": 0,
         "y": 1
       },
@@ -70,7 +70,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
@@ -81,7 +83,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcdbr_cluster_size{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-$member\"}",
+          "expr": "min(etcdbr_cluster_size{job=\"kube-etcd3-backup-restore-$role\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "",
@@ -118,8 +120,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
-        "x": 4,
+        "w": 8,
+        "x": 8,
         "y": 1
       },
       "id": 49,
@@ -129,7 +131,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
@@ -176,8 +180,8 @@
       },
       "gridPos": {
         "h": 5,
-        "w": 4,
-        "x": 8,
+        "w": 8,
+        "x": 16,
         "y": 1
       },
       "id": 51,
@@ -187,7 +191,9 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "fields": "",
           "values": false
         },
@@ -208,176 +214,196 @@
       "type": "stat"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "prometheus",
-      "description": "Shows whether the selected etcd member is a \"Leader\", \"Follower\" or a \"Learner\"",
+      "description": "Shows whether all etcd members are healthy (0=Unhealthy, 1=Healthy) over time",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "from": "",
-              "id": 1,
-              "text": "Follower",
-              "to": "",
-              "type": 1,
-              "value": "0"
-            },
-            {
-              "from": "",
-              "id": 2,
-              "text": "Learner",
-              "to": "",
-              "type": 1,
-              "value": "1"
-            },
-            {
-              "from": "",
-              "id": 3,
-              "text": "Leader",
-              "to": "",
-              "type": 1,
-              "value": "2"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "green",
-                "value": 2
-              }
-            ]
-          }
-        },
+        "defaults": {},
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 5,
-        "w": 4,
+        "h": 8,
+        "w": 12,
         "x": 12,
-        "y": 1
+        "y": 6
       },
-      "id": 63,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["last"],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.5.32",
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "\"etcd-$role-$member\" Membership Status",
-      "type": "stat"
-    },
-    {
-      "datasource": "prometheus",
-      "description": "Shows whether the selected etcd member is healthy or not",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "from": "",
-              "id": 1,
-              "text": "Unhealthy",
-              "to": "",
-              "type": 1,
-              "value": "0"
-            },
-            {
-              "from": "",
-              "id": 2,
-              "text": "Healthy",
-              "to": "",
-              "type": 1,
-              "value": "1"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 1
-      },
+      "hiddenSeries": false,
       "id": 67,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["last"],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.32",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_has_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}",
+          "expr": "etcd_server_has_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}",
           "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
-      "title": "\"etcd-$role-$member\" Member Health Status",
-      "type": "stat"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Member Health Status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "0=Unhealthy  1=Healthy",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Shows the membership state (0=Follower, 1=Learner, 2=Leader) for all etcd members over time",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 63,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.32",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Membership Status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "0=Follower  1=Learner  2=Leader",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "datasource": "prometheus",
@@ -385,7 +411,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 14
       },
       "id": 57,
       "title": "Cluster Operations",
@@ -410,7 +436,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 7
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 69,
@@ -441,7 +467,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$role\"}[1d])",
+          "expr": "increase(etcd_server_leader_changes_seen_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[1d])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -507,7 +533,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 7
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 77,
@@ -538,7 +564,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_heartbeat_send_failures_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])",
           "instant": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -607,7 +633,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 7
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 22,
@@ -740,7 +766,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "hiddenSeries": false,
       "id": 73,
@@ -771,7 +797,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": "etcd-$role",
           "refId": "A"
@@ -837,7 +863,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 14
+        "y": 22
       },
       "hiddenSeries": false,
       "id": 71,
@@ -868,7 +894,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_learner_promote_successes{job=\"kube-etcd3-$role\"}",
+          "expr": "etcd_server_learner_promote_successes{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -934,7 +960,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 14
+        "y": 22
       },
       "hiddenSeries": false,
       "id": 75,
@@ -965,7 +991,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])) by (le))",
           "instant": false,
           "interval": "",
           "legendFormat": "etcd-$role",
@@ -1022,7 +1048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 55,
       "panels": [],
@@ -1030,71 +1056,100 @@
       "type": "row"
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "prometheus",
-      "description": "Total number of active peers in the cluster for the selected member",
+      "description": "Total number of active peers in the cluster per member",
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "green",
-                "value": 2
-              }
-            ]
-          }
-        },
+        "defaults": {},
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 4,
         "x": 0,
-        "y": 22
+        "y": 30
       },
+      "hiddenSeries": false,
       "id": 79,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["last"],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.32",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(etcd_network_active_peers{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"})",
+          "expr": "sum(etcd_network_active_peers{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}) by (pod)",
           "instant": false,
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
-      "title": "\"etcd-$role-$member\" Active Peers",
-      "type": "stat"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Active Peers (All Members)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1113,7 +1168,7 @@
         "h": 5,
         "w": 6,
         "x": 4,
-        "y": 22
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 81,
@@ -1144,9 +1199,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"kube-etcd3-$role\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_network_peer_round_trip_time_seconds_bucket{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])) by (pod, le))",
           "interval": "",
-          "legendFormat": "etcd-$role",
+          "legendFormat": "{{pod}}",
           "refId": "A"
         }
       ],
@@ -1199,7 +1254,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Network rate for data sent from selected member to other members in the cluster",
+      "description": "Network rate for data sent from each member to other members in the cluster",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1210,7 +1265,7 @@
         "h": 5,
         "w": 7,
         "x": 10,
-        "y": 22
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 82,
@@ -1241,9 +1296,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}[5m])",
+          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m])",
           "interval": "",
-          "legendFormat": "{{To}}",
+          "legendFormat": "{{pod}} -> {{To}}",
           "refId": "A"
         }
       ],
@@ -1296,7 +1351,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Network rate for data received by selected member from other members in the cluster",
+      "description": "Network rate for data received by each member from other members in the cluster",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1307,7 +1362,7 @@
         "h": 5,
         "w": 7,
         "x": 17,
-        "y": 22
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 83,
@@ -1338,9 +1393,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-$member\"}[5m])",
+          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m])",
           "interval": "",
-          "legendFormat": "{{From}}",
+          "legendFormat": "{{pod}} <- {{From}}",
           "refId": "A"
         }
       ],
@@ -1394,7 +1449,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 53,
       "panels": [],
@@ -1418,7 +1473,7 @@
         "h": 5,
         "w": 7,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 84,
@@ -1449,7 +1504,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_slow_apply_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1515,7 +1570,7 @@
         "h": 5,
         "w": 7,
         "x": 7,
-        "y": 28
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 85,
@@ -1546,7 +1601,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$role\"}[$__rate_interval])",
+          "expr": "rate(etcd_server_slow_read_indexes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -1598,7 +1653,10 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": ["controlplane", "seed"],
+  "tags": [
+    "controlplane",
+    "seed"
+  ],
   "templating": {
     "list": [
       {
@@ -1636,37 +1694,32 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "0",
-          "value": "0"
+          "text": "All",
+          "value": "$__all"
         },
+        "datasource": "prometheus",
+        "definition": "label_values(etcd_server_has_leader{job=\"kube-etcd3-$role\"}, pod)",
         "description": null,
         "error": null,
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": null,
-        "multi": false,
+        "multi": true,
         "name": "member",
-        "options": [
-          {
-            "selected": true,
-            "text": "0",
-            "value": "0"
-          },
-          {
-            "selected": false,
-            "text": "1",
-            "value": "1"
-          },
-          {
-            "selected": false,
-            "text": "2",
-            "value": "2"
-          }
-        ],
-        "query": "0, 1, 2",
-        "queryValue": "",
+        "options": [],
+        "query": {
+          "query": "label_values(etcd_server_has_leader{job=\"kube-etcd3-$role\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": ".*-(\\d+)$",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -1675,7 +1728,16 @@
     "to": "now"
   },
   "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
     "time_options": [
       "5m",
       "15m",

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
@@ -291,9 +291,10 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "max": 1,
+          "min": 0,
+          "show": true,
+          "decimals": 0
         },
         {
           "format": "short",
@@ -301,13 +302,15 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": true,
+          "decimals": 0
         }
       ],
       "yaxis": {
         "align": false,
         "alignLevel": null
-      }
+      },
+      "decimals": 0
     },
     {
       "aliasColors": {},
@@ -315,7 +318,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Shows the membership state (0=Follower, 1=Learner, 2=Leader) for all etcd members over time",
+      "description": "Shows the membership state for all etcd members over time (0=Learner, 1=Follower, 2=Leader)",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -357,7 +360,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}*2 + etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}",
+          "expr": "2 * etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"} + (1 - etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}) * (1 - etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"})",
           "instant": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -387,23 +390,26 @@
           "format": "short",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "max": 2,
+          "min": 0,
+          "show": true,
+          "decimals": 0
         },
         {
           "format": "short",
-          "label": "0=Follower  1=Learner  2=Leader",
+          "label": "0=Learner  1=Follower  2=Leader",
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": true,
+          "decimals": 0
         }
       ],
       "yaxis": {
         "align": false,
         "alignLevel": null
-      }
+      },
+      "decimals": 0
     },
     {
       "datasource": "prometheus",
@@ -1114,7 +1120,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Active Peers (All Members)",
+      "title": "Active Peers",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
@@ -803,7 +803,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_add_learner_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
           "interval": "",
           "legendFormat": "etcd-$role",
           "refId": "A"
@@ -997,7 +997,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\",pod=~\".*$role-($member)\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_member_remove_duration_seconds_bucket{job=\"kube-etcd3-backup-restore-$role\"}[$__rate_interval])) by (le))",
           "instant": false,
           "interval": "",
           "legendFormat": "etcd-$role",
@@ -1302,7 +1302,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m]),\n    \"from\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"To\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
+          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval]),\n    \"from\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"To\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
           "interval": "",
           "legendFormat": "{{from}} -> {{pod}}",
           "refId": "A"
@@ -1399,7 +1399,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m]),\n    \"receiver\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"From\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
+          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[$__rate_interval]),\n    \"receiver\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"From\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
           "interval": "",
           "legendFormat": "{{receiver}} <- {{pod}}",
           "refId": "A"

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/etcd-cluster-details-dashboard.json
@@ -360,7 +360,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "2 * etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"} + (1 - etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}) * (1 - etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"})",
+          "expr": "1 + etcd_server_is_leader{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"} - etcd_server_is_learner{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -1067,7 +1067,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Total number of active peers in the cluster per member",
+      "description": "Total number of active peers in the cluster for the selected member",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1302,9 +1302,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m])",
+          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_sent_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m]),\n    \"from\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"To\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
           "interval": "",
-          "legendFormat": "{{pod}} -> {{To}}",
+          "legendFormat": "{{from}} -> {{pod}}",
           "refId": "A"
         }
       ],
@@ -1399,9 +1399,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m])",
+          "expr": "label_replace(\n  label_replace(\n    rate(etcd_network_peer_received_bytes_total{job=\"kube-etcd3-$role\",pod=~\".*$role-($member)\"}[5m]),\n    \"receiver\", \"$1\", \"pod\", \"(.*)\"\n  ),\n  \"server_id\", \"$1\", \"From\", \"(.*)\"\n)\n* on(job, server_id) group_left(pod)\netcd_server_id{job=\"kube-etcd3-$role\"}",
           "interval": "",
-          "legendFormat": "{{pod}} <- {{From}}",
+          "legendFormat": "{{receiver}} <- {{pod}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Enhance the ETCD Cluster Details Plutono dashboard to show the state history of all cluster members over time and the health of all members at a glance:
- Membership Status: updated the graph to show state changes (leader, follower, learner) for all members simultaneously over time
- Member Health Status: show health for all cluster members at once
- Peer Networking panels: show metrics for all members simultaneously
- Keep the member as template variable to be able to select multiple entities and the default value is showing All memebers

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Test screenshot is showed below:
<img width="1412" height="1242" alt="Screenshot 2026-05-27 at 11 03 09" src="https://github.com/user-attachments/assets/ee5e2927-d1c2-4b5c-9f48-3c9bc3ea9bbf" />



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
