### PR TITLE
Cleanup `TODO` and remove `delete-on-invalid-update` annotation from `node-local-dns` 

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -231,6 +231,12 @@ In order to properly follow-up with such TODOs and to prevent them from piling u
   ```
   The associated person should actively drive the implementation of the referenced issue (unless it cannot be done because of third-party dependencies or conditions) so that the TODO statement does not get stale.
 - TODO statements without actionable tasks or those that are unlikely to ever be implemented (maybe because of very low priorities) should not be specified in the first place. If a TODO is specified, the associated person should make sure to actively follow-up.
+- Some TODO statements accompany code that performs a one-time migration of resources deployed inside a `Shoot` cluster (for example, changing an immutable field of a workload managed by `gardener-resource-manager`).
+  Extra care is needed before following up on such TODOs, because a `Shoot` can stay hibernated for the entire planned timeframe of the TODO.
+  While a `Shoot` is hibernated, its `gardener-resource-manager` is scaled down to `0`, so the migration code never runs for that `Shoot`.
+  If the migration code is removed before the `Shoot` wakes up, the migration will never be performed, and the `Shoot`'s wake up can fail.
+  Therefore, before removing such a TODO and its associated code, or before deploying the gardener version where the code is removed, make sure that the migration has actually taken place for all `Shoot`s.
+  A common approach is to prepare a script that checks (and, if needed, enforces) that all `Shoot`s have adopted the migration, and to reference the required check as a prerequisite in the (breaking) release note so that operators can run it before updating to the gardener version in which the TODO is resolved.
 
 ### Deprecations and Backwards-Compatibility
 

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -401,9 +401,6 @@ status:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-local-dns-worker-aaaa",
 						Namespace: metav1.NamespaceSystem,
-						Annotations: map[string]string{
-							resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-						},
 						Labels: map[string]string{
 							labelKey:                                    labelValue,
 							v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -402,9 +402,6 @@ status:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "node-local-dns-worker-aaaa",
 						Namespace: metav1.NamespaceSystem,
-						Annotations: map[string]string{
-							resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-						},
 						Labels: map[string]string{
 							labelKey:                                    labelValue,
 							v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -161,13 +160,6 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-local-dns-" + worker.Name,
 				Namespace: metav1.NamespaceSystem,
-				Annotations: map[string]string{
-					// This annotation is required so that the new label selector that includes the worker's name,
-					// introduced with https://github.com/gardener/gardener/pull/14286, can be applied by GRM as
-					// the `spec.selector` field is immutable.
-					// TODO(plkokanov): Remove this annotation after v1.140 has been released.
-					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-				},
 				Labels: map[string]string{
 					labelKey:                                    nodelocaldnsconstants.LabelValue,
 					v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/networking/coredns"
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -161,13 +160,6 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "node-local-dns-" + poolName,
 				Namespace: metav1.NamespaceSystem,
-				Annotations: map[string]string{
-					// This annotation is required so that the new label selector that includes the worker's name,
-					// introduced with https://github.com/gardener/gardener/pull/14286, can be applied by GRM as
-					// the `spec.selector` field is immutable.
-					// TODO(plkokanov): Remove this annotation after v1.140 has been released.
-					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-				},
 				Labels: map[string]string{
 					labelKey:                                    nodelocaldnsconstants.LabelValue,
 					v1beta1constants.GardenRole:                 v1beta1constants.GardenRoleSystemComponent,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up a TODO that was added with https://github.com/gardener/gardener/pull/14286/ 

The `node-local-dns` Daemonset had the `delete-on-invalid-update` annotation due to changes in the label selector and pod template labels that were introduced in https://github.com/gardener/gardener/pull/14286/ 

Now that enough time has passed, this annotation can be dropped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @RadaBDimitrova 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `resources.gardener.cloud/delete-on-invalid-update=true` annotation was removed from the `node-local-dns` DaemonSet. The annotation was previously used due to changes in the label selector and pod template labels introduced in https://github.com/gardener/gardener/pull/14286. 
The `node-local-dns` is a DaemonSet installed in `Shoot` clusters via `ManagedResource`. For hibernated shoot clusters, the `gardener-resource-manager` is scaled to 0 and there is a chance that the changes to the labels were not applied.
Before upgrading to this `gardenlet` version, operators need to ensure that the changes to the labels were applied for all such clusters.
To do that, operators can compare the `generation` and `status.observedGeneration` of the `shoot-core-node-local-dns` `ManagedResource` with the script from [this gist](https://gist.github.com/plkokanov/513534e4502b70eea0241b57b14e4c28).
```
