### PR TITLE
feat(logging): Restart Node `OpenTelemetry Collector` if `/metrics` does not respond

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -24,7 +24,7 @@ const (
 	UnitNameHealthCheck = "opentelemetry-collector-healthcheck.service"
 
 	// UnitNameHealthCheckTimer is the name of the opentelemetry-collector timer.
-	UnitNameHealthCheckTimer = "opentelemetry-collector.timer"
+	UnitNameHealthCheckTimer = "opentelemetry-collector-healthcheck.timer"
 
 	// PathDirectory is the path for the opentelemetry-collector's directory.
 	PathDirectory = "/var/lib/opentelemetry-collector"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -20,6 +20,16 @@ const (
 	// UnitName is the name of the opentelemetry-collector service.
 	UnitName = "opentelemetry-collector.service"
 
+	// UnitNameHealthCheck is the name of the opentelemetry-collector healthcheck oneshot.
+	UnitNameHealthCheck = "opentelemetry-collector-healthcheck.service"
+
+	// UnitNameRestart is the name of the opentelemetry-collector restart oneshot
+	// triggered via OnFailure when the healthcheck fails.
+	UnitNameRestart = "opentelemetry-collector-restart.service"
+
+	// UnitNameTimer is the name of the opentelemetry-collector timer.
+	UnitNameTimer = "opentelemetry-collector.timer"
+
 	// PathDirectory is the path for the opentelemetry-collector's directory.
 	PathDirectory = "/var/lib/opentelemetry-collector"
 	// PathAuthToken is the path for the file containing opentelemetry-collector's authentication that gets
@@ -76,7 +86,13 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, err
 	}
 
-	units = append(units, getOpenTelemetryCollectorUnit())
+	units = append(
+		units,
+		getOpenTelemetryCollectorUnit(),
+		getOpenTelemetryCollectorHealthCheckUnit(),
+		getOpenTelemetryCollectorRestartUnit(),
+		getOpenTelemetryCollectorTimerUnit(),
+	)
 	files = append(files, collectorConfigFile, getOpenTelemetryCollectorCAFile(ctx), extensionsv1alpha1.File{
 		Path:        openTelemetryCollectorBinaryPath,
 		Permissions: new(uint32(0700)),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -23,10 +23,6 @@ const (
 	// UnitNameHealthCheck is the name of the opentelemetry-collector healthcheck oneshot.
 	UnitNameHealthCheck = "opentelemetry-collector-healthcheck.service"
 
-	// UnitNameRestart is the name of the opentelemetry-collector restart oneshot
-	// triggered via OnFailure when the healthcheck fails.
-	UnitNameRestart = "opentelemetry-collector-restart.service"
-
 	// UnitNameTimer is the name of the opentelemetry-collector timer.
 	UnitNameTimer = "opentelemetry-collector.timer"
 
@@ -90,7 +86,6 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		units,
 		getOpenTelemetryCollectorUnit(),
 		getOpenTelemetryCollectorHealthCheckUnit(),
-		getOpenTelemetryCollectorRestartUnit(),
 		getOpenTelemetryCollectorTimerUnit(),
 	)
 	files = append(files, collectorConfigFile, getOpenTelemetryCollectorCAFile(ctx), extensionsv1alpha1.File{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -23,8 +23,8 @@ const (
 	// UnitNameHealthCheck is the name of the opentelemetry-collector healthcheck oneshot.
 	UnitNameHealthCheck = "opentelemetry-collector-healthcheck.service"
 
-	// UnitNameTimer is the name of the opentelemetry-collector timer.
-	UnitNameTimer = "opentelemetry-collector.timer"
+	// UnitNameHealthCheckTimer is the name of the opentelemetry-collector timer.
+	UnitNameHealthCheckTimer = "opentelemetry-collector.timer"
 
 	// PathDirectory is the path for the opentelemetry-collector's directory.
 	PathDirectory = "/var/lib/opentelemetry-collector"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -127,7 +127,7 @@ func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitNameHealthCheck,
 		Command: new(extensionsv1alpha1.CommandStart),
-		Enable:  new(true),
+		Enable:  new(false),
 		Content: new(`[Unit]
 Description=Health check for ` + UnitName + `
 After=` + UnitName + `

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -9,6 +9,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"strconv"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -119,5 +120,51 @@ ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:up
 ExecStartPre=/bin/sh -c "test -s ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentelemetry-collector --config=` + PathConfig),
 		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
+	}
+}
+
+func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
+	return extensionsv1alpha1.Unit{
+		Name:    UnitNameHealthCheck,
+		Command: ptr.To(extensionsv1alpha1.CommandStart),
+		Enable:  ptr.To(true),
+		Content: ptr.To(`[Unit]
+Description=opentelemetry-collector health check
+OnFailure=` + UnitNameRestart + `
+[Install]
+WantedBy=multi-user.target
+[Service]
+Type=oneshot
+ExecCondition=/bin/sh -c "systemctl is-active --quiet ` + UnitName + `"
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics"`),
+	}
+}
+
+func getOpenTelemetryCollectorRestartUnit() extensionsv1alpha1.Unit {
+	return extensionsv1alpha1.Unit{
+		Name:    UnitNameRestart,
+		Command: ptr.To(extensionsv1alpha1.CommandStart),
+		Enable:  ptr.To(true),
+		Content: ptr.To(`[Unit]
+Description=Restart ` + UnitName + ` when ` + UnitNameHealthCheck + ` fails
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "systemctl restart ` + UnitName + `"`),
+	}
+}
+
+func getOpenTelemetryCollectorTimerUnit() extensionsv1alpha1.Unit {
+	return extensionsv1alpha1.Unit{
+		Name:    UnitNameTimer,
+		Command: ptr.To(extensionsv1alpha1.CommandStart),
+		Enable:  ptr.To(true),
+		Content: ptr.To(`[Unit]
+Description=Run ` + UnitNameHealthCheck + ` every 5 minutes to validate that ` + UnitName + ` is working as expected
+[Install]
+WantedBy=multi-user.target
+[Timer]
+OnCalendar=*:0/5
+AccuracySec=1min
+Unit=` + UnitNameHealthCheck),
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -129,27 +129,15 @@ func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
-Description=opentelemetry-collector health check
-OnFailure=` + UnitNameRestart + `
+Description=Health check for ` + UnitName + `
+After=` + UnitName + `
+Requisite=` + UnitName + `
 [Install]
 WantedBy=multi-user.target
 [Service]
 Type=oneshot
-ExecCondition=/bin/sh -c "systemctl is-active --quiet ` + UnitName + `"
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics"`),
-	}
-}
-
-func getOpenTelemetryCollectorRestartUnit() extensionsv1alpha1.Unit {
-	return extensionsv1alpha1.Unit{
-		Name:    UnitNameRestart,
-		Command: new(extensionsv1alpha1.CommandStart),
-		Enable:  new(true),
-		Content: new(`[Unit]
-Description=Restart ` + UnitName + ` when ` + UnitNameHealthCheck + ` fails
-[Service]
-Type=oneshot
-ExecStart=/bin/sh -c "systemctl restart ` + UnitName + `"`),
+ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart ` + UnitName + `'
+ExecStart=/usr/bin/curl -fsS --max-time 5 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics`),
 	}
 }
 
@@ -161,9 +149,10 @@ func getOpenTelemetryCollectorTimerUnit() extensionsv1alpha1.Unit {
 		Content: new(`[Unit]
 Description=Run ` + UnitNameHealthCheck + ` every 5 minutes to validate that ` + UnitName + ` is working as expected
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target
 [Timer]
-OnCalendar=*:0/5
+OnBootSec=2min
+OnUnitActiveSec=5min
 AccuracySec=1min
 Unit=` + UnitNameHealthCheck),
 	}

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -136,7 +136,9 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/sh -c "systemctl is-active --quiet ` + UnitName + `"
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics"`),
+# Error code 28 is for timeout
+# https://curl.se/libcurl/c/libcurl-errors.html
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics; rc=$?; [ $rc -eq 28 ] && exit 1 || exit 0"; echo $?`),
 	}
 }
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -126,9 +126,9 @@ ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentel
 func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitNameHealthCheck,
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(`[Unit]
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
 Description=opentelemetry-collector health check
 OnFailure=` + UnitNameRestart + `
 [Install]
@@ -145,9 +145,9 @@ ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPor
 func getOpenTelemetryCollectorRestartUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitNameRestart,
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(`[Unit]
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
 Description=Restart ` + UnitName + ` when ` + UnitNameHealthCheck + ` fails
 [Service]
 Type=oneshot
@@ -158,9 +158,9 @@ ExecStart=/bin/sh -c "systemctl restart ` + UnitName + `"`),
 func getOpenTelemetryCollectorTimerUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitNameTimer,
-		Command: ptr.To(extensionsv1alpha1.CommandStart),
-		Enable:  ptr.To(true),
-		Content: ptr.To(`[Unit]
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
 Description=Run ` + UnitNameHealthCheck + ` every 5 minutes to validate that ` + UnitName + ` is working as expected
 [Install]
 WantedBy=multi-user.target

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -148,7 +148,7 @@ Description=Run ` + UnitNameHealthCheck + ` every 5 minutes to validate that ` +
 [Install]
 WantedBy=timers.target
 [Timer]
-OnBootSec=2min
+OnBootSec=15min
 OnUnitActiveSec=5min
 AccuracySec=1min
 Unit=` + UnitNameHealthCheck),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -136,9 +136,7 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/sh -c "systemctl is-active --quiet ` + UnitName + `"
-# Error code 28 is for timeout
-# https://curl.se/libcurl/c/libcurl-errors.html
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics; rc=$?; [ $rc -eq 28 ] && exit 1 || exit 0"; echo $?`),
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics"`),
 	}
 }
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -135,13 +135,17 @@ Requisite=` + UnitName + `
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart ` + UnitName + `'
+# Note: We intentionally curl the /metrics endpoint rather than /healthz.
+# We know that /metrics reliably times out when there are issues such as file descriptor leaks.
+# If we can verify that /healthz behaves the same, we should switch to using it instead,
+# since health checks are typically expected to target /healthz rather than /metrics.
 ExecStart=/usr/bin/curl -fsS --max-time 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics`),
 	}
 }
 
 func getOpenTelemetryCollectorTimerUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
-		Name:    UnitNameTimer,
+		Name:    UnitNameHealthCheckTimer,
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -125,8 +125,9 @@ ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentel
 
 func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
-		Name:   UnitNameHealthCheck,
-		Enable: new(true),
+		Name:    UnitNameHealthCheck,
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
 		Content: new(`[Unit]
 Description=Health check for ` + UnitName + `
 After=` + UnitName + `
@@ -134,7 +135,7 @@ Requisite=` + UnitName + `
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart ` + UnitName + `'
-ExecStart=/usr/bin/curl -fsS --max-time 5 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics`),
+ExecStart=/usr/bin/curl -fsS --max-time 15 http://127.0.0.1:` + strconv.Itoa(MetricsPort) + `/metrics`),
 	}
 }
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -125,15 +125,12 @@ ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentel
 
 func getOpenTelemetryCollectorHealthCheckUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
-		Name:    UnitNameHealthCheck,
-		Command: new(extensionsv1alpha1.CommandStart),
-		Enable:  new(true),
+		Name:   UnitNameHealthCheck,
+		Enable: new(true),
 		Content: new(`[Unit]
 Description=Health check for ` + UnitName + `
 After=` + UnitName + `
 Requisite=` + UnitName + `
-[Install]
-WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart ` + UnitName + `'

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -300,25 +300,15 @@ users:
 				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]
-Description=opentelemetry-collector health check
-OnFailure=opentelemetry-collector-restart.service
+Description=Health check for opentelemetry-collector.service
+After=opentelemetry-collector.service
+Requisite=opentelemetry-collector.service
 [Install]
 WantedBy=multi-user.target
 [Service]
 Type=oneshot
-ExecCondition=/bin/sh -c "systemctl is-active --quiet opentelemetry-collector.service"
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics"`),
-			}
-
-			otelRestartUnit := extensionsv1alpha1.Unit{
-				Name:    UnitNameRestart,
-				Command: new(extensionsv1alpha1.CommandStart),
-				Enable:  new(true),
-				Content: new(`[Unit]
-Description=Restart opentelemetry-collector.service when opentelemetry-collector-healthcheck.service fails
-[Service]
-Type=oneshot
-ExecStart=/bin/sh -c "systemctl restart opentelemetry-collector.service"`),
+ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart opentelemetry-collector.service'
+ExecStart=/usr/bin/curl -fsS --max-time 5 http://127.0.0.1:18888/metrics`),
 			}
 
 			otelTimerUnit := extensionsv1alpha1.Unit{
@@ -328,14 +318,15 @@ ExecStart=/bin/sh -c "systemctl restart opentelemetry-collector.service"`),
 				Content: new(`[Unit]
 Description=Run opentelemetry-collector-healthcheck.service every 5 minutes to validate that opentelemetry-collector.service is working as expected
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target
 [Timer]
-OnCalendar=*:0/5
+OnBootSec=2min
+OnUnitActiveSec=5min
 AccuracySec=1min
 Unit=opentelemetry-collector-healthcheck.service`),
 			}
 
-			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit, otelHealthCheckUnit, otelRestartUnit, otelTimerUnit}
+			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit, otelHealthCheckUnit, otelTimerUnit}
 
 			Expect(units).To(ConsistOf(expectedUnits))
 			Expect(files).To(ConsistOf(expectedFiles))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -317,7 +317,7 @@ Description=Run opentelemetry-collector-healthcheck.service every 5 minutes to v
 [Install]
 WantedBy=timers.target
 [Timer]
-OnBootSec=2min
+OnBootSec=15min
 OnUnitActiveSec=5min
 AccuracySec=1min
 Unit=opentelemetry-collector-healthcheck.service`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -289,7 +289,47 @@ users:
 				"/var/lib/opentelemetry-collector/kubeconfig",
 			}
 
-			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit}
+			otelHealthCheckUnit := extensionsv1alpha1.Unit{
+				Name:    UnitNameHealthCheck,
+				Command: ptr.To(extensionsv1alpha1.CommandStart),
+				Enable:  ptr.To(true),
+				Content: ptr.To(`[Unit]
+Description=opentelemetry-collector health check
+OnFailure=opentelemetry-collector-restart.service
+[Install]
+WantedBy=multi-user.target
+[Service]
+Type=oneshot
+ExecCondition=/bin/sh -c "systemctl is-active --quiet opentelemetry-collector.service"
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics"`),
+			}
+
+			otelRestartUnit := extensionsv1alpha1.Unit{
+				Name:    UnitNameRestart,
+				Command: ptr.To(extensionsv1alpha1.CommandStart),
+				Enable:  ptr.To(true),
+				Content: ptr.To(`[Unit]
+Description=Restart opentelemetry-collector.service when opentelemetry-collector-healthcheck.service fails
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "systemctl restart opentelemetry-collector.service"`),
+			}
+
+			otelTimerUnit := extensionsv1alpha1.Unit{
+				Name:    UnitNameTimer,
+				Command: ptr.To(extensionsv1alpha1.CommandStart),
+				Enable:  ptr.To(true),
+				Content: ptr.To(`[Unit]
+Description=Run opentelemetry-collector-healthcheck.service every 5 minutes to validate that opentelemetry-collector.service is working as expected
+[Install]
+WantedBy=multi-user.target
+[Timer]
+OnCalendar=*:0/5
+AccuracySec=1min
+Unit=opentelemetry-collector-healthcheck.service`),
+			}
+
+			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit, otelHealthCheckUnit, otelRestartUnit, otelTimerUnit}
 
 			Expect(units).To(ConsistOf(expectedUnits))
 			Expect(files).To(ConsistOf(expectedFiles))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -93,6 +93,11 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: /var/lib/opentelemetry-collector/auth-token
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: /healthz
+  pprof:
+    endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -96,9 +96,6 @@ extensions:
   health_check:
     endpoint: 0.0.0.0:13133
     path: /healthz
-  # TODO(iypetrov): Enable after Vali is removed  
-  # pprof:
-  #   endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -296,8 +296,8 @@ users:
 			}
 
 			otelHealthCheckUnit := extensionsv1alpha1.Unit{
-				Name:    UnitNameHealthCheck,
-				Enable:  new(true),
+				Name:   UnitNameHealthCheck,
+				Enable: new(true),
 				Content: new(`[Unit]
 Description=Health check for opentelemetry-collector.service
 After=opentelemetry-collector.service

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -303,11 +303,15 @@ Requisite=opentelemetry-collector.service
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart opentelemetry-collector.service'
+# Note: We intentionally curl the /metrics endpoint rather than /healthz.
+# We know that /metrics reliably times out when there are issues such as file descriptor leaks.
+# If we can verify that /healthz behaves the same, we should switch to using it instead,
+# since health checks are typically expected to target /healthz rather than /metrics.
 ExecStart=/usr/bin/curl -fsS --max-time 15 http://127.0.0.1:18888/metrics`),
 			}
 
 			otelTimerUnit := extensionsv1alpha1.Unit{
-				Name:    UnitNameTimer,
+				Name:    UnitNameHealthCheckTimer,
 				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -96,8 +96,9 @@ extensions:
   health_check:
     endpoint: 0.0.0.0:13133
     path: /healthz
-  pprof:
-    endpoint: 0.0.0.0:1777
+  # TODO(iypetrov): Enable after Vali is removed  
+  # pprof:
+  #   endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:
@@ -221,7 +222,7 @@ service:
       level: INFO
       encoding: json
 
-  extensions: [file_storage, bearertokenauth]
+  extensions: [file_storage, bearertokenauth, health_check]
   pipelines:
     logs/journal:
       receivers: [journald/journal]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -301,9 +301,7 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/sh -c "systemctl is-active --quiet opentelemetry-collector.service"
-# Error code 28 is for timeout
-# https://curl.se/libcurl/c/libcurl-errors.html
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics; rc=$?; [ $rc -eq 28 ] && exit 1 || exit 0"; echo $?`),
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics"`),
 			}
 
 			otelRestartUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -291,9 +291,9 @@ users:
 
 			otelHealthCheckUnit := extensionsv1alpha1.Unit{
 				Name:    UnitNameHealthCheck,
-				Command: ptr.To(extensionsv1alpha1.CommandStart),
-				Enable:  ptr.To(true),
-				Content: ptr.To(`[Unit]
+				Command: new(extensionsv1alpha1.CommandStart),
+				Enable:  new(true),
+				Content: new(`[Unit]
 Description=opentelemetry-collector health check
 OnFailure=opentelemetry-collector-restart.service
 [Install]
@@ -308,9 +308,9 @@ ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics; rc=$?; [ $rc
 
 			otelRestartUnit := extensionsv1alpha1.Unit{
 				Name:    UnitNameRestart,
-				Command: ptr.To(extensionsv1alpha1.CommandStart),
-				Enable:  ptr.To(true),
-				Content: ptr.To(`[Unit]
+				Command: new(extensionsv1alpha1.CommandStart),
+				Enable:  new(true),
+				Content: new(`[Unit]
 Description=Restart opentelemetry-collector.service when opentelemetry-collector-healthcheck.service fails
 [Service]
 Type=oneshot
@@ -319,9 +319,9 @@ ExecStart=/bin/sh -c "systemctl restart opentelemetry-collector.service"`),
 
 			otelTimerUnit := extensionsv1alpha1.Unit{
 				Name:    UnitNameTimer,
-				Command: ptr.To(extensionsv1alpha1.CommandStart),
-				Enable:  ptr.To(true),
-				Content: ptr.To(`[Unit]
+				Command: new(extensionsv1alpha1.CommandStart),
+				Enable:  new(true),
+				Content: new(`[Unit]
 Description=Run opentelemetry-collector-healthcheck.service every 5 minutes to validate that opentelemetry-collector.service is working as expected
 [Install]
 WantedBy=multi-user.target

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -298,7 +298,7 @@ users:
 			otelHealthCheckUnit := extensionsv1alpha1.Unit{
 				Name:    UnitNameHealthCheck,
 				Command: new(extensionsv1alpha1.CommandStart),
-				Enable:  new(true),
+				Enable:  new(false),
 				Content: new(`[Unit]
 Description=Health check for opentelemetry-collector.service
 After=opentelemetry-collector.service

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -296,8 +296,9 @@ users:
 			}
 
 			otelHealthCheckUnit := extensionsv1alpha1.Unit{
-				Name:   UnitNameHealthCheck,
-				Enable: new(true),
+				Name:    UnitNameHealthCheck,
+				Command: new(extensionsv1alpha1.CommandStart),
+				Enable:  new(true),
 				Content: new(`[Unit]
 Description=Health check for opentelemetry-collector.service
 After=opentelemetry-collector.service
@@ -305,7 +306,7 @@ Requisite=opentelemetry-collector.service
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart opentelemetry-collector.service'
-ExecStart=/usr/bin/curl -fsS --max-time 5 http://127.0.0.1:18888/metrics`),
+ExecStart=/usr/bin/curl -fsS --max-time 15 http://127.0.0.1:18888/metrics`),
 			}
 
 			otelTimerUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -297,14 +297,11 @@ users:
 
 			otelHealthCheckUnit := extensionsv1alpha1.Unit{
 				Name:    UnitNameHealthCheck,
-				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]
 Description=Health check for opentelemetry-collector.service
 After=opentelemetry-collector.service
 Requisite=opentelemetry-collector.service
-[Install]
-WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecStopPost=/bin/sh -c '[ "$SERVICE_RESULT" = "success" ] || systemctl restart opentelemetry-collector.service'

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -301,7 +301,9 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/sh -c "systemctl is-active --quiet opentelemetry-collector.service"
-ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics"`),
+# Error code 28 is for timeout
+# https://curl.se/libcurl/c/libcurl-errors.html
+ExecStart=/bin/sh -c "curl -fsSm 15 http://127.0.0.1:18888/metrics; rc=$?; [ $rc -eq 28 ] && exit 1 || exit 0"; echo $?`),
 			}
 
 			otelRestartUnit := extensionsv1alpha1.Unit{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -9,6 +9,11 @@ extensions:
     create_directory: true
   bearertokenauth:
     filename: {{ .pathAuthToken }}
+  health_check:
+    endpoint: 0.0.0.0:13133
+    path: /healthz
+  pprof:
+    endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -12,8 +12,9 @@ extensions:
   health_check:
     endpoint: 0.0.0.0:13133
     path: /healthz
-  pprof:
-    endpoint: 0.0.0.0:1777
+  # TODO(iypetrov): Enable after Vali is removed  
+  # pprof:
+  #   endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:
@@ -137,7 +138,7 @@ service:
       level: INFO
       encoding: json
 
-  extensions: [file_storage, bearertokenauth]
+  extensions: [file_storage, bearertokenauth, health_check]
   pipelines:
     logs/journal:
       receivers: [journald/journal]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/templates/opentelemetry-collector-config.yaml.tpl
@@ -12,9 +12,6 @@ extensions:
   health_check:
     endpoint: 0.0.0.0:13133
     path: /healthz
-  # TODO(iypetrov): Enable after Vali is removed  
-  # pprof:
-  #   endpoint: 0.0.0.0:1777
 
 receivers:
   journald/journal:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
The goal of this PR is to introduce resiliency logic into the OpenTelemetry Collector systemd service to handle performance constraints and automatically restart the service in cases such as resource leaks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add logic to restart the OpenTelemetry Collector systemd service when it enters a degraded state due to resource leaks.
```
