### PR TITLE
Respect EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK flag in seed reconciler

### DIFF
--- a/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/seed/seed/reconciler_reconcile.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -41,6 +42,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	"github.com/gardener/gardener/pkg/utils/validation/kubernetesversion"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
@@ -62,25 +64,31 @@ func (r *Reconciler) reconcile(
 	}
 
 	// Check whether the Kubernetes version of the Seed cluster fulfills the minimal requirements.
-	if err := r.checkMinimumK8SVersion(r.SeedClientSet.Version()); err != nil {
+	if err := r.checkMinimumK8SVersion(r.SeedClientSet.Version(), log); err != nil {
 		return err
 	}
 
 	return r.runReconcileSeedFlow(ctx, log, seedObj, seedIsGarden, seedIsShoot, seedIsSelfHostedShoot)
 }
 
-func (r *Reconciler) checkMinimumK8SVersion(version string) error {
+func (r *Reconciler) checkMinimumK8SVersion(version string, log logr.Logger) error {
 	const minKubernetesVersion = "1.32"
 
 	seedVersionOK, err := versionutils.CompareVersions(version, ">=", minKubernetesVersion)
 	if err != nil {
 		return err
 	}
-	if !seedVersionOK {
-		return fmt.Errorf("the Kubernetes version of the Seed cluster must be at least %s", minKubernetesVersion)
+
+	if seedVersionOK {
+		return nil
 	}
 
-	return nil
+	if os.Getenv(kubernetesversion.EnvExperimentalDisableKubernetesVersionCheck) == "true" {
+		log.Info("Proceeding with unsupported Kubernetes version (version check disabled via flag)", "version", version, "flag", kubernetesversion.EnvExperimentalDisableKubernetesVersionCheck)
+		return nil
+	}
+
+	return fmt.Errorf("the Kubernetes version of the Seed cluster must be at least %s, but is %s", minKubernetesVersion, version)
 }
 
 func (r *Reconciler) runReconcileSeedFlow(

--- a/pkg/utils/validation/kubernetesversion/version.go
+++ b/pkg/utils/validation/kubernetesversion/version.go
@@ -22,20 +22,15 @@ var SupportedVersions = []string{
 	"1.35",
 }
 
-// envExperimentalDisableKubernetesVersionCheck holds the name of the environment variable to prevent a crash
+// EnvExperimentalDisableKubernetesVersionCheck holds the name of the environment variable to prevent a crash
 // if the detected k8s version is not in the list of supported k8s versions.
 // This should only be used if you know exactly what you are doing and on your own risk.
-const envExperimentalDisableKubernetesVersionCheck = "EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK"
+const EnvExperimentalDisableKubernetesVersionCheck = "EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK"
 
 // CheckIfSupported checks if the provided version is part of the supported Kubernetes versions list.
 // Experimental: If the environment variable `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK` is set to "true",
 // the check will be skipped.
 func CheckIfSupported(gitVersion string) error {
-	if os.Getenv(envExperimentalDisableKubernetesVersionCheck) == "true" {
-		logf.Log.Info("Skipping the check if the Kubernetes version is supported because flag is set to true", "flag", envExperimentalDisableKubernetesVersionCheck)
-		return nil
-	}
-
 	for _, supportedVersion := range SupportedVersions {
 		ok, err := versionutils.CompareVersions(gitVersion, "~", supportedVersion)
 		if err != nil {
@@ -45,6 +40,11 @@ func CheckIfSupported(gitVersion string) error {
 		if ok {
 			return nil
 		}
+	}
+
+	if os.Getenv(EnvExperimentalDisableKubernetesVersionCheck) == "true" {
+		logf.Log.Info("Proceeding with unsupported Kubernetes version (version check disabled via flag)", "version", gitVersion, "flag", EnvExperimentalDisableKubernetesVersionCheck)
+		return nil
 	}
 
 	return fmt.Errorf("unsupported kubernetes version %q", gitVersion)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

Respect `EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK` flag in seed reconciler, where the minimum version is checked as well. 

The original use case in #13221 was to run on newer unsupported versions. We would like to use the flag to run Gardener on older, no longer supported versions. In this case the check in the seed reconciler is blocking.

This PR also changes the behavior of the flag slightly. The check will now be executed and the result will still be logged, but not throw an error. This way it provides more information and does not log, if the version is valid. The flag can no longer be used to skip the check entirely, for example if the cluster version parsing to semver fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Please backport this fix to all supported Gardener versions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`EXPERIMENTAL_DISABLE_KUBERNETES_VERSION_CHECK` flag logs check results but ignores errors. It also disables version check in the seed reconciler.
```
