### PR TITLE
fix: prevent unbound variable error on empty array expansion in `wait-for.sh`

### DIFF
--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -54,7 +54,8 @@ while [ "${retries}" -lt "${TIMEOUT}" ]; do
   fi
 
   # Check the status of each condition
-  for condition in "${CONDITIONS[@]}"; do
+  for condition in "${CONDITIONS[@]:-}"; do
+    [ -z "$condition" ] && continue
     if ! echo "${CONDITION_STATES}" | yq -e '.[] | select(.type == "'"${condition}"'").status == "True"' &>/dev/null; then
       ALL_CONDITIONS_TRUE=false
       break

--- a/hack/usage/wait-for.sh
+++ b/hack/usage/wait-for.sh
@@ -54,8 +54,7 @@ while [ "${retries}" -lt "${TIMEOUT}" ]; do
   fi
 
   # Check the status of each condition
-  for condition in "${CONDITIONS[@]:-}"; do
-    [ -z "$condition" ] && continue
+  for condition in ${CONDITIONS[@]+"${CONDITIONS[@]}"}; do
     if ! echo "${CONDITION_STATES}" | yq -e '.[] | select(.type == "'"${condition}"'").status == "True"' &>/dev/null; then
       ALL_CONDITIONS_TRUE=false
       break


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
If you're running Bash older than version 4.4, you may encounter the following error when executing `hack/usage/wait-for.sh`:
```bash
bash dev-setup/../hack/usage/wait-for.sh: line 71: CONDITIONS[@]: unbound variable
```
This happens because older versions of Bash treat an empty array as unset, causing `set -o nounset` to trigger an error when the array is expanded. After Bash 4.4 this issue is fixed as described [here](https://tiswww.case.edu/php/chet/bash/CHANGES):
> a.  Using ${a[@]} or ${a[*]} with an array without any assigned elements when
>     the nounset option is enabled no longer throws an unbound variable error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Update `hack/usage/wait-for.sh` to handle empty arrays gracefully in older Bash versions, preventing an unbound variable error.
```
