### PR TITLE
local-setup: ipv6 dns resolver for macos

### DIFF
--- a/dev-setup/infra.sh
+++ b/dev-setup/infra.sh
@@ -131,11 +131,13 @@ EOF
       fi
 
       if [[ "$OSTYPE" == "darwin"* ]]; then
-        local desired_resolver_config="nameserver $dns_ip"
-        if ! grep -q "$desired_resolver_config" /etc/resolver/local.gardener.cloud ; then
+        if ! grep -q "$dns_ip" /etc/resolver/local.gardener.cloud || ! grep -q "$dns_ipv6" /etc/resolver/local.gardener.cloud ; then
           echo "Configuring macOS to resolve the local.gardener.cloud zone using the local setup's DNS server"
           ${SUDO}mkdir -p /etc/resolver
-          echo "$desired_resolver_config" | ${SUDO}tee /etc/resolver/local.gardener.cloud
+          cat <<EOF | ${SUDO}tee /etc/resolver/local.gardener.cloud
+nameserver $dns_ipv6
+nameserver $dns_ip
+EOF
         fi
       elif [[ "$OSTYPE" == "linux"* && -f /etc/systemd/resolved.conf ]]; then
         if [[ ! -d /etc/systemd/resolved.conf.d ]]; then


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Use both IPv6 and IPv4 IPs of the local dns server in MacOS resolver config.

In my setup with VPN connectivity only the IPv6 server works. Having both nameservers configured allows to have a fallthrough mechanism if one of the both IPs do not work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @cerealsnow @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
