### PR TITLE
Fix `hack/usage/generate-kubeconfig.sh` when invoked without arguments

### DIFF
--- a/hack/usage/generate-kubeconfig.sh
+++ b/hack/usage/generate-kubeconfig.sh
@@ -269,7 +269,7 @@ case "$command" in
   self-hosted-shoot|shs)
     shift; cmd_self_hosted_shoot "$@" ;;
   shoot)
-    shift; cmd_shoot "$@" ;;
+    [[ $# -gt 0 ]] && shift; cmd_shoot "$@" ;;
   --help|-h)
     usage 0 ;;
   --*)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
I follow the [Deploying Gardener Locally](https://github.com/gardener/gardener/blob/v1.144.0/docs/deployment/getting_started_locally.md) guide.
After creating a Shoot cluster for local development I tried to create a kubeconfig. 
It is done via the `./hack/usage/generate-kubeconfig.sh` script.
When the script is invoked without arguments, it fails with:
```
% ./hack/usage/generate-kubeconfig.sh
(silently fails)
% echo $?
1

% bash -x ./hack/usage/generate-kubeconfig.sh
+ set -euo pipefail
+++ dirname ./hack/usage/generate-kubeconfig.sh
++ cd ./hack/usage
++ pwd
+ SCRIPT_DIR=/home/user/go/src/github.com/gardener/gardener/hack/usage
+ command=shoot
+ case "$command" in
+ shift
```

With the changes from this PR when no arguments are provided it falls back to the `shoot` subcommand case without errors. Now, it checks if there are arguments provided and if so it won't shift.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14614

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The `hack/usage/generate-kubeconfig.sh` script is now fixed to no longer fail when invoked without arguments — it now correctly defaults to the `shoot` subcommand.
```
