### PR TITLE
dev-setup: order DNS resolvers on macOS

### DIFF
--- a/dev-setup/infra.sh
+++ b/dev-setup/infra.sh
@@ -135,8 +135,8 @@ EOF
           echo "Configuring macOS to resolve the local.gardener.cloud zone using the local setup's DNS server"
           ${SUDO}mkdir -p /etc/resolver
           cat <<EOF | ${SUDO}tee /etc/resolver/local.gardener.cloud
-nameserver $dns_ipv6
 nameserver $dns_ip
+nameserver $dns_ipv6
 EOF
         fi
       elif [[ "$OSTYPE" == "linux"* && -f /etc/systemd/resolved.conf ]]; then


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

The DNS resolvers order for `local.gardener.cloud` in local dev setup differs on macOS and Linux. 

On macOS the order is:

- IPv6 first, IPv4 next

On Linux the order is:

- IPv4 first, IPv6 next

At first this is inconsistent, but it also causes an issue for local dev setups on macOS with IPv4 resolvers only.

Running `make kind-up gardener-up` on macOS with IPv4 resolvers only results in this error.

```
Deploy Failed. Could not connect to cluster due to "https://api.virtual-garden.local.gardener.cloud/version": dial tcp: lookup api.virtual-garden.local.gardener.cloud: no such host. Check your connection for the cluster.
```

This issue has to do with the ordering of the DNS resolvers. 

```
$ cat /etc/resolver/local.gardener.cloud
nameserver fd00:ff::53
nameserver 172.18.255.53
```

Note that in the output below there is no IPv6 resolver (lack of `AAAA` records).

```
$ scutil --dns 
...
resolver #8
  domain   : local.gardener.cloud
  nameserver[0] : 172.18.255.53
  flags    : Request A records
  reach    : 0x00030002 (Reachable,Local Address,Directly Reachable Address)
```

On a machine with IPv6 resolving the result from `scutil(8)` should look like this.

```
resolver #8
  domain   : local.gardener.cloud
  nameserver[0] : fd00:ff::53
  nameserver[1] : 172.18.255.53
  flags    : Request A records, Request AAAA records
  reach    : 0x00030002 (Reachable,Local Address,Directly Reachable Address)
```

This PR makes the DNS ordering on macOS consistent with the ordering on Linux, and fixes the issue with local dev setup on systems with IPv4 resolving only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The local development setup on macOS contains changes which affect the order of DNS resolvers in `/etc/resolver/local.gardener.cloud` file. In order to regenerate the `/etc/resolver/local.gardener.cloud` file you can either remove it, or manually re-order the DNS resolvers.
```
