### PR TITLE
[release-v1.142] Automated cherry pick of #14801: Clean up `Shoot` encryption provider type sync

### DIFF
--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -87,7 +87,6 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 	}
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
-
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -88,8 +88,6 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
 
-	// Ensure that encrypted provider type is set in `status.credentials.encryptionAtRest.providerType`.
-	SyncEncryptedProviderStatus(newShoot)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -311,9 +309,6 @@ func (shootStatusStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.
 		newShoot.Generation = oldShoot.Generation + 1
 	}
 
-	// Ensure that encrypted provider type is set in `status.credentials.encryptionAtRest.providerType`.
-	SyncEncryptedProviderStatus(newShoot)
-
 	// Ensure credentialsRef is synced even on /status subresource requests.
 	// Some clients are patching just the status which still results in update events
 	// for those watching the resource.
@@ -470,26 +465,5 @@ func SyncDNSProviderCredentials(shoot *core.Shoot) {
 		// - both fields are unset -> we have nothing to sync
 		// - both fields are set -> let the validation check if they are correct
 		// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
-	}
-}
-
-// SyncEncryptedProviderStatus ensures the status fields shoot.spec.kubernetes.kubeAPIServer.encryptionConfig.provider.type
-// and shoot.status.credentials.encryptionAtRest.providerType are in sync, when status provider type in not set.
-// TODO(AleksandarSavchev): Remove this function after v1.137 has been released.
-func SyncEncryptedProviderStatus(shoot *core.Shoot) {
-	encryptionProviderType := gardencorehelper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer)
-	if len(encryptionProviderType) == 0 {
-		return
-	}
-
-	if shoot.Status.Credentials == nil {
-		shoot.Status.Credentials = &core.ShootCredentials{}
-	}
-	if shoot.Status.Credentials.EncryptionAtRest == nil {
-		shoot.Status.Credentials.EncryptionAtRest = &core.EncryptionAtRest{}
-	}
-
-	if len(shoot.Status.Credentials.EncryptionAtRest.Provider.Type) == 0 {
-		shoot.Status.Credentials.EncryptionAtRest.Provider.Type = encryptionProviderType
 	}
 }

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -247,63 +247,6 @@ var _ = Describe("Strategy", func() {
 			})
 		})
 
-		DescribeTable("should sync encryption provider in status.credentials.encryptionAtRest.providerType",
-			func(providerType *core.EncryptionProviderType, status core.ShootStatus, expectedStatus core.ShootStatus) {
-				oldShoot := &core.Shoot{
-					Spec: core.ShootSpec{
-						Kubernetes: core.Kubernetes{
-							KubeAPIServer: &core.KubeAPIServerConfig{
-								EncryptionConfig: &core.EncryptionConfig{
-									Provider: core.EncryptionProvider{
-										Type: providerType,
-									},
-								},
-							},
-						},
-					},
-					Status: status,
-				}
-				newShoot := oldShoot.DeepCopy()
-
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Status).To(Equal(expectedStatus))
-			},
-			Entry("sync with encryption provider", ptr.To(core.EncryptionProviderTypeAESCBC), core.ShootStatus{},
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderTypeAESCBC,
-							},
-						},
-					},
-				},
-			),
-			Entry("do not overwrite existing provider in status", ptr.To(core.EncryptionProviderTypeAESCBC),
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderType("foo"),
-							},
-						},
-					},
-				},
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderType("foo"),
-							},
-						},
-					},
-				},
-			),
-			Entry("do not sync when encryption provider is nil", nil, core.ShootStatus{}, core.ShootStatus{}),
-			Entry("do not sync when encryption provider is empty", ptr.To(core.EncryptionProviderType("")), core.ShootStatus{}, core.ShootStatus{}),
-		)
-
 		Context("seedName change", func() {
 			BeforeEach(func() {
 				oldShoot = &core.Shoot{
@@ -1063,63 +1006,6 @@ var _ = Describe("Strategy", func() {
 				Entry("rotation phase is not prepared", nil, &core.ETCDEncryptionKeyRotation{Phase: core.RotationCompleting, AutoCompleteAfterPrepared: ptr.To(true)}, false),
 			)
 		})
-
-		DescribeTable("should sync encryption provider in  status.credentials.encryptionAtRest.providerType",
-			func(providerType *core.EncryptionProviderType, status core.ShootStatus, expectedStatus core.ShootStatus) {
-				oldShoot := &core.Shoot{
-					Spec: core.ShootSpec{
-						Kubernetes: core.Kubernetes{
-							KubeAPIServer: &core.KubeAPIServerConfig{
-								EncryptionConfig: &core.EncryptionConfig{
-									Provider: core.EncryptionProvider{
-										Type: providerType,
-									},
-								},
-							},
-						},
-					},
-					Status: status,
-				}
-				newShoot := oldShoot.DeepCopy()
-
-				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-
-				Expect(newShoot.Status).To(Equal(expectedStatus))
-			},
-			Entry("sync with encryption provider", ptr.To(core.EncryptionProviderTypeAESCBC), core.ShootStatus{},
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderTypeAESCBC,
-							},
-						},
-					},
-				},
-			),
-			Entry("do not overwrite existing provider in status", ptr.To(core.EncryptionProviderTypeAESCBC),
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderType("foo"),
-							},
-						},
-					},
-				},
-				core.ShootStatus{
-					Credentials: &core.ShootCredentials{
-						EncryptionAtRest: &core.EncryptionAtRest{
-							Provider: core.EncryptionProviderStatus{
-								Type: core.EncryptionProviderType("foo"),
-							},
-						},
-					},
-				},
-			),
-			Entry("do not sync when encryption provider is nil", nil, core.ShootStatus{}, core.ShootStatus{}),
-			Entry("do not sync when encryption provider is empty", ptr.To(core.EncryptionProviderType("")), core.ShootStatus{}, core.ShootStatus{}),
-		)
 
 		Context("DNS Provider Credentials", func() {
 			// TODO(vpnachev): Remove this context once support for Kubernetes 1.34 is dropped.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -814,7 +814,9 @@ func (r *Reconciler) updateShootStatusOperationStart(
 	}
 
 	// Start encryption rotation when encryption provider type is changed.
-	if v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != v1beta1helper.GetEncryptionProviderTypeInStatus(shoot.Status) &&
+	currentEncryptionProviderType := v1beta1helper.GetEncryptionProviderTypeInStatus(shoot.Status)
+	if len(currentEncryptionProviderType) > 0 &&
+		v1beta1helper.GetEncryptionProviderType(shoot.Spec.Kubernetes.KubeAPIServer) != currentEncryptionProviderType &&
 		(etcdEncryptionRotationPhase == gardencorev1beta1.RotationCompleted || len(etcdEncryptionRotationPhase) == 0) {
 		startRotationETCDEncryptionKey(shoot, true, &now)
 	}

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -441,9 +441,10 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.RewriteEncryptedDataAddLabel(ctx, o.Logger, o.SeedClientSet.Client(), o.ShootClientSet, o.SecretsManager, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer, o.Shoot.ResourcesToEncrypt, o.Shoot.EncryptedResources, gardenerutils.DefaultGVKsForEncryption())
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
-				sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
-				v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting),
+			SkipIf: o.Shoot.HibernationEnabled ||
+				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
+					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		snapshotETCD = g.Add(flow.Task{
@@ -451,7 +452,7 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return secretsrotation.SnapshotETCDAfterRewritingEncryptedData(ctx, o.SeedClientSet.Client(), botanist.SnapshotEtcd, o.Shoot.ControlPlaneNamespace, v1beta1constants.DeploymentNameKubeAPIServer)
 			}),
-			SkipIf: !allowBackup ||
+			SkipIf: !allowBackup || o.Shoot.HibernationEnabled ||
 				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationPreparing &&
 					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
 					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting)),
@@ -499,10 +500,11 @@ func (r *Reconciler) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 				return nil
 			}).RetryUntilTimeout(30*time.Second, 10*time.Minute),
-			SkipIf: v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
-				sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
-				v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
-				v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPrepared),
+			SkipIf: o.Shoot.HibernationEnabled ||
+				(v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) != gardencorev1beta1.RotationCompleting &&
+					sets.New(o.Shoot.ResourcesToEncrypt...).Equal(sets.New(o.Shoot.EncryptedResources...)) && (o.Shoot.EncryptionProviderToUse == o.Shoot.UsedEncryptionProvider ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing ||
+					v1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPrepared)),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, snapshotETCD),
 		})
 		deployKubeScheduler = g.Add(flow.Task{

--- a/pkg/operator/controller/garden/garden/reconciler.go
+++ b/pkg/operator/controller/garden/garden/reconciler.go
@@ -295,7 +295,9 @@ func (r *Reconciler) updateStatusOperationStart(ctx context.Context, garden *ope
 	}
 
 	// Start encryption rotation when encryption provider type is changed.
-	if helper.GetKubeAPIServerEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer) != helper.GetEncryptionProviderTypeInStatus(garden.Status) &&
+	currentEncryptionProviderType := helper.GetEncryptionProviderTypeInStatus(garden.Status)
+	if len(currentEncryptionProviderType) > 0 &&
+		helper.GetKubeAPIServerEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer) != currentEncryptionProviderType &&
 		(etcdEncryptionRotationPhase == gardencorev1beta1.RotationCompleted || len(etcdEncryptionRotationPhase) == 0) {
 		startRotationETCDEncryptionKey(garden, true, &now)
 	}

--- a/pkg/operator/webhook/defaulting/garden/handler.go
+++ b/pkg/operator/webhook/defaulting/garden/handler.go
@@ -10,7 +10,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	operatorv1alpha1helper "github.com/gardener/gardener/pkg/api/operator/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 )
@@ -53,17 +52,6 @@ func (h *Handler) Default(_ context.Context, obj runtime.Object) error {
 	}
 	if garden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig.Provider.Type == nil {
 		garden.Spec.VirtualCluster.Gardener.APIServer.EncryptionConfig.Provider.Type = garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer.EncryptionConfig.Provider.Type
-	}
-
-	if garden.Status.Credentials == nil {
-		garden.Status.Credentials = &operatorv1alpha1.Credentials{}
-	}
-	if garden.Status.Credentials.EncryptionAtRest == nil {
-		garden.Status.Credentials.EncryptionAtRest = &operatorv1alpha1.EncryptionAtRest{}
-	}
-
-	if len(garden.Status.Credentials.EncryptionAtRest.Provider.Type) == 0 {
-		garden.Status.Credentials.EncryptionAtRest.Provider.Type = operatorv1alpha1helper.GetKubeAPIServerEncryptionProviderType(garden.Spec.VirtualCluster.Kubernetes.KubeAPIServer)
 	}
 
 	return nil

--- a/pkg/operator/webhook/defaulting/garden/handler_test.go
+++ b/pkg/operator/webhook/defaulting/garden/handler_test.go
@@ -35,7 +35,6 @@ var _ = Describe("Handler", func() {
 		var (
 			defaultKubeAPIServerConfig   *operatorv1alpha1.KubeAPIServerConfig
 			defaultGardenAPIServerConfig *operatorv1alpha1.GardenerAPIServerConfig
-			defaultStatus                operatorv1alpha1.GardenStatus
 		)
 
 		BeforeEach(func() {
@@ -63,15 +62,6 @@ var _ = Describe("Handler", func() {
 					},
 				},
 			}
-			defaultStatus = operatorv1alpha1.GardenStatus{
-				Credentials: &operatorv1alpha1.Credentials{
-					EncryptionAtRest: &operatorv1alpha1.EncryptionAtRest{
-						Provider: operatorv1alpha1.EncryptionProviderStatus{
-							Type: gardencorev1beta1.EncryptionProviderTypeAESCBC,
-						},
-					},
-				},
-			}
 		})
 
 		It("should default all expected fields", func() {
@@ -95,7 +85,6 @@ var _ = Describe("Handler", func() {
 						},
 					},
 				},
-				Status: defaultStatus,
 			}))
 		})
 


### PR DESCRIPTION
/kind bug
/area security
/kind cleanup

Cherry pick of #14801 on release-v1.142.

#14801: Clean up `Shoot` encryption provider type sync

**Release Notes:**
```bugfix operator
A bug has been fixed where `Garden` resources would start encryption key rotation on creation.
```