### PR TITLE
Fix NOTE markdown syntax in getting started guides

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -179,7 +179,7 @@ Since the [ko](https://skaffold.dev/docs/builders/builder-types/ko/) builder is 
 
 ## Creating a `Shoot` Cluster
 
-> ![NOTE]
+> [!NOTE]
 > The following steps assume that you are using the kubeconfig that points to the virtual garden cluster: `export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig`.
 
 You can wait for the `Seed` to be ready by running:

--- a/docs/deployment/getting_started_locally_with_gardenadm.md
+++ b/docs/deployment/getting_started_locally_with_gardenadm.md
@@ -320,7 +320,7 @@ make seed-up KUBECONFIG=./dev-setup/kubeconfigs/self-hosted-shoot/kubeconfig
 
 This deploys a seed gardenlet via a `ManagedSeed` into the self-hosted shoot.
 
-> ![NOTE]
+> [!NOTE]
 > The following steps assume that you are using the kubeconfig that points to the virtual garden cluster: `export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig`.
 
 You can wait for the `Seed` to be ready by running:
@@ -340,7 +340,7 @@ Once the `Seed` is ready, you can create shoot clusters on top of it.
 
 ### Creating a (Hosted) `Shoot` Cluster
 
-> ![NOTE]
+> [!NOTE]
 > The following steps assume that you are using the kubeconfig that points to the virtual garden cluster: `export KUBECONFIG=$PWD/dev-setup/kubeconfigs/virtual-garden/kubeconfig`.
 
 In order to create a first (hosted) shoot cluster, just run:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
There was a syntax mistake in the visualisation of NOTE blocks in the getting started markdown files.
Before:
<img width="1081" height="132" alt="Screenshot 2026-06-08 at 10 57 36" src="https://github.com/user-attachments/assets/7b360267-0e2a-49a9-96fd-3cdec3377cc4" />
After:
<img width="1081" height="168" alt="Screenshot 2026-06-08 at 10 58 53" src="https://github.com/user-attachments/assets/1d4b6bfa-db90-4921-ac91-07dd0f6c213e" />
Documentation: https://github.com/orgs/community/discussions/16925


**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
