### PR TITLE
Remove deprecation warnings for MutatingAdmissionPolicy resources

### DIFF
--- a/dev-setup/kind/cluster/components/node/kustomization.yaml
+++ b/dev-setup/kind/cluster/components/node/kustomization.yaml
@@ -48,6 +48,8 @@ patches:
         kind: ClusterConfiguration
         apiServer:
           extraArgs:
+            # TODO(DobromirNPeev): Remove once kind uses a Kubernetes version 1.36+.
+            # The MutatingAdmissionPolicy feature gate is promoted to GA and enabled by default in Kubernetes 1.36.
             feature-gates: "MutatingAdmissionPolicy=true"
             runtime-config: "admissionregistration.k8s.io/v1beta1=true"
         controllerManager:

--- a/dev-setup/kind/cluster/components/node/kustomization.yaml
+++ b/dev-setup/kind/cluster/components/node/kustomization.yaml
@@ -49,7 +49,7 @@ patches:
         apiServer:
           extraArgs:
             feature-gates: "MutatingAdmissionPolicy=true"
-            runtime-config: "admissionregistration.k8s.io/v1alpha1=true,admissionregistration.k8s.io/v1beta1=true"
+            runtime-config: "admissionregistration.k8s.io/v1beta1=true"
         controllerManager:
           extraArgs:
             # TODO(LucaBernstein): Remove once kind uses a Kubernetes version that includes the fix for

--- a/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
+++ b/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingAdmissionPolicy
 metadata:
   name: node-status-capacity
@@ -28,7 +28,7 @@ spec:
           }
         }
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: node-status-capacity


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
The local kind cluster applies MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding resources using the `admissionregistration.k8s.io/v1alpha1` API version. Since the local kind cluster's Kubernetes version was upgraded to Kubernetes 1.35.1, kubectl now emits deprecation warnings on every apply:
```
  Warning: admissionregistration.k8s.io/v1alpha1 MutatingAdmissionPolicy is deprecated in v1.35+, unavailable in v1.38+
```

This PR switches both resources to `admissionregistration.k8s.io/v1beta1`, which has been stable since Kubernetes 1.34, and removes v1alpha1 from the API server's runtime-config.

Before:
```
% make kind-up
...
Warning: admissionregistration.k8s.io/v1alpha1 MutatingAdmissionPolicy is deprecated in v1.35+, unavailable in v1.38+
mutatingadmissionpolicy.admissionregistration.k8s.io/node-status-capacity serverside-applied
Warning: admissionregistration.k8s.io/v1alpha1 MutatingAdmissionPolicyBinding is deprecated in v1.35+, unavailable in v1.38+
mutatingadmissionpolicybinding.admissionregistration.k8s.io/node-status-capacity serverside-applied
...
```

After:
```
% make kind-up
...
mutatingadmissionpolicy.admissionregistration.k8s.io/node-status-capacity serverside-applied
mutatingadmissionpolicybinding.admissionregistration.k8s.io/node-status-capacity serverside-applied
...
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
 NONE
```
