### PR TITLE
Fix Authenticationconfig validation not including advertised SA issuer

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
+++ b/pkg/admissioncontroller/webhook/admission/auditpolicy/add.go
@@ -5,6 +5,8 @@
 package auditpolicy
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -52,6 +54,6 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 	}
 }
 
-func admitConfig(auditPolicyRaw string, _ []*gardencore.Shoot) (int32, error) {
+func admitConfig(_ context.Context, auditPolicyRaw string, _ []*gardencore.Shoot) (int32, error) {
 	return configvalidator.AdmitAuditPolicy(auditPolicyRaw)
 }

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
@@ -207,7 +207,8 @@ func getIssuersFromShoot(shoot *gardencore.Shoot) []string {
 
 	for _, addr := range shoot.Status.AdvertisedAddresses {
 		switch addr.Name {
-		case v1beta1constants.AdvertisedAddressInternal,
+		case v1beta1constants.AdvertisedAddressServiceAccountIssuer,
+			v1beta1constants.AdvertisedAddressInternal,
 			v1beta1constants.AdvertisedAddressExternal:
 			issuers = append(issuers, addr.URL)
 		}

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
@@ -24,6 +24,7 @@ import (
 
 	gardencorehelper "github.com/gardener/gardener/pkg/api/core/helper"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/webhook/configvalidator"
 )
 
@@ -118,6 +119,13 @@ func getIssuersFromShoot(shoot *gardencore.Shoot) []string {
 	issuers = append(issuers, gardencorehelper.GetShootServiceAccountConfigAcceptedIssuers(shoot.Spec.Kubernetes.KubeAPIServer)...)
 	if issuer := gardencorehelper.GetShootServiceAccountConfigIssuer(shoot.Spec.Kubernetes.KubeAPIServer); issuer != nil {
 		issuers = append(issuers, *issuer)
+	}
+
+	for _, addr := range shoot.Status.AdvertisedAddresses {
+		if addr.Name == v1beta1constants.AdvertisedAddressServiceAccountIssuer {
+			issuers = append(issuers, addr.URL)
+			break
+		}
 	}
 
 	return issuers

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add.go
@@ -5,12 +5,15 @@
 package authenticationconfig
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/apis/apiserver"
@@ -25,6 +28,7 @@ import (
 	gardencorehelper "github.com/gardener/gardener/pkg/api/core/helper"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/webhook/configvalidator"
 )
 
@@ -52,6 +56,7 @@ func AddToManager(mgr manager.Manager) error {
 
 // NewHandler returns a new handler for validating authentication configuration.
 func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission.Handler {
+	h := &handler{apiReader: apiReader}
 	return &configvalidator.Handler{
 		APIReader: apiReader,
 		Client:    c,
@@ -63,13 +68,20 @@ func NewHandler(apiReader, c client.Reader, decoder admission.Decoder) admission
 			return gardencorehelper.GetShootAuthenticationConfigurationConfigMapName(shoot.Spec.Kubernetes.KubeAPIServer)
 		},
 		SkipValidationOnShootUpdate: func(shoot, oldShoot *gardencore.Shoot) bool {
+			if gardencorehelper.HasManagedIssuer(shoot) != gardencorehelper.HasManagedIssuer(oldShoot) {
+				return false
+			}
 			if !gardencorehelper.IsLegacyAnonymousAuthenticationSet(oldShoot.Spec.Kubernetes.KubeAPIServer) && gardencorehelper.IsLegacyAnonymousAuthenticationSet(shoot.Spec.Kubernetes.KubeAPIServer) {
 				return false // Don't skip validation when the deprecated anonymous authentication is being set.
 			}
 			return sets.New(getIssuersFromShoot(shoot)...).Equal(sets.New(getIssuersFromShoot(oldShoot)...))
 		},
-		AdmitConfig: admitConfig,
+		AdmitConfig: h.admitConfig,
 	}
+}
+
+type handler struct {
+	apiReader client.Reader
 }
 
 var decoder runtime.Decoder
@@ -81,7 +93,7 @@ func init() {
 	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 }
 
-func admitConfig(authenticationConfigurationRaw string, shoots []*gardencore.Shoot) (int32, error) {
+func (h *handler) admitConfig(ctx context.Context, authenticationConfigurationRaw string, shoots []*gardencore.Shoot) (int32, error) {
 	obj, schemaVersion, err := decoder.Decode([]byte(authenticationConfigurationRaw), nil, nil)
 	if err != nil {
 		return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided authentication configuration: %w", err)
@@ -92,7 +104,12 @@ func admitConfig(authenticationConfigurationRaw string, shoots []*gardencore.Sho
 		return http.StatusInternalServerError, fmt.Errorf("failed to cast to authentication configuration type: %v", schemaVersion)
 	}
 
-	if errList := apiservervalidation.ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), authenticationConfig, getDisallowedIssuers(shoots)); len(errList) != 0 {
+	disallowedIssuers, err := h.getDisallowedIssuers(ctx, shoots)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	if errList := apiservervalidation.ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), authenticationConfig, disallowedIssuers); len(errList) != 0 {
 		return http.StatusUnprocessableEntity, fmt.Errorf("provided invalid authentication configuration: %v", errList)
 	}
 
@@ -105,12 +122,79 @@ func admitConfig(authenticationConfigurationRaw string, shoots []*gardencore.Sho
 	return 0, nil
 }
 
-func getDisallowedIssuers(shoots []*gardencore.Shoot) []string {
+func (h *handler) getDisallowedIssuers(ctx context.Context, shoots []*gardencore.Shoot) ([]string, error) {
 	var disallowedIssuers []string
 	for _, shoot := range shoots {
 		disallowedIssuers = append(disallowedIssuers, getIssuersFromShoot(shoot)...)
 	}
-	return disallowedIssuers
+
+	computedIssuers, err := h.computeManagedIssuers(ctx, shoots)
+	if err != nil {
+		return nil, err
+	}
+	disallowedIssuers = append(disallowedIssuers, computedIssuers...)
+
+	return disallowedIssuers, nil
+}
+
+func (h *handler) computeManagedIssuers(ctx context.Context, shoots []*gardencore.Shoot) ([]string, error) {
+	var managedShoots []*gardencore.Shoot
+	for _, shoot := range shoots {
+		if gardencorehelper.HasManagedIssuer(shoot) && shoot.UID != "" {
+			managedShoots = append(managedShoots, shoot)
+		}
+	}
+
+	if len(managedShoots) == 0 {
+		return nil, nil
+	}
+
+	hostname, err := h.getServiceAccountIssuerHostname(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if hostname == "" {
+		return nil, nil
+	}
+
+	var issuers []string
+	for _, shoot := range managedShoots {
+		projectName, err := h.getProjectName(ctx, shoot.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		if projectName == "" {
+			continue
+		}
+		issuers = append(issuers, gardenerutils.ComputeManagedServiceAccountIssuerURL(hostname, projectName, string(shoot.UID)))
+	}
+
+	return issuers, nil
+}
+
+func (h *handler) getServiceAccountIssuerHostname(ctx context.Context) (string, error) {
+	secretList := &corev1.SecretList{}
+	if err := h.apiReader.List(ctx, secretList,
+		client.InNamespace(v1beta1constants.GardenNamespace),
+		client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer},
+	); err != nil {
+		return "", fmt.Errorf("failed to list service account issuer secrets: %w", err)
+	}
+
+	if len(secretList.Items) == 0 {
+		return "", nil
+	}
+
+	return string(secretList.Items[0].Data["hostname"]), nil
+}
+
+func (h *handler) getProjectName(ctx context.Context, namespace string) (string, error) {
+	ns := &corev1.Namespace{}
+	if err := h.apiReader.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		return "", fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+	}
+
+	return ns.Labels[v1beta1constants.ProjectName], nil
 }
 
 func getIssuersFromShoot(shoot *gardencore.Shoot) []string {
@@ -122,9 +206,10 @@ func getIssuersFromShoot(shoot *gardencore.Shoot) []string {
 	}
 
 	for _, addr := range shoot.Status.AdvertisedAddresses {
-		if addr.Name == v1beta1constants.AdvertisedAddressServiceAccountIssuer {
+		switch addr.Name {
+		case v1beta1constants.AdvertisedAddressInternal,
+			v1beta1constants.AdvertisedAddressExternal:
 			issuers = append(issuers, addr.URL)
-			break
 		}
 	}
 

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhook/admission/authenticationconfig"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
@@ -127,6 +128,21 @@ jwt:
     username:
       claim: username
       prefix: "abc:"
+`
+
+		managedIssuerAuthenticationConfiguration = `
+---
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://managed.example.com/projects/my-project/shoots/some-uid/issuer
+    audiences:
+    - example-client-id
+  claimMappings:
+    username:
+      claim: username
+      prefix: "managed:"
 `
 
 		anonymousAuthenticationConfiguration = `
@@ -303,6 +319,22 @@ anonymous:
 				newShoot.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = new(true)
 				test(admissionv1.Update, shootv1beta1, newShoot, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 			})
+
+			It("references a valid authenticationConfiguration when the service account issuer advertised address uses a different URL (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": validAuthenticationConfiguration},
+				})).To(Succeed())
+				shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: v1beta1constants.AdvertisedAddressServiceAccountIssuer,
+							URL:  "https://api.my-shoot.my-project.example.com",
+						},
+					},
+				}
+				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
+			})
 		})
 
 		Context("Deny", func() {
@@ -354,6 +386,22 @@ anonymous:
 					Data:       map[string]string{"config.yaml": invalidIssuerUrl},
 				})).To(Succeed())
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://abc.com\": URL must not overlap with disallowed issuers:", "")
+			})
+
+			It("contains service account issuer from status advertised addresses in the authentication configuration", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": managedIssuerAuthenticationConfiguration},
+				})).To(Succeed())
+				shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: v1beta1constants.AdvertisedAddressServiceAccountIssuer,
+							URL:  "https://managed.example.com/projects/my-project/shoots/some-uid/issuer",
+						},
+					},
+				}
+				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://managed.example.com/projects/my-project/shoots/some-uid/issuer\": URL must not overlap with disallowed issuers:", "")
 			})
 
 			It("enables legacy anonymous authentication on the kube-apiserver when anonymous authentication configuration is already present", func() {
@@ -456,6 +504,23 @@ anonymous:
 					newCm.Data["config.yaml"] = invalidIssuerUrl
 
 					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://abc.com\": URL must not overlap with disallowed issuers:", "")
+				})
+
+				It("contains service account issuer from status advertised addresses in the authentication configuration", func() {
+					shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+						AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+							{
+								Name: v1beta1constants.AdvertisedAddressServiceAccountIssuer,
+								URL:  "https://managed.example.com/projects/my-project/shoots/some-uid/issuer",
+							},
+						},
+					}
+					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
+
+					newCm := cm.DeepCopy()
+					newCm.Data["config.yaml"] = managedIssuerAuthenticationConfiguration
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://managed.example.com/projects/my-project/shoots/some-uid/issuer\": URL must not overlap with disallowed issuers:", "")
 				})
 
 				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {

--- a/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
+++ b/pkg/admissioncontroller/webhook/admission/authenticationconfig/add_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -143,6 +144,51 @@ jwt:
     username:
       claim: username
       prefix: "managed:"
+`
+
+		computedManagedIssuerAuthenticationConfiguration = `
+---
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://issuer.example.com/projects/test-project/shoots/test-shoot-uid/issuer
+    audiences:
+    - example-client-id
+  claimMappings:
+    username:
+      claim: username
+      prefix: "managed:"
+`
+
+		defaultIssuerAuthenticationConfiguration = `
+---
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://api.fake-shoot-name.test-project.internal.example.com
+    audiences:
+    - example-client-id
+  claimMappings:
+    username:
+      claim: username
+      prefix: "default:"
+`
+
+		externalIssuerAuthenticationConfiguration = `
+---
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://api.fake-shoot-name.test-project.external.example.com
+    audiences:
+    - example-client-id
+  claimMappings:
+    username:
+      claim: username
+      prefix: "default:"
 `
 
 		anonymousAuthenticationConfiguration = `
@@ -335,6 +381,72 @@ anonymous:
 				}
 				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
 			})
+
+			It("allows auth config with managed issuer URL when shoot has no UID yet (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   shootNamespace,
+						Labels: map[string]string{v1beta1constants.ProjectName: "test-project"},
+					},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot-service-account-issuer",
+						Namespace: v1beta1constants.GardenNamespace,
+						Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer},
+					},
+					Data: map[string][]byte{"hostname": []byte("issuer.example.com")},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": computedManagedIssuerAuthenticationConfiguration},
+				})).To(Succeed())
+
+				shootv1beta1.Annotations = map[string]string{v1beta1constants.AnnotationAuthenticationIssuer: v1beta1constants.AnnotationAuthenticationIssuerManaged}
+				// No UID set - computed issuer should be skipped
+				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
+			})
+
+			It("allows auth config with different URL when shoot has managed issuer (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   shootNamespace,
+						Labels: map[string]string{v1beta1constants.ProjectName: "test-project"},
+					},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot-service-account-issuer",
+						Namespace: v1beta1constants.GardenNamespace,
+						Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer},
+					},
+					Data: map[string][]byte{"hostname": []byte("issuer.example.com")},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": validAuthenticationConfiguration},
+				})).To(Succeed())
+
+				shootv1beta1.UID = types.UID("test-shoot-uid")
+				shootv1beta1.Annotations = map[string]string{v1beta1constants.AnnotationAuthenticationIssuer: v1beta1constants.AnnotationAuthenticationIssuerManaged}
+				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
+			})
+
+			It("allows auth config when the default issuer URL is not used (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": validAuthenticationConfiguration},
+				})).To(Succeed())
+				shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: v1beta1constants.AdvertisedAddressInternal,
+							URL:  "https://api.fake-shoot-name.test-project.internal.example.com",
+						},
+					},
+				}
+				test(admissionv1.Create, nil, shootv1beta1, true, statusCodeAllowed, "referenced authentication configuration is valid", "")
+			})
 		})
 
 		Context("Deny", func() {
@@ -402,6 +514,63 @@ anonymous:
 					},
 				}
 				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://managed.example.com/projects/my-project/shoots/some-uid/issuer\": URL must not overlap with disallowed issuers:", "")
+			})
+
+			It("denies authentication configuration containing the computed managed issuer URL (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   shootNamespace,
+						Labels: map[string]string{v1beta1constants.ProjectName: "test-project"},
+					},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot-service-account-issuer",
+						Namespace: v1beta1constants.GardenNamespace,
+						Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer},
+					},
+					Data: map[string][]byte{"hostname": []byte("issuer.example.com")},
+				})).To(Succeed())
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": computedManagedIssuerAuthenticationConfiguration},
+				})).To(Succeed())
+
+				shootv1beta1.UID = types.UID("test-shoot-uid")
+				shootv1beta1.Annotations = map[string]string{v1beta1constants.AnnotationAuthenticationIssuer: v1beta1constants.AnnotationAuthenticationIssuerManaged}
+				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://issuer.example.com/projects/test-project/shoots/test-shoot-uid/issuer\": URL must not overlap with disallowed issuers:", "")
+			})
+
+			It("denies authentication configuration containing the default issuer URL from internal advertised address (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": defaultIssuerAuthenticationConfiguration},
+				})).To(Succeed())
+				shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: v1beta1constants.AdvertisedAddressInternal,
+							URL:  "https://api.fake-shoot-name.test-project.internal.example.com",
+						},
+					},
+				}
+				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://api.fake-shoot-name.test-project.internal.example.com\": URL must not overlap with disallowed issuers:", "")
+			})
+
+			It("denies authentication configuration containing the default issuer URL from external advertised address (CREATE)", func() {
+				Expect(fakeClient.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: shootNamespace},
+					Data:       map[string]string{"config.yaml": externalIssuerAuthenticationConfiguration},
+				})).To(Succeed())
+				shootv1beta1.Status = gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: v1beta1constants.AdvertisedAddressExternal,
+							URL:  "https://api.fake-shoot-name.test-project.external.example.com",
+						},
+					},
+				}
+				test(admissionv1.Create, nil, shootv1beta1, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://api.fake-shoot-name.test-project.external.example.com\": URL must not overlap with disallowed issuers:", "")
 			})
 
 			It("enables legacy anonymous authentication on the kube-apiserver when anonymous authentication configuration is already present", func() {
@@ -521,6 +690,32 @@ anonymous:
 					newCm.Data["config.yaml"] = managedIssuerAuthenticationConfiguration
 
 					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://managed.example.com/projects/my-project/shoots/some-uid/issuer\": URL must not overlap with disallowed issuers:", "")
+				})
+
+				It("denies ConfigMap update with computed managed issuer URL", func() {
+					Expect(fakeClient.Create(ctx, &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   shootNamespace,
+							Labels: map[string]string{v1beta1constants.ProjectName: "test-project"},
+						},
+					})).To(Succeed())
+					Expect(fakeClient.Create(ctx, &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "shoot-service-account-issuer",
+							Namespace: v1beta1constants.GardenNamespace,
+							Labels:    map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleShootServiceAccountIssuer},
+						},
+						Data: map[string][]byte{"hostname": []byte("issuer.example.com")},
+					})).To(Succeed())
+
+					shootv1beta1.UID = types.UID("test-shoot-uid")
+					shootv1beta1.Annotations = map[string]string{v1beta1constants.AnnotationAuthenticationIssuer: v1beta1constants.AnnotationAuthenticationIssuerManaged}
+					Expect(fakeClient.Update(ctx, shootv1beta1)).To(Succeed())
+
+					newCm := cm.DeepCopy()
+					newCm.Data["config.yaml"] = computedManagedIssuerAuthenticationConfiguration
+
+					test(admissionv1.Update, cm, newCm, false, statusCodeInvalid, "provided invalid authentication configuration: [jwt[0].issuer.url: Invalid value: \"https://issuer.example.com/projects/test-project/shoots/test-shoot-uid/issuer\": URL must not overlap with disallowed issuers:", "")
 				})
 
 				It("uses anonymous authentication and has the legacy kube-apiserver setting already enabled", func() {

--- a/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
+++ b/pkg/admissioncontroller/webhook/admission/authorizationconfig/add.go
@@ -5,6 +5,7 @@
 package authorizationconfig
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"slices"
@@ -79,7 +80,7 @@ func init() {
 	decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 }
 
-func admitConfig(authorizationConfigurationRaw string, shoots []*gardencore.Shoot) (int32, error) {
+func admitConfig(_ context.Context, authorizationConfigurationRaw string, shoots []*gardencore.Shoot) (int32, error) {
 	obj, schemaVersion, err := decoder.Decode([]byte(authorizationConfigurationRaw), nil, nil)
 	if err != nil {
 		return http.StatusUnprocessableEntity, fmt.Errorf("failed to decode the provided authorization configuration: %w", err)

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -28,6 +28,7 @@ import (
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
@@ -254,8 +255,8 @@ func (b *Botanist) computeKubeAPIServerServiceAccountConfig(externalHostname str
 		if config == nil {
 			config = &gardencorev1beta1.ServiceAccountConfig{}
 		}
-		config.Issuer = new(fmt.Sprintf("https://%s/projects/%s/shoots/%s/issuer", *b.Shoot.ServiceAccountIssuerHostname, b.Garden.Project.Name, b.Shoot.GetInfo().UID))
-		jwksURI = new(fmt.Sprintf("https://%s/projects/%s/shoots/%s/issuer/jwks", *b.Shoot.ServiceAccountIssuerHostname, b.Garden.Project.Name, b.Shoot.GetInfo().UID))
+		config.Issuer = new(gardenerutils.ComputeManagedServiceAccountIssuerURL(*b.Shoot.ServiceAccountIssuerHostname, b.Garden.Project.Name, string(b.Shoot.GetInfo().UID)))
+		jwksURI = new(gardenerutils.ComputeManagedServiceAccountIssuerURL(*b.Shoot.ServiceAccountIssuerHostname, b.Garden.Project.Name, string(b.Shoot.GetInfo().UID)) + "/jwks")
 	}
 
 	serviceAccountConfig := kubeapiserver.ComputeKubeAPIServerServiceAccountConfig(

--- a/pkg/gardenlet/operation/botanist/kubeapiserver.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserver.go
@@ -27,8 +27,8 @@ import (
 	resourcemanagerconstants "github.com/gardener/gardener/pkg/component/gardener/resourcemanager/constants"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
 	"github.com/gardener/gardener/pkg/component/shared"
-	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -936,3 +936,9 @@ func CalculateWorkerPoolHashForInPlaceUpdate(workerPoolName string, kubernetesVe
 
 	return utils.ComputeSHA256Hex([]byte(result.String()))[:16], nil
 }
+
+// ComputeManagedServiceAccountIssuerURL computes the managed service account issuer URL for a shoot
+// given the discovery server hostname, the project name, and the shoot UID.
+func ComputeManagedServiceAccountIssuerURL(hostname, projectName, shootUID string) string {
+	return fmt.Sprintf("https://%s/projects/%s/shoots/%s/issuer", hostname, projectName, shootUID)
+}

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -408,6 +408,14 @@ var _ = Describe("Shoot", func() {
 		Entry("test two", "bar", types.UID("4-5"), "bar--4-5"),
 	)
 
+	DescribeTable("#ComputeManagedServiceAccountIssuerURL",
+		func(hostname, projectName, shootUID, expected string) {
+			Expect(ComputeManagedServiceAccountIssuerURL(hostname, projectName, shootUID)).To(Equal(expected))
+		},
+		Entry("standard inputs", "discovery.example.com", "my-project", "abc-123", "https://discovery.example.com/projects/my-project/shoots/abc-123/issuer"),
+		Entry("custom domain", "custom.issuer.io", "garden-prod", "uid-456", "https://custom.issuer.io/projects/garden-prod/shoots/uid-456/issuer"),
+	)
+
 	DescribeTable("#IsShootProjectConfigMap",
 		func(name, expectedShootName string, expectedOK bool) {
 			shootName, ok := IsShootProjectConfigMap(name)

--- a/pkg/webhook/configvalidator/handler.go
+++ b/pkg/webhook/configvalidator/handler.go
@@ -63,7 +63,7 @@ type Handler struct {
 	ConfigMapDataKey            string
 	GetConfigMapNameFromShoot   func(shoot *gardencore.Shoot) string
 	SkipValidationOnShootUpdate func(shoot, oldShoot *gardencore.Shoot) bool
-	AdmitConfig                 func(configRaw string, shootsReferencingConfigMap []*gardencore.Shoot) (int32, error)
+	AdmitConfig                 func(ctx context.Context, configRaw string, shootsReferencingConfigMap []*gardencore.Shoot) (int32, error)
 
 	GetNamespace                func() string
 	GetConfigMapNamesFromGarden func(garden *operatorv1alpha1.Garden) []string
@@ -203,7 +203,7 @@ func (h *Handler) admitShoot(ctx context.Context, request admission.Request) adm
 		return admission.Errored(http.StatusUnprocessableEntity, fmt.Errorf("error getting %s from ConfigMap %s: %w", h.ConfigMapPurpose, client.ObjectKeyFromObject(configMap), err))
 	}
 
-	if errCode, err := h.AdmitConfig(configRaw, []*gardencore.Shoot{shoot}); err != nil {
+	if errCode, err := h.AdmitConfig(ctx, configRaw, []*gardencore.Shoot{shoot}); err != nil {
 		return admission.Errored(errCode, err)
 	}
 
@@ -259,7 +259,7 @@ func (h *Handler) admitConfigMapForShoots(ctx context.Context, request admission
 		return admissionwebhook.Allowed(fmt.Sprintf("%s did not change", h.ConfigMapPurpose))
 	}
 
-	if errCode, err := h.AdmitConfig(configRaw, shoots); err != nil {
+	if errCode, err := h.AdmitConfig(ctx, configRaw, shoots); err != nil {
 		return admission.Errored(errCode, err)
 	}
 

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -233,7 +233,7 @@ var _ = Describe("Handler", func() {
 			configMap.Data = map[string]string{"config.yaml": "foo"}
 			Expect(fakeClient.Update(ctx, configMap)).To(Succeed())
 
-			handler.AdmitConfig = func(_ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeFalse())
@@ -245,7 +245,7 @@ var _ = Describe("Handler", func() {
 			configMap.Data = map[string]string{"config.yaml": "foo"}
 			Expect(fakeClient.Update(ctx, configMap)).To(Succeed())
 
-			handler.AdmitConfig = func(_ string, _ []*core.Shoot) (int32, error) { return 0, nil }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 0, nil }
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeTrue())
@@ -362,7 +362,7 @@ var _ = Describe("Handler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			request.OldObject.Raw = rawConfigMap
 
-			handler.AdmitConfig = func(_ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeFalse())
@@ -385,7 +385,7 @@ var _ = Describe("Handler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			request.OldObject.Raw = rawConfigMap
 
-			handler.AdmitConfig = func(_ string, _ []*core.Shoot) (int32, error) { return 0, nil }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 0, nil }
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeTrue())

--- a/pkg/webhook/configvalidator/handler_test.go
+++ b/pkg/webhook/configvalidator/handler_test.go
@@ -233,7 +233,9 @@ var _ = Describe("Handler", func() {
 			configMap.Data = map[string]string{"config.yaml": "foo"}
 			Expect(fakeClient.Update(ctx, configMap)).To(Succeed())
 
-			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) {
+				return 1337, fmt.Errorf("fake error")
+			}
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeFalse())
@@ -362,7 +364,9 @@ var _ = Describe("Handler", func() {
 			Expect(err).NotTo(HaveOccurred())
 			request.OldObject.Raw = rawConfigMap
 
-			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) { return 1337, fmt.Errorf("fake error") }
+			handler.AdmitConfig = func(_ context.Context, _ string, _ []*core.Shoot) (int32, error) {
+				return 1337, fmt.Errorf("fake error")
+			}
 
 			response := handler.Handle(ctx, request)
 			Expect(response.Allowed).To(BeFalse())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind bug

**What this PR does / why we need it**:
The structured authentication configuration validation only checked issuers from `spec.kubernetes.kubeAPIServer.serviceAccountConfig`. It missed the actual service account issuer from `shoot.status.advertisedAddresses`, which includes the managed issuer and the default issuer. This allowed invalid configurations that caused the kube-apiserver to crash.

This PR adds the advertised service account issuer to the disallowed issuers list during validation.

**Which issue(s) this PR fixes**:
Fixes #14974

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed where the structured authentication configuration validation did not consider the service account issuer from `shoot.status.advertisedAddresses` as a disallowed issuer, allowing configurations that would cause the kube-apiserver to enter `CrashLoopBackOff`.
```
