### PR TITLE
Do not ignore changes to seedName quietly when not done via binding subresource

### DIFF
--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -70,8 +70,7 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
 
-	newShoot.Status = oldShoot.Status               // can only be changed by shoots/status subresource
-	newShoot.Spec.SeedName = oldShoot.Spec.SeedName // can only be changed by shoots/binding subresource
+	newShoot.Status = oldShoot.Status // can only be changed by shoots/status subresource
 
 	if op, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok {
 		newShoot.Annotations[v1beta1constants.GardenerOperation] = cleanUpOperation(op)

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -283,24 +283,6 @@ var _ = Describe("Strategy", func() {
 			),
 		)
 
-		Context("seedName change", func() {
-			BeforeEach(func() {
-				oldShoot = &core.Shoot{
-					Spec: core.ShootSpec{
-						SeedName: new("seed"),
-					},
-				}
-				newShoot = oldShoot.DeepCopy()
-			})
-
-			It("should not allow change of seedName on shoot spec update", func() {
-				newShoot.Spec.SeedName = new("new-seed")
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Spec.SeedName).To(Equal(oldShoot.Spec.SeedName))
-			})
-		})
-
 		Context("generation increment", func() {
 			var (
 				oldShoot *core.Shoot


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
We already have validations in place to reject the update if the seed name is not changed via the binding subresource,
https://github.com/gardener/gardener/blob/93022988b116ef7acb6397c6589fc83bb183fd7e/plugin/pkg/shoot/validator/admission.go#L450-L453
We need not silently ignore the change in shoot strategy. Without this it's not clear to the user that the seed name is not actually changed because the patch succeeds.

```
❯ kubectl patch shoot local-wl -n garden-local --type=merge -p '{"spec":{"seedName":"new-seed"}}'

shoot.core.gardener.cloud/local-wl patched
```


Previously, ie; before https://github.com/gardener/gardener/issues/2158 and this [change](https://github.com/gardener/gardener/pull/13352/changes#diff-279968515ef9a63760ad3936541fcf055a647877460573be64e3e1a87703c92b), the Shoot validator plugin was a mutating plugin, which means, it ran before `PrepareForUpdate` is called, and hence it used to error out. Now that the plugin is a validating plugin, it is invoked only after `PrepareForUpdate`, by that time the field name is already overwritten to the old seed name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @plkokanov @seshachalam-yv 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The gardener-apiserver now rejects attempts to change the `spec.seedName` of the `Shoot` unless it is done via the binding subresource. Previously, these invalid updates were silently ignored.
```
