### PR TITLE
[GEP-28] Add `gardenadm init --backup-data-path` flag for etcd restoration from local etcd data

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -74,6 +74,7 @@ build:
             - pkg/component/clusteridentity
             - pkg/component/crddeployer
             - pkg/component/etcd/bootstrap
+            - pkg/component/etcd/bootstrap/backuprestore
             - pkg/component/etcd/copybackupstask
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants

--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -75,6 +75,7 @@ build:
             - pkg/component/clusteridentity
             - pkg/component/crddeployer
             - pkg/component/etcd/bootstrap
+            - pkg/component/etcd/bootstrap/backuprestore
             - pkg/component/etcd/copybackupstask
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants
@@ -602,6 +603,7 @@ build:
             - pkg/component/clusteridentity
             - pkg/component/crddeployer
             - pkg/component/etcd/bootstrap
+            - pkg/component/etcd/bootstrap/backuprestore
             - pkg/component/etcd/copybackupstask
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -120,6 +120,7 @@ build:
             - pkg/component/clusteridentity
             - pkg/component/crddeployer
             - pkg/component/etcd/bootstrap
+            - pkg/component/etcd/bootstrap/backuprestore
             - pkg/component/etcd/copybackupstask
             - pkg/component/etcd/etcd
             - pkg/component/etcd/etcd/constants

--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -23,11 +23,12 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
 ### Options
 
 ```
-  -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-  -h, --help                 help for init
-      --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
-      --use-host-network     If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
-  -z, --zone string          Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+      --backup-data-path string   Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+  -d, --config-dir string         Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+  -h, --help                      help for init
+      --use-bootstrap-etcd        If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
+      --use-host-network          If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
+  -z, --zone string               Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -23,6 +23,7 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
 ### Options
 
 ```
+      --backup-data-path string   Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
   -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
       --force                If set, the init command will be executed even if the control plane is already initialized.
   -h, --help                 help for init

--- a/docs/cli-reference/gardenadm/gardenadm_init.md
+++ b/docs/cli-reference/gardenadm/gardenadm_init.md
@@ -24,12 +24,12 @@ gardenadm init --config-dir /path/to/manifests --zone zone-a
 
 ```
       --backup-data-path string   Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
-  -d, --config-dir string    Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
-      --force                If set, the init command will be executed even if the control plane is already initialized.
-  -h, --help                 help for init
-      --use-bootstrap-etcd   If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
-      --use-host-network     If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
-  -z, --zone string          Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
+  -d, --config-dir string         Path to a directory containing the Gardener configuration files for the init command, i.e., files containing resources like CloudProfile, Shoot, etc. The files must be in YAML/JSON and have .{yaml,yml,json} file extensions to be considered.
+      --force                     If set, the init command will be executed even if the control plane is already initialized.
+  -h, --help                      help for init
+      --use-bootstrap-etcd        If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.
+      --use-host-network          If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.
+  -z, --zone string               Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.
 ```
 
 ### Options inherited from parent commands

--- a/hack/resolve-etcd-version-from-etcd-druid.sh
+++ b/hack/resolve-etcd-version-from-etcd-druid.sh
@@ -31,3 +31,9 @@ echo "Found etcd version string: $ETCD_VERSION"
 # Update images.yaml with the resolved etcd tag
 echo "Updating $1 with etcd $ETCD_VERSION tag"
 yq -i "(.images[] | select(.name == \"etcd\") ).tag = \"$ETCD_VERSION\"" "$1"
+
+# Extract etcd-backup-restore-next tag from etcd-druid images.yaml and update containers.yaml
+ETCDBRCTL_TAG=$(yq '.images[] | select(.name == "etcd-backup-restore-next") | .tag' "$WORKDIR/images.yaml")
+echo "Found etcd-backup-restore tag: $ETCDBRCTL_TAG"
+echo "Updating $1 with etcd-backup-restore $ETCDBRCTL_TAG tag"
+yq -i "(.images[] | select(.name == \"etcd-backup-restore\") ).tag = \"$ETCDBRCTL_TAG\"" "$1"

--- a/imagevector/containers.go
+++ b/imagevector/containers.go
@@ -35,6 +35,8 @@ const (
 	ContainerImageNameEnvoyProxy = "envoy-proxy"
 	// ContainerImageNameEtcd is a constant for an image in the image vector with name 'etcd'.
 	ContainerImageNameEtcd = "etcd"
+	// ContainerImageNameEtcdBackupRestore is a constant for an image in the image vector with name 'etcd-backup-restore'.
+	ContainerImageNameEtcdBackupRestore = "etcd-backup-restore"
 	// ContainerImageNameEtcdDruid is a constant for an image in the image vector with name 'etcd-druid'.
 	ContainerImageNameEtcdDruid = "etcd-druid"
 	// ContainerImageNameEventLogger is a constant for an image in the image vector with name 'event-logger'.

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -73,8 +73,8 @@ images:
 
   - name: etcd-backup-restore
     sourceRepository: github.com/gardener/etcd-backup-restore
-    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
-    tag: "v0.40.0"
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
+    tag: "v0.42.0"
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -71,6 +71,10 @@ images:
           comment: >
             pause-container is not accessible from outside k8s clusters and not interacted with from other containers or other systems
 
+  - name: etcd-backup-restore
+    sourceRepository: github.com/gardener/etcd-backup-restore
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl
+    tag: "v0.40.0"
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -71,10 +71,6 @@ images:
           comment: >
             pause-container is not accessible from outside k8s clusters and not interacted with from other containers or other systems
 
-  - name: etcd-backup-restore
-    sourceRepository: github.com/gardener/etcd-backup-restore
-    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
-    tag: "v0.43.0"
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid
@@ -83,6 +79,10 @@ images:
     sourceRepository: github.com/etcd-io/etcd
     repository: gcr.io/etcd-development/etcd
     tag: "v3.5.27"
+  - name: etcd-backup-restore
+    sourceRepository: github.com/gardener/etcd-backup-restore
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
+    tag: "v0.43.0"
   - name: dependency-watchdog
     sourceRepository: github.com/gardener/dependency-watchdog
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dependency-watchdog

--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -74,7 +74,7 @@ images:
   - name: etcd-backup-restore
     sourceRepository: github.com/gardener/etcd-backup-restore
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl
-    tag: "v0.42.0"
+    tag: "v0.43.0"
   - name: etcd-druid
     sourceRepository: github.com/gardener/etcd-druid
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/etcd-druid

--- a/pkg/component/etcd/bootstrap/backuprestore/backuprestore_suite_test.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/backuprestore_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package backuprestore_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackupRestore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Etcd Bootstrap BackupRestore Suite")
+}

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package backuprestore
+
+import (
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/gardener/gardener/pkg/component/etcd/etcd"
+	staticpodtranslator "github.com/gardener/gardener/pkg/gardenadm/staticpod"
+)
+
+const (
+	// EtcdConfigFileName is the key/filename of the etcd config inside the ConfigMap.
+	EtcdConfigFileName = "etcd.conf.yaml"
+
+	configMapName = "etcd-bootstrap-main-config"
+
+	volumeNameBackupBuckets = "backup-buckets"
+	volumeNameRestoreTmp    = "restoration-tmp"
+	volumeNameEtcdConf      = "etcd-conf"
+
+	volumeMountPathBackupBuckets = "/root"
+	volumeMountPathRestoreTmp    = "/tmp/restorationtmp"
+	volumeMountPathEtcdConf      = "/var/etcd/config"
+)
+
+// Config contains configuration for running etcdbrctl initialize before starting the bootstrap etcd.
+//
+// The init container is only added when this config is not nil.
+type Config struct {
+	EtcdbrctlImage        string
+	StoreContainer        string
+	StorePrefix           string
+	BackupBucketsHostPath string
+}
+
+// ShouldRun reports whether the backup-restore init container should be injected.
+func (cfg *Config) ShouldRun() bool {
+	return cfg != nil &&
+		cfg.BackupBucketsHostPath != "" &&
+		cfg.StoreContainer != ""
+}
+
+// ConfigMap returns the fully populated etcd-config ConfigMap for the etcdbrctl init container.
+func (cfg *Config) ConfigMap(namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			EtcdConfigFileName: cfg.EtcdInitializeConfig(),
+		},
+	}
+}
+
+// InitContainer returns the etcdbrctl-initialize init container spec.
+func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
+	dataDir := staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(role))
+
+	return corev1.Container{
+		Name:            "etcdbrctl-initialize",
+		Image:           cfg.EtcdbrctlImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                ptr.To[int64](0),
+			RunAsGroup:               ptr.To[int64](0),
+			AllowPrivilegeEscalation: ptr.To(false),
+		},
+		Args: []string{
+			"initialize",
+			"--storage-provider=Local",
+			"--store-container=" + cfg.StoreContainer,
+			"--store-prefix=" + cfg.StorePrefix,
+			"--data-dir=" + filepath.Join(dataDir, "new.etcd"),
+			"--restoration-temp-snapshots-dir=" + volumeMountPathRestoreTmp,
+		},
+		Env: []corev1.EnvVar{
+			{Name: "POD_NAME", Value: "etcd-bootstrap-main"},
+			{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: volumeNameBackupBuckets, MountPath: volumeMountPathBackupBuckets},
+			{Name: dataVolumeName, MountPath: staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(role))},
+			{Name: volumeNameRestoreTmp, MountPath: volumeMountPathRestoreTmp},
+			{Name: volumeNameEtcdConf, MountPath: volumeMountPathEtcdConf},
+		},
+	}
+}
+
+// Volumes returns the volumes needed by the backup-restore init container.
+func (cfg *Config) Volumes() []corev1.Volume {
+	return []corev1.Volume{
+		{Name: volumeNameBackupBuckets, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: cfg.BackupBucketsHostPath, Type: ptr.To(corev1.HostPathDirectoryOrCreate)}}},
+		{Name: volumeNameRestoreTmp, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+		{Name: volumeNameEtcdConf, VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}, Items: []corev1.KeyToPath{{Key: EtcdConfigFileName, Path: EtcdConfigFileName}}}}},
+	}
+}
+
+// EtcdInitializeConfig returns the etcd config YAML used during initialization.
+func (cfg *Config) EtcdInitializeConfig() string {
+	return `advertise-client-urls:
+  etcd-bootstrap-main:
+  - https://localhost:2379
+auto-compaction-mode: periodic
+auto-compaction-retention: 30m
+client-transport-security:
+  auto-tls: false
+  cert-file: /var/etcd/ssl/server/tls.crt
+  client-cert-auth: true
+  key-file: /var/etcd/ssl/server/tls.key
+  trusted-ca-file: /var/etcd/ssl/ca/bundle.crt
+data-dir: /var/etcd/data/new.etcd
+enable-v2: false
+initial-advertise-peer-urls:
+  etcd-bootstrap-main:
+  - http://localhost:2380
+initial-cluster: etcd-bootstrap-main=http://localhost:2380
+initial-cluster-state: new
+initial-cluster-token: etcd-cluster
+listen-client-urls: https://0.0.0.0:2379
+listen-peer-urls: http://0.0.0.0:2380
+metrics: extensive
+name: etcd-config
+quota-backend-bytes: 8589934592
+snapshot-count: 10000
+`
+}

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	staticpodtranslator "github.com/gardener/gardener/pkg/gardenadm/staticpod"
@@ -69,9 +68,9 @@ func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
 		Image:           cfg.EtcdbrctlImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                ptr.To[int64](0),
-			RunAsGroup:               ptr.To[int64](0),
-			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsUser:                new(int64(0)),
+			RunAsGroup:               new(int64(0)),
+			AllowPrivilegeEscalation: new(false),
 		},
 		Args: []string{
 			"initialize",
@@ -97,7 +96,7 @@ func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
 // Volumes returns the volumes needed by the backup-restore init container.
 func (cfg *Config) Volumes() []corev1.Volume {
 	return []corev1.Volume{
-		{Name: volumeNameBackupBuckets, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: cfg.BackupBucketsHostPath, Type: ptr.To(corev1.HostPathDirectoryOrCreate)}}},
+		{Name: volumeNameBackupBuckets, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: cfg.BackupBucketsHostPath, Type: new(corev1.HostPathDirectoryOrCreate)}}},
 		{Name: volumeNameRestoreTmp, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		{Name: volumeNameEtcdConf, VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: configMapName}, Items: []corev1.KeyToPath{{Key: EtcdConfigFileName, Path: EtcdConfigFileName}}}}},
 	}

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
@@ -107,8 +107,12 @@ func (cfg *Config) InitContainer(dataVolumeName string) corev1.Container {
 			RunAsGroup:               new(int64(0)),
 			AllowPrivilegeEscalation: new(false),
 		},
-		// using initialize as restore is for manual/administrative restores
 		Args: []string{
+			// using "initialize" (instead of the "restore" command) as it is the safer, idempotent
+			// choice for a re-runnable init container: it validates the existing data directory and
+			// only restores from the backup store when the data is missing or corrupt (in contrast to
+			// "restore" which unconditionally overwrites the data directory from the latest snapshot
+			// without validation, and would roll back healthy state on every pod restart)
 			"initialize",
 			"--storage-provider=Local",
 			"--store-container=" + cfg.StoreContainer,

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
@@ -5,11 +5,13 @@
 package backuprestore
 
 import (
+	"fmt"
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	staticpodtranslator "github.com/gardener/gardener/pkg/gardenadm/staticpod"
 )
@@ -31,7 +33,7 @@ const (
 
 // Config contains configuration for running etcdbrctl initialize before starting the bootstrap etcd.
 //
-// The init container is only added when this config is not nil.
+// The etcdbrctl-initialize init container is only added when this config is not nil.
 type Config struct {
 	EtcdbrctlImage        string
 	StoreContainer        string
@@ -39,14 +41,44 @@ type Config struct {
 	BackupBucketsHostPath string
 }
 
-// ShouldRun reports whether the backup-restore init container should be injected.
+// ConfigFromBackupDataPath builds a Config from the local backup data path on the node and the etcdbrctl image.
+// The path is expected to have the structure:
+//
+//	<backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+func ConfigFromBackupDataPath(path, etcdbrctlImage string) (*Config, error) {
+	if path == "" {
+		return nil, fmt.Errorf("backup data path must not be empty")
+	}
+
+	// Strip the trailing version dir (e.g. "v2") to get the etcd-main dir, then walk up the structure.
+	etcdMainDir := filepath.Dir(path)                                  // .../etcd-main
+	entryDir := filepath.Dir(etcdMainDir)                              // .../<namespace>--<uid>
+	bucketDir := filepath.Dir(entryDir)                                // .../<bucketName>
+	backupBucketsRoot := filepath.Dir(bucketDir)                       // <backupBucketsRoot>
+	storeContainer := filepath.Base(bucketDir)                         // <bucketName>
+	storePrefix := filepath.Join(filepath.Base(entryDir), "etcd-main") // <namespace>--<uid>/etcd-main
+
+	if storeContainer == "" || storeContainer == "." || storeContainer == string(filepath.Separator) ||
+		backupBucketsRoot == "" || filepath.Base(entryDir) == "." {
+		return nil, fmt.Errorf("backup data path %q does not have the expected structure <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2", path)
+	}
+
+	return &Config{
+		EtcdbrctlImage:        etcdbrctlImage,
+		StoreContainer:        storeContainer,
+		StorePrefix:           storePrefix,
+		BackupBucketsHostPath: backupBucketsRoot,
+	}, nil
+}
+
+// ShouldRun reports whether the etcdbrctl-initialize init container should be injected.
 func (cfg *Config) ShouldRun() bool {
 	return cfg != nil &&
 		cfg.BackupBucketsHostPath != "" &&
 		cfg.StoreContainer != ""
 }
 
-// ConfigMap returns the fully populated etcd-config ConfigMap for the etcdbrctl init container.
+// ConfigMap returns the fully populated etcd-config ConfigMap for the etcdbrctl-initialize init container.
 func (cfg *Config) ConfigMap(namespace string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -60,8 +92,11 @@ func (cfg *Config) ConfigMap(namespace string) *corev1.ConfigMap {
 }
 
 // InitContainer returns the etcdbrctl-initialize init container spec.
-func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
-	dataDir := staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(role))
+//
+// The backup-restore initialization only ever runs for the main etcd (see ShouldRun and the caller in
+// staticpods.go), hence the main etcd's data directory is used directly.
+func (cfg *Config) InitContainer(dataVolumeName string) corev1.Container {
+	dataDir := staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(v1beta1constants.ETCDRoleMain))
 
 	return corev1.Container{
 		Name:            "etcdbrctl-initialize",
@@ -87,14 +122,14 @@ func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: volumeNameBackupBuckets, MountPath: volumeMountPathBackupBuckets},
-			{Name: dataVolumeName, MountPath: staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(role))},
+			{Name: dataVolumeName, MountPath: dataDir},
 			{Name: volumeNameRestoreTmp, MountPath: volumeMountPathRestoreTmp},
 			{Name: volumeNameEtcdConf, MountPath: volumeMountPathEtcdConf},
 		},
 	}
 }
 
-// Volumes returns the volumes needed by the backup-restore init container.
+// Volumes returns the volumes needed by the etcdbrctl-initialize init container.
 func (cfg *Config) Volumes() []corev1.Volume {
 	return []corev1.Volume{
 		{Name: volumeNameBackupBuckets, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: cfg.BackupBucketsHostPath, Type: new(corev1.HostPathDirectoryOrCreate)}}},
@@ -116,7 +151,6 @@ client-transport-security:
   client-cert-auth: true
   key-file: /var/etcd/ssl/server/tls.key
   trusted-ca-file: /var/etcd/ssl/ca/bundle.crt
-data-dir: /var/etcd/data/new.etcd
 enable-v2: false
 initial-advertise-peer-urls:
   etcd-bootstrap-main:

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore.go
@@ -72,6 +72,7 @@ func (cfg *Config) InitContainer(role, dataVolumeName string) corev1.Container {
 			RunAsGroup:               new(int64(0)),
 			AllowPrivilegeEscalation: new(false),
 		},
+		// using initialize as restore is for manual/administrative restores
 		Args: []string{
 			"initialize",
 			"--storage-provider=Local",

--- a/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore_test.go
+++ b/pkg/component/etcd/bootstrap/backuprestore/etcd_backup_restore_test.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package backuprestore_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+
+	. "github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
+)
+
+var _ = Describe("BackupRestore", func() {
+	const (
+		etcdbrctlImage = "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.43.0"
+		namespace      = "shoot--foo--bar"
+	)
+
+	Describe("#ConfigFromBackupDataPath", func() {
+		It("should decompose a well-formed backup data path", func() {
+			cfg, err := ConfigFromBackupDataPath("/etc/gardener/local-backupbuckets/my-bucket/shoot--foo--bar--abc123/etcd-main/v2", etcdbrctlImage)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg).To(Equal(&Config{
+				EtcdbrctlImage:        etcdbrctlImage,
+				StoreContainer:        "my-bucket",
+				StorePrefix:           "shoot--foo--bar--abc123/etcd-main",
+				BackupBucketsHostPath: "/etc/gardener/local-backupbuckets",
+			}))
+		})
+
+		It("should pass the etcdbrctl image through unchanged", func() {
+			cfg, err := ConfigFromBackupDataPath("/root/bucket/ns--uid/etcd-main/v2", "some-other-image:latest")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.EtcdbrctlImage).To(Equal("some-other-image:latest"))
+		})
+
+		It("should return an error for an empty path", func() {
+			cfg, err := ConfigFromBackupDataPath("", etcdbrctlImage)
+			Expect(err).To(MatchError(ContainSubstring("must not be empty")))
+			Expect(cfg).To(BeNil())
+		})
+
+		It("should return an error for a too-short/malformed path", func() {
+			cfg, err := ConfigFromBackupDataPath("etcd-main/v2", etcdbrctlImage)
+			Expect(err).To(MatchError(ContainSubstring("does not have the expected structure")))
+			Expect(cfg).To(BeNil())
+		})
+	})
+
+	Describe("#ShouldRun", func() {
+		It("should return false for a nil config", func() {
+			var cfg *Config
+			Expect(cfg.ShouldRun()).To(BeFalse())
+		})
+
+		It("should return false when required fields are empty", func() {
+			Expect((&Config{}).ShouldRun()).To(BeFalse())
+			Expect((&Config{BackupBucketsHostPath: "/root"}).ShouldRun()).To(BeFalse())
+			Expect((&Config{StoreContainer: "bucket"}).ShouldRun()).To(BeFalse())
+		})
+
+		It("should return true when required fields are populated", func() {
+			cfg := &Config{BackupBucketsHostPath: "/root", StoreContainer: "bucket"}
+			Expect(cfg.ShouldRun()).To(BeTrue())
+		})
+	})
+
+	Describe("#InitContainer", func() {
+		var cfg *Config
+
+		BeforeEach(func() {
+			cfg = &Config{
+				EtcdbrctlImage:        etcdbrctlImage,
+				StoreContainer:        "my-bucket",
+				StorePrefix:           "shoot--foo--bar--abc123/etcd-main",
+				BackupBucketsHostPath: "/etc/gardener/local-backupbuckets",
+			}
+		})
+
+		It("should render the etcdbrctl-initialize init container spec", func() {
+			container := cfg.InitContainer("data")
+
+			Expect(container.Name).To(Equal("etcdbrctl-initialize"))
+			Expect(container.Image).To(Equal(etcdbrctlImage))
+			Expect(container.Args).To(Equal([]string{
+				"initialize",
+				"--storage-provider=Local",
+				"--store-container=my-bucket",
+				"--store-prefix=shoot--foo--bar--abc123/etcd-main",
+				"--data-dir=/var/lib/etcd-main/data/new.etcd",
+				"--restoration-temp-snapshots-dir=/tmp/restorationtmp",
+			}))
+			Expect(container.Env).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("POD_NAME"), "Value": Equal("etcd-bootstrap-main")}),
+			))
+			Expect(container.VolumeMounts).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("backup-buckets"), "MountPath": Equal("/root")}),
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("data"), "MountPath": Equal("/var/lib/etcd-main/data")}),
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("restoration-tmp"), "MountPath": Equal("/tmp/restorationtmp")}),
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-conf"), "MountPath": Equal("/var/etcd/config")}),
+			))
+		})
+	})
+
+	Describe("#Volumes", func() {
+		It("should render the volumes needed by the init container", func() {
+			cfg := &Config{BackupBucketsHostPath: "/etc/gardener/local-backupbuckets"}
+			volumes := cfg.Volumes()
+
+			Expect(volumes).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("backup-buckets")}),
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("restoration-tmp")}),
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-conf")}),
+			))
+
+			for _, v := range volumes {
+				if v.Name == "backup-buckets" {
+					Expect(v.VolumeSource.HostPath).NotTo(BeNil())
+					Expect(v.VolumeSource.HostPath.Path).To(Equal("/etc/gardener/local-backupbuckets"))
+				}
+			}
+		})
+	})
+
+	Describe("#ConfigMap", func() {
+		It("should render the etcd-config ConfigMap", func() {
+			cfg := &Config{}
+			cm := cfg.ConfigMap(namespace)
+
+			Expect(cm.Name).To(Equal("etcd-bootstrap-main-config"))
+			Expect(cm.Namespace).To(Equal(namespace))
+			Expect(cm.Data).To(HaveKey(EtcdConfigFileName))
+		})
+	})
+
+	Describe("#EtcdInitializeConfig", func() {
+		It("should render the etcd config YAML with the expected cluster fields", func() {
+			config := (&Config{}).EtcdInitializeConfig()
+
+			Expect(config).To(ContainSubstring("advertise-client-urls:"))
+			Expect(config).To(ContainSubstring("initial-advertise-peer-urls:"))
+			Expect(config).To(ContainSubstring("initial-cluster: etcd-bootstrap-main=http://localhost:2380"))
+			Expect(config).To(ContainSubstring("etcd-bootstrap-main:"))
+			// data-dir is intentionally not set here; the restore target comes from the init container's --data-dir flag.
+			Expect(config).NotTo(ContainSubstring("data-dir:"))
+		})
+	})
+})

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -17,6 +17,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	staticpodtranslator "github.com/gardener/gardener/pkg/gardenadm/staticpod"
@@ -45,6 +46,8 @@ type Values struct {
 	Image string
 	// Role is the role of this etcd instance (main or events).
 	Role string
+	// BackupRestore configures an optional init container that runs `etcdbrctl initialize`.
+	BackupRestore *backuprestore.Config
 	// PortClient is the port for the client connections.
 	PortClient int32
 	// PortPeer is the port for the peer connections.
@@ -96,6 +99,19 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 		return fmt.Errorf("failed to generate etcd peer certificate: %w", err)
 	}
 
+	if e.values.BackupRestore.ShouldRun() {
+		configMap := e.values.BackupRestore.ConfigMap(e.namespace)
+		configMap.Labels = e.labels()
+		_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, configMap, func() error {
+			configMap.Labels = e.labels()
+			configMap.Data = map[string]string{backuprestore.EtcdConfigFileName: e.values.BackupRestore.EtcdInitializeConfig()}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed creating or patching etcd initialize config ConfigMap: %w", err)
+		}
+	}
+
 	statefulSet := e.emptyStatefulSet()
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, statefulSet, func() error {
 		statefulSet.Labels = e.labels()
@@ -111,7 +127,7 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 						Command: []string{
 							"etcd",
 							"--name=" + statefulSet.Name,
-							"--data-dir=" + volumeMountPathData,
+							"--data-dir=" + volumeMountPathData + "/new.etcd",
 							"--experimental-initial-corrupt-check=true",
 							"--experimental-watch-progress-notify-interval=5s",
 							"--snapshot-count=10000",
@@ -208,7 +224,10 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 								HostPath: &corev1.HostPathVolumeSource{
 									// etcds managed by etcd-druid store their data in <data-dir>/new.etcd, so let's
 									// prepare for the take-over already now
-									Path: staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(e.values.Role)) + "/new.etcd",
+									// new.etcd is not part of path as backup-restore init container needs to do initial cleanup
+									// of the data directory before restoring the backup, and having new.etcd in the volume path
+									// causes the cleanup to fail
+									Path: staticpodtranslator.StatefulSetVolumeClaimTemplateHostPath(etcd.Name(e.values.Role)),
 									Type: new(corev1.HostPathDirectoryOrCreate),
 								},
 							},
@@ -256,6 +275,11 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 					},
 				},
 			},
+		}
+
+		if e.values.BackupRestore.ShouldRun() {
+			statefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{e.values.BackupRestore.InitContainer(e.values.Role, volumeNameData)}
+			statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, e.values.BackupRestore.Volumes()...)
 		}
 
 		return nil

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -101,7 +101,6 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 
 	if e.values.BackupRestore.ShouldRun() {
 		configMap := e.values.BackupRestore.ConfigMap(e.namespace)
-		configMap.Labels = e.labels()
 		_, err = controllerutils.GetAndCreateOrMergePatch(ctx, e.client, configMap, func() error {
 			configMap.Labels = e.labels()
 			configMap.Data = map[string]string{backuprestore.EtcdConfigFileName: e.values.BackupRestore.EtcdInitializeConfig()}

--- a/pkg/component/etcd/bootstrap/etcd.go
+++ b/pkg/component/etcd/bootstrap/etcd.go
@@ -277,7 +277,7 @@ func (e *etcdDeployer) Deploy(ctx context.Context) error {
 		}
 
 		if e.values.BackupRestore.ShouldRun() {
-			statefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{e.values.BackupRestore.InitContainer(e.values.Role, volumeNameData)}
+			statefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{e.values.BackupRestore.InitContainer(volumeNameData)}
 			statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, e.values.BackupRestore.Volumes()...)
 		}
 

--- a/pkg/component/etcd/bootstrap/etcd_test.go
+++ b/pkg/component/etcd/bootstrap/etcd_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
@@ -72,7 +73,7 @@ var _ = Describe("Etcd", func() {
 					Name: "data",
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/var/lib/etcd-main/data/new.etcd",
+							Path: "/var/lib/etcd-main/data",
 							Type: new(corev1.HostPathDirectoryOrCreate),
 						},
 					},
@@ -83,6 +84,43 @@ var _ = Describe("Etcd", func() {
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-peer-ca")}),
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-peer-server-tls")}),
 			))
+		})
+
+		It("should create and mount etcd initialize config via ConfigMap", func() {
+			etcd = New(c, namespace, sm, Values{
+				Image: image,
+				Role:  "main",
+				BackupRestore: &backuprestore.Config{
+					EtcdbrctlImage:        "europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.40.0",
+					StoreContainer:        "my-bucket",
+					StorePrefix:           "prefix",
+					BackupBucketsHostPath: "/etc/gardener/local-backupbuckets",
+				},
+			})
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet)).To(Succeed())
+
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "etcd-bootstrap-main-config", Namespace: namespace}}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+			Expect(cm.Data).To(HaveKey("etcd.conf.yaml"))
+
+			Expect(statefulSet.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(statefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts).To(ContainElement(
+				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-conf"), "MountPath": Equal("/var/etcd/config")}),
+			))
+
+			var etcdConfVolume *corev1.Volume
+			for i := range statefulSet.Spec.Template.Spec.Volumes {
+				v := &statefulSet.Spec.Template.Spec.Volumes[i]
+				if v.Name == "etcd-conf" {
+					etcdConfVolume = v
+					break
+				}
+			}
+			Expect(etcdConfVolume).NotTo(BeNil())
+			Expect(etcdConfVolume.VolumeSource.ConfigMap).NotTo(BeNil())
+			Expect(etcdConfVolume.VolumeSource.ConfigMap.Name).To(Equal("etcd-bootstrap-main-config"))
 		})
 	})
 

--- a/pkg/component/etcd/bootstrap/etcd_test.go
+++ b/pkg/component/etcd/bootstrap/etcd_test.go
@@ -106,6 +106,15 @@ var _ = Describe("Etcd", func() {
 			Expect(cm.Data).To(HaveKey("etcd.conf.yaml"))
 
 			Expect(statefulSet.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Name).To(Equal("etcdbrctl-initialize"))
+			Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Args).To(Equal([]string{
+				"initialize",
+				"--storage-provider=Local",
+				"--store-container=my-bucket",
+				"--store-prefix=prefix",
+				"--data-dir=/var/lib/etcd-main/data/new.etcd",
+				"--restoration-temp-snapshots-dir=/tmp/restorationtmp",
+			}))
 			Expect(statefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts).To(ContainElement(
 				MatchFields(IgnoreExtras, Fields{"Name": Equal("etcd-conf"), "MountPath": Equal("/var/etcd/config")}),
 			))

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -64,6 +64,10 @@ type GardenadmBotanist struct {
 	// This field is only relevant for shoot with unmanaged infrastructure.
 	Zone *string
 
+	// BackupDataPath is the local path on the node where the etcd backup data is stored.
+	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
+	BackupDataPath string
+
 	operatingSystemConfigSecret       *corev1.Secret
 	gardenerResourceManagerServiceIPs []string
 	useEtcdManagedByDruid             bool

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -62,6 +62,10 @@ type GardenadmBotanist struct {
 	// This field is only relevant for shoot with unmanaged infrastructure.
 	Zone *string
 
+	// BackupDataPath is the local path on the node where the etcd backup data is stored.
+	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
+	BackupDataPath string
+
 	operatingSystemConfigSecret *corev1.Secret
 
 	// controlPlaneMachines is set by ListControlPlaneMachines during `gardenadm bootstrap`.

--- a/pkg/gardenadm/botanist/controlplane.go
+++ b/pkg/gardenadm/botanist/controlplane.go
@@ -28,6 +28,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	resourcemanagerconstants "github.com/gardener/gardener/pkg/component/gardener/resourcemanager/constants"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
@@ -57,12 +58,38 @@ func (b *GardenadmBotanist) deployETCD(role string) func(context.Context) error 
 			return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcd, err)
 		}
 
+		var etcdBackupRestore *backuprestore.Config
+
+		if role == v1beta1constants.ETCDRoleMain && b.BackupDataPath != "" {
+			etcdbrctlImage, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameEtcdBackupRestore)
+			if err != nil {
+				return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcdBackupRestore, err)
+			}
+
+			// Path structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+			// Strip the trailing version dir (e.g. "v2") to get the etcd-main dir.
+			etcdMainDir := filepath.Dir(b.BackupDataPath)                      // .../etcd-main
+			entryDir := filepath.Dir(etcdMainDir)                              // .../<namespace>--<uid>
+			bucketDir := filepath.Dir(entryDir)                                // .../<bucketName>
+			backupBucketsRoot := filepath.Dir(bucketDir)                       // <backupBucketsRoot>
+			storeContainer := filepath.Base(bucketDir)                         // <bucketName>
+			storePrefix := filepath.Join(filepath.Base(entryDir), "etcd-main") // <namespace>--<uid>/etcd-main
+
+			etcdBackupRestore = &backuprestore.Config{
+				EtcdbrctlImage:        etcdbrctlImage.String(),
+				StoreContainer:        storeContainer,
+				StorePrefix:           storePrefix,
+				BackupBucketsHostPath: backupBucketsRoot,
+			}
+		}
+
 		return bootstrapetcd.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.SecretsManager, bootstrapetcd.Values{
-			Image:       image.String(),
-			Role:        role,
-			PortClient:  portClient,
-			PortPeer:    portPeer,
-			PortMetrics: portMetrics,
+			Image:         image.String(),
+			Role:          role,
+			BackupRestore: etcdBackupRestore,
+			PortClient:    portClient,
+			PortPeer:      portPeer,
+			PortMetrics:   portMetrics,
 		}).Deploy(ctx)
 	}
 }

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -37,11 +37,11 @@ import (
 // DeployOperatingSystemConfigSecretForBootstrap deploys the OperatingSystemConfig resource and adds its content into
 // a Secret so that gardener-node-agent can read it and reconcile its content.
 func (b *GardenadmBotanist) DeployOperatingSystemConfigSecretForBootstrap(ctx context.Context) error {
-	if err := b.DeployControlPlaneDeployments(ctx, true); err != nil {
+	if err := b.DeployControlPlaneDeployments(ctx, true, b.BackupDataPath); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true)
+	oscData, controlPlaneWorkerPoolName, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, true, b.BackupDataPath)
 	if err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -505,6 +505,8 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*botanist.Garden
 		b.Zone = new(opts.Zone)
 	}
 
+	b.BackupDataPath = opts.BackupDataPath
+
 	kubeconfigFileExists, err := b.FS.Exists(botanist.PathKubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed checking whether kubeconfig file %s exists: %w", botanist.PathKubeconfig, err)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -522,6 +522,8 @@ func bootstrapControlPlane(ctx context.Context, opts *Options) (*gardenadmbotani
 		b.Zone = new(opts.Zone)
 	}
 
+	b.BackupDataPath = opts.BackupDataPath
+
 	kubeconfigFileExists, err := b.FS.Exists(botanist.PathKubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed checking whether kubeconfig file %s exists: %w", botanist.PathKubeconfig, err)

--- a/pkg/gardenadm/cmd/init/init.go
+++ b/pkg/gardenadm/cmd/init/init.go
@@ -380,7 +380,7 @@ func run(ctx context.Context, opts *Options) error {
 		deployControlPlaneDeployments = g.Add(flow.Task{
 			Name: "Deploying control plane components as Deployments/StatefulSets and updating gardener-node-agent Secret",
 			Fn: func(ctx context.Context) error {
-				return b.DeployStaticControlPlaneDeployments(ctx, opts.UseBootstrapEtcd)
+				return b.DeployStaticControlPlaneDeployments(ctx, opts.UseBootstrapEtcd, b.BackupDataPath)
 			},
 			Dependencies: flow.NewTaskIDs(waitUntilControlPlaneReady, waitUntilEtcdsReady),
 		})

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -34,6 +34,10 @@ type Options struct {
 	// If it has exactly one zone configured, that zone is automatically applied and the flag is optional.
 	// If it has no zones configured, this flag must not be set.
 	Zone string
+	// BackupDataPath is the local path on the node where the etcd backup data is stored.
+	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
+	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+	BackupDataPath string
 }
 
 // ParseArgs parses the arguments to the options.
@@ -93,4 +97,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseBootstrapEtcd, "use-bootstrap-etcd", false, "If set, the control plane continues using the bootstrap etcd instead of transitioning to etcd-druid. This can be useful for testing purposes to save time.")
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
+	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -38,8 +38,9 @@ type Options struct {
 	Zone string
 	// BackupDataPath is the local path on the node where the etcd backup data is stored.
 	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
-	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
-	//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
+	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2.
+	//
+	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
 	BackupDataPath string
 }
 
@@ -101,6 +102,6 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
-	//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
+	// TODO(Kostov6): Support specifying the backup root path after backup resource manifests are imported.
 	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -36,6 +36,10 @@ type Options struct {
 	// If it has exactly one zone configured, that zone is automatically applied and the flag is optional.
 	// If it has no zones configured, this flag must not be set.
 	Zone string
+	// BackupDataPath is the local path on the node where the etcd backup data is stored.
+	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
+	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+	BackupDataPath string
 }
 
 // ParseArgs parses the arguments to the options.
@@ -96,4 +100,5 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
+	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenadm/cmd/init/options.go
+++ b/pkg/gardenadm/cmd/init/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	// BackupDataPath is the local path on the node where the etcd backup data is stored.
 	// When set, the bootstrap etcd will be initialized from this path using the Local storage provider.
 	// The path is expected to have the structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+	//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
 	BackupDataPath string
 }
 
@@ -100,5 +101,6 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.UseHostNetwork, "use-host-network", false, "If set, gardener-resource-manager and extensions continue to run in host network instead of getting redeployed into the pod network after bootstrapping. This can be useful for testing purposes to save time.")
 	fs.StringVarP(&o.Zone, "zone", "z", "", "Availability zone for the new node. Required if the control plane worker pool in the Shoot has multiple zones configured. Optional if exactly one zone is configured (applied automatically). Must not be set if no zones are configured.")
 	fs.BoolVar(&o.Force, "force", false, "If set, the init command will be executed even if the control plane is already initialized.")
+	//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
 	fs.StringVar(&o.BackupDataPath, "backup-data-path", "", "Local path on the node where the etcd backup data is stored. Expected structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2")
 }

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -40,7 +40,7 @@ type staticControlPlaneComponent struct {
 	mutate       func(*corev1.Pod)
 }
 
-func (b *Botanist) deployETCD(role string) func(context.Context) error {
+func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(context.Context) error {
 	var portClient, portPeer, portMetrics int32 = 2379, 2380, 2381
 	if role == v1beta1constants.ETCDRoleEvents {
 		portClient, portPeer, portMetrics = etcdconstants.StaticPodPortEtcdEventsClient, 2383, 2384
@@ -68,7 +68,7 @@ func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 	return b.DeployKubeAPIServer(ctx)
 }
 
-func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool) []staticControlPlaneComponent {
+func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool, bootstrapEtcdBackupPath string) []staticControlPlaneComponent {
 	var (
 		components []staticControlPlaneComponent
 
@@ -85,8 +85,8 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool) []staticC
 
 	if useBootstrapEtcd {
 		components = append(components,
-			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleMain), bootstrapetcd.Name(v1beta1constants.ETCDRoleMain), &appsv1.StatefulSet{}, nil},
-			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleEvents), bootstrapetcd.Name(v1beta1constants.ETCDRoleEvents), &appsv1.StatefulSet{}, nil},
+			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleMain, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleMain), &appsv1.StatefulSet{}, nil},
+			staticControlPlaneComponent{b.deployETCD(v1beta1constants.ETCDRoleEvents, bootstrapEtcdBackupPath), bootstrapetcd.Name(v1beta1constants.ETCDRoleEvents), &appsv1.StatefulSet{}, nil},
 		)
 	} else {
 		components = append(components,
@@ -105,12 +105,12 @@ func (b *Botanist) staticControlPlaneComponents(useBootstrapEtcd bool) []staticC
 // DeployStaticControlPlaneDeployments deploys the deployments for the static control plane components. It also updates
 // the OperatingSystemConfig, waits for it to be reconciled by the OS extension, and deploys the ManagedResource
 // containing the Secret with OperatingSystemConfig for gardener-node-agent.
-func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool) error {
-	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd); err != nil {
+func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) error {
+	if err := b.DeployControlPlaneDeployments(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath); err != nil {
 		return fmt.Errorf("failed deploying control plane deployments: %w", err)
 	}
 
-	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd); err != nil {
+	if _, _, err := b.DeployOperatingSystemConfigWithStaticPods(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath); err != nil {
 		return fmt.Errorf("failed deploying OperatingSystemConfig: %w", err)
 	}
 
@@ -127,8 +127,8 @@ func (b *Botanist) DeployStaticControlPlaneDeployments(ctx context.Context, useB
 }
 
 // DeployControlPlaneDeployments runs the Deploy function of the control plane components.
-func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool) error {
-	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd) {
+func (b *Botanist) DeployControlPlaneDeployments(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) error {
+	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
 		if err := b.deployControlPlaneComponent(ctx, component.deploy, component.targetObject, component.name); err != nil {
 			return fmt.Errorf("failed deploying %q: %w", component.name, err)
 		}
@@ -185,8 +185,8 @@ func (b *Botanist) populateStaticAdminTokenToAccessTokenSecret(ctx context.Conte
 
 // DeployOperatingSystemConfigWithStaticPods deploys the OperatingSystemConfig containing the files for the control
 // plane components running as static pods.
-func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context, useBootstrapEtcd bool) (*operatingsystemconfig.Data, string, error) {
-	pods, err := b.staticControlPlanePods(ctx, useBootstrapEtcd)
+func (b *Botanist) DeployOperatingSystemConfigWithStaticPods(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) (*operatingsystemconfig.Data, string, error) {
+	pods, err := b.staticControlPlanePods(ctx, useBootstrapEtcd, bootstrapEtcdBackupPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed computing files for static control plane pods: %w", err)
 	}
@@ -248,10 +248,10 @@ func (s staticPods) allFiles() []extensionsv1alpha1.File {
 	return files
 }
 
-func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd bool) (staticPods, error) {
+func (b *Botanist) staticControlPlanePods(ctx context.Context, useBootstrapEtcd bool, bootstrapEtcdBackupPath string) (staticPods, error) {
 	var pods staticPods
 
-	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd) {
+	for _, component := range b.staticControlPlaneComponents(useBootstrapEtcd, bootstrapEtcdBackupPath) {
 		if err := b.SeedClientSet.Client().Get(ctx, client.ObjectKey{Name: component.name, Namespace: b.Shoot.ControlPlaneNamespace}, component.targetObject); err != nil {
 			return nil, fmt.Errorf("failed reading object for %q: %w", component.name, err)
 		}

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -20,6 +20,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	bootstrapetcd "github.com/gardener/gardener/pkg/component/etcd/bootstrap"
+	"github.com/gardener/gardener/pkg/component/etcd/bootstrap/backuprestore"
 	etcdconstants "github.com/gardener/gardener/pkg/component/etcd/etcd/constants"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig"
 	kubeapiserver "github.com/gardener/gardener/pkg/component/kubernetes/apiserver"
@@ -52,12 +53,38 @@ func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(
 			return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcd, err)
 		}
 
+		var etcdBackupRestore *backuprestore.Config
+
+		if role == v1beta1constants.ETCDRoleMain && bootstrapEtcdBackupPath != "" {
+			etcdbrctlImage, err := imagevector.Containers().FindImage(imagevector.ContainerImageNameEtcdBackupRestore)
+			if err != nil {
+				return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcdBackupRestore, err)
+			}
+
+			// Path structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
+			// Strip the trailing version dir (e.g. "v2") to get the etcd-main dir.
+			etcdMainDir := filepath.Dir(bootstrapEtcdBackupPath)               // .../etcd-main
+			entryDir := filepath.Dir(etcdMainDir)                              // .../<namespace>--<uid>
+			bucketDir := filepath.Dir(entryDir)                                // .../<bucketName>
+			backupBucketsRoot := filepath.Dir(bucketDir)                       // <backupBucketsRoot>
+			storeContainer := filepath.Base(bucketDir)                         // <bucketName>
+			storePrefix := filepath.Join(filepath.Base(entryDir), "etcd-main") // <namespace>--<uid>/etcd-main
+
+			etcdBackupRestore = &backuprestore.Config{
+				EtcdbrctlImage:        etcdbrctlImage.String(),
+				StoreContainer:        storeContainer,
+				StorePrefix:           storePrefix,
+				BackupBucketsHostPath: backupBucketsRoot,
+			}
+		}
+
 		return bootstrapetcd.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, b.SecretsManager, bootstrapetcd.Values{
-			Image:       image.String(),
-			Role:        role,
-			PortClient:  portClient,
-			PortPeer:    portPeer,
-			PortMetrics: portMetrics,
+			Image:         image.String(),
+			Role:          role,
+			BackupRestore: etcdBackupRestore,
+			PortClient:    portClient,
+			PortPeer:      portPeer,
+			PortMetrics:   portMetrics,
 		}).Deploy(ctx)
 	}
 }

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -61,21 +61,9 @@ func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(
 				return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcdBackupRestore, err)
 			}
 
-			//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
-			// Path structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
-			// Strip the trailing version dir (e.g. "v2") to get the etcd-main dir.
-			etcdMainDir := filepath.Dir(bootstrapEtcdBackupPath)               // .../etcd-main
-			entryDir := filepath.Dir(etcdMainDir)                              // .../<namespace>--<uid>
-			bucketDir := filepath.Dir(entryDir)                                // .../<bucketName>
-			backupBucketsRoot := filepath.Dir(bucketDir)                       // <backupBucketsRoot>
-			storeContainer := filepath.Base(bucketDir)                         // <bucketName>
-			storePrefix := filepath.Join(filepath.Base(entryDir), "etcd-main") // <namespace>--<uid>/etcd-main
-
-			etcdBackupRestore = &backuprestore.Config{
-				EtcdbrctlImage:        etcdbrctlImage.String(),
-				StoreContainer:        storeContainer,
-				StorePrefix:           storePrefix,
-				BackupBucketsHostPath: backupBucketsRoot,
+			etcdBackupRestore, err = backuprestore.ConfigFromBackupDataPath(bootstrapEtcdBackupPath, etcdbrctlImage.String())
+			if err != nil {
+				return fmt.Errorf("failed building backup-restore config from path %q: %w", bootstrapEtcdBackupPath, err)
 			}
 		}
 

--- a/pkg/gardenlet/operation/botanist/staticpods.go
+++ b/pkg/gardenlet/operation/botanist/staticpods.go
@@ -61,6 +61,7 @@ func (b *Botanist) deployETCD(role string, bootstrapEtcdBackupPath string) func(
 				return fmt.Errorf("failed fetching image %s: %w", imagevector.ContainerImageNameEtcdBackupRestore, err)
 			}
 
+			//TODO(Kostov6): support any path after this information is extracted from the discovered backup resources
 			// Path structure: <backupBucketsRoot>/<bucketName>/<namespace>--<uid>/etcd-main/v2
 			// Strip the trailing version dir (e.g. "v2") to get the etcd-main dir.
 			etcdMainDir := filepath.Dir(bootstrapEtcdBackupPath)               // .../etcd-main


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area disaster-recovery
/kind enhancement

**What this PR does / why we need it**:
This PR introduces `--backup-data-path` that when specified the bootstrap etcd pod will have a etcd-backup-restore init container that will load the snapshot data from that path into the bootstrap etcd

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15345
Part of https://github.com/gardener/gardener/issues/15264

**Special notes for your reviewer**:
You can test it locally with:
```bash
#!/usr/bin/env bash

set -e

function targetMachine() {
  KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER="$PWD/dev-setup/kubeconfigs/self-hosted-shoot/kubeconfig"
  ./hack/usage/generate-kubeconfig.sh self-hosted-shoot --docker gind-machine-0 > "$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
  export KUBECONFIG="$KUBECONFIG_SELFHOSTEDSHOOT_CLUSTER"
}

echo "> Setting up gind (machine containers only)..."
make gind-up SCENARIO=machines

echo "> Initializing control plane Node..."
# TODO: Can we use the "--use-bootstrap-etcd" flag?
docker exec -ti gind-machine-0 gardenadm init -d /gardenadm/resources

echo "> Joining gind-machine-1 worker Node..."
JOIN_COMMAND_1=$(docker exec -ti gind-machine-0 gardenadm token create --print-join-command | tr -d '"')
docker exec -ti gind-machine-1 $(echo $JOIN_COMMAND_1)
echo "> Joining gind-machine-2 worker Node..."
JOIN_COMMAND_2=$(docker exec -ti gind-machine-0 gardenadm token create --print-join-command | tr -d '"')
docker exec -ti gind-machine-2 $(echo $JOIN_COMMAND_2)

targetMachine

echo
echo "> Simulating a disaster event..."
echo "> Stopping the gind-machine-0 container..."
docker stop gind-machine-0
echo "> Deleting the gind-machine-0 container with its volumes..."
docker rm --volumes gind-machine-0

echo "> Setting up gind (recreating the gind-machine-0 container)..."
make gind-up SCENARIO=machines

echo "> Restoring the control plane Node..."
backup_data_path=$(find dev/local-backupbuckets | grep v2$ | grep -v garden)
docker cp dev/local-backupbuckets gind-machine-0:/local-backupbuckets
docker exec -ti gind-machine-0 gardenadm init -d /gardenadm/resources --use-bootstrap-etcd --backup-data-path "/${backup_data_path#dev/}"
```

The bootstrap phase will fail with `Error: failed bootstrapping control plane: 1 error occurred: * task "Initializing connection to Kubernetes control plane" failed: retry failed with context deadline exceeded, last error: failed to GET /readyz endpoint of kube-apiserve` but we can see that old etcd data will be used

```bash
root@gind-machine-0:/# k get mr
NAME                                          CLASS   APPLIED   HEALTHY   PROGRESSING   AGE
extension-controlplane-configuration-seed     seed    True      True      False         10m
extension-controlplane-seed                   seed    True      False     False         10m
extension-controlplane-shoot                          True      True      False         10m
extension-controlplane-storageclasses                 True      True      False         10m
extension-networking-calico-config                    True      False     False         12m
networking-calico                             seed    True      True      False         12m
provider-local                                seed    True      True      False         12m
shoot-core-coredns                                    True      True      False         11m
shoot-core-gardener-resource-manager                  True      True      False         12m
shoot-core-kube-apiserver                             True      True      False         10m
shoot-core-kube-controller-manager                    True      True      False         10m
shoot-core-kube-proxy                                 True      True      False         12m
shoot-core-kube-proxy-control-plane-v1.35             True      True      False         12m
shoot-core-kube-proxy-control-plane-v1.35.4           True      True      False         12m
shoot-core-kube-proxy-worker-v1.35                    True      True      False         12m
shoot-core-kube-proxy-worker-v1.35.4                  True      False     False         12m
shoot-core-kube-scheduler                             True      True      False         10m
shoot-core-namespaces                                 True      True      False         12m
shoot-core-system                                     True      True      False         12m
shoot-gardener-node-agent                             True      True      False         10m
system                                        seed    True      True      False         12m
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new `--backup-data-path` flag is introduced to `gardenadm init`. It loads the etcd snapshot data from a local path on the host into the bootstrap etcd. The flag will be used in future self-hosted Shoot cluster disaster recovery scenarios.
```
