### PR TITLE
Remove `ShootState` secret format type migration

### DIFF
--- a/cmd/gardenlet/app/app.go
+++ b/cmd/gardenlet/app/app.go
@@ -516,7 +516,7 @@ func (g *garden) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := g.runMigrations(ctx, log, gardenCluster); err != nil {
+	if err := g.runMigrations(ctx, log); err != nil {
 		return err
 	}
 

--- a/cmd/gardenlet/app/migration.go
+++ b/cmd/gardenlet/app/migration.go
@@ -6,25 +6,15 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/gardener/gardener/cmd/internal/migration"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils/flow"
-	"github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 )
 
-func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenCluster cluster.Cluster) error {
+func (g *garden) runMigrations(ctx context.Context, log logr.Logger) error {
 	seedClient := g.mgr.GetClient()
 
 	if features.DefaultFeatureGate.Enabled(features.VPAInPlaceUpdates) {
@@ -36,140 +26,5 @@ func (g *garden) runMigrations(ctx context.Context, log logr.Logger, gardenClust
 			return fmt.Errorf("failed to migrate VerticalPodAutoscaler with 'MigrateVPAUpdateModeToRecreate' migration: %w", err)
 		}
 	}
-
-	if err := migrateShootStateSecretFormat(ctx, gardenCluster.GetClient(), seedClient, log); err != nil {
-		return fmt.Errorf("failed to migrate ShootState secret format: %w", err)
-	}
-	if g.selfHostedShootInfo == nil {
-		if err := g.removeObsoleteShootStates(ctx, log, gardenCluster.GetAPIReader(), gardenCluster.GetClient()); err != nil {
-			return fmt.Errorf("failed to remove obsolete ShootStates: %w", err)
-		}
-	}
-
 	return nil
-}
-
-// A bug in v1.140 caused unintended ShootState creations for Shoots running on ManagedSeeds. This function is
-// making gardenlet cleaning them up automatically (when responsible for a managed seed).
-// TODO(tobschli): Remove this migration after v1.143 has been released.
-func (g *garden) removeObsoleteShootStates(ctx context.Context, log logr.Logger, apiReader client.Reader, c client.Client) error {
-	if err := apiReader.Get(ctx, client.ObjectKey{Name: g.config.SeedConfig.Name, Namespace: v1beta1constants.GardenNamespace}, &seedmanagementv1alpha1.ManagedSeed{}); err != nil {
-		// Forbidden is treated like NotFound because the SeedAuthorizer only grants access to ManagedSeeds
-		// related to this seed via the resource graph. For unmanaged seeds, no ManagedSeed exists and no graph
-		// edge is present, so the authorizer returns Forbidden.
-		if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) {
-			return fmt.Errorf("failed checking whether gardenlet is responsible for a managed seed: %w", err)
-		}
-		// ManagedSeed was not found, hence gardenlet is responsible for an unmanaged seed.
-		log.Info("gardenlet is responsible for unmanaged seed, skip unintended ShootState cleanup")
-		return nil
-	}
-
-	log.Info("gardenlet is responsible for a managed seed, check if unintendedly created ShootStates (due to a bug in gardenlet@v1.140.{0,1}) have to be cleaned up")
-
-	shootList := &gardencorev1beta1.ShootList{}
-	if err := c.List(ctx, shootList); err != nil {
-		return fmt.Errorf("failed listing Shoots: %w", err)
-	}
-
-	var (
-		shootInMigrationOrRestore = func(status gardencorev1beta1.ShootStatus) bool {
-			return status.LastOperation != nil &&
-				(status.LastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate ||
-					(status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore &&
-						status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded))
-		}
-		tasks []flow.TaskFn
-	)
-
-	for _, shoot := range shootList.Items {
-		if shootInMigrationOrRestore(shoot.Status) {
-			log.Info("Skipping Shoot in migration or restore for obsolete ShootState cleanup", "shoot", client.ObjectKeyFromObject(&shoot))
-			continue
-		}
-
-		tasks = append(tasks, func(ctx context.Context) error {
-			log.Info("Deleting unintendedly created ShootState (if it exists)", "shootState", client.ObjectKeyFromObject(&shoot))
-			return shootstate.Delete(ctx, c, &shoot)
-		})
-	}
-
-	return flow.Parallel(tasks...)(ctx)
-}
-
-// TODO(tobschli): Remove this migration after v1.143 has been released.
-func migrateShootStateSecretFormat(ctx context.Context, gardenClient client.Client, seedClient client.Client, log logr.Logger) error {
-	shootList := &gardencorev1beta1.ShootList{}
-	if err := gardenClient.List(ctx, shootList); err != nil {
-		return fmt.Errorf("failed listing Shoots: %w", err)
-	}
-
-	var tasks []flow.TaskFn
-
-	for _, shoot := range shootList.Items {
-		tasks = append(tasks, func(ctx context.Context) error {
-			shootState := &gardencorev1beta1.ShootState{}
-			if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(&shoot), shootState); err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return fmt.Errorf("failed getting ShootState for Shoot %s: %w", client.ObjectKeyFromObject(&shoot), err)
-			}
-
-			var (
-				patch   = client.MergeFrom(shootState.DeepCopy())
-				changed bool
-			)
-
-			for i, entry := range shootState.Spec.Gardener {
-				if entry.Type != v1beta1constants.DataTypeSecret {
-					continue
-				}
-
-				var newFormat shootstate.SecretState
-				if err := json.Unmarshal(entry.Data.Raw, &newFormat); err == nil && newFormat.Data != nil {
-					continue
-				}
-				newFormat = shootstate.SecretState{}
-
-				var oldFormat map[string][]byte
-				if err := json.Unmarshal(entry.Data.Raw, &oldFormat); err != nil {
-					return fmt.Errorf("failed to unmarshal secret data for secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
-				}
-
-				newFormat = shootstate.SecretState{
-					Data: oldFormat,
-					Type: corev1.SecretTypeOpaque,
-				}
-
-				secret := &corev1.Secret{}
-				if err := seedClient.Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: entry.Name}, secret); err != nil {
-					return fmt.Errorf("failed getting secret %s for ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
-				}
-
-				newFormat.Type = secret.Type
-				newFormat.Immutable = secret.Immutable
-
-				newRaw, err := json.Marshal(newFormat)
-				if err != nil {
-					return fmt.Errorf("failed marshalling secret %s in ShootState %s: %w", entry.Name, client.ObjectKeyFromObject(shootState), err)
-				}
-
-				shootState.Spec.Gardener[i].Data.Raw, changed = newRaw, true
-			}
-
-			if !changed {
-				return nil
-			}
-
-			if err := gardenClient.Patch(ctx, shootState, patch); err != nil {
-				return fmt.Errorf("failed patching ShootState %s: %w", client.ObjectKeyFromObject(shootState), err)
-			}
-
-			log.Info("Successfully migrated ShootState secret format", "shootState", client.ObjectKeyFromObject(shootState))
-			return nil
-		})
-	}
-
-	return flow.Parallel(tasks...)(ctx)
 }

--- a/pkg/gardenlet/operation/botanist/secrets.go
+++ b/pkg/gardenlet/operation/botanist/secrets.go
@@ -127,38 +127,22 @@ func (b *Botanist) restoreSecretsFromShootState(ctx context.Context) error {
 // restoreSecretFromPersistedData restores a Kubernetes Secret from persisted GardenerResourceData.
 // It handles both formats (with Immutable and Type fields) and (plain map[string][]byte)
 func restoreSecretFromPersistedData(ctx context.Context, seedClient client.Client, objectMeta metav1.ObjectMeta, rawData []byte) error {
-	var newSecretInfo shootstate.SecretState
-
 	var (
-		secretData map[string][]byte
-		immutable  *bool
 		secretType = corev1.SecretTypeOpaque
+		secretInfo shootstate.SecretState
 	)
-
-	if err := json.Unmarshal(rawData, &newSecretInfo); err != nil || newSecretInfo.Data == nil {
-		// TODO(tobschli): Remove this fallback after v1.143 has been released, as ShootStates will be reconciled and use the new format.
-		// plain map[string][]byte
-		if err := json.Unmarshal(rawData, &secretData); err != nil {
-			return fmt.Errorf("failed unmarshalling secret data for secret %s: neither new nor old format matched: %w", objectMeta.Name, err)
-		}
-
-		if objectMeta.Labels[secretsmanager.LabelKeyManagedBy] == secretsmanager.LabelValueSecretsManager {
-			secret := secretsmanager.Secret(objectMeta, secretData)
-			return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))
-		}
-	} else {
-		secretData = newSecretInfo.Data
-		immutable = newSecretInfo.Immutable
-		if newSecretInfo.Type != "" {
-			secretType = newSecretInfo.Type
-		}
+	if err := json.Unmarshal(rawData, &secretInfo); err != nil || secretInfo.Data == nil {
+		return fmt.Errorf("failed to restore secret from PersistedData: %w", err)
+	}
+	if secretInfo.Type != "" {
+		secretType = secretInfo.Type
 	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: objectMeta,
 		Type:       secretType,
-		Data:       secretData,
-		Immutable:  immutable,
+		Data:       secretInfo.Data,
+		Immutable:  secretInfo.Immutable,
 	}
 
 	return client.IgnoreAlreadyExists(seedClient.Create(ctx, secret))

--- a/pkg/gardenlet/operation/botanist/secrets_test.go
+++ b/pkg/gardenlet/operation/botanist/secrets_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/gardener/gardener/pkg/gardenlet/operation/botanist"
 	seedpkg "github.com/gardener/gardener/pkg/gardenlet/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/gardenlet/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils"
+	shootstate "github.com/gardener/gardener/pkg/utils/gardener/shootstate"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -453,73 +453,52 @@ var _ = Describe("Secrets", func() {
 								Name:   "ca",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("ca")},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("ca")}, Immutable: new(true)})},
 							},
 							{
 								Name:   "ca-client",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("ca-client")},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("ca-client")}, Immutable: new(true)})},
 							},
 							{
 								Name:   "ca-etcd",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("ca-etcd")},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("ca-etcd")}, Immutable: new(true)})},
 							},
 							{
 								Name:   "non-ca-secret",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity},
-								Data:   runtime.RawExtension{Raw: rawData("non-ca-secret")},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{}, Immutable: new(true)})},
 							},
 							{
 								Name:   "extension-foo-secret",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "secrets-manager", "manager-identity": "extension-foo"},
-								Data:   runtime.RawExtension{Raw: rawData("extension-foo-secret")},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("extension-foo-secret")}, Immutable: new(true)})},
 							},
 							{
 								Name: "secret-without-labels",
 								Type: "secret",
-								Data: runtime.RawExtension{Raw: rawData("secret-without-labels")},
+								Data: runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("secret-without-labels")}})},
 							},
 							{
 								Name:   "new-format-secret",
 								Type:   "secret",
 								Labels: map[string]string{"managed-by": "test"},
-								Data: runtime.RawExtension{
-									Raw: rawData("new-format-secret", struct {
-										Immutable *bool
-										Type      corev1.SecretType
-									}{
-										Immutable: new(true),
-										Type:      corev1.SecretTypeOpaque,
-									})},
+								Data:   runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("new-format-secret")}, Immutable: new(true), Type: corev1.SecretTypeOpaque})},
 							},
 							{
 								Name: "new-format-mutable-secret",
 								Type: "secret",
-								Data: runtime.RawExtension{
-									Raw: rawData("new-format-mutable-secret", struct {
-										Immutable *bool
-										Type      corev1.SecretType
-									}{
-										Immutable: new(false),
-										Type:      corev1.SecretTypeOpaque,
-									})},
+								Data: runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("new-format-mutable-secret")}, Immutable: new(false), Type: corev1.SecretTypeOpaque})},
 							},
 							{
 								Name: "new-format-tls-secret",
 								Type: "secret",
-								Data: runtime.RawExtension{
-									Raw: rawData("new-format-tls-secret", struct {
-										Immutable *bool
-										Type      corev1.SecretType
-									}{
-										Immutable: new(true),
-										Type:      corev1.SecretTypeTLS,
-									})},
+								Data: runtime.RawExtension{Raw: rawData(shootstate.SecretState{Data: map[string][]byte{"data-for": []byte("new-format-tls-secret")}, Immutable: new(true), Type: corev1.SecretTypeTLS})},
 							},
 							{
 								Name: "some-other-data",
@@ -551,7 +530,7 @@ var _ = Describe("Secrets", func() {
 				Expect(secret.Immutable).To(PointTo(BeTrue()))
 				Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
 				Expect(secret.Labels).To(Equal(map[string]string{"managed-by": "secrets-manager", "manager-identity": fakesecretsmanager.ManagerIdentity}))
-				Expect(secret.Data).To(Equal(map[string][]byte{"data-for": []byte(secret.Name)}))
+				Expect(secret.Data).To(BeEmpty())
 
 				By("Verify external secrets got restored")
 				Expect(seedClient.Get(ctx, client.ObjectKey{Namespace: controlPlaneNamespace, Name: "extension-foo-secret"}, secret)).To(Succeed())
@@ -611,27 +590,7 @@ func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.
 	}
 }
 
-func rawData(value string, opts ...struct {
-	Immutable *bool
-	Type      corev1.SecretType
-}) []byte {
-	if len(opts) == 0 {
-		return []byte(`{"data-for":"` + utils.EncodeBase64([]byte(value)) + `"}`)
-	}
-
-	o := opts[0]
-
-	type newFormat struct {
-		Data      map[string][]byte `json:"data"`
-		Immutable *bool             `json:"immutable,omitempty"`
-		Type      corev1.SecretType `json:"type,omitempty"`
-	}
-
-	b, _ := json.Marshal(newFormat{
-		Data:      map[string][]byte{"data-for": []byte(value)},
-		Immutable: o.Immutable,
-		Type:      o.Type,
-	})
-
+func rawData(state shootstate.SecretState) []byte {
+	b, _ := json.Marshal(state)
 	return b
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`gardenlet` migration code was removed that converted the secret data to a new format, which was introduced with [#14268](https://github.com/gardener/gardener/pull/14268). 
```

```noteworthy operator
`gardenlet` migration code was removed that cleaned up `ShootState`s that were wrongfully created.
```