### PR TITLE
Allow blackbox exporter in the runtime cluster access to private networks

### DIFF
--- a/pkg/operator/controller/garden/garden/components.go
+++ b/pkg/operator/controller/garden/garden/components.go
@@ -1643,8 +1643,9 @@ func (r *Reconciler) newBlackboxExporter(garden *operatorv1alpha1.Garden, secret
 			IsGardenCluster: true,
 			VPAEnabled:      true,
 			PodLabels: map[string]string{
-				v1beta1constants.LabelNetworkPolicyToPublicNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-				v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
+				v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(v1beta1constants.LabelNetworkPolicyIstioIngressNamespaceAlias+"-"+v1beta1constants.DefaultSNIIngressServiceName, 9443): v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(gardenerapiserver.DeploymentName, 8443):                                                                                v1beta1constants.LabelNetworkPolicyAllowed,
 				gardenerutils.NetworkPolicyLabel(gardenerdiscoveryserver.ServiceName, 8081):                                                                             v1beta1constants.LabelNetworkPolicyAllowed,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This is only relevant for the local setup. After

- https://github.com/gardener/gardener/pull/14415

the local setup deploys load balancers as docker containers that serve the istio ingresses and listen on private IPs. Therefore, the blackbox exporter in the runtime cluster needs private network access so that HTTP probes against the virtual cluster and dashboard ingresses work. 

**Special notes for your reviewer**:

/cc @rickardsjp @chrkl @istvanballok 

**Release note**:

```other operator
The blackbox exporter in the runtime cluster is granted access to private networks. This is only relevant for the local setup, where the istio ingresses are deployed in a docker container listening on private IPs.
```
