### PR TITLE
fix: logs not ingested into VictoriaLogs in garden namespace

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -649,7 +649,7 @@ images:
     resourceId:
       name: fluent-bit-plugin
     sourceRepository: github.com/gardener/logging
-    repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-plugin
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin
     tag: "v1.6.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -649,8 +649,8 @@ images:
     resourceId:
       name: fluent-bit-plugin
     sourceRepository: github.com/gardener/logging
-    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin
-    tag: "v1.5.0"
+    repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-plugin
+    tag: "v1.6.0-dev-0fdbc7cf-dirty"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -650,7 +650,7 @@ images:
       name: fluent-bit-plugin
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-plugin
-    tag: "v1.6.0-dev-e8c8135c-dirty"
+    tag: "v1.6.0-dev-cc48ec38-dirty"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -650,7 +650,7 @@ images:
       name: fluent-bit-plugin
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-plugin
-    tag: "v1.6.0-dev-cc48ec38-dirty"
+    tag: "v1.6.0"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -650,7 +650,7 @@ images:
       name: fluent-bit-plugin
     sourceRepository: github.com/gardener/logging
     repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/fluent-bit-plugin
-    tag: "v1.6.0-dev-0fdbc7cf-dirty"
+    tag: "v1.6.0-dev-e8c8135c-dirty"
     labels:
       - name: 'gardener.cloud/cve-categorisation'
         value:

--- a/pkg/component/observability/logging/fluentbit/fluentbit.go
+++ b/pkg/component/observability/logging/fluentbit/fluentbit.go
@@ -506,6 +506,16 @@ func (f *fluentBit) getFluentBit() *fluentbitv1alpha2.FluentBit {
 					Resources: []string{"clusters"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					APIGroups: []string{"opentelemetry.io"},
+					Resources: []string{"opentelemetrycollectors"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
 			},
 			Service: fluentbitv1alpha2.FluentBitService{
 				Name:        v1beta1constants.DaemonSetNameFluentBit,

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
@@ -33,7 +33,6 @@ const (
 
 	// Plugin seed types
 	seedTypeOTLPGRPC = "otlp_grpc"
-	seedTypeNOOP     = "noop"
 
 	// Match patterns
 	matchJournald   = "journald.*"
@@ -138,27 +137,14 @@ QueueName ` + queueNameSeedJournald + `
 	}
 }
 
-// GetDynamicClusterOutput returns the dynamic fluent-bit-to-vali output used by the Fluent Operator
-// on a seed cluster (gardenlet path). On a seed there is no static ClusterOutput, so the
-// gardener-plugin's seedClient fallback is the route for non-`shoot-*` records (seed-system pods in
-// the `garden` namespace) — keep SeedType as otlp_grpc.
+// GetDynamicClusterOutput returns the dynamic fluent-bit-to-vali output used by the Fluent Operator.
+// On the gardenlet path (a seed without a co-located garden) there is no static ClusterOutput, so
+// the gardener-plugin's seedClient fallback is the route for non-`shoot-*` records (seed-system
+// pods in the `garden` namespace). On the operator path (garden runtime, including the seedIsGarden
+// scenario) this is the only ClusterOutput deployed for kubernetes.* records — the static
+// ClusterOutput is intentionally skipped there to avoid log duplication, and the seedClient
+// fallback ships garden-namespace records to the local OpenTelemetry Collector.
 func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
-	return getDynamicClusterOutput(labels, seedTypeOTLPGRPC)
-}
-
-// GetDynamicClusterOutputForOperator returns the dynamic fluent-bit-to-vali output used by the
-// Fluent Operator on the garden runtime cluster (gardener-operator path). It is identical to
-// GetDynamicClusterOutput except SeedType is `noop`: on the garden runtime cluster the static
-// ClusterOutput already ships every kubernetes.* record matching this output's filter, so the
-// gardener-plugin's seedClient fallback (used when DynamicHostRegex doesn't match the record's
-// namespace) would otherwise duplicate every garden runtime container record into the garden
-// OpenTelemetry Collector. The OTLP-off variant is unaffected (its underlying gardenervali plugin
-// already filters by `gardener.cloud/role:shoot` namespace label, so no fallback occurs).
-func GetDynamicClusterOutputForOperator(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
-	return getDynamicClusterOutput(labels, seedTypeNOOP)
-}
-
-func getDynamicClusterOutput(labels map[string]string, seedType string) *fluentbitv1alpha2.ClusterOutput {
 	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
 		return &fluentbitv1alpha2.ClusterOutput{
 			ObjectMeta: metav1.ObjectMeta{
@@ -171,7 +157,7 @@ func getDynamicClusterOutput(labels map[string]string, seedType string) *fluentb
 Match                     ` + matchKubernetes + `
 LogLevel                  error
 Retry_Limit               10
-SeedType                  ` + seedType + `
+SeedType                  ` + seedTypeOTLPGRPC + `
 ShootType                 otlp_grpc
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true
@@ -208,7 +194,7 @@ TagKey                    tag`,
 
 	// Legacy vali variant (OpenTelemetryCollector feature gate off): the gardenervali plugin filters
 	// records by the `gardener.cloud/role:shoot` namespace label before any seedClient fallback can
-	// run, so the seedType parameter is irrelevant on this branch.
+	// run.
 	return &fluentbitv1alpha2.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   outputNameVali,

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
@@ -234,7 +234,7 @@ DQueDir                   ` + dqueDir + `
 DQueName                  ` + dqueNameGarden + `
 Origin                    ` + originGarden + `
 HostnameValue             ${NODE_NAME}
-FallbackToTagWhenMetadataIsMissing false`,
+FallbackToTagWhenMetadataIsMissing true`,
 				},
 			},
 		}

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
@@ -31,6 +31,10 @@ const (
 	// Endpoints
 	endpointOTelCollector = "opentelemetry-collector-collector.garden.svc:4317"
 
+	// Plugin seed types
+	seedTypeOTLPGRPC = "otlp_grpc"
+	seedTypeNOOP     = "noop"
+
 	// Match patterns
 	matchJournald   = "journald.*"
 	matchSystemd    = "systemd.*"
@@ -100,7 +104,7 @@ func GetDefaultClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluste
 				CustomPlugin: &custom.CustomPlugin{
 					Config: `Name ` + pluginNameGardener + `
 Match                     ` + matchSystemd + `
-SeedType                  otlp_grpc
+SeedType                  ` + seedTypeOTLPGRPC + `
 LogLevel                  error
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true
@@ -134,8 +138,27 @@ QueueName ` + queueNameSeedJournald + `
 	}
 }
 
-// GetDynamicClusterOutput returns the dynamic fluent-bit-to-vali output used by the Fluent Operator.
+// GetDynamicClusterOutput returns the dynamic fluent-bit-to-vali output used by the Fluent Operator
+// on a seed cluster (gardenlet path). On a seed there is no static ClusterOutput, so the
+// gardener-plugin's seedClient fallback is the route for non-`shoot-*` records (seed-system pods in
+// the `garden` namespace) — keep SeedType as otlp_grpc.
 func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
+	return getDynamicClusterOutput(labels, seedTypeOTLPGRPC)
+}
+
+// GetDynamicClusterOutputForOperator returns the dynamic fluent-bit-to-vali output used by the
+// Fluent Operator on the garden runtime cluster (gardener-operator path). It is identical to
+// GetDynamicClusterOutput except SeedType is `noop`: on the garden runtime cluster the static
+// ClusterOutput already ships every kubernetes.* record matching this output's filter, so the
+// gardener-plugin's seedClient fallback (used when DynamicHostRegex doesn't match the record's
+// namespace) would otherwise duplicate every garden runtime container record into the garden
+// OpenTelemetry Collector. The OTLP-off variant is unaffected (its underlying gardenervali plugin
+// already filters by `gardener.cloud/role:shoot` namespace label, so no fallback occurs).
+func GetDynamicClusterOutputForOperator(labels map[string]string) *fluentbitv1alpha2.ClusterOutput {
+	return getDynamicClusterOutput(labels, seedTypeNOOP)
+}
+
+func getDynamicClusterOutput(labels map[string]string, seedType string) *fluentbitv1alpha2.ClusterOutput {
 	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
 		return &fluentbitv1alpha2.ClusterOutput{
 			ObjectMeta: metav1.ObjectMeta{
@@ -148,7 +171,7 @@ func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluste
 Match                     ` + matchKubernetes + `
 LogLevel                  error
 Retry_Limit               10
-SeedType                  otlp_grpc
+SeedType                  ` + seedType + `
 ShootType                 otlp_grpc
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true
@@ -183,6 +206,9 @@ TagKey                    tag`,
 		}
 	}
 
+	// Legacy vali variant (OpenTelemetryCollector feature gate off): the gardenervali plugin filters
+	// records by the `gardener.cloud/role:shoot` namespace label before any seedClient fallback can
+	// run, so the seedType parameter is irrelevant on this branch.
 	return &fluentbitv1alpha2.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   outputNameVali,
@@ -226,7 +252,7 @@ func GetStaticClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluster
 				CustomPlugin: &custom.CustomPlugin{
 					Config: `Name ` + pluginNameGardener + `
 Match                     ` + matchKubernetes + `
-SeedType                  otlp_grpc
+SeedType                  ` + seedTypeOTLPGRPC + `
 LogLevel                  error
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
@@ -31,9 +31,6 @@ const (
 	// Endpoints
 	endpointOTelCollector = "opentelemetry-collector-collector.garden.svc:4317"
 
-	// Plugin seed types
-	seedTypeOTLPGRPC = "otlp_grpc"
-
 	// Match patterns
 	matchJournald   = "journald.*"
 	matchSystemd    = "systemd.*"
@@ -103,7 +100,7 @@ func GetDefaultClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluste
 				CustomPlugin: &custom.CustomPlugin{
 					Config: `Name ` + pluginNameGardener + `
 Match                     ` + matchSystemd + `
-SeedType                  ` + seedTypeOTLPGRPC + `
+SeedType                  otlp_grpc
 LogLevel                  error
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true
@@ -157,7 +154,7 @@ func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluste
 Match                     ` + matchKubernetes + `
 LogLevel                  error
 Retry_Limit               10
-SeedType                  ` + seedTypeOTLPGRPC + `
+SeedType                  otlp_grpc
 ShootType                 otlp_grpc
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true
@@ -238,7 +235,7 @@ func GetStaticClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluster
 				CustomPlugin: &custom.CustomPlugin{
 					Config: `Name ` + pluginNameGardener + `
 Match                     ` + matchKubernetes + `
-SeedType                  ` + seedTypeOTLPGRPC + `
+SeedType                  otlp_grpc
 LogLevel                  error
 Endpoint                  ` + endpointOTelCollector + `
 Insecure                  true

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs.go
@@ -152,7 +152,7 @@ func GetDynamicClusterOutput(labels map[string]string) *fluentbitv1alpha2.Cluste
 				CustomPlugin: &custom.CustomPlugin{
 					Config: `Name ` + pluginNameGardener + `
 Match                     ` + matchKubernetes + `
-LogLevel                  error
+LogLevel                  info
 Retry_Limit               10
 SeedType                  otlp_grpc
 ShootType                 otlp_grpc

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
@@ -5,8 +5,6 @@
 package fluentcustomresources_test
 
 import (
-	"strings"
-
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/custom"
 	. "github.com/onsi/ginkgo/v2"
@@ -105,75 +103,6 @@ TagKey                    tag`,
 					},
 				},
 			))
-		})
-	})
-
-	Describe("#GetDynamicClusterOutputForOperator", func() {
-		var (
-			labels = map[string]string{"some-key": "some-value"}
-		)
-
-		It("should return the expected DynamicClusterOutput custom resources with SeedType=noop", func() {
-			fluentBitClusterOutputs := GetDynamicClusterOutputForOperator(labels)
-
-			Expect(fluentBitClusterOutputs).To(Equal(
-				&fluentbitv1alpha2.ClusterOutput{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "opentelemetry",
-						Labels: labels,
-					},
-					Spec: fluentbitv1alpha2.OutputSpec{
-						CustomPlugin: &custom.CustomPlugin{
-							Config: `Name gardener
-Match                     kubernetes.*
-LogLevel                  error
-Retry_Limit               10
-SeedType                  noop
-ShootType                 otlp_grpc
-Endpoint                  opentelemetry-collector-collector.garden.svc:4317
-Insecure                  true
-Timeout                   15m
-
-DynamicHostPath           {"kubernetes": {"namespace_name": "namespace"}}
-DynamicHostPrefix         opentelemetry-collector-collector.
-DynamicHostSuffix         .svc.cluster.local:4317
-DynamicHostRegex          ^shoot-
-
-DQueDir                   /var/fluentbit/dque
-DQueName                  dynamic
-DQueSync                  normal
-
-DQueBatchProcessorMaxQueueSize    15000
-DQueBatchProcessorMaxBatchSize    500
-DQueBatchProcessorExportInterval  1s
-DQueBatchProcessorExportTimeout   15m
-RetryEnabled              true
-RetryInitialInterval      1s
-RetryMaxInterval          5m
-RetryMaxElapsedTime       15m
-
-HostnameValue          ${NODE_NAME}
-Origin                 seed
-FallbackToTagWhenMetadataIsMissing true
-SendLogsToSeedWhenShootIsInHibernatedState false
-SendLogsToShootWhenIsInDeletionState false
-TagKey                    tag`,
-						},
-					},
-				},
-			))
-		})
-
-		It("should differ from GetDynamicClusterOutput only in the SeedType line", func() {
-			seed := GetDynamicClusterOutput(labels)
-			operator := GetDynamicClusterOutputForOperator(labels)
-
-			Expect(operator.ObjectMeta).To(Equal(seed.ObjectMeta))
-			Expect(operator.Spec.CustomPlugin.Config).To(ContainSubstring("SeedType                  noop"))
-			Expect(seed.Spec.CustomPlugin.Config).To(ContainSubstring("SeedType                  otlp_grpc"))
-			// Replacing the SeedType line in the operator config should yield the seed config.
-			normalized := strings.Replace(operator.Spec.CustomPlugin.Config, "SeedType                  noop", "SeedType                  otlp_grpc", 1)
-			Expect(normalized).To(Equal(seed.Spec.CustomPlugin.Config))
 		})
 	})
 

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
@@ -132,7 +132,7 @@ DQueDir                   /var/fluentbit/dque
 DQueName                  garden
 Origin                    garden
 HostnameValue             ${NODE_NAME}
-FallbackToTagWhenMetadataIsMissing false`,
+FallbackToTagWhenMetadataIsMissing true`,
 						},
 					},
 				},

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
@@ -5,6 +5,8 @@
 package fluentcustomresources_test
 
 import (
+	"strings"
+
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/custom"
 	. "github.com/onsi/ginkgo/v2"
@@ -103,6 +105,75 @@ TagKey                    tag`,
 					},
 				},
 			))
+		})
+	})
+
+	Describe("#GetDynamicClusterOutputForOperator", func() {
+		var (
+			labels = map[string]string{"some-key": "some-value"}
+		)
+
+		It("should return the expected DynamicClusterOutput custom resources with SeedType=noop", func() {
+			fluentBitClusterOutputs := GetDynamicClusterOutputForOperator(labels)
+
+			Expect(fluentBitClusterOutputs).To(Equal(
+				&fluentbitv1alpha2.ClusterOutput{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "opentelemetry",
+						Labels: labels,
+					},
+					Spec: fluentbitv1alpha2.OutputSpec{
+						CustomPlugin: &custom.CustomPlugin{
+							Config: `Name gardener
+Match                     kubernetes.*
+LogLevel                  error
+Retry_Limit               10
+SeedType                  noop
+ShootType                 otlp_grpc
+Endpoint                  opentelemetry-collector-collector.garden.svc:4317
+Insecure                  true
+Timeout                   15m
+
+DynamicHostPath           {"kubernetes": {"namespace_name": "namespace"}}
+DynamicHostPrefix         opentelemetry-collector-collector.
+DynamicHostSuffix         .svc.cluster.local:4317
+DynamicHostRegex          ^shoot-
+
+DQueDir                   /var/fluentbit/dque
+DQueName                  dynamic
+DQueSync                  normal
+
+DQueBatchProcessorMaxQueueSize    15000
+DQueBatchProcessorMaxBatchSize    500
+DQueBatchProcessorExportInterval  1s
+DQueBatchProcessorExportTimeout   15m
+RetryEnabled              true
+RetryInitialInterval      1s
+RetryMaxInterval          5m
+RetryMaxElapsedTime       15m
+
+HostnameValue          ${NODE_NAME}
+Origin                 seed
+FallbackToTagWhenMetadataIsMissing true
+SendLogsToSeedWhenShootIsInHibernatedState false
+SendLogsToShootWhenIsInDeletionState false
+TagKey                    tag`,
+						},
+					},
+				},
+			))
+		})
+
+		It("should differ from GetDynamicClusterOutput only in the SeedType line", func() {
+			seed := GetDynamicClusterOutput(labels)
+			operator := GetDynamicClusterOutputForOperator(labels)
+
+			Expect(operator.ObjectMeta).To(Equal(seed.ObjectMeta))
+			Expect(operator.Spec.CustomPlugin.Config).To(ContainSubstring("SeedType                  noop"))
+			Expect(seed.Spec.CustomPlugin.Config).To(ContainSubstring("SeedType                  otlp_grpc"))
+			// Replacing the SeedType line in the operator config should yield the seed config.
+			normalized := strings.Replace(operator.Spec.CustomPlugin.Config, "SeedType                  noop", "SeedType                  otlp_grpc", 1)
+			Expect(normalized).To(Equal(seed.Spec.CustomPlugin.Config))
 		})
 	})
 

--- a/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
+++ b/pkg/component/observability/logging/fluentcustomresources/cluster_outputs_test.go
@@ -67,7 +67,7 @@ FallbackToTagWhenMetadataIsMissing false`,
 						CustomPlugin: &custom.CustomPlugin{
 							Config: `Name gardener
 Match                     kubernetes.*
-LogLevel                  error
+LogLevel                  info
 Retry_Limit               10
 SeedType                  otlp_grpc
 ShootType                 otlp_grpc

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator.go
@@ -110,6 +110,11 @@ func (f *fluentOperator) Deploy(ctx context.Context) error {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
 					APIGroups: []string{"extensions.gardener.cloud"},
 					Resources: []string{"clusters"},
 					Verbs:     []string{"get", "list", "watch"},

--- a/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
+++ b/pkg/component/observability/logging/fluentoperator/fluentoperator_test.go
@@ -126,6 +126,11 @@ var _ = Describe("Fluent Operator", func() {
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
+					Verbs:     []string{"get", "list", "watch"},
+					APIGroups: []string{"apiextensions.k8s.io"},
+					Resources: []string{"customresourcedefinitions"},
+				},
+				{
 					APIGroups: []string{"extensions.gardener.cloud"},
 					Resources: []string{"clusters"},
 					Verbs:     []string{"get", "list", "watch"},

--- a/pkg/component/observability/opentelemetry/collector/collector_test.go
+++ b/pkg/component/observability/opentelemetry/collector/collector_test.go
@@ -740,6 +740,38 @@ var _ = Describe("OpenTelemetry Collector", func() {
 				getKubeRBACProxyClusterRoleBinding(),
 			))
 		})
+
+		It("should add the logs/victorialogs pipeline when VictoriaLogsBackend is enabled", func() {
+			values.VictoriaLogsBackend = true
+			component = New(c, namespace, values, fakeSecretManager)
+
+			Expect(component.Deploy(ctx)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(customResourcesManagedResource), customResourcesManagedResource)).To(Succeed())
+
+			tlsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "logging-tls",
+					Namespace: namespace,
+				},
+			}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(tlsSecret), tlsSecret)).To(Succeed())
+
+			openTelemetryCollector.Spec.Config.Service.Pipelines["logs/victorialogs"] = &otelv1beta1.Pipeline{
+				Exporters:  []string{"otlphttp/victorialogs"},
+				Receivers:  []string{"otlp"},
+				Processors: []string{"batch"},
+			}
+
+			Expect(customResourcesManagedResource).To(consistOf(
+				openTelemetryCollector,
+				getGateway(),
+				getVirtualService(),
+				getDestinationRule(),
+				getTLSSecret(tlsSecret),
+				serviceMonitor,
+				serviceAccount,
+			))
+		})
 	})
 
 	Describe("#Destroy", func() {

--- a/pkg/component/shared/fluent_custom_resources.go
+++ b/pkg/component/shared/fluent_custom_resources.go
@@ -13,13 +13,14 @@ import (
 )
 
 // NewFluentOperatorCustomResources instantiates a new `Fluent Operator Custom Resources` component.
+// Any number of ClusterOutputs may be passed; nil entries are skipped.
 func NewFluentOperatorCustomResources(
 	c client.Client,
 	gardenNamespaceName string,
 	enabled bool,
 	suffix string,
 	centralLoggingConfigurations []component.CentralLoggingConfiguration,
-	output *fluentbitv1alpha2.ClusterOutput,
+	extraOutputs ...*fluentbitv1alpha2.ClusterOutput,
 ) (
 	deployer component.DeployWaiter,
 	err error,
@@ -51,8 +52,10 @@ func NewFluentOperatorCustomResources(
 		}
 	}
 
-	if output != nil {
-		outputs = append(outputs, output)
+	for _, o := range extraOutputs {
+		if o != nil {
+			outputs = append(outputs, o)
+		}
 	}
 
 	deployer = fluentcustomresources.New(

--- a/pkg/component/shared/fluent_custom_resources.go
+++ b/pkg/component/shared/fluent_custom_resources.go
@@ -13,14 +13,13 @@ import (
 )
 
 // NewFluentOperatorCustomResources instantiates a new `Fluent Operator Custom Resources` component.
-// Any number of ClusterOutputs may be passed; nil entries are skipped.
 func NewFluentOperatorCustomResources(
 	c client.Client,
 	gardenNamespaceName string,
 	enabled bool,
 	suffix string,
 	centralLoggingConfigurations []component.CentralLoggingConfiguration,
-	extraOutputs ...*fluentbitv1alpha2.ClusterOutput,
+	output *fluentbitv1alpha2.ClusterOutput,
 ) (
 	deployer component.DeployWaiter,
 	err error,
@@ -52,10 +51,8 @@ func NewFluentOperatorCustomResources(
 		}
 	}
 
-	for _, o := range extraOutputs {
-		if o != nil {
-			outputs = append(outputs, o)
-		}
+	if output != nil {
+		outputs = append(outputs, output)
 	}
 
 	deployer = fluentcustomresources.New(

--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
-	"github.com/gardener/gardener/pkg/features"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
@@ -26,6 +25,7 @@ func NewOpenTelemetryCollector(
 	secretNameServerCA string,
 	clusterType component.ClusterType,
 	isGardenCluster bool,
+	victoriaLogsBackend bool,
 ) (
 	deployer collector.Interface,
 	err error,
@@ -53,7 +53,7 @@ func NewOpenTelemetryCollector(
 			PriorityClassName:       priorityClassName,
 			ClusterType:             clusterType,
 			IsGardenCluster:         isGardenCluster,
-			VictoriaLogsBackend:     features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
+			VictoriaLogsBackend:     victoriaLogsBackend,
 		},
 		secretsManager,
 	), nil

--- a/pkg/component/shared/opentelemetry_collector.go
+++ b/pkg/component/shared/opentelemetry_collector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/component/observability/opentelemetry/collector"
+	"github.com/gardener/gardener/pkg/features"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
 
@@ -52,6 +53,7 @@ func NewOpenTelemetryCollector(
 			PriorityClassName:       priorityClassName,
 			ClusterType:             clusterType,
 			IsGardenCluster:         isGardenCluster,
+			VictoriaLogsBackend:     features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
 		},
 		secretsManager,
 	), nil

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -839,7 +839,7 @@ func (r *Reconciler) newFluentCustomResources(seedIsGarden bool) (deployer compo
 	}
 
 	var output *fluentbitv1alpha2.ClusterOutput
-	if gardenlethelper.IsValiEnabled(&r.Config) {
+	if gardenlethelper.IsValiEnabled(&r.Config) || features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
 		output = fluentcustomresources.GetDynamicClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource})
 	}
 

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -970,6 +970,7 @@ func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Int
 		v1beta1constants.SecretNameCASeed,
 		component.ClusterTypeSeed,
 		seedIsGarden,
+		features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1419,13 +1419,18 @@ func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) 
 	// namespace records, seed-system pods). The static ClusterOutput is intentionally skipped — it
 	// would match the same kubernetes.* records and duplicate every garden runtime container log
 	// into the garden OpenTelemetry Collector.
+	output := fluentcustomresources.GetStaticClusterOutput(customResourcesLabels)
+	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
+		output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
+	}
+
 	return sharedcomponent.NewFluentOperatorCustomResources(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		true,
 		"-garden",
 		logging.GardenCentralLoggingConfigurations,
-		fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels),
+		output,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1410,13 +1411,23 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 }
 
 func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) {
+	customResourcesLabels := map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}
+	// In a garden-as-seed setup the gardenlet skips deploying the fluent-operator custom resources
+	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision both the
+	// static and the dynamic ClusterOutputs itself. The shape of the dynamic output (OTLP vs vali)
+	// is selected internally by GetDynamicClusterOutput based on the OpenTelemetryCollector feature
+	// gate, so it can be appended unconditionally.
+	outputs := []*fluentbitv1alpha2.ClusterOutput{
+		fluentcustomresources.GetStaticClusterOutput(customResourcesLabels),
+		fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels),
+	}
 	return sharedcomponent.NewFluentOperatorCustomResources(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		true,
 		"-garden",
 		logging.GardenCentralLoggingConfigurations,
-		fluentcustomresources.GetStaticClusterOutput(map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}),
+		outputs...,
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
@@ -1413,27 +1412,20 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) {
 	customResourcesLabels := map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}
 	// In a garden-as-seed setup the gardenlet skips deploying the fluent-operator custom resources
-	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision both the
-	// static and the dynamic ClusterOutputs itself. The shape of the dynamic output (OTLP vs vali)
-	// is selected internally by getDynamicClusterOutput based on the OpenTelemetryCollector feature
-	// gate, so it can be appended unconditionally.
-	//
-	// The dynamic ClusterOutput uses the operator-specific variant with SeedType=noop: on the garden
-	// runtime cluster the static ClusterOutput already ships every kubernetes.* record matching this
-	// output's filter, so the gardener-plugin's seedClient fallback (used when DynamicHostRegex
-	// doesn't match the record's namespace) would otherwise duplicate every garden runtime container
-	// record into the garden OpenTelemetry Collector.
-	outputs := []*fluentbitv1alpha2.ClusterOutput{
-		fluentcustomresources.GetStaticClusterOutput(customResourcesLabels),
-		fluentcustomresources.GetDynamicClusterOutputForOperator(customResourcesLabels),
-	}
+	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision the
+	// dynamic ClusterOutput itself. We deploy only the dynamic ClusterOutput (with the default
+	// SeedType=otlp_grpc): it ships shoot-namespace records via DynamicHostRegex and falls back to
+	// the local OpenTelemetry Collector via the seedClient route for everything else (garden-
+	// namespace records, seed-system pods). The static ClusterOutput is intentionally skipped — it
+	// would match the same kubernetes.* records and duplicate every garden runtime container log
+	// into the garden OpenTelemetry Collector.
 	return sharedcomponent.NewFluentOperatorCustomResources(
 		r.RuntimeClientSet.Client(),
 		r.GardenNamespace,
 		true,
 		"-garden",
 		logging.GardenCentralLoggingConfigurations,
-		outputs...,
+		fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels),
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -17,7 +17,6 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,7 +86,6 @@ import (
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
-	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -331,7 +329,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.fluentOperatorCustomResources, err = r.newFluentCustomResources(ctx)
+	c.fluentOperatorCustomResources, err = r.newFluentCustomResources()
 	if err != nil {
 		return
 	}
@@ -1411,33 +1409,12 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 	)
 }
 
-func (r *Reconciler) newFluentCustomResources(ctx context.Context) (component.DeployWaiter, error) {
+func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) {
 	customResourcesLabels := map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}
-	// In a garden-as-seed setup the gardenlet skips deploying the fluent-operator custom resources
-	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision the
-	// dynamic ClusterOutput itself. We deploy only the dynamic ClusterOutput (with the default
-	// SeedType=otlp_grpc): it ships shoot-namespace records via DynamicHostRegex and falls back to
-	// the local OpenTelemetry Collector via the seedClient route for everything else (garden-
-	// namespace records, seed-system pods). The static ClusterOutput is intentionally skipped — it
-	// would match the same kubernetes.* records and duplicate every garden runtime container log
-	// into the garden OpenTelemetry Collector.
+
 	output := fluentcustomresources.GetStaticClusterOutput(customResourcesLabels)
 	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
-		// When this runtime cluster is later promoted to a Seed (garden-as-seed),
-		// the gardenlet installs the extensions.gardener.cloud/v1alpha1.Cluster CRD,
-		// at which point we switch the ClusterOutput from its static form to the
-		// dynamic form (adding DynamicHost* fields). The dynamic form activates the
-		// fluent-bit gardener output plugin's Cluster reconciler, which requires that
-		// CRD; deploying it before the promotion crash-loops fluent-bit. The transition
-		// is picked up automatically via fluent-bit's hot-reload once the operator
-		// re-renders the ClusterOutput on a subsequent reconciliation.
-		clusterResourcesExist, err := kubernetesutils.ResourcesExist(ctx, r.RuntimeClientSet.Client(), &extensionsv1alpha1.ClusterList{}, operatorclient.RuntimeScheme)
-		if err != nil && !meta.IsNoMatchError(err) {
-			return nil, err
-		}
-		if clusterResourcesExist {
-			output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
-		}
+		output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
 	}
 
 	return sharedcomponent.NewFluentOperatorCustomResources(

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -17,6 +17,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +87,7 @@ import (
 	sharedcomponent "github.com/gardener/gardener/pkg/component/shared"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
+	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -329,7 +331,7 @@ func (r *Reconciler) instantiateComponents(
 	if err != nil {
 		return
 	}
-	c.fluentOperatorCustomResources, err = r.newFluentCustomResources()
+	c.fluentOperatorCustomResources, err = r.newFluentCustomResources(ctx)
 	if err != nil {
 		return
 	}
@@ -1409,7 +1411,7 @@ func (r *Reconciler) newFluentBit() (component.DeployWaiter, error) {
 	)
 }
 
-func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) {
+func (r *Reconciler) newFluentCustomResources(ctx context.Context) (component.DeployWaiter, error) {
 	customResourcesLabels := map[string]string{v1beta1constants.LabelKeyCustomLoggingResource: v1beta1constants.LabelValueCustomLoggingResource}
 	// In a garden-as-seed setup the gardenlet skips deploying the fluent-operator custom resources
 	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision the
@@ -1421,7 +1423,21 @@ func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) 
 	// into the garden OpenTelemetry Collector.
 	output := fluentcustomresources.GetStaticClusterOutput(customResourcesLabels)
 	if features.DefaultFeatureGate.Enabled(features.OpenTelemetryCollector) {
-		output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
+		// When this runtime cluster is later promoted to a Seed (garden-as-seed),
+		// the gardenlet installs the extensions.gardener.cloud/v1alpha1.Cluster CRD,
+		// at which point we switch the ClusterOutput from its static form to the
+		// dynamic form (adding DynamicHost* fields). The dynamic form activates the
+		// fluent-bit gardener output plugin's Cluster reconciler, which requires that
+		// CRD; deploying it before the promotion crash-loops fluent-bit. The transition
+		// is picked up automatically via fluent-bit's hot-reload once the operator
+		// re-renders the ClusterOutput on a subsequent reconciliation.
+		gardenIsSeed, err := kubernetesutils.ResourcesExist(ctx, r.RuntimeClientSet.Client(), &extensionsv1alpha1.ClusterList{}, operatorclient.RuntimeScheme)
+		if err != nil && !meta.IsNoMatchError(err) {
+			return nil, err
+		}
+		if gardenIsSeed {
+			output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
+		}
 	}
 
 	return sharedcomponent.NewFluentOperatorCustomResources(

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1726,6 +1726,7 @@ func (r *Reconciler) newOpenTelemetryCollector(secretsManager secretsmanager.Int
 		operatorv1alpha1.SecretNameCARuntime,
 		component.ClusterTypeSeed,
 		true,
+		features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend),
 	)
 }
 

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1431,11 +1431,11 @@ func (r *Reconciler) newFluentCustomResources(ctx context.Context) (component.De
 		// CRD; deploying it before the promotion crash-loops fluent-bit. The transition
 		// is picked up automatically via fluent-bit's hot-reload once the operator
 		// re-renders the ClusterOutput on a subsequent reconciliation.
-		gardenIsSeed, err := kubernetesutils.ResourcesExist(ctx, r.RuntimeClientSet.Client(), &extensionsv1alpha1.ClusterList{}, operatorclient.RuntimeScheme)
+		clusterResourcesExist, err := kubernetesutils.ResourcesExist(ctx, r.RuntimeClientSet.Client(), &extensionsv1alpha1.ClusterList{}, operatorclient.RuntimeScheme)
 		if err != nil && !meta.IsNoMatchError(err) {
 			return nil, err
 		}
-		if gardenIsSeed {
+		if clusterResourcesExist {
 			output = fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels)
 		}
 	}

--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1415,11 +1415,17 @@ func (r *Reconciler) newFluentCustomResources() (component.DeployWaiter, error) 
 	// In a garden-as-seed setup the gardenlet skips deploying the fluent-operator custom resources
 	// (see reconciler_reconcile.go: SkipIf: seedIsGarden), so the operator must provision both the
 	// static and the dynamic ClusterOutputs itself. The shape of the dynamic output (OTLP vs vali)
-	// is selected internally by GetDynamicClusterOutput based on the OpenTelemetryCollector feature
+	// is selected internally by getDynamicClusterOutput based on the OpenTelemetryCollector feature
 	// gate, so it can be appended unconditionally.
+	//
+	// The dynamic ClusterOutput uses the operator-specific variant with SeedType=noop: on the garden
+	// runtime cluster the static ClusterOutput already ships every kubernetes.* record matching this
+	// output's filter, so the gardener-plugin's seedClient fallback (used when DynamicHostRegex
+	// doesn't match the record's namespace) would otherwise duplicate every garden runtime container
+	// record into the garden OpenTelemetry Collector.
 	outputs := []*fluentbitv1alpha2.ClusterOutput{
 		fluentcustomresources.GetStaticClusterOutput(customResourcesLabels),
-		fluentcustomresources.GetDynamicClusterOutput(customResourcesLabels),
+		fluentcustomresources.GetDynamicClusterOutputForOperator(customResourcesLabels),
 	}
 	return sharedcomponent.NewFluentOperatorCustomResources(
 		r.RuntimeClientSet.Client(),

--- a/pkg/operator/features/features.go
+++ b/pkg/operator/features/features.go
@@ -22,6 +22,10 @@ func RegisterFeatureGates() {
 		features.PrometheusHealthChecks,
 		features.RemoveVali,
 		features.DisableNginxIngressInGarden,
+		// OpenTelemetryCollector is registered here so the operator can wire the
+		// OTel→VictoriaLogs pipeline (see newFluentCustomResources). This also
+		// flips the garden fluent-bit init image and the static ClusterOutput to
+		// the OTLP path; see #13961 for the rollout context.
 		features.OpenTelemetryCollector,
 	)))
 }

--- a/pkg/operator/features/features.go
+++ b/pkg/operator/features/features.go
@@ -22,5 +22,6 @@ func RegisterFeatureGates() {
 		features.PrometheusHealthChecks,
 		features.RemoveVali,
 		features.DisableNginxIngressInGarden,
+		features.OpenTelemetryCollector,
 	)))
 }

--- a/pkg/operator/features/features.go
+++ b/pkg/operator/features/features.go
@@ -25,7 +25,7 @@ func RegisterFeatureGates() {
 		// OpenTelemetryCollector is registered here so the operator can wire the
 		// OTel→VictoriaLogs pipeline (see newFluentCustomResources). This also
 		// flips the garden fluent-bit init image and the static ClusterOutput to
-		// the OTLP path; see #13961 for the rollout context.
+		// the OTLP path; see https://github.com/gardener/gardener/pull/13961 for the rollout context.
 		features.OpenTelemetryCollector,
 	)))
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Logs were not being ingested into the VictoriaLogs instance in the garden namespace, even though both VictoriaLogs and the OpenTelemetry collector were deployed and healthy. Only Vali received logs — and only via fluent-bit pushing directly to it, bypassing the OTel collector entirely. The reasons for that are:
- OpenTelemetryCollector feature gate was never registered for gardener-operator
- VictoriaLogsBackend was hard-coded off when constructing the collector

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where no logs were ingested in VictoriaLogs when `OpenTelemetryCollector` & `VictoriaLogsBackend` feature flags were enabled. To facilitate the fix, the `OpenTelemetryCollector` feature flag is now also defined on the `gardener-operator` and enabled by default.
```
