### PR TITLE
Use `clock` instead of `time.Now` in `DeployGardenerResourceManager` function

### DIFF
--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/component-base/version"
+	clockutils "k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -121,8 +122,6 @@ func NewTargetGardenerResourceManager(
 }
 
 var (
-	// Now is an alias for time.Now(). Exposed for testing.
-	Now = time.Now()
 	// TimeoutWaitForGardenerResourceManagerBootstrapping is the maximum time the bootstrap process for the
 	// gardener-resource-manager may take.
 	// Exposed for testing.
@@ -140,6 +139,7 @@ var (
 func DeployGardenerResourceManager(
 	ctx context.Context,
 	c client.Client,
+	clock clockutils.Clock,
 	secretsManager secretsmanager.Interface,
 	gardenerResourceManager resourcemanager.Interface,
 	namespace string,
@@ -156,7 +156,7 @@ func DeployGardenerResourceManager(
 		gardenerResourceManager.SetReplicas(&replicaCount)
 	}
 
-	mustBootstrap, err := mustBootstrapGardenerResourceManager(ctx, c, gardenerResourceManager, namespace)
+	mustBootstrap, err := mustBootstrapGardenerResourceManager(ctx, c, clock, gardenerResourceManager, namespace)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func DeployGardenerResourceManager(
 		timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForGardenerResourceManagerBootstrapping)
 		defer cancel()
 
-		if err := WaitUntilGardenerResourceManagerBootstrapped(timeoutCtx, c, namespace); err != nil {
+		if err := WaitUntilGardenerResourceManagerBootstrapped(timeoutCtx, c, clock, namespace); err != nil {
 			return err
 		}
 	}
@@ -193,7 +193,7 @@ func DeployGardenerResourceManager(
 	return gardenerResourceManager.Deploy(ctx)
 }
 
-func mustBootstrapGardenerResourceManager(ctx context.Context, c client.Client, gardenerResourceManager resourcemanager.Interface, namespace string) (bool, error) {
+func mustBootstrapGardenerResourceManager(ctx context.Context, c client.Client, clock clockutils.Clock, gardenerResourceManager resourcemanager.Interface, namespace string) (bool, error) {
 	if ptr.Deref(gardenerResourceManager.GetReplicas(), 0) == 0 {
 		return false, nil // GRM should not be scaled up, hence no need to bootstrap.
 	}
@@ -215,7 +215,7 @@ func mustBootstrapGardenerResourceManager(ctx context.Context, c client.Client, 
 	if err2 != nil {
 		return false, fmt.Errorf("could not parse renew timestamp: %w", err2)
 	}
-	if Now.UTC().After(renewTime.UTC()) {
+	if clock.Now().UTC().After(renewTime.UTC()) {
 		return true, nil // Shoot token was not renewed.
 	}
 
@@ -269,7 +269,7 @@ func reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx context.Conte
 	)
 }
 
-func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.Client, namespace string) error {
+func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.Client, clock clockutils.Clock, namespace string) error {
 	shootAccessSecret := gardenerutils.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, namespace)
 
 	if err := retryutils.Until(ctx, IntervalWaitForGardenerResourceManagerBootstrapping, func(ctx context.Context) (bool, error) {
@@ -290,7 +290,7 @@ func waitUntilGardenerResourceManagerBootstrapped(ctx context.Context, c client.
 			return retryutils.SevereError(fmt.Errorf("could not parse renew timestamp: %w", err2))
 		}
 
-		if Now.UTC().After(renewTime.UTC()) {
+		if clock.Now().UTC().After(renewTime.UTC()) {
 			return retryutils.MinorError(errors.New("token not yet renewed"))
 		}
 

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -178,7 +178,6 @@ var _ = Describe("ResourceManager", func() {
 			bootstrapKubeconfigSecret *corev1.Secret
 			shootAccessSecret         *corev1.Secret
 			managedResource           *resourcesv1alpha1.ManagedResource
-			now                       time.Time
 		)
 
 		BeforeEach(func() {
@@ -186,9 +185,7 @@ var _ = Describe("ResourceManager", func() {
 
 			resourceManager = &fakeresourcemanager.ResourceManager{}
 
-			now = time.Unix(60, 0)
-
-			fakeClock = testclock.NewFakeClock(now)
+			fakeClock = testclock.NewFakeClock(time.Unix(60, 0))
 
 			scheme = runtime.NewScheme()
 			Expect(kubernetesscheme.AddToScheme(scheme)).To(Succeed())
@@ -217,7 +214,7 @@ var _ = Describe("ResourceManager", func() {
 					Name:      "shoot-access-gardener-resource-manager",
 					Namespace: namespace,
 					Annotations: map[string]string{
-						"serviceaccount.resources.gardener.cloud/token-renew-timestamp": now.Add(time.Hour).Format(time.RFC3339),
+						"serviceaccount.resources.gardener.cloud/token-renew-timestamp": fakeClock.Now().Add(time.Hour).Format(time.RFC3339),
 					},
 				},
 			}
@@ -278,7 +275,7 @@ var _ = Describe("ResourceManager", func() {
 					})
 
 					It("bootstraps because the shoot access secret was not renewed", func() {
-						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": now.Add(-time.Hour).Format(time.RFC3339)}
+						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": fakeClock.Now().Add(-time.Hour).Format(time.RFC3339)}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
@@ -360,7 +357,7 @@ var _ = Describe("ResourceManager", func() {
 					})
 
 					It("fails because the shoot access token was not renewed", func() {
-						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": now.Add(-time.Hour).Format(time.RFC3339)}
+						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": fakeClock.Now().Add(-time.Hour).Format(time.RFC3339)}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -168,7 +168,7 @@ var _ = Describe("ResourceManager", func() {
 			fakeErr         = errors.New("fake err")
 
 			fakeClient    client.Client
-			fakeClock     clock.Clock
+			fakeClock     *testclock.FakeClock
 			k8sSeedClient kubernetes.Interface
 			scheme        *runtime.Scheme
 
@@ -278,6 +278,17 @@ var _ = Describe("ResourceManager", func() {
 						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": fakeClock.Now().Add(-time.Hour).Format(time.RFC3339)}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+					})
+
+					It("bootstraps because the shoot token expired while the shoot was hibernated", func() {
+						// Token is valid at startup (renew timestamp is 1h in the future).
+						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
+						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
+
+						// Simulate time passing while the shoot was hibernated: clock advances past the renew timestamp.
+						fakeClock.Step(2 * time.Hour)
 
 						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -17,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -166,6 +168,7 @@ var _ = Describe("ResourceManager", func() {
 			fakeErr         = errors.New("fake err")
 
 			fakeClient    client.Client
+			fakeClock     clock.Clock
 			k8sSeedClient kubernetes.Interface
 			scheme        *runtime.Scheme
 
@@ -184,7 +187,8 @@ var _ = Describe("ResourceManager", func() {
 			resourceManager = &fakeresourcemanager.ResourceManager{}
 
 			now = time.Unix(60, 0)
-			DeferCleanup(test.WithVar(&Now, now))
+
+			fakeClock = testclock.NewFakeClock(now)
 
 			scheme = runtime.NewScheme()
 			Expect(kubernetesscheme.AddToScheme(scheme)).To(Succeed())
@@ -234,7 +238,7 @@ var _ = Describe("ResourceManager", func() {
 				})
 
 				It("should set the secrets and deploy", func() {
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 
 					Expect(resourceManager.Replicas).To(PointTo(Equal(int32(2))))
 					Expect(resourceManager.Secrets.BootstrapKubeconfig).To(BeNil())
@@ -243,7 +247,7 @@ var _ = Describe("ResourceManager", func() {
 
 				It("should fail when the deploy function fails", func() {
 					resourceManager.DeployError = fakeErr
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
 				})
 			})
 		})
@@ -252,7 +256,7 @@ var _ = Describe("ResourceManager", func() {
 			Context("with success", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVar(&WaitUntilGardenerResourceManagerBootstrapped,
-						func(_ context.Context, _ client.Client, _ string) error { return nil },
+						func(_ context.Context, _ client.Client, _ clock.Clock, _ string) error { return nil },
 					))
 				})
 
@@ -264,13 +268,13 @@ var _ = Describe("ResourceManager", func() {
 
 				Context("deploy with 2 replicas", func() {
 					It("bootstraps because the shoot access secret was not found", func() {
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 
 					It("bootstraps because the shoot access secret was never reconciled", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 
 					It("bootstraps because the shoot access secret was not renewed", func() {
@@ -278,13 +282,13 @@ var _ = Describe("ResourceManager", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource was not found", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource indicates that the shoot access token lost access", func() {
@@ -297,7 +301,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 
 					It("bootstraps because the managed resource indicates that the shoot access token was invalidated", func() {
@@ -310,7 +314,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(Succeed())
 					})
 				})
 			})
@@ -330,7 +334,7 @@ var _ = Describe("ResourceManager", func() {
 					k8sSeedClient = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
 					sm = fakesecretsmanager.New(fakeClient, namespace)
 
-					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
+					Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(fakeErr))
 				})
 
 				Context("waiting for bootstrapping process", func() {
@@ -345,14 +349,14 @@ var _ = Describe("ResourceManager", func() {
 						shootAccessSecret.Annotations = nil
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(ContainSubstring("token not yet generated")))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress)).To(MatchError(ContainSubstring("token not yet generated")))
 					})
 
 					It("fails because the shoot access token renew timestamp cannot be parsed", func() {
 						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": "foo"}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("could not parse renew timestamp"))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("could not parse renew timestamp"))
 					})
 
 					It("fails because the shoot access token was not renewed", func() {
@@ -360,7 +364,7 @@ var _ = Describe("ResourceManager", func() {
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("token not yet renewed"))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring("token not yet renewed"))
 					})
 
 					It("fails because the managed resource is not getting healthy", func() {
@@ -371,7 +375,7 @@ var _ = Describe("ResourceManager", func() {
 						}
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 
-						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", namespace, managedResource.Name)))
+						Expect(DeployGardenerResourceManager(ctx, k8sSeedClient.Client(), fakeClock, sm, resourceManager, namespace, setReplicas, getAPIServerAddress).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", namespace, managedResource.Name)))
 					})
 				})
 			})

--- a/pkg/gardenlet/operation/botanist/resource_manager.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager.go
@@ -89,6 +89,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	return shared.DeployGardenerResourceManager(
 		ctx,
 		b.SeedClientSet.Client(),
+		b.Clock,
 		b.SecretsManager,
 		b.Shoot.Components.ControlPlane.ResourceManager,
 		b.Shoot.ControlPlaneNamespace,

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -15,6 +15,8 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -195,6 +197,7 @@ var _ = Describe("ResourceManager", func() {
 			controlPlaneNamespace = "fake-seed-ns"
 
 			fakeClient    client.Client
+			fakeClock     *testclock.FakeClock
 			rm            *fakeresourcemanager.ResourceManager
 			kubeAPIServer *fakeKubeAPIServer
 			now           time.Time
@@ -206,7 +209,8 @@ var _ = Describe("ResourceManager", func() {
 
 		BeforeEach(func() {
 			now = time.Now()
-			DeferCleanup(test.WithVar(&shared.Now, now))
+			fakeClock = testclock.NewFakeClock(now)
+			botanist.Clock = fakeClock
 
 			rm = &fakeresourcemanager.ResourceManager{}
 			kubeAPIServer = &fakeKubeAPIServer{autoscalingReplicas: new(int32(1))}
@@ -368,7 +372,7 @@ var _ = Describe("ResourceManager", func() {
 			Context("with success", func() {
 				BeforeEach(func() {
 					DeferCleanup(test.WithVar(&shared.WaitUntilGardenerResourceManagerBootstrapped,
-						func(_ context.Context, _ client.Client, _ string) error { return nil },
+						func(_ context.Context, _ client.Client, _ clock.Clock, _ string) error { return nil },
 					))
 				})
 

--- a/pkg/gardenlet/operation/botanist/resource_manager_test.go
+++ b/pkg/gardenlet/operation/botanist/resource_manager_test.go
@@ -200,7 +200,6 @@ var _ = Describe("ResourceManager", func() {
 			fakeClock     *testclock.FakeClock
 			rm            *fakeresourcemanager.ResourceManager
 			kubeAPIServer *fakeKubeAPIServer
-			now           time.Time
 
 			bootstrapKubeconfigSecret *corev1.Secret
 			shootAccessSecret         *corev1.Secret
@@ -208,8 +207,7 @@ var _ = Describe("ResourceManager", func() {
 		)
 
 		BeforeEach(func() {
-			now = time.Now()
-			fakeClock = testclock.NewFakeClock(now)
+			fakeClock = testclock.NewFakeClock(time.Now())
 			botanist.Clock = fakeClock
 
 			rm = &fakeresourcemanager.ResourceManager{}
@@ -226,7 +224,7 @@ var _ = Describe("ResourceManager", func() {
 					Name:      "shoot-access-gardener-resource-manager",
 					Namespace: controlPlaneNamespace,
 					Annotations: map[string]string{
-						resourcesv1alpha1.ServiceAccountTokenRenewTimestamp: now.Add(time.Hour).Format(time.RFC3339),
+						resourcesv1alpha1.ServiceAccountTokenRenewTimestamp: fakeClock.Now().Add(time.Hour).Format(time.RFC3339),
 					},
 				},
 			}
@@ -397,7 +395,7 @@ var _ = Describe("ResourceManager", func() {
 
 					It("bootstraps because the shoot access secret was not renewed", func() {
 						shootAccessSecret.Annotations = map[string]string{
-							resourcesv1alpha1.ServiceAccountTokenRenewTimestamp: now.Add(-time.Hour).Format(time.RFC3339),
+							resourcesv1alpha1.ServiceAccountTokenRenewTimestamp: fakeClock.Now().Add(-time.Hour).Format(time.RFC3339),
 						}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
@@ -504,7 +502,7 @@ var _ = Describe("ResourceManager", func() {
 					})
 
 					It("fails because the shoot access token was not renewed", func() {
-						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": now.Add(-time.Hour).Format(time.RFC3339)}
+						shootAccessSecret.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": fakeClock.Now().Add(-time.Hour).Format(time.RFC3339)}
 						Expect(fakeClient.Create(ctx, shootAccessSecret)).To(Succeed())
 						Expect(fakeClient.Create(ctx, managedResource)).To(Succeed())
 

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -1068,6 +1068,7 @@ func (r *Reconciler) deployVirtualGardenGardenerResourceManager(secretsManager s
 		return shared.DeployGardenerResourceManager(
 			ctx,
 			r.RuntimeClientSet.Client(),
+			r.Clock,
 			secretsManager,
 			resourceManager,
 			r.GardenNamespace,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind regression

**What this PR does / why we need it**:

After PR #14633, the `gardener-resource-manager` bootstrap detection used a frozen `Now` variable (a `time.Time` captured at gardenlet startup) instead of calling `time.Now()` dynamically. This caused a crash loop when a hibernating shoot woke up after its authentication token had expired: the bootstrap mechanism never triggered because the startup-time snapshot appeared valid, even though the token had since expired. See #14933 for more details.

This PR replaces the frozen `Now` package-level variable with a `clock.Clock` parameter passed explicitly to `DeployGardenerResourceManager`. This removes the global mutable state that was both the root cause of the bug and a testing antipattern.


**Which issue(s) this PR fixes**:
Fixes #14933

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed where `gardener-resource-manager` would crash-loop after a hibernated shoot woke up with an expired authentication token. The bootstrap detection now evaluates the current time dynamically instead of using a value frozen at gardenlet startup.
```
