### PR TITLE
Prometheus recording-rule improvements related to metering

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
@@ -75,8 +75,6 @@ spec:
             metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
           /
             (metering:disk_usage_seconds != 0)
-        or
-          metering:persistent_volume_claims:sum_by_namespace:sum_over_time
 
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
@@ -129,8 +127,6 @@ spec:
             metering:cpu_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:cpu_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
@@ -156,8 +152,6 @@ spec:
             metering:cpu_requests:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:cpu_requests:sum_by_namespace:sum_over_time
 
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
@@ -183,8 +177,6 @@ spec:
             metering:memory_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:memory_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
@@ -210,8 +202,6 @@ spec:
             metering:working_set_memory:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:working_set_memory:sum_by_namespace:sum_over_time
 
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
@@ -237,8 +227,6 @@ spec:
             metering:memory_requests:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:memory_requests:sum_by_namespace:sum_over_time
 
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
@@ -264,8 +252,6 @@ spec:
             metering:network_transmit:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:network_transmit:sum_by_namespace:sum_over_time
 
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
@@ -291,8 +277,6 @@ spec:
             metering:network_receive:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:network_receive:sum_by_namespace:sum_over_time
 
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
@@ -318,8 +302,6 @@ spec:
             metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:persistent_volume_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
@@ -28,14 +28,14 @@ spec:
       expr: |2
           (metering:working_set_memory:sum_by_namespace > bool 0) * 60
         +
-          (last_over_time(metering:memory_usage_seconds[10m]) or metering:working_set_memory:sum_by_namespace * 0)
+          (last_over_time(metering:memory_usage_seconds[30m]) or metering:working_set_memory:sum_by_namespace * 0)
 
     - record: metering:disk_usage_seconds
       expr: |2
           (metering:persistent_volume_claims:sum_by_namespace > bool 0) * 60
         +
           (
-              last_over_time(metering:disk_usage_seconds[10m])
+              last_over_time(metering:disk_usage_seconds[30m])
             or
               metering:persistent_volume_claims:sum_by_namespace * 0
           )
@@ -44,7 +44,7 @@ spec:
       expr: |2
           metering:memory_usage_seconds
         or
-            last_over_time(metering:memory_usage_seconds:this_month[10m])
+            last_over_time(metering:memory_usage_seconds:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -52,7 +52,7 @@ spec:
       expr: |2
           metering:disk_usage_seconds
         or
-            last_over_time(metering:disk_usage_seconds:this_month[10m])
+            last_over_time(metering:disk_usage_seconds:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -65,7 +65,7 @@ spec:
           metering:persistent_volume_claims:sum_by_namespace
         +
           (
-              last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[30m])
             or
               metering:persistent_volume_claims:sum_by_namespace * 0
           )
@@ -83,7 +83,7 @@ spec:
       expr: |2
           metering:persistent_volume_claims:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -119,7 +119,7 @@ spec:
           metering:cpu_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:cpu_usage:sum_by_namespace * 0
           )
@@ -137,7 +137,7 @@ spec:
       expr: |2
           metering:cpu_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -146,7 +146,7 @@ spec:
           metering:cpu_requests:sum_by_namespace
         +
           (
-              last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[30m])
             or
               metering:cpu_requests:sum_by_namespace * 0
           )
@@ -164,7 +164,7 @@ spec:
       expr: |2
           metering:cpu_requests:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -173,7 +173,7 @@ spec:
           metering:memory_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:memory_usage:sum_by_namespace * 0
           )
@@ -191,7 +191,7 @@ spec:
       expr: |2
           metering:memory_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -200,7 +200,7 @@ spec:
           metering:working_set_memory:sum_by_namespace
         +
           (
-              last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[30m])
             or
               metering:working_set_memory:sum_by_namespace * 0
           )
@@ -218,7 +218,7 @@ spec:
       expr: |2
           metering:working_set_memory:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -227,7 +227,7 @@ spec:
           metering:memory_requests:sum_by_namespace
         +
           (
-              last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[30m])
             or
               metering:memory_requests:sum_by_namespace * 0
           )
@@ -245,7 +245,7 @@ spec:
       expr: |2
           metering:memory_requests:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -254,7 +254,7 @@ spec:
           metering:network_transmit:sum_by_namespace
         +
           (
-              last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[30m])
             or
               metering:network_transmit:sum_by_namespace * 0
           )
@@ -272,7 +272,7 @@ spec:
       expr: |2
           metering:network_transmit:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -281,7 +281,7 @@ spec:
           metering:network_receive:sum_by_namespace
         +
           (
-              last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[30m])
             or
               metering:network_receive:sum_by_namespace * 0
           )
@@ -299,7 +299,7 @@ spec:
       expr: |2
           metering:network_receive:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -308,7 +308,7 @@ spec:
           metering:persistent_volume_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:persistent_volume_usage:sum_by_namespace * 0
           )
@@ -326,6 +326,6 @@ spec:
       expr: |2
           metering:persistent_volume_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2

--- a/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/assets/prometheusrules/metering.rules.stateful.yaml
@@ -72,9 +72,9 @@ spec:
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
       expr: |2
-            metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:disk_usage_seconds != 0)
+          metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:disk_usage_seconds != 0)
 
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
@@ -124,9 +124,9 @@ spec:
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:cpu_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:cpu_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
@@ -149,9 +149,9 @@ spec:
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time
       expr: |2
-            metering:cpu_requests:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:cpu_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
@@ -174,9 +174,9 @@ spec:
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:memory_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:memory_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
@@ -199,9 +199,9 @@ spec:
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time
       expr: |2
-            metering:working_set_memory:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:working_set_memory:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
@@ -224,9 +224,9 @@ spec:
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time
       expr: |2
-            metering:memory_requests:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:memory_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
@@ -249,9 +249,9 @@ spec:
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time
       expr: |2
-            metering:network_transmit:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:network_transmit:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
@@ -274,9 +274,9 @@ spec:
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time
       expr: |2
-            metering:network_receive:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:network_receive:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
@@ -299,9 +299,9 @@ spec:
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
@@ -21,7 +21,7 @@ cat <<EOF
         metering:$NAME:sum_by_namespace
       +
         (
-            last_over_time(metering:$NAME:sum_by_namespace:sum_over_time[10m])
+            last_over_time(metering:$NAME:sum_by_namespace:sum_over_time[30m])
           or
             metering:$NAME:sum_by_namespace * 0
         )
@@ -39,7 +39,7 @@ cat <<EOF
     expr: |2
         metering:$NAME:sum_by_namespace:avg_over_time
       or
-          last_over_time(metering:$NAME:sum_by_namespace:avg_over_time:this_month[10m])
+          last_over_time(metering:$NAME:sum_by_namespace:avg_over_time:this_month[30m])
         + on (year, month) group_left ()
           _year_month2
 

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
@@ -31,8 +31,6 @@ cat <<EOF
           metering:$NAME:sum_by_namespace:sum_over_time * 60
         /
           (metering:memory_usage_seconds != 0)
-      or
-        metering:$NAME:sum_by_namespace:sum_over_time
 
 
   - record: metering:$NAME:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.sh
@@ -28,9 +28,9 @@ cat <<EOF
 
   - record: metering:$NAME:sum_by_namespace:avg_over_time
     expr: |2
-          metering:$NAME:sum_by_namespace:sum_over_time * 60
-        /
-          (metering:memory_usage_seconds != 0)
+        metering:$NAME:sum_by_namespace:sum_over_time * 60
+      /
+        (metering:memory_usage_seconds != 0)
 
 
   - record: metering:$NAME:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
@@ -75,8 +75,6 @@ spec:
             metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
           /
             (metering:disk_usage_seconds != 0)
-        or
-          metering:persistent_volume_claims:sum_by_namespace:sum_over_time
 
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
@@ -129,8 +127,6 @@ spec:
             metering:cpu_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:cpu_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
@@ -156,8 +152,6 @@ spec:
             metering:cpu_requests:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:cpu_requests:sum_by_namespace:sum_over_time
 
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
@@ -183,8 +177,6 @@ spec:
             metering:memory_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:memory_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
@@ -210,8 +202,6 @@ spec:
             metering:working_set_memory:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:working_set_memory:sum_by_namespace:sum_over_time
 
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
@@ -237,8 +227,6 @@ spec:
             metering:memory_requests:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:memory_requests:sum_by_namespace:sum_over_time
 
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
@@ -264,8 +252,6 @@ spec:
             metering:network_transmit:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:network_transmit:sum_by_namespace:sum_over_time
 
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
@@ -291,8 +277,6 @@ spec:
             metering:network_receive:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:network_receive:sum_by_namespace:sum_over_time
 
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
@@ -318,8 +302,6 @@ spec:
             metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
           /
             (metering:memory_usage_seconds != 0)
-        or
-          metering:persistent_volume_usage:sum_by_namespace:sum_over_time
 
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
@@ -28,14 +28,14 @@ spec:
       expr: |2
           (metering:working_set_memory:sum_by_namespace > bool 0) * 60
         +
-          (last_over_time(metering:memory_usage_seconds[10m]) or metering:working_set_memory:sum_by_namespace * 0)
+          (last_over_time(metering:memory_usage_seconds[30m]) or metering:working_set_memory:sum_by_namespace * 0)
 
     - record: metering:disk_usage_seconds
       expr: |2
           (metering:persistent_volume_claims:sum_by_namespace > bool 0) * 60
         +
           (
-              last_over_time(metering:disk_usage_seconds[10m])
+              last_over_time(metering:disk_usage_seconds[30m])
             or
               metering:persistent_volume_claims:sum_by_namespace * 0
           )
@@ -44,7 +44,7 @@ spec:
       expr: |2
           metering:memory_usage_seconds
         or
-            last_over_time(metering:memory_usage_seconds:this_month[10m])
+            last_over_time(metering:memory_usage_seconds:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -52,7 +52,7 @@ spec:
       expr: |2
           metering:disk_usage_seconds
         or
-            last_over_time(metering:disk_usage_seconds:this_month[10m])
+            last_over_time(metering:disk_usage_seconds:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -65,7 +65,7 @@ spec:
           metering:persistent_volume_claims:sum_by_namespace
         +
           (
-              last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:persistent_volume_claims:sum_by_namespace:sum_over_time[30m])
             or
               metering:persistent_volume_claims:sum_by_namespace * 0
           )
@@ -83,7 +83,7 @@ spec:
       expr: |2
           metering:persistent_volume_claims:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -119,7 +119,7 @@ spec:
           metering:cpu_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:cpu_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:cpu_usage:sum_by_namespace * 0
           )
@@ -137,7 +137,7 @@ spec:
       expr: |2
           metering:cpu_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:cpu_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -146,7 +146,7 @@ spec:
           metering:cpu_requests:sum_by_namespace
         +
           (
-              last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:cpu_requests:sum_by_namespace:sum_over_time[30m])
             or
               metering:cpu_requests:sum_by_namespace * 0
           )
@@ -164,7 +164,7 @@ spec:
       expr: |2
           metering:cpu_requests:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:cpu_requests:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -173,7 +173,7 @@ spec:
           metering:memory_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:memory_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:memory_usage:sum_by_namespace * 0
           )
@@ -191,7 +191,7 @@ spec:
       expr: |2
           metering:memory_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:memory_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -200,7 +200,7 @@ spec:
           metering:working_set_memory:sum_by_namespace
         +
           (
-              last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:working_set_memory:sum_by_namespace:sum_over_time[30m])
             or
               metering:working_set_memory:sum_by_namespace * 0
           )
@@ -218,7 +218,7 @@ spec:
       expr: |2
           metering:working_set_memory:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:working_set_memory:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -227,7 +227,7 @@ spec:
           metering:memory_requests:sum_by_namespace
         +
           (
-              last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:memory_requests:sum_by_namespace:sum_over_time[30m])
             or
               metering:memory_requests:sum_by_namespace * 0
           )
@@ -245,7 +245,7 @@ spec:
       expr: |2
           metering:memory_requests:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:memory_requests:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -254,7 +254,7 @@ spec:
           metering:network_transmit:sum_by_namespace
         +
           (
-              last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:network_transmit:sum_by_namespace:sum_over_time[30m])
             or
               metering:network_transmit:sum_by_namespace * 0
           )
@@ -272,7 +272,7 @@ spec:
       expr: |2
           metering:network_transmit:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:network_transmit:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -281,7 +281,7 @@ spec:
           metering:network_receive:sum_by_namespace
         +
           (
-              last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:network_receive:sum_by_namespace:sum_over_time[30m])
             or
               metering:network_receive:sum_by_namespace * 0
           )
@@ -299,7 +299,7 @@ spec:
       expr: |2
           metering:network_receive:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:network_receive:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2
 
@@ -308,7 +308,7 @@ spec:
           metering:persistent_volume_usage:sum_by_namespace
         +
           (
-              last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[10m])
+              last_over_time(metering:persistent_volume_usage:sum_by_namespace:sum_over_time[30m])
             or
               metering:persistent_volume_usage:sum_by_namespace * 0
           )
@@ -326,6 +326,6 @@ spec:
       expr: |2
           metering:persistent_volume_usage:sum_by_namespace:avg_over_time
         or
-            last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[10m])
+            last_over_time(metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month[30m])
           + on (year, month) group_left ()
             _year_month2

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/prometheusrules/metering.rules.stateful.yaml
@@ -72,9 +72,9 @@ spec:
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time
       expr: |2
-            metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:disk_usage_seconds != 0)
+          metering:persistent_volume_claims:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:disk_usage_seconds != 0)
 
 
     - record: metering:persistent_volume_claims:sum_by_namespace:avg_over_time:this_month
@@ -124,9 +124,9 @@ spec:
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:cpu_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:cpu_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:cpu_usage:sum_by_namespace:avg_over_time:this_month
@@ -149,9 +149,9 @@ spec:
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time
       expr: |2
-            metering:cpu_requests:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:cpu_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:cpu_requests:sum_by_namespace:avg_over_time:this_month
@@ -174,9 +174,9 @@ spec:
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:memory_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:memory_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:memory_usage:sum_by_namespace:avg_over_time:this_month
@@ -199,9 +199,9 @@ spec:
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time
       expr: |2
-            metering:working_set_memory:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:working_set_memory:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:working_set_memory:sum_by_namespace:avg_over_time:this_month
@@ -224,9 +224,9 @@ spec:
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time
       expr: |2
-            metering:memory_requests:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:memory_requests:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:memory_requests:sum_by_namespace:avg_over_time:this_month
@@ -249,9 +249,9 @@ spec:
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time
       expr: |2
-            metering:network_transmit:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:network_transmit:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:network_transmit:sum_by_namespace:avg_over_time:this_month
@@ -274,9 +274,9 @@ spec:
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time
       expr: |2
-            metering:network_receive:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:network_receive:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:network_receive:sum_by_namespace:avg_over_time:this_month
@@ -299,9 +299,9 @@ spec:
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time
       expr: |2
-            metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
-          /
-            (metering:memory_usage_seconds != 0)
+          metering:persistent_volume_usage:sum_by_namespace:sum_over_time * 60
+        /
+          (metering:memory_usage_seconds != 0)
 
 
     - record: metering:persistent_volume_usage:sum_by_namespace:avg_over_time:this_month

--- a/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/assets/prometheusrules/metering-meta.yaml
@@ -19,11 +19,17 @@ spec:
         *
           0
 
+  # _garden_shoot_info
+
+    - record: _garden_shoot_info
+      expr: |2
+        group (garden_shoot_info) by(shoot_uid, project, name, iaas, region, seed, seed_iaas, seed_region, failure_tolerance, version, cost_object_type, cost_object, cost_object_owner, gardener_version, is_seed, is_workerless, is_hibernated) * 0
+
   # garden_shoot_info:this_month
 
     - record: garden_shoot_info:this_month
       expr: |2
-          (garden_shoot_info + on () group_left (year, month) _year_month2)
+          (_garden_shoot_info + on () group_left (year, month) _year_month2)
         or
           last_over_time(garden_shoot_info:this_month[30m]) + on (year, month) group_left () _year_month2
 
@@ -40,10 +46,10 @@ spec:
           (
               last_over_time(garden_shoot_info:timestamp[30m])
             or ignoring (timestamp)
-              garden_shoot_info + on () group_left (timestamp) _timestamp
+              _garden_shoot_info + on () group_left (timestamp) _timestamp
           )
         and ignoring (timestamp)
-          garden_shoot_info
+          _garden_shoot_info
 
   # garden_shoot_info :timestamp :this_month
 

--- a/pkg/component/observability/monitoring/prometheus/garden/testdata/metering-meta.prometheusrule.test.yaml
+++ b/pkg/component/observability/monitoring/prometheus/garden/testdata/metering-meta.prometheusrule.test.yaml
@@ -3,6 +3,53 @@ rule_files:
 
 tests:
 
+# _garden_shoot_info
+- name: _garden_shoot_info
+  input_series:
+  - series: garden_shoot_info{
+        shoot_uid         = "6fe5a58a-f98e-4cf3-9fbd-197d5bcb2a78",
+        project           = "some-project",
+        name              = "some-shoot",
+        iaas              = "shoot-iaas",
+        region            = "shoot-region",
+        seed              = "some-seed",
+        seed_iaas         = "seed-iaas",
+        seed_region       = "seed-region",
+        failure_tolerance = "zone",
+        version           = "1.26.7",
+        cost_object_type  = "some-cost-object-type",
+        cost_object       = "0101010xxx",
+        cost_object_owner = "some-owner",
+        gardener_version  = "1.42.3",
+        is_seed           = "false",
+        is_workerless     = "false",
+        is_hibernated     = "false",
+        status            = "healthy",
+        some_label        = "some-value"}
+    values: 0
+  promql_expr_test:
+  - expr: _garden_shoot_info
+    exp_samples:
+    - labels: _garden_shoot_info{
+        shoot_uid         = "6fe5a58a-f98e-4cf3-9fbd-197d5bcb2a78",
+        project           = "some-project",
+        name              = "some-shoot",
+        iaas              = "shoot-iaas",
+        region            = "shoot-region",
+        seed              = "some-seed",
+        seed_iaas         = "seed-iaas",
+        seed_region       = "seed-region",
+        failure_tolerance = "zone",
+        version           = "1.26.7",
+        cost_object_type  = "some-cost-object-type",
+        cost_object       = "0101010xxx",
+        cost_object_owner = "some-owner",
+        gardener_version  = "1.42.3",
+        is_seed           = "false",
+        is_workerless     = "false",
+        is_hibernated     = "false"}
+      value: 0
+
 # metering:*:sum_by_namespace:meta merge in meta data from the garden_shoot_info metrics
 - name: metering:cpu_requests:sum_by_namespace:meta
   input_series:


### PR DESCRIPTION
**How to categorize this PR?**
/area metering
/kind regression
/kind bug

**What this PR does / why we need it**:

This PR bundles three independent improvements to the metering recording rules. Per-commit details and rationale are in the respective commit messages; in short:

1. Project `garden_shoot_info` to only the labels that are relevant for metering, mitigating a performance regression caused by a recent label addition in gardener-metrics-exporter ([PR 145](https://github.com/gardener/gardener-metrics-exporter/pull/145)).
2. Unify and increase the `last_over_time()` window in the metering rules to 30m.
3. Drop a bogus `or sum_over_time` fallback in the cache / aggregate `:avg_over_time` recording rules.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The changes have been verified using the remote local setup.

cc @vicwicker

**Release note**:

```bugfix operator
Fix a recent regression and two long-standing bugs in the Prometheus recording rules related to metering: a load regression in garden Prometheus caused by an added metadata label, metering accumulation resets across short outages, and inflated averages for short-lived shoots.
```