### PR TITLE
[GEP-32] Implement NamespacedCloudProfile controller logic

### DIFF
--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -140,7 +140,7 @@ func getImageName(bastion *gardencorev1beta1.Bastion, images []gardencorev1beta1
 	// take the first image from cloud profile that is supported and capabilities including arch are compatible
 	for _, image := range images {
 		for _, version := range image.Versions {
-			if v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
+			if !v1beta1helper.VersionIsSupported(version.ExpirableVersion) {
 				continue
 			}
 			if !slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version, capabilityDefinitions), bastionArchitecture) {
@@ -183,7 +183,7 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 
 	var greatest *semver.Version
 	for _, version := range image.Versions {
-		if v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
+		if !v1beta1helper.VersionIsSupported(version.ExpirableVersion) {
 			continue
 		}
 		if !slices.Contains(v1beta1helper.GetArchitecturesFromImageVersion(version, capabilityDefinitions), machineArch) {

--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -91,9 +91,8 @@ func findSupportedArchitectures(images []gardencorev1beta1.MachineImage, machine
 				// Skip versions that are not the specified one.
 				continue
 			}
-			// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
-			// multiple patch versions supported within the same minor.
-			// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+			// TODO(rapsnx): There is a regression in old classifications, which allowed to bypass validations.
+			// Update this when issue: https://github.com/gardener/gardener/issues/14328 is resolved.
 			if version.Classification != nil && v1beta1helper.VersionIsSupported(version.ExpirableVersion) {
 				architectures.Insert(v1beta1helper.GetArchitecturesFromImageVersion(version, capabilityDefinitions)...)
 			}
@@ -173,9 +172,8 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 			return "", fmt.Errorf("image version %s not found not found in cloudProfile", *bastion.MachineImage.Version)
 		}
 
-		// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
-		// multiple patch versions supported within the same minor.
-		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+		// TODO(rapsnx): There is a regression in old classifications, which allowed to bypass validations.
+		// Update this when issue: https://github.com/gardener/gardener/issues/14328 is resolved.
 		v := image.Versions[versionIndex]
 		if v.Classification != nil && !v1beta1helper.VersionIsSupported(v.ExpirableVersion) {
 			return "", fmt.Errorf("specified image %s in version %s is not classified supported", imageName, *bastion.MachineImage.Version)

--- a/extensions/pkg/bastion/machine.go
+++ b/extensions/pkg/bastion/machine.go
@@ -91,9 +91,10 @@ func findSupportedArchitectures(images []gardencorev1beta1.MachineImage, machine
 				// Skip versions that are not the specified one.
 				continue
 			}
-			// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-0032-PR.
-			//  The current behavior for nil classifications is treated differently across the codebase.
-			if version.Classification != nil && v1beta1helper.CurrentLifecycleClassification(version.ExpirableVersion) == gardencorev1beta1.ClassificationSupported {
+			// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
+			// multiple patch versions supported within the same minor.
+			// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+			if version.Classification != nil && v1beta1helper.VersionIsSupported(version.ExpirableVersion) {
 				architectures.Insert(v1beta1helper.GetArchitecturesFromImageVersion(version, capabilityDefinitions)...)
 			}
 			if machineImageVersion != "" {
@@ -172,9 +173,11 @@ func getImageVersion(bastion *gardencorev1beta1.Bastion, imageName, machineArch 
 			return "", fmt.Errorf("image version %s not found not found in cloudProfile", *bastion.MachineImage.Version)
 		}
 
-		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-0032-PR.
-		//  The current behavior for nil classifications is treated differently across the codebase.
-		if image.Versions[versionIndex].Classification != nil && v1beta1helper.CurrentLifecycleClassification(image.Versions[versionIndex].ExpirableVersion) != gardencorev1beta1.ClassificationSupported {
+		// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
+		// multiple patch versions supported within the same minor.
+		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+		v := image.Versions[versionIndex]
+		if v.Classification != nil && !v1beta1helper.VersionIsSupported(v.ExpirableVersion) {
 			return "", fmt.Errorf("specified image %s in version %s is not classified supported", imageName, *bastion.MachineImage.Version)
 		}
 

--- a/pkg/api/core/helper/cloudprofile.go
+++ b/pkg/api/core/helper/cloudprofile.go
@@ -321,11 +321,8 @@ func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
 func FilterVersionsWithClassification(versions []core.ExpirableVersion, classification core.VersionClassification) []core.ExpirableVersion {
 	var result []core.ExpirableVersion
 	for _, version := range versions {
-		// TODO:(rapsnx) This function gets all supported versions, so if a lifecycle stage has a supported stage
-		// which is not active, it is also collected.
-		// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
-		// multiple patch versions supported within the same minor.
-		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+		// TODO(rapsnx): There is a regression in old classifications, which allowed to bypass validations.
+		// Update this when issue: https://github.com/gardener/gardener/issues/14328 is resolved.
 		if (version.Classification == nil || *version.Classification != classification) &&
 			!slices.ContainsFunc(version.Lifecycle, func(s core.LifecycleStage) bool {
 				return s.Classification == classification

--- a/pkg/api/core/helper/cloudprofile.go
+++ b/pkg/api/core/helper/cloudprofile.go
@@ -321,10 +321,11 @@ func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
 func FilterVersionsWithClassification(versions []core.ExpirableVersion, classification core.VersionClassification) []core.ExpirableVersion {
 	var result []core.ExpirableVersion
 	for _, version := range versions {
-		// TODO:rapsnx This function gets all supported versions, so if a lifecycle stage has a supported stage
+		// TODO:(rapsnx) This function gets all supported versions, so if a lifecycle stage has a supported stage
 		// which is not active, it is also collected.
-		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-0032-PR.
-		//  The current behavior for nil classifications is treated differently across the codebase.
+		// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
+		// multiple patch versions supported within the same minor.
+		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
 		if (version.Classification == nil || *version.Classification != classification) &&
 			!slices.ContainsFunc(version.Lifecycle, func(s core.LifecycleStage) bool {
 				return s.Classification == classification

--- a/pkg/api/core/helper/cloudprofile.go
+++ b/pkg/api/core/helper/cloudprofile.go
@@ -22,11 +22,6 @@ import (
 // CurrentLifecycleClassification returns the current lifecycle classification of the given version.
 // An empty classification is interpreted as supported. If the version is expired, it returns ClassificationExpired.
 func CurrentLifecycleClassification(version core.ExpirableVersion) core.VersionClassification {
-	var (
-		currentClassification = core.ClassificationUnavailable
-		currentTime           = time.Now()
-	)
-
 	if len(version.Lifecycle) == 0 && (version.Classification != nil || version.ExpirationDate != nil) {
 		// Deprecated: legacy classification/expiration fields are used, converting them to lifecycle stages.
 		// Remove once the legacy fields are removed.
@@ -49,6 +44,9 @@ func CurrentLifecycleClassification(version core.ExpirableVersion) core.VersionC
 		return core.ClassificationSupported
 	}
 
+	currentTime := time.Now()
+	currentClassification := core.ClassificationUnavailable
+
 	for _, stage := range version.Lifecycle {
 		startTime := time.Time{}
 		if stage.StartTime != nil {
@@ -63,9 +61,30 @@ func CurrentLifecycleClassification(version core.ExpirableVersion) core.VersionC
 	return currentClassification
 }
 
+// VersionIsExpired reports whether the given version is expired.
+func VersionIsExpired(version core.ExpirableVersion) bool {
+	return CurrentLifecycleClassification(version) == core.ClassificationExpired
+}
+
+// VersionIsActive reports whether the given version is active.
+func VersionIsActive(version core.ExpirableVersion) bool {
+	curr := CurrentLifecycleClassification(version)
+	return curr != core.ClassificationExpired && curr != core.ClassificationUnavailable
+}
+
 // VersionIsSupported reports whether the given version is supported.
 func VersionIsSupported(version core.ExpirableVersion) bool {
 	return CurrentLifecycleClassification(version) == core.ClassificationSupported
+}
+
+// VersionIsPreview reports whether the given version is in preview.
+func VersionIsPreview(version core.ExpirableVersion) bool {
+	return CurrentLifecycleClassification(version) == core.ClassificationPreview
+}
+
+// VersionIsDeprecated reports whether the given version is deprecated.
+func VersionIsDeprecated(version core.ExpirableVersion) bool {
+	return CurrentLifecycleClassification(version) == core.ClassificationDeprecated
 }
 
 // SupportedLifecycleClassification returns the lifecycle stage in which the version is classified as supported.
@@ -155,7 +174,7 @@ func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPre
 			return core.ExpirableVersion{}, core.ExpirableVersion{}, fmt.Errorf("error while parsing expirable version '%s': %s", version.Version, err.Error())
 		}
 
-		if filterPreviewVersions && CurrentLifecycleClassification(version) == core.ClassificationPreview {
+		if filterPreviewVersions && VersionIsPreview(version) {
 			continue
 		}
 
@@ -164,7 +183,7 @@ func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPre
 			latestExpirableVersion = version
 		}
 
-		if CurrentLifecycleClassification(version) != core.ClassificationDeprecated {
+		if !VersionIsDeprecated(version) {
 			if latestNonDeprecatedSemVerVersion == nil || v.GreaterThan(latestNonDeprecatedSemVerVersion) {
 				latestNonDeprecatedSemVerVersion = v
 				latestNonDeprecatedExpirableVersion = version
@@ -302,6 +321,8 @@ func GetMachineImageDiff(old, new []core.MachineImage) MachineImageDiff {
 func FilterVersionsWithClassification(versions []core.ExpirableVersion, classification core.VersionClassification) []core.ExpirableVersion {
 	var result []core.ExpirableVersion
 	for _, version := range versions {
+		// TODO:rapsnx This function gets all supported versions, so if a lifecycle stage has a supported stage
+		// which is not active, it is also collected.
 		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-0032-PR.
 		//  The current behavior for nil classifications is treated differently across the codebase.
 		if (version.Classification == nil || *version.Classification != classification) &&

--- a/pkg/api/core/helper/cloudprofile.go
+++ b/pkg/api/core/helper/cloudprofile.go
@@ -44,8 +44,10 @@ func CurrentLifecycleClassification(version core.ExpirableVersion) core.VersionC
 		return core.ClassificationSupported
 	}
 
-	currentTime := time.Now()
-	currentClassification := core.ClassificationUnavailable
+	var (
+		currentTime           = time.Now()
+		currentClassification = core.ClassificationUnavailable
+	)
 
 	for _, stage := range version.Lifecycle {
 		startTime := time.Time{}

--- a/pkg/api/core/helper/cloudprofile_test.go
+++ b/pkg/api/core/helper/cloudprofile_test.go
@@ -433,8 +433,7 @@ var _ = Describe("CloudProfile Helper", func() {
 
 			Expect(diff.RemovedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.RemovedVersions).To(BeEmpty())
-			// TODO:(rapsnx)
-			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
+			Expect(diff.RemovedVersionClassifications).To(BeEmpty())
 			Expect(diff.AddedImages.UnsortedList()).To(ConsistOf("image-2", "image-3"))
 			Expect(diff.AddedVersions).To(BeEquivalentTo(
 				map[string]sets.Set[string]{
@@ -470,8 +469,55 @@ var _ = Describe("CloudProfile Helper", func() {
 					"image-3": sets.New("version-1", "version-2"),
 				},
 			))
-			// TODO:(rapsnx)
-			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
+			Expect(diff.RemovedVersionClassifications).To(BeEmpty())
+			Expect(diff.AddedImages.UnsortedList()).To(BeEmpty())
+			Expect(diff.AddedVersions).To(BeEmpty())
+		})
+
+		It("should return the diff of a removed classification lifecycle", func() {
+			versions1 := []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{
+							Version: "version-1",
+							Lifecycle: []core.LifecycleStage{
+								{
+									Classification: classificationPreview,
+								},
+								{
+									Classification: classificationSupported,
+								},
+							},
+						}},
+					},
+				},
+			}
+
+			versions2 := []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{
+							Version: "version-1",
+							Lifecycle: []core.LifecycleStage{
+								{
+									Classification: classificationPreview,
+								},
+							},
+						}},
+					},
+				},
+			}
+			diff := GetMachineImageDiff(versions1, versions2)
+
+			Expect(diff.RemovedImages.UnsortedList()).To(BeEmpty())
+			Expect(diff.RemovedVersions).To(BeEmpty())
+			Expect(diff.RemovedVersionClassifications["image-1"]["version-1"]).To(Equal(
+				sets.Set[core.VersionClassification]{
+					classificationSupported: {},
+				},
+			))
 			Expect(diff.AddedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.AddedVersions).To(BeEmpty())
 		})
@@ -481,8 +527,7 @@ var _ = Describe("CloudProfile Helper", func() {
 
 			Expect(diff.RemovedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.RemovedVersions).To(BeEmpty())
-			// TODO:(rapsnx)
-			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
+			Expect(diff.RemovedVersionClassifications).To(BeEmpty())
 			Expect(diff.AddedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.AddedVersions).To(BeEmpty())
 		})

--- a/pkg/api/core/helper/cloudprofile_test.go
+++ b/pkg/api/core/helper/cloudprofile_test.go
@@ -433,6 +433,7 @@ var _ = Describe("CloudProfile Helper", func() {
 
 			Expect(diff.RemovedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.RemovedVersions).To(BeEmpty())
+			// TODO:(rapsnx)
 			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
 			Expect(diff.AddedImages.UnsortedList()).To(ConsistOf("image-2", "image-3"))
 			Expect(diff.AddedVersions).To(BeEquivalentTo(
@@ -469,6 +470,7 @@ var _ = Describe("CloudProfile Helper", func() {
 					"image-3": sets.New("version-1", "version-2"),
 				},
 			))
+			// TODO:(rapsnx)
 			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
 			Expect(diff.AddedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.AddedVersions).To(BeEmpty())
@@ -479,6 +481,7 @@ var _ = Describe("CloudProfile Helper", func() {
 
 			Expect(diff.RemovedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.RemovedVersions).To(BeEmpty())
+			// TODO:(rapsnx)
 			// TODO(LucaBernstein, vknabel): Add RemovedVersionClassifications case
 			Expect(diff.AddedImages.UnsortedList()).To(BeEmpty())
 			Expect(diff.AddedVersions).To(BeEmpty())

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/api"
@@ -85,6 +87,46 @@ func VersionIsSupported(version gardencorev1beta1.ExpirableVersion) bool {
 // VersionIsPreview reports whether the given version is in preview.
 func VersionIsPreview(version gardencorev1beta1.ExpirableVersion) bool {
 	return CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationPreview
+}
+
+// DurationUntilNextVersionLifecycleStage returns the duration until the earliest upcoming lifecycle start time
+// of any Kubernetes version or MachineImageVersion in the given <cloudProfile>.
+// If no future lifecycle start is found, it returns 0.
+func DurationUntilNextVersionLifecycleStage(cloudProfile *gardencorev1beta1.CloudProfileSpec, clock clock.Clock) time.Duration {
+	if cloudProfile == nil {
+		return 0
+	}
+
+	var next time.Time
+	now := clock.Now()
+
+	evaluate := func(t *metav1.Time) {
+		if t == nil {
+			return
+		}
+		if now.Before(t.Time) && (next.IsZero() || next.After(t.Time)) {
+			next = t.Time
+		}
+	}
+
+	for _, version := range cloudProfile.Kubernetes.Versions {
+		for _, stage := range version.Lifecycle {
+			evaluate(stage.StartTime)
+		}
+	}
+
+	for _, image := range cloudProfile.MachineImages {
+		for _, version := range image.Versions {
+			for _, stage := range version.Lifecycle {
+				evaluate(stage.StartTime)
+			}
+		}
+	}
+
+	if next.IsZero() {
+		return 0
+	}
+	return next.Sub(now)
 }
 
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -27,11 +27,6 @@ import (
 // CurrentLifecycleClassification returns the current lifecycle classification of the given version.
 // An empty classification is interpreted as supported. If the version is expired, it returns ClassificationExpired.
 func CurrentLifecycleClassification(version gardencorev1beta1.ExpirableVersion) gardencorev1beta1.VersionClassification {
-	var (
-		currentClassification = gardencorev1beta1.ClassificationUnavailable
-		currentTime           = time.Now()
-	)
-
 	if len(version.Lifecycle) == 0 && (version.Classification != nil || version.ExpirationDate != nil) {
 		// Deprecated: legacy classification/expiration fields are used, converting them to lifecycle stages.
 		// Remove once the legacy fields are removed.
@@ -53,6 +48,9 @@ func CurrentLifecycleClassification(version gardencorev1beta1.ExpirableVersion) 
 	if len(version.Lifecycle) == 0 {
 		return gardencorev1beta1.ClassificationSupported
 	}
+
+	currentTime := time.Now()
+	currentClassification := gardencorev1beta1.ClassificationUnavailable
 
 	for _, stage := range version.Lifecycle {
 		startTime := time.Time{}
@@ -87,6 +85,11 @@ func VersionIsSupported(version gardencorev1beta1.ExpirableVersion) bool {
 // VersionIsPreview reports whether the given version is in preview.
 func VersionIsPreview(version gardencorev1beta1.ExpirableVersion) bool {
 	return CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationPreview
+}
+
+// VersionIsDeprecated reports whether the given version is deprecated.
+func VersionIsDeprecated(version gardencorev1beta1.ExpirableVersion) bool {
+	return CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationDeprecated
 }
 
 // DurationUntilNextVersionLifecycleStage returns the duration until the earliest upcoming lifecycle start time
@@ -624,7 +627,7 @@ func FilterExpiredVersion() func(expirableVersion gardencorev1beta1.ExpirableVer
 // returns true if it is deprecated
 func FilterDeprecatedVersion() func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error) {
 	return func(expirableVersion gardencorev1beta1.ExpirableVersion, _ *semver.Version) (bool, error) {
-		return CurrentLifecycleClassification(expirableVersion) == gardencorev1beta1.ClassificationDeprecated, nil
+		return VersionIsDeprecated(expirableVersion), nil
 	}
 }
 

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -94,11 +94,11 @@ func VersionIsDeprecated(version gardencorev1beta1.ExpirableVersion) bool {
 	return CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationDeprecated
 }
 
-// DurationUntilNextVersionLifecycleStage returns the duration until the earliest upcoming lifecycle start time
-// of any Kubernetes version or MachineImageVersion in the given <cloudProfile>.
+// DurationUntilNextVersionTransition returns the duration until the earliest upcoming lifecycle start time
+// or expiration date of any Kubernetes version or MachineImageVersion in the given <cloudProfile>.
 // If no future lifecycle start is found, it returns 0.
-func DurationUntilNextVersionLifecycleStage(cloudProfile *gardencorev1beta1.CloudProfileSpec, clock clock.Clock) time.Duration {
-	if cloudProfile == nil {
+func DurationUntilNextVersionTransition(cloudProfile *gardencorev1beta1.CloudProfileSpec, clock clock.Clock) time.Duration {
+	if cloudProfile == nil || clock == nil {
 		return 0
 	}
 
@@ -114,17 +114,24 @@ func DurationUntilNextVersionLifecycleStage(cloudProfile *gardencorev1beta1.Clou
 		}
 	}
 
-	for _, version := range cloudProfile.Kubernetes.Versions {
-		for _, stage := range version.Lifecycle {
+	evaluateVersion := func(v gardencorev1beta1.ExpirableVersion) {
+		if v.ExpirationDate != nil {
+			evaluate(v.ExpirationDate)
+			return
+		}
+
+		for _, stage := range v.Lifecycle {
 			evaluate(stage.StartTime)
 		}
 	}
 
+	for _, version := range cloudProfile.Kubernetes.Versions {
+		evaluateVersion(version)
+	}
+
 	for _, image := range cloudProfile.MachineImages {
 		for _, version := range image.Versions {
-			for _, stage := range version.Lifecycle {
-				evaluate(stage.StartTime)
-			}
+			evaluateVersion(version.ExpirableVersion)
 		}
 	}
 

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -49,8 +49,10 @@ func CurrentLifecycleClassification(version gardencorev1beta1.ExpirableVersion) 
 		return gardencorev1beta1.ClassificationSupported
 	}
 
-	currentTime := time.Now()
-	currentClassification := gardencorev1beta1.ClassificationUnavailable
+	var (
+		currentTime           = time.Now()
+		currentClassification = gardencorev1beta1.ClassificationUnavailable
+	)
 
 	for _, stage := range version.Lifecycle {
 		startTime := time.Time{}

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -23,10 +23,14 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
+func IsUsingLegacyClassifications(version gardencorev1beta1.ExpirableVersion) bool {
+	return len(version.Lifecycle) == 0 && (version.Classification != nil || version.ExpirationDate != nil)
+}
+
 // CurrentLifecycleClassification returns the current lifecycle classification of the given version.
 // An empty classification is interpreted as supported. If the version is expired, it returns ClassificationExpired.
 func CurrentLifecycleClassification(version gardencorev1beta1.ExpirableVersion) gardencorev1beta1.VersionClassification {
-	if len(version.Lifecycle) == 0 && (version.Classification != nil || version.ExpirationDate != nil) {
+	if IsUsingLegacyClassifications(version) {
 		// Deprecated: legacy classification/expiration fields are used, converting them to lifecycle stages.
 		// Remove once the legacy fields are removed.
 

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -109,13 +109,17 @@ func DurationUntilNextVersionTransition(cloudProfile *gardencorev1beta1.CloudPro
 		if t == nil {
 			return
 		}
-		if now.Before(t.Time) && (next.IsZero() || next.After(t.Time)) {
+
+		isInFuture := now.Before(t.Time)
+		isBeforeNext := next.IsZero() || next.After(t.Time)
+
+		if isInFuture && isBeforeNext {
 			next = t.Time
 		}
 	}
 
 	evaluateVersion := func(v gardencorev1beta1.ExpirableVersion) {
-		if v.ExpirationDate != nil {
+		if len(v.Lifecycle) == 0 {
 			evaluate(v.ExpirationDate)
 			return
 		}
@@ -125,11 +129,11 @@ func DurationUntilNextVersionTransition(cloudProfile *gardencorev1beta1.CloudPro
 		}
 	}
 
-	for _, version := range cloudProfile.Kubernetes.Versions {
+	for _, version := range cloudProfile.Spec.Kubernetes.Versions {
 		evaluateVersion(version)
 	}
 
-	for _, image := range cloudProfile.MachineImages {
+	for _, image := range cloudProfile.Spec.MachineImages {
 		for _, version := range image.Versions {
 			evaluateVersion(version.ExpirableVersion)
 		}

--- a/pkg/api/core/v1beta1/helper/cloudprofile.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener/pkg/api"
@@ -97,13 +96,8 @@ func VersionIsDeprecated(version gardencorev1beta1.ExpirableVersion) bool {
 // DurationUntilNextVersionTransition returns the duration until the earliest upcoming lifecycle start time
 // or expiration date of any Kubernetes version or MachineImageVersion in the given <cloudProfile>.
 // If no future lifecycle start is found, it returns 0.
-func DurationUntilNextVersionTransition(cloudProfile *gardencorev1beta1.CloudProfileSpec, clock clock.Clock) time.Duration {
-	if cloudProfile == nil || clock == nil {
-		return 0
-	}
-
+func DurationUntilNextVersionTransition(cloudProfileSpec *gardencorev1beta1.CloudProfileSpec, now time.Time) time.Duration {
 	var next time.Time
-	now := clock.Now()
 
 	evaluate := func(t *metav1.Time) {
 		if t == nil {
@@ -129,11 +123,11 @@ func DurationUntilNextVersionTransition(cloudProfile *gardencorev1beta1.CloudPro
 		}
 	}
 
-	for _, version := range cloudProfile.Spec.Kubernetes.Versions {
+	for _, version := range cloudProfileSpec.Kubernetes.Versions {
 		evaluateVersion(version)
 	}
 
-	for _, image := range cloudProfile.Spec.MachineImages {
+	for _, image := range cloudProfileSpec.MachineImages {
 		for _, version := range image.Versions {
 			evaluateVersion(version.ExpirableVersion)
 		}

--- a/pkg/api/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile_test.go
@@ -194,7 +194,7 @@ var _ = Describe("CloudProfile Helper", func() {
 			}
 			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
 
-			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
 		})
 
 		It("should return the duration of the next version lifecycle without a chronological order", func() {
@@ -208,7 +208,7 @@ var _ = Describe("CloudProfile Helper", func() {
 			}
 			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
 
-			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 1*time.Hour, 100*time.Millisecond))
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 1*time.Hour, 100*time.Millisecond))
 		})
 
 		It("should return the duration of the next version lifecycle with start time in the past", func() {
@@ -222,7 +222,7 @@ var _ = Describe("CloudProfile Helper", func() {
 			}
 			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
 
-			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
 		})
 	})
 

--- a/pkg/api/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile_test.go
@@ -162,13 +162,13 @@ var _ = Describe("CloudProfile Helper", func() {
 
 	Describe("Get the duration until the next lifecycle stage from the CloudProfile", func() {
 		var (
-			now          = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-			cloudProfile gardencorev1beta1.CloudProfile
+			now              = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			cloudProfileSpec gardencorev1beta1.CloudProfileSpec
 		)
 
 		BeforeEach(func() {
-			cloudProfile = gardencorev1beta1.CloudProfile{
-				Spec: gardencorev1beta1.CloudProfileSpec{
+			cloudProfileSpec =
+				gardencorev1beta1.CloudProfileSpec{
 					Kubernetes: gardencorev1beta1.KubernetesSettings{
 						Versions: []gardencorev1beta1.ExpirableVersion{
 							{},
@@ -181,14 +181,13 @@ var _ = Describe("CloudProfile Helper", func() {
 							},
 						},
 					},
-				},
-			}
+				}
 		})
 
 		addK8sLifecycles := func(ts ...time.Duration) {
 			for _, t := range ts {
-				cloudProfile.Spec.Kubernetes.Versions[0].Lifecycle = append(
-					cloudProfile.Spec.Kubernetes.Versions[0].Lifecycle,
+				cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = append(
+					cloudProfileSpec.Kubernetes.Versions[0].Lifecycle,
 					gardencorev1beta1.LifecycleStage{
 						StartTime: ptr.To(metav1.NewTime(now.Add(t))),
 					},
@@ -198,8 +197,8 @@ var _ = Describe("CloudProfile Helper", func() {
 
 		addMachineLifecycles := func(ts ...time.Duration) {
 			for _, t := range ts {
-				cloudProfile.Spec.MachineImages[0].Versions[0].ExpirableVersion.Lifecycle = append(
-					cloudProfile.Spec.MachineImages[0].Versions[0].ExpirableVersion.Lifecycle,
+				cloudProfileSpec.MachineImages[0].Versions[0].Lifecycle = append(
+					cloudProfileSpec.MachineImages[0].Versions[0].Lifecycle,
 					gardencorev1beta1.LifecycleStage{
 						StartTime: ptr.To(metav1.NewTime(now.Add(t))),
 					},
@@ -209,57 +208,57 @@ var _ = Describe("CloudProfile Helper", func() {
 
 		It("should prefer lifecycle over expiration ", func() {
 			addK8sLifecycles(2*time.Hour, 5*time.Hour)
-			cloudProfile.Spec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			cloudProfileSpec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should use expiration if now lifecycle is set", func() {
-			cloudProfile.Spec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			cloudProfileSpec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next k8s version lifecycle based on a chronological order", func() {
 			addK8sLifecycles(2*time.Hour, 5*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next k8s version lifecycle without a chronological order", func() {
 			addK8sLifecycles(3*time.Hour, 1*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next k8s version lifecycle with start time in the past", func() {
 			addK8sLifecycles(3*time.Hour, -1*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 3*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next machine version lifecycle based on a chronological order", func() {
 			addMachineLifecycles(2*time.Hour, 5*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next machine version lifecycle without a chronological order", func() {
 			addMachineLifecycles(3*time.Hour, 1*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
 			)
 		})
 
 		It("should return the duration of the next machine version lifecycle with start time in the past", func() {
 			addMachineLifecycles(3*time.Hour, -1*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 3*time.Hour, 100*time.Millisecond),
 			)
 		})
@@ -267,7 +266,7 @@ var _ = Describe("CloudProfile Helper", func() {
 		It("should return the duration of the next k8s and machine version lifecycle", func() {
 			addK8sLifecycles(1*time.Hour, 2*time.Hour)
 			addMachineLifecycles(3*time.Hour, 4*time.Hour)
-			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, now)).To(
 				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
 			)
 		})

--- a/pkg/api/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile_test.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -157,6 +160,70 @@ var _ = Describe("CloudProfile Helper", func() {
 			Expect(classification).To(Equal(gardencorev1beta1.ClassificationPreview))
 		})
 
+	})
+
+	Describe("Get the duration until the next lifecycle stage from the CloudProfile", func() {
+		var (
+			fakeNow          time.Time
+			fakeClock        clock.Clock
+			cloudProfileSpec = gardencorev1beta1.CloudProfileSpec{
+				Kubernetes: gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{
+						{
+							Lifecycle: []gardencorev1beta1.LifecycleStage{},
+						},
+					},
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			fakeNow = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			fakeClock = testclock.NewFakeClock(fakeNow)
+
+		})
+
+		It("should return the duration of the next version lifecycle based on a chronological order", func() {
+			Lifecycles := []gardencorev1beta1.LifecycleStage{
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
+				},
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(5 * time.Hour))),
+				},
+			}
+			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
+
+			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+		})
+
+		It("should return the duration of the next version lifecycle without a chronological order", func() {
+			Lifecycles := []gardencorev1beta1.LifecycleStage{
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
+				},
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(1 * time.Hour))),
+				},
+			}
+			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
+
+			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 1*time.Hour, 100*time.Millisecond))
+		})
+
+		It("should return the duration of the next version lifecycle with start time in the past", func() {
+			Lifecycles := []gardencorev1beta1.LifecycleStage{
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
+				},
+				{
+					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(-1 * time.Hour))),
+				},
+			}
+			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
+
+			Expect(DurationUntilNextVersionLifecycleStage(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+		})
 	})
 
 	Describe("#FindMachineImageVersion", func() {

--- a/pkg/api/core/v1beta1/helper/cloudprofile_test.go
+++ b/pkg/api/core/v1beta1/helper/cloudprofile_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/clock"
-	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	. "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
@@ -164,65 +162,114 @@ var _ = Describe("CloudProfile Helper", func() {
 
 	Describe("Get the duration until the next lifecycle stage from the CloudProfile", func() {
 		var (
-			fakeNow          time.Time
-			fakeClock        clock.Clock
-			cloudProfileSpec = gardencorev1beta1.CloudProfileSpec{
-				Kubernetes: gardencorev1beta1.KubernetesSettings{
-					Versions: []gardencorev1beta1.ExpirableVersion{
+			now          = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			cloudProfile gardencorev1beta1.CloudProfile
+		)
+
+		BeforeEach(func() {
+			cloudProfile = gardencorev1beta1.CloudProfile{
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					Kubernetes: gardencorev1beta1.KubernetesSettings{
+						Versions: []gardencorev1beta1.ExpirableVersion{
+							{},
+						},
+					},
+					MachineImages: []gardencorev1beta1.MachineImage{
 						{
-							Lifecycle: []gardencorev1beta1.LifecycleStage{},
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{},
+							},
 						},
 					},
 				},
 			}
-		)
-
-		BeforeEach(func() {
-			fakeNow = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-			fakeClock = testclock.NewFakeClock(fakeNow)
-
 		})
 
-		It("should return the duration of the next version lifecycle based on a chronological order", func() {
-			Lifecycles := []gardencorev1beta1.LifecycleStage{
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
-				},
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(5 * time.Hour))),
-				},
+		addK8sLifecycles := func(ts ...time.Duration) {
+			for _, t := range ts {
+				cloudProfile.Spec.Kubernetes.Versions[0].Lifecycle = append(
+					cloudProfile.Spec.Kubernetes.Versions[0].Lifecycle,
+					gardencorev1beta1.LifecycleStage{
+						StartTime: ptr.To(metav1.NewTime(now.Add(t))),
+					},
+				)
 			}
-			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
+		}
 
-			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+		addMachineLifecycles := func(ts ...time.Duration) {
+			for _, t := range ts {
+				cloudProfile.Spec.MachineImages[0].Versions[0].ExpirableVersion.Lifecycle = append(
+					cloudProfile.Spec.MachineImages[0].Versions[0].ExpirableVersion.Lifecycle,
+					gardencorev1beta1.LifecycleStage{
+						StartTime: ptr.To(metav1.NewTime(now.Add(t))),
+					},
+				)
+			}
+		}
+
+		It("should prefer lifecycle over expiration ", func() {
+			addK8sLifecycles(2*time.Hour, 5*time.Hour)
+			cloudProfile.Spec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
+			)
 		})
 
-		It("should return the duration of the next version lifecycle without a chronological order", func() {
-			Lifecycles := []gardencorev1beta1.LifecycleStage{
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
-				},
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(1 * time.Hour))),
-				},
-			}
-			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
-
-			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 1*time.Hour, 100*time.Millisecond))
+		It("should use expiration if now lifecycle is set", func() {
+			cloudProfile.Spec.Kubernetes.Versions[0].ExpirationDate = ptr.To(metav1.NewTime(now.Add(1 * time.Hour)))
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
+			)
 		})
 
-		It("should return the duration of the next version lifecycle with start time in the past", func() {
-			Lifecycles := []gardencorev1beta1.LifecycleStage{
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(3 * time.Hour))),
-				},
-				{
-					StartTime: ptr.To(metav1.NewTime(fakeNow.Add(-1 * time.Hour))),
-				},
-			}
-			cloudProfileSpec.Kubernetes.Versions[0].Lifecycle = Lifecycles
+		It("should return the duration of the next k8s version lifecycle based on a chronological order", func() {
+			addK8sLifecycles(2*time.Hour, 5*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
+			)
+		})
 
-			Expect(DurationUntilNextVersionTransition(&cloudProfileSpec, fakeClock)).To(BeNumerically("~", 3*time.Hour, 100*time.Millisecond))
+		It("should return the duration of the next k8s version lifecycle without a chronological order", func() {
+			addK8sLifecycles(3*time.Hour, 1*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
+			)
+		})
+
+		It("should return the duration of the next k8s version lifecycle with start time in the past", func() {
+			addK8sLifecycles(3*time.Hour, -1*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 3*time.Hour, 100*time.Millisecond),
+			)
+		})
+
+		It("should return the duration of the next machine version lifecycle based on a chronological order", func() {
+			addMachineLifecycles(2*time.Hour, 5*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 2*time.Hour, 100*time.Millisecond),
+			)
+		})
+
+		It("should return the duration of the next machine version lifecycle without a chronological order", func() {
+			addMachineLifecycles(3*time.Hour, 1*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
+			)
+		})
+
+		It("should return the duration of the next machine version lifecycle with start time in the past", func() {
+			addMachineLifecycles(3*time.Hour, -1*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 3*time.Hour, 100*time.Millisecond),
+			)
+		})
+
+		It("should return the duration of the next k8s and machine version lifecycle", func() {
+			addK8sLifecycles(1*time.Hour, 2*time.Hour)
+			addMachineLifecycles(3*time.Hour, 4*time.Hour)
+			Expect(DurationUntilNextVersionTransition(&cloudProfile, now)).To(
+				BeNumerically("~", 1*time.Hour, 100*time.Millisecond),
+			)
 		})
 	})
 

--- a/pkg/api/core/validation/cloudprofile.go
+++ b/pkg/api/core/validation/cloudprofile.go
@@ -187,9 +187,10 @@ func validateCloudProfileKubernetesSettings(kubernetes core.KubernetesSettings, 
 func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// NOTE: Lifecycle classifications treat nil classifications as default, which differs in old classification.
-	// Keep skipping old classifications if they are nil.
-	if (version.Classification != nil || len(version.Lifecycle) > 0) && helper.VersionIsSupported(version) {
+	// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
+	// multiple patch versions supported within the same minor.
+	// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+	if version.Classification != nil && helper.VersionIsSupported(version) {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {
 			// check is already performed by caller, avoid duplicate error
@@ -479,9 +480,10 @@ func checkImageSupport(bastionImageName string, imageVersions []core.MachineImag
 			archSupported = true
 		}
 
-		// TODO(LucaBernstein): Check whether this behavior should be corrected (i.e. changed) in a later GEP-0032-PR.
-		//  The current behavior for nil classifications is treated differently across the codebase.
-		if version.Classification != nil && helper.CurrentLifecycleClassification(version.ExpirableVersion) == core.ClassificationSupported {
+		// FIXME: If in old classifications classification is nil, check got skipped, therefore it was possible to have
+		// multiple patch versions supported within the same minor.
+		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+		if version.Classification != nil && helper.VersionIsSupported(version.ExpirableVersion) {
 			validClassification = true
 		}
 		if archSupported && validClassification {

--- a/pkg/api/core/validation/cloudprofile.go
+++ b/pkg/api/core/validation/cloudprofile.go
@@ -187,9 +187,8 @@ func validateCloudProfileKubernetesSettings(kubernetes core.KubernetesSettings, 
 func validateSupportedVersionsConfiguration(version core.ExpirableVersion, allVersions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
-	// multiple patch versions supported within the same minor.
-	// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+	// TODO(rapsnx): There is a regression in old classifications, which allowed to bypass validations.
+	// Update this when issue: https://github.com/gardener/gardener/issues/14328 is resolved.
 	if version.Classification != nil && helper.VersionIsSupported(version) {
 		currentSemVer, err := semver.NewVersion(version.Version)
 		if err != nil {
@@ -480,9 +479,8 @@ func checkImageSupport(bastionImageName string, imageVersions []core.MachineImag
 			archSupported = true
 		}
 
-		// FIXME: If in old classifications classification is nil, check got skipped, therefore it was possible to have
-		// multiple patch versions supported within the same minor.
-		// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
+		// TODO(rapsnx): There is a regression in old classifications, which allowed to bypass validations.
+		// Update this when issue: https://github.com/gardener/gardener/issues/14328 is resolved.
 		if version.Classification != nil && helper.VersionIsSupported(version.ExpirableVersion) {
 			validClassification = true
 		}

--- a/pkg/api/core/validation/cloudprofile_test.go
+++ b/pkg/api/core/validation/cloudprofile_test.go
@@ -399,6 +399,44 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
 					})
 
+					It("should allow multiple supported within the some minor", func() {
+						cloudProfile.Spec.MachineImages = []core.MachineImage{
+							{
+								Name: machineImageName,
+								Versions: []core.MachineImageVersion{
+									{
+										ExpirableVersion: core.ExpirableVersion{
+											Version: "3.4.6",
+											Lifecycle: []core.LifecycleStage{
+												{
+													Classification: supportedClassification,
+												},
+											},
+										},
+										CRI:           []core.CRI{{Name: "containerd"}},
+										Architectures: []string{"amd64"},
+									},
+									{
+										ExpirableVersion: core.ExpirableVersion{
+											Version: "3.4.7",
+											Lifecycle: []core.LifecycleStage{
+												{
+													Classification: supportedClassification,
+												},
+											},
+										},
+										CRI:           []core.CRI{{Name: "containerd"}},
+										Architectures: []string{"amd64"},
+									},
+								},
+								UpdateStrategy: &updateStrategyMajor,
+							},
+						}
+						errorList := ValidateCloudProfile(cloudProfile)
+
+						Expect(errorList).To(BeEmpty())
+					})
+
 					It("should forbid expired lifecycle stage on latest kubernetes version", func() {
 						expirationDate := &metav1.Time{Time: time.Now().AddDate(0, 0, 1)}
 						cloudProfile.Spec.Kubernetes.Versions = []core.ExpirableVersion{
@@ -668,34 +706,38 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						}))))
 					})
 
-					It("only allow one supported version per minor version using Lifecycle", func() {
-						time1 := metav1.Now()
-						time2 := metav1.Time{Time: metav1.Now().Add(time.Hour)}
-						time3 := metav1.Time{Time: metav1.Now().Add(2 * time.Hour)}
-						cloudProfile.Spec.Kubernetes.Versions = []core.ExpirableVersion{
-							{
-								Version: "1.1.0",
-								Lifecycle: []core.LifecycleStage{
-									{Classification: previewClassification},
-									{Classification: supportedClassification, StartTime: &time1},
-									{Classification: deprecatedClassification, StartTime: &time3},
-								},
-							},
-							{
-								Version: "1.1.1",
-								Lifecycle: []core.LifecycleStage{
-									{Classification: supportedClassification, StartTime: &time2},
-								},
-							},
-						}
-						errorList := ValidateCloudProfile(cloudProfile)
+					// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
+					// multiple patch versions supported within the same minor.
+					// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
 
-						Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeForbidden),
-							"Field":  Equal("spec.kubernetes.versions[0]"),
-							"Detail": ContainSubstring("\"supported\" lifecycle stages must not overlap per minor version"),
-						}))))
-					})
+					// It("only allow one supported version per minor version using Lifecycle", func() {
+					// 	time1 := metav1.Now()
+					// 	time2 := metav1.Time{Time: metav1.Now().Add(time.Hour)}
+					// 	time3 := metav1.Time{Time: metav1.Now().Add(2 * time.Hour)}
+					// 	cloudProfile.Spec.Kubernetes.Versions = []core.ExpirableVersion{
+					// 		{
+					// 			Version: "1.1.0",
+					// 			Lifecycle: []core.LifecycleStage{
+					// 				{Classification: previewClassification},
+					// 				{Classification: supportedClassification, StartTime: &time1},
+					// 				{Classification: deprecatedClassification, StartTime: &time3},
+					// 			},
+					// 		},
+					// 		{
+					// 			Version: "1.1.1",
+					// 			Lifecycle: []core.LifecycleStage{
+					// 				{Classification: supportedClassification, StartTime: &time2},
+					// 			},
+					// 		},
+					// 	}
+					// 	errorList := ValidateCloudProfile(cloudProfile)
+					//
+					// 	Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					// 		"Type":   Equal(field.ErrorTypeForbidden),
+					// 		"Field":  Equal("spec.kubernetes.versions[0]"),
+					// 		"Detail": ContainSubstring("\"supported\" lifecycle stages must not overlap per minor version"),
+					// 	}))))
+					// })
 
 					It("allow multiple supported version per minor version if their lifecycle start times do not overlap", func() {
 						time1 := metav1.Now()

--- a/pkg/api/core/validation/cloudprofile_test.go
+++ b/pkg/api/core/validation/cloudprofile_test.go
@@ -706,39 +706,6 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						}))))
 					})
 
-					// FIXME:(rapnx) If in old classifications classification is nil, check got skipped, therefore it was possible to have
-					// multiple patch versions supported within the same minor.
-					// For now we keep this behavior for both new & old lifecycle, until issue <issue> is resolved.
-
-					// It("only allow one supported version per minor version using Lifecycle", func() {
-					// 	time1 := metav1.Now()
-					// 	time2 := metav1.Time{Time: metav1.Now().Add(time.Hour)}
-					// 	time3 := metav1.Time{Time: metav1.Now().Add(2 * time.Hour)}
-					// 	cloudProfile.Spec.Kubernetes.Versions = []core.ExpirableVersion{
-					// 		{
-					// 			Version: "1.1.0",
-					// 			Lifecycle: []core.LifecycleStage{
-					// 				{Classification: previewClassification},
-					// 				{Classification: supportedClassification, StartTime: &time1},
-					// 				{Classification: deprecatedClassification, StartTime: &time3},
-					// 			},
-					// 		},
-					// 		{
-					// 			Version: "1.1.1",
-					// 			Lifecycle: []core.LifecycleStage{
-					// 				{Classification: supportedClassification, StartTime: &time2},
-					// 			},
-					// 		},
-					// 	}
-					// 	errorList := ValidateCloudProfile(cloudProfile)
-					//
-					// 	Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					// 		"Type":   Equal(field.ErrorTypeForbidden),
-					// 		"Field":  Equal("spec.kubernetes.versions[0]"),
-					// 		"Detail": ContainSubstring("\"supported\" lifecycle stages must not overlap per minor version"),
-					// 	}))))
-					// })
-
 					It("allow multiple supported version per minor version if their lifecycle start times do not overlap", func() {
 						time1 := metav1.Now()
 						time3 := metav1.Time{Time: metav1.Now().Add(2 * time.Hour)}
@@ -762,11 +729,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 
 						Expect(errorList).To(BeEmpty())
 					})
-
-					// NOTE:(rapsn) End of GEP-0032 featuregate
 				})
-
-				// NOTE:(rapsn) K8S
 			})
 
 			It("should forbid duplicated kubernetes versions", func() {

--- a/pkg/apiserver/registry/core/cloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/cloudprofile/strategy.go
@@ -100,7 +100,7 @@ func dropInactiveVersions(cloudProfile *core.CloudProfile) {
 	var validKubernetesVersions []core.ExpirableVersion
 
 	for _, version := range cloudProfile.Spec.Kubernetes.Versions {
-		if !gardencorehelper.CurrentLifecycleClassification(version).IsActive() {
+		if !gardencorehelper.VersionIsActive(version) {
 			continue
 		}
 		validKubernetesVersions = append(validKubernetesVersions, version)
@@ -112,7 +112,7 @@ func dropInactiveVersions(cloudProfile *core.CloudProfile) {
 		var validMachineImageVersions []core.MachineImageVersion
 
 		for _, version := range machineImage.Versions {
-			if gardencorehelper.CurrentLifecycleClassification(version.ExpirableVersion) == core.ClassificationExpired {
+			if gardencorehelper.VersionIsExpired(version.ExpirableVersion) {
 				continue
 			}
 			validMachineImageVersions = append(validMachineImageVersions, version)

--- a/pkg/apiserver/registry/core/namespacedcloudprofile/strategy.go
+++ b/pkg/apiserver/registry/core/namespacedcloudprofile/strategy.go
@@ -115,7 +115,7 @@ func dropInactiveKubernetesVersions(newProfile, oldProfile *core.NamespacedCloud
 
 		for _, version := range newProfile.Spec.Kubernetes.Versions {
 			if _, exists := existingKubernetesVersions[version.Version]; !exists &&
-				!helper.CurrentLifecycleClassification(version).IsActive() {
+				!helper.VersionIsActive(version) {
 				continue
 			}
 			validKubernetesVersions = append(validKubernetesVersions, version)
@@ -138,7 +138,7 @@ func dropInactiveMachineImageVersions(newProfile, oldProfile *core.NamespacedClo
 
 		for _, version := range machineImage.Versions {
 			if _, exists := existingMachineImageVersions.GetImageVersion(machineImage.Name, version.Version); !exists &&
-				!helper.CurrentLifecycleClassification(version.ExpirableVersion).IsActive() {
+				!helper.VersionIsActive(version.ExpirableVersion) {
 				continue
 			}
 			validMachineImageVersions = append(validMachineImageVersions, version)

--- a/pkg/controllermanager/controller/cloudprofile/add.go
+++ b/pkg/controllermanager/controller/cloudprofile/add.go
@@ -5,6 +5,7 @@
 package cloudprofile
 
 import (
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -24,6 +25,9 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorder(ControllerName + "-controller")
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
 	}
 
 	return builder.

--- a/pkg/controllermanager/controller/cloudprofile/add.go
+++ b/pkg/controllermanager/controller/cloudprofile/add.go
@@ -5,7 +5,6 @@
 package cloudprofile
 
 import (
-	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -25,9 +24,6 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 	}
 	if r.Recorder == nil {
 		r.Recorder = mgr.GetEventRecorder(ControllerName + "-controller")
-	}
-	if r.Clock == nil {
-		r.Clock = clock.RealClock{}
 	}
 
 	return builder.

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -107,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	return reconcile.Result{
-		RequeueAfter: v1beta1helper.DurationUntilNextVersionLifecycleStage(&cloudProfile.Spec, r.Clock),
+		RequeueAfter: v1beta1helper.DurationUntilNextVersionTransition(&cloudProfile.Spec, r.Clock),
 	}, nil
 }
 

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -13,11 +13,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -29,6 +31,8 @@ type Reconciler struct {
 	Client   client.Client
 	Config   controllermanagerconfigv1alpha1.CloudProfileControllerConfiguration
 	Recorder events.EventRecorder
+
+	Clock clock.Clock
 }
 
 // Reconcile performs the main reconciliation logic.
@@ -97,5 +101,59 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	return reconcile.Result{}, nil
+	err := r.patchCloudProfileStatusVersions(ctx, cloudProfile)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to patch CloudProfile status versions: %w", err)
+	}
+
+	return reconcile.Result{
+		RequeueAfter: v1beta1helper.DurationUntilNextVersionLifecycleStage(&cloudProfile.Spec, r.Clock),
+	}, nil
+}
+
+// patchCloudProfileStatusVersions generate the cloudProfile status from the given cloudProfile spec.
+func (r *Reconciler) patchCloudProfileStatusVersions(ctx context.Context, cloudProfile *gardencorev1beta1.CloudProfile) error {
+	if cloudProfile == nil {
+		return nil
+	}
+
+	patch := client.MergeFrom(cloudProfile.DeepCopy())
+	cloudProfile.Status.Kubernetes = nil
+	cloudProfile.Status.MachineImages = nil
+
+	// Kubernetes versions
+	k8sVersions := cloudProfile.Spec.Kubernetes.Versions
+	if len(k8sVersions) > 0 {
+		cloudProfile.Status.Kubernetes = &gardencorev1beta1.KubernetesStatus{
+			Versions: make([]gardencorev1beta1.ExpirableVersionStatus, 0, len(k8sVersions)),
+		}
+		for _, v := range k8sVersions {
+			cloudProfile.Status.Kubernetes.Versions = append(cloudProfile.Status.Kubernetes.Versions, gardencorev1beta1.ExpirableVersionStatus{
+				Version:        v.Version,
+				Classification: v1beta1helper.CurrentLifecycleClassification(v),
+			})
+		}
+	}
+
+	// Machine images
+	machineImages := cloudProfile.Spec.MachineImages
+	if len(machineImages) > 0 {
+		cloudProfile.Status.MachineImages = make([]gardencorev1beta1.MachineImageStatus, 0, len(machineImages))
+		for _, image := range machineImages {
+			imageStatus := gardencorev1beta1.MachineImageStatus{
+				Name:     image.Name,
+				Versions: make([]gardencorev1beta1.ExpirableVersionStatus, 0, len(image.Versions)),
+			}
+
+			for _, v := range image.Versions {
+				imageStatus.Versions = append(imageStatus.Versions, gardencorev1beta1.ExpirableVersionStatus{
+					Version:        v.Version,
+					Classification: v1beta1helper.CurrentLifecycleClassification(v.ExpirableVersion),
+				})
+			}
+
+			cloudProfile.Status.MachineImages = append(cloudProfile.Status.MachineImages, imageStatus)
+		}
+	}
+	return r.Client.Status().Patch(ctx, cloudProfile, patch)
 }

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -46,50 +46,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	// The deletionTimestamp labels the CloudProfile as intended to get deleted. Before deletion, it has to be ensured that
-	// no Shoots, Seeds and other NamespacedCloudProfiles are assigned to the CloudProfile anymore.
-	// If this is the case then the controller will remove the finalizers from the CloudProfile so that it can be garbage collected.
 	if cloudProfile.DeletionTimestamp != nil {
-		if !sets.New(cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
-			return reconcile.Result{}, nil
-		}
-
-		namespacedCloudProfileList, err := controllerutils.GetNamespacedCloudProfilesReferencingCloudProfile(ctx, r.Client, cloudProfile.Name)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if len(namespacedCloudProfileList.Items) != 0 {
-			var associatedNamespacedCloudProfiles []string
-			for _, namespacedCloudProfile := range namespacedCloudProfileList.Items {
-				associatedNamespacedCloudProfiles = append(associatedNamespacedCloudProfiles, fmt.Sprintf("%s/%s", namespacedCloudProfile.Namespace, namespacedCloudProfile.Name))
-			}
-			message := fmt.Sprintf("Cannot delete CloudProfile, because the following NamespacedCloudProfiles are still referencing it: %+v", associatedNamespacedCloudProfiles)
-			r.Recorder.Eventf(cloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionDelete, message)
-			return reconcile.Result{}, errors.New(message)
-		}
-		log.Info("No NamespacedCloudProfiles are referencing the CloudProfile")
-
-		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.Client, cloudProfile)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if len(associatedShoots) == 0 {
-			log.Info("No Shoots are referencing the CloudProfile, deletion accepted")
-
-			if controllerutil.ContainsFinalizer(cloudProfile, gardencorev1beta1.GardenerName) {
-				log.Info("Removing finalizer")
-				if err := controllerutils.RemoveFinalizers(ctx, r.Client, cloudProfile, gardencorev1beta1.GardenerName); err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-				}
-			}
-
-			return reconcile.Result{}, nil
-		}
-
-		message := fmt.Sprintf("Cannot delete CloudProfile, because the following Shoots are still referencing it: %+v", associatedShoots)
-		r.Recorder.Eventf(cloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionDelete, message)
-		return reconcile.Result{}, errors.New(message)
+		return r.delete(ctx, cloudProfile)
 	}
 
 	if !controllerutil.ContainsFinalizer(cloudProfile, gardencorev1beta1.GardenerName) {
@@ -99,8 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	err := r.patchCloudProfileStatusVersions(ctx, cloudProfile)
-	if err != nil {
+	if err := r.patchCloudProfileStatusVersions(ctx, cloudProfile); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to patch CloudProfile status versions: %w", err)
 	}
 
@@ -109,12 +66,56 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}, nil
 }
 
-// patchCloudProfileStatusVersions generate the cloudProfile status from the given cloudProfile spec.
-func (r *Reconciler) patchCloudProfileStatusVersions(ctx context.Context, cloudProfile *gardencorev1beta1.CloudProfile) error {
-	if cloudProfile == nil {
-		return nil
+// delete deletes the CloudProfile as intended by its deletionTimestamp. Before deletion, it has to be ensured that
+// no Shoots, Seeds, or other NamespacedCloudProfiles are assigned to the CloudProfile anymore.
+// If this is the case, the controller will remove the finalizers from the CloudProfile so that it can be garbage collected.
+func (r *Reconciler) delete(ctx context.Context, cloudProfile *gardencorev1beta1.CloudProfile) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	if !sets.New(cloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		return reconcile.Result{}, nil
 	}
 
+	namespacedCloudProfileList, err := controllerutils.GetNamespacedCloudProfilesReferencingCloudProfile(ctx, r.Client, cloudProfile.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(namespacedCloudProfileList.Items) != 0 {
+		var associatedNamespacedCloudProfiles []string
+		for _, namespacedCloudProfile := range namespacedCloudProfileList.Items {
+			associatedNamespacedCloudProfiles = append(associatedNamespacedCloudProfiles, fmt.Sprintf("%s/%s", namespacedCloudProfile.Namespace, namespacedCloudProfile.Name))
+		}
+		message := fmt.Sprintf("Cannot delete CloudProfile, because the following NamespacedCloudProfiles are still referencing it: %+v", associatedNamespacedCloudProfiles)
+		r.Recorder.Eventf(cloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionDelete, message)
+		return reconcile.Result{}, errors.New(message)
+	}
+	log.Info("No NamespacedCloudProfiles are referencing the CloudProfile")
+
+	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.Client, cloudProfile)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(associatedShoots) == 0 {
+		log.Info("No Shoots are referencing the CloudProfile, deletion accepted")
+
+		if controllerutil.ContainsFinalizer(cloudProfile, gardencorev1beta1.GardenerName) {
+			log.Info("Removing finalizer")
+			if err := controllerutils.RemoveFinalizers(ctx, r.Client, cloudProfile, gardencorev1beta1.GardenerName); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	message := fmt.Sprintf("Cannot delete CloudProfile, because the following Shoots are still referencing it: %+v", associatedShoots)
+	r.Recorder.Eventf(cloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionDelete, message)
+	return reconcile.Result{}, errors.New(message)
+}
+
+// patchCloudProfileStatusVersions generate the cloudProfile status from the given cloudProfile spec.
+func (r *Reconciler) patchCloudProfileStatusVersions(ctx context.Context, cloudProfile *gardencorev1beta1.CloudProfile) error {
 	patch := client.MergeFrom(cloudProfile.DeepCopy())
 	cloudProfile.Status.Kubernetes = nil
 	cloudProfile.Status.MachineImages = nil

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,8 +31,6 @@ type Reconciler struct {
 	Client   client.Client
 	Config   controllermanagerconfigv1alpha1.CloudProfileControllerConfiguration
 	Recorder events.EventRecorder
-
-	Clock clock.Clock
 }
 
 // Reconcile performs the main reconciliation logic.
@@ -107,7 +105,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	return reconcile.Result{
-		RequeueAfter: v1beta1helper.DurationUntilNextVersionTransition(&cloudProfile.Spec, r.Clock),
+		RequeueAfter: v1beta1helper.DurationUntilNextVersionTransition(&cloudProfile.Spec, time.Now()),
 	}, nil
 }
 

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -7,12 +7,15 @@ package cloudprofile_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -35,6 +38,7 @@ var _ = Describe("Reconciler", func() {
 
 		cloudProfileName string
 		fakeErr          error
+		fakeClock        *testclock.FakeClock
 		reconciler       reconcile.Reconciler
 		cloudProfile     *gardencorev1beta1.CloudProfile
 	)
@@ -42,16 +46,19 @@ var _ = Describe("Reconciler", func() {
 	BeforeEach(func() {
 		cloudProfileName = "test-cloudprofile"
 		fakeErr = errors.New("fake err")
+		fakeClock = testclock.NewFakeClock(time.Now())
 
 		fakeClient = fakeclient.NewClientBuilder().
 			WithScheme(kubernetes.GardenScheme).
+			WithStatusSubresource(&gardencorev1beta1.CloudProfile{}).
 			WithIndex(
 				&gardencorev1beta1.NamespacedCloudProfile{},
 				core.NamespacedCloudProfileParentRefName,
 				indexer.NamespacedCloudProfileParentRefNameIndexerFunc,
 			).
 			Build()
-		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
+		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}, Clock: fakeClock}
+
 		cloudProfile = &gardencorev1beta1.CloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cloudProfileName,
@@ -107,7 +114,7 @@ var _ = Describe("Reconciler", func() {
 			Expect(patchCalls).To(Equal(1))
 		})
 
-		It("should ensure the finalizer (no error)", func() {
+		It("should ensure the finalizer", func() {
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
@@ -199,6 +206,121 @@ var _ = Describe("Reconciler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, &gardencorev1beta1.CloudProfile{})).To(BeNotFoundError())
+		})
+	})
+
+	Context("status reconciliation", func() {
+		var (
+			now    time.Time
+			future *metav1.Time
+			past   *metav1.Time
+
+			testStatus = func(wantStatus gardencorev1beta1.CloudProfileStatus) reconcile.Result {
+				Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(err).NotTo(HaveOccurred())
+
+				got := &gardencorev1beta1.CloudProfile{}
+				Expect(fakeClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, got)).To(Succeed())
+				Expect(got.Status).To(Equal(wantStatus))
+
+				return result
+			}
+		)
+
+		BeforeEach(func() {
+			now = fakeClock.Now()
+			future = &metav1.Time{Time: now.Add(24 * time.Hour)}
+			past = &metav1.Time{Time: now.Add(-24 * time.Hour)}
+		})
+
+		It("should reconcile status of lifecycle classifications and requeue due to upcoming stage", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.28.2",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+							StartTime:      past,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+							StartTime:      future,
+						},
+					},
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				},
+			}
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
+		})
+
+		It("should reconcile status of old classifications and requeue due to expiration date", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version:        "1.28.2",
+					ExpirationDate: past,
+					Classification: ptr.To(gardencorev1beta1.ClassificationSupported),
+				},
+				{
+					Version:        "1.30.2",
+					ExpirationDate: future,
+					Classification: ptr.To(gardencorev1beta1.ClassificationSupported),
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationExpired,
+						},
+						{
+							Version:        "1.30.2",
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+					},
+				},
+			}
+
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
+		})
+
+		It("should reconcile status of lifecycle classifications but not requeue without upcoming stages", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.28.2",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported, StartTime: past},
+					},
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+					},
+				},
+			}
+
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 })

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +37,6 @@ var _ = Describe("Reconciler", func() {
 
 		cloudProfileName string
 		fakeErr          error
-		fakeClock        *testclock.FakeClock
 		reconciler       reconcile.Reconciler
 		cloudProfile     *gardencorev1beta1.CloudProfile
 	)
@@ -46,7 +44,6 @@ var _ = Describe("Reconciler", func() {
 	BeforeEach(func() {
 		cloudProfileName = "test-cloudprofile"
 		fakeErr = errors.New("fake err")
-		fakeClock = testclock.NewFakeClock(time.Now())
 
 		fakeClient = fakeclient.NewClientBuilder().
 			WithScheme(kubernetes.GardenScheme).
@@ -57,7 +54,7 @@ var _ = Describe("Reconciler", func() {
 				indexer.NamespacedCloudProfileParentRefNameIndexerFunc,
 			).
 			Build()
-		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}, Clock: fakeClock}
+		reconciler = &Reconciler{Client: fakeClient, Recorder: &events.FakeRecorder{}}
 
 		cloudProfile = &gardencorev1beta1.CloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
@@ -229,7 +226,7 @@ var _ = Describe("Reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			now = fakeClock.Now()
+			now = time.Now()
 			future = &metav1.Time{Time: now.Add(24 * time.Hour)}
 			past = &metav1.Time{Time: now.Add(-24 * time.Hour)}
 		})

--- a/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler_test.go
@@ -208,9 +208,10 @@ var _ = Describe("Reconciler", func() {
 
 	Context("status reconciliation", func() {
 		var (
-			now    time.Time
-			future *metav1.Time
-			past   *metav1.Time
+			now        time.Time
+			past       *metav1.Time
+			future     *metav1.Time
+			moreFuture *metav1.Time
 
 			testStatus = func(wantStatus gardencorev1beta1.CloudProfileStatus) reconcile.Result {
 				Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
@@ -227,39 +228,9 @@ var _ = Describe("Reconciler", func() {
 
 		BeforeEach(func() {
 			now = time.Now()
-			future = &metav1.Time{Time: now.Add(24 * time.Hour)}
 			past = &metav1.Time{Time: now.Add(-24 * time.Hour)}
-		})
-
-		It("should reconcile status of lifecycle classifications and requeue due to upcoming stage", func() {
-			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
-				{
-					Version: "1.28.2",
-					Lifecycle: []gardencorev1beta1.LifecycleStage{
-						{
-							Classification: gardencorev1beta1.ClassificationPreview,
-							StartTime:      past,
-						},
-						{
-							Classification: gardencorev1beta1.ClassificationSupported,
-							StartTime:      future,
-						},
-					},
-				},
-			}
-
-			wantStatus := gardencorev1beta1.CloudProfileStatus{
-				Kubernetes: &gardencorev1beta1.KubernetesStatus{
-					Versions: []gardencorev1beta1.ExpirableVersionStatus{
-						{
-							Version:        "1.28.2",
-							Classification: gardencorev1beta1.ClassificationPreview,
-						},
-					},
-				},
-			}
-			result := testStatus(wantStatus)
-			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
+			future = &metav1.Time{Time: now.Add(24 * time.Hour)}
+			moreFuture = &metav1.Time{Time: now.Add(48 * time.Hour)}
 		})
 
 		It("should reconcile status of old classifications and requeue due to expiration date", func() {
@@ -295,12 +266,50 @@ var _ = Describe("Reconciler", func() {
 			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
 		})
 
-		It("should reconcile status of lifecycle classifications but not requeue without upcoming stages", func() {
+		It("should reconcile status of lifecycle classifications and requeue due to upcoming stage", func() {
 			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
 				{
 					Version: "1.28.2",
 					Lifecycle: []gardencorev1beta1.LifecycleStage{
-						{Classification: gardencorev1beta1.ClassificationSupported, StartTime: past},
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+							StartTime:      past,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+							StartTime:      future,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationDeprecated,
+							StartTime:      moreFuture,
+						},
+					},
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				},
+			}
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
+		})
+
+		It("should reconcile status of lifecycle classifications but not requeue without upcoming stage", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.28.2",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+							StartTime:      past,
+						},
 					},
 				},
 			}
@@ -311,6 +320,68 @@ var _ = Describe("Reconciler", func() {
 						{
 							Version:        "1.28.2",
 							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+					},
+				},
+			}
+
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("should reconcile status of lifecycle classifications and requeue due to upcoming stage without initial start time", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.28.2",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+							StartTime:      future,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+							StartTime:      moreFuture,
+						},
+					},
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				},
+			}
+
+			result := testStatus(wantStatus)
+			Expect(result.RequeueAfter).To(BeNumerically("~", future.Sub(now), time.Second))
+		})
+
+		It("should reconcile status of lifecycle classifications but not requeue without upcoming stage and initial start time", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.28.2",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				},
+			}
+
+			wantStatus := gardencorev1beta1.CloudProfileStatus{
+				Kubernetes: &gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.28.2",
+							Classification: gardencorev1beta1.ClassificationPreview,
 						},
 					},
 				},

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	gardencorehelper "github.com/gardener/gardener/pkg/api/core/helper"
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	controllermanagerconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/controllermanager/v1alpha1"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -50,35 +52,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	// The deletionTimestamp labels the NamespacedCloudProfile as intended to get deleted. Before deletion, it has to be ensured that
-	// no Shoots and Seed are assigned to the NamespacedCloudProfile anymore. If this is the case then the controller will remove
-	// the finalizers from the NamespacedCloudProfile so that it can be garbage collected.
 	if namespacedCloudProfile.DeletionTimestamp != nil {
-		if !sets.New(namespacedCloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
-			return reconcile.Result{}, nil
-		}
-
-		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.Client, namespacedCloudProfile)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if len(associatedShoots) == 0 {
-			log.Info("No Shoots are referencing the NamespacedCloudProfile, deletion accepted")
-
-			if controllerutil.ContainsFinalizer(namespacedCloudProfile, gardencorev1beta1.GardenerName) {
-				log.Info("Removing finalizer")
-				if err := controllerutils.RemoveFinalizers(ctx, r.Client, namespacedCloudProfile, gardencorev1beta1.GardenerName); err != nil {
-					return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
-				}
-			}
-
-			return reconcile.Result{}, nil
-		}
-
-		message := fmt.Sprintf("Cannot delete NamespacedCloudProfile, because the following Shoots are still referencing it: %+v", associatedShoots)
-		r.Recorder.Eventf(namespacedCloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionReconcile, message)
-		return reconcile.Result{}, fmt.Errorf("%s", message)
+		return r.delete(ctx, namespacedCloudProfile)
 	}
 
 	if !controllerutil.ContainsFinalizer(namespacedCloudProfile, gardencorev1beta1.GardenerName) {
@@ -101,7 +76,42 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{
+		RequeueAfter: v1beta1helper.DurationUntilNextVersionTransition(&namespacedCloudProfile.Status.CloudProfileSpec, time.Now()),
+	}, nil
+}
+
+// delete deletes the NamespacedCloudProfile as intended by its deletionTimestamp. Before deletion, it has to be ensured that
+// no Shoots or Seeds, are assigned to the CloudProfile anymore.
+// If this is the case, the controller will remove the finalizers from the NamespacedCloudProfile so that it can be garbage collected.
+func (r *Reconciler) delete(ctx context.Context, namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	if !sets.New(namespacedCloudProfile.Finalizers...).Has(gardencorev1beta1.GardenerName) {
+		return reconcile.Result{}, nil
+	}
+
+	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, r.Client, namespacedCloudProfile)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(associatedShoots) == 0 {
+		log.Info("No Shoots are referencing the NamespacedCloudProfile, deletion accepted")
+
+		if controllerutil.ContainsFinalizer(namespacedCloudProfile, gardencorev1beta1.GardenerName) {
+			log.Info("Removing finalizer")
+			if err := controllerutils.RemoveFinalizers(ctx, r.Client, namespacedCloudProfile, gardencorev1beta1.GardenerName); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	message := fmt.Sprintf("Cannot delete NamespacedCloudProfile, because the following Shoots are still referencing it: %+v", associatedShoots)
+	r.Recorder.Eventf(namespacedCloudProfile, nil, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, gardencorev1beta1.EventActionReconcile, message)
+	return reconcile.Result{}, fmt.Errorf("%s", message)
 }
 
 func mergeAndPatchCloudProfile(ctx context.Context, c client.Client, namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile, parentCloudProfile *gardencorev1beta1.CloudProfile) error {
@@ -117,7 +127,7 @@ func MergeCloudProfiles(namespacedCloudProfile *gardencorev1beta1.NamespacedClou
 	namespacedCloudProfile.Status.CloudProfileSpec = cloudProfile.Spec
 
 	if namespacedCloudProfile.Spec.Kubernetes != nil {
-		namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, namespacedCloudProfile.Spec.Kubernetes.Versions, expirableVersionKeyFunc, mergeExpirationDates, false)
+		namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions = mergeDeep(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions, namespacedCloudProfile.Spec.Kubernetes.Versions, expirableVersionKeyFunc, mergeExpirableVersions, false)
 	}
 
 	// TODO(Roncossek): Remove TransformSpecToParentFormat once all CloudProfiles have been migrated to use CapabilityFlavors and the Architecture fields are effectively forbidden or have been removed.
@@ -182,16 +192,93 @@ func defaultMachineImageArchitectures(cloudProfile gardencore.CloudProfileSpec, 
 }
 
 var (
-	expirableVersionKeyFunc    = func(v gardencorev1beta1.ExpirableVersion) string { return v.Version }
-	machineImageKeyFunc        = func(i gardencorev1beta1.MachineImage) string { return i.Name }
-	machineImageVersionKeyFunc = func(v gardencorev1beta1.MachineImageVersion) string { return v.Version }
-	machineTypeKeyFunc         = func(t gardencorev1beta1.MachineType) string { return t.Name }
-	volumeTypeKeyFunc          = func(t gardencorev1beta1.VolumeType) string { return t.Name }
+	expirableVersionKeyFunc        = func(v gardencorev1beta1.ExpirableVersion) string { return v.Version }
+	classificationLifecycleKeyFunc = func(c gardencorev1beta1.LifecycleStage) string { return string(c.Classification) }
+	machineImageKeyFunc            = func(i gardencorev1beta1.MachineImage) string { return i.Name }
+	machineImageVersionKeyFunc     = func(v gardencorev1beta1.MachineImageVersion) string { return v.Version }
+	machineTypeKeyFunc             = func(t gardencorev1beta1.MachineType) string { return t.Name }
+	volumeTypeKeyFunc              = func(t gardencorev1beta1.VolumeType) string { return t.Name }
 )
 
-func mergeExpirationDates(base, override gardencorev1beta1.ExpirableVersion) gardencorev1beta1.ExpirableVersion {
-	base.ExpirationDate = override.ExpirationDate
+func mergeExpirableVersions(base, override gardencorev1beta1.ExpirableVersion) gardencorev1beta1.ExpirableVersion {
+	migratedBase := migrateVersionToLifecycles(base)
+	migratedOverride := migrateVersionToLifecycles(override)
+
+	overrideIsUsingLegacyClassifications := v1beta1helper.IsUsingLegacyClassifications(override)
+
+	migratedBase.Lifecycle = mergeDeep(
+		migratedBase.Lifecycle,
+		migratedOverride.Lifecycle,
+		classificationLifecycleKeyFunc,
+		mergeClassificationLifecycles,
+		overrideIsUsingLegacyClassifications,
+	)
+
+	slices.SortFunc(migratedBase.Lifecycle, compareLifecycleStages)
+	adjustLifecycleStartTimes(migratedBase.Lifecycle, migratedOverride.Lifecycle)
+
+	return migratedBase
+}
+
+func adjustLifecycleStartTimes(base, override []gardencorev1beta1.LifecycleStage) {
+	for _, overrideStage := range override {
+		if overrideStage.StartTime == nil {
+			continue
+		}
+
+		for i := range base {
+			comparison := compareLifecycleStages(base[i], overrideStage)
+
+			switch {
+			case comparison < 0 && base[i].StartTime != nil && overrideStage.StartTime.Before(base[i].StartTime):
+				base[i].StartTime = overrideStage.StartTime
+			case comparison > 0 && (base[i].StartTime == nil || base[i].StartTime.Before(overrideStage.StartTime)):
+				base[i].StartTime = overrideStage.StartTime
+			}
+		}
+	}
+}
+
+func compareLifecycleStages(a, b gardencorev1beta1.LifecycleStage) int {
+	order := map[gardencorev1beta1.VersionClassification]int{
+		gardencorev1beta1.ClassificationUnavailable: 0,
+		gardencorev1beta1.ClassificationPreview:     1,
+		gardencorev1beta1.ClassificationSupported:   2,
+		gardencorev1beta1.ClassificationDeprecated:  3,
+		gardencorev1beta1.ClassificationExpired:     4,
+	}
+	return order[a.Classification] - order[b.Classification]
+}
+
+func mergeClassificationLifecycles(base, override gardencorev1beta1.LifecycleStage) gardencorev1beta1.LifecycleStage {
+	base.StartTime = override.StartTime
 	return base
+}
+
+// migrateVersionToLifecycles converts a legacy ExpirableVersion using Classification or ExpirationDate
+// to lifecycle classifications. If lifecycle classifications are already set, it returns the version unchanged.
+func migrateVersionToLifecycles(version gardencorev1beta1.ExpirableVersion) gardencorev1beta1.ExpirableVersion {
+	if len(version.Lifecycle) > 0 {
+		return version
+	}
+
+	result := gardencorev1beta1.ExpirableVersion{
+		Version: version.Version,
+		Lifecycle: []gardencorev1beta1.LifecycleStage{
+			{
+				Classification: v1beta1helper.CurrentLifecycleClassification(version),
+			},
+		},
+	}
+
+	if version.ExpirationDate != nil {
+		result.Lifecycle = append(result.Lifecycle, gardencorev1beta1.LifecycleStage{
+			Classification: gardencorev1beta1.ClassificationExpired,
+			StartTime:      version.ExpirationDate,
+		})
+	}
+
+	return result
 }
 
 func mergeMachineImages(base, override gardencorev1beta1.MachineImage) gardencorev1beta1.MachineImage {
@@ -211,10 +298,14 @@ func mergeMachineImageVersions(base, override gardencorev1beta1.MachineImageVers
 		// If the NamespacedCloudProfile machine image version has been there before, do not merge it with the parent CloudProfile machine image version.
 		return override
 	}
-	base.ExpirableVersion = mergeExpirationDates(base.ExpirableVersion, override.ExpirableVersion)
+	base.ExpirableVersion = mergeExpirableVersions(base.ExpirableVersion, override.ExpirableVersion)
 	return base
 }
 
+// mergeDeep merges override slice into baseArr slice by key.
+// Existing items are replaced, or merged with mergeFunc when provided.
+// New override items are added only if allowAdditional is true.
+// The original order from baseArr is preserved.
 func mergeDeep[T any](baseArr, override []T, keyFunc func(T) string, mergeFunc func(T, T) T, allowAdditional bool) []T {
 	existing := utils.CreateOrderedMapFromSlice(baseArr, keyFunc)
 	for _, value := range override {

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler.go
@@ -200,24 +200,43 @@ var (
 	volumeTypeKeyFunc              = func(t gardencorev1beta1.VolumeType) string { return t.Name }
 )
 
+// mergeExpirableVersions merges one parent ExpirableVersion with a NamespacedCloudProfile override.
+// Old classification and ExpirationDate fields are first migrated to lifecycle classifications so
+// old classifications can be merged with lifecycle classifications from parent data.
 func mergeExpirableVersions(base, override gardencorev1beta1.ExpirableVersion) gardencorev1beta1.ExpirableVersion {
 	migratedBase := migrateVersionToLifecycles(base)
 	migratedOverride := migrateVersionToLifecycles(override)
 
-	overrideIsUsingLegacyClassifications := v1beta1helper.IsUsingLegacyClassifications(override)
+	allowAdditionalLifecycleClassifications := v1beta1helper.IsUsingLegacyClassifications(override)
+
+	if allowAdditionalLifecycleClassifications && override.Classification != nil {
+		migratedBase.Lifecycle = removeImplicitLaterLifecycleClassifications(migratedBase.Lifecycle, migratedOverride.Lifecycle[0].Classification)
+	}
 
 	migratedBase.Lifecycle = mergeDeep(
 		migratedBase.Lifecycle,
 		migratedOverride.Lifecycle,
 		classificationLifecycleKeyFunc,
 		mergeClassificationLifecycles,
-		overrideIsUsingLegacyClassifications,
+		allowAdditionalLifecycleClassifications,
 	)
 
 	slices.SortFunc(migratedBase.Lifecycle, compareLifecycleStages)
 	adjustLifecycleStartTimes(migratedBase.Lifecycle, migratedOverride.Lifecycle)
 
 	return migratedBase
+}
+
+// removeImplicitLaterLifecycleClassifications removes implicit no-start lifecycle classifications that are later than the
+// old classification override. Without this, an old classification such as preview
+// would be immediately superseded by the parent default supported stage during migration.
+func removeImplicitLaterLifecycleClassifications(stages []gardencorev1beta1.LifecycleStage, classification gardencorev1beta1.VersionClassification) []gardencorev1beta1.LifecycleStage {
+	classificationStage := gardencorev1beta1.LifecycleStage{Classification: classification}
+	return slices.DeleteFunc(stages, func(stage gardencorev1beta1.LifecycleStage) bool {
+		isImplicitStage := stage.StartTime == nil
+		isLaterStage := compareLifecycleStages(stage, classificationStage) > 0
+		return isImplicitStage && isLaterStage
+	})
 }
 
 func adjustLifecycleStartTimes(base, override []gardencorev1beta1.LifecycleStage) {

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -217,7 +217,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{{Version: "1.0.0"}}))
 		})
 
-		It("should merge Kubernetes versions correctly", func() {
+		It("should ignore ExpirationDate set only in NamespacedCloudProfile", func() {
 			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
 				{Version: "1.0.0", ExpirationDate: &newExpiryDate},
 			}
@@ -231,12 +231,260 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 
 			updated := &gardencorev1beta1.NamespacedCloudProfile{}
 			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
-			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(ConsistOf(
-				MatchFields(IgnoreExtras, Fields{
-					"Version":        Equal("1.0.0"),
-					"ExpirationDate": Equal(&newExpiryDate),
-				}),
-			))
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+					},
+				},
+			}))
+		})
+
+		FIt("should merge Kubernetes versions ExpirationDates correctly", func() {
+			cloudProfileExpiryDate := metav1.NewTime(newExpiryDate.Add(24 * time.Hour))
+			newLaterExpiryDate := metav1.NewTime(newExpiryDate.Add(48 * time.Hour))
+
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0", ExpirationDate: &cloudProfileExpiryDate},
+				{Version: "2.0.0"},
+				{Version: "3.0.0"},
+			}
+			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0", ExpirationDate: &newExpiryDate},
+				{Version: "2.0.0", ExpirationDate: &newLaterExpiryDate},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(result.RequeueAfter).To(BeNumerically("~", newExpiryDate.Sub(time.Now()), time.Second))
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(ConsistOf([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newExpiryDate},
+					},
+				},
+				{
+					Version: "2.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newLaterExpiryDate},
+					},
+				},
+				{
+					Version: "3.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+					},
+				},
+			}))
+		})
+
+		It("should ignore Lifecycle expired classification set only in NamespacedCloudProfile", func() {
+			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationExpired,
+							StartTime:      &newExpiryDate,
+						},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+					},
+				},
+			}))
+		})
+
+		It("should reconcile lifecycle classifications and requeue due to upcoming stage without initial start time", func() {
+			future := metav1.NewTime(newExpiryDate.Add(24 * time.Hour))
+			moreFuture := metav1.NewTime(newExpiryDate.Add(48 * time.Hour))
+
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+							StartTime:      &future,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationDeprecated,
+							StartTime:      &moreFuture,
+						},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically("~", 24*time.Hour, time.Second))
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationPreview},
+						{Classification: gardencorev1beta1.ClassificationSupported, StartTime: &future},
+						{Classification: gardencorev1beta1.ClassificationDeprecated, StartTime: &moreFuture},
+					},
+				},
+			}))
+		})
+
+		It("should reconcile lifecycle classifications but not requeue without upcoming stage and initial start time", func() {
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationPreview},
+					},
+				},
+			}))
+		})
+
+		It("should adjust supported startTime to deprecated startTime when before", func() {
+			now := time.Now().Truncate(time.Second)
+			overriddenDeprecatedDate := &metav1.Time{Time: now}
+			supportedDate := &metav1.Time{Time: now.AddDate(0, 0, 1)}
+			deprecatedDate := &metav1.Time{Time: now.AddDate(0, 0, 2)}
+
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.1.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationPreview},
+						{Classification: gardencorev1beta1.ClassificationSupported, StartTime: supportedDate},
+						{Classification: gardencorev1beta1.ClassificationDeprecated, StartTime: deprecatedDate},
+					},
+				},
+			}
+			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.1.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationDeprecated, StartTime: overriddenDeprecatedDate},
+					},
+				},
+			}
+
+			namespacedcloudprofilecontroller.MergeCloudProfiles(namespacedCloudProfile, cloudProfile)
+
+			Expect(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions[0].Lifecycle).To(Equal([]gardencorev1beta1.LifecycleStage{
+				{Classification: gardencorev1beta1.ClassificationPreview},
+				{Classification: gardencorev1beta1.ClassificationSupported, StartTime: overriddenDeprecatedDate},
+				{Classification: gardencorev1beta1.ClassificationDeprecated, StartTime: overriddenDeprecatedDate},
+			}))
+		})
+
+		It("should merge Kubernetes version Lifecycles classification startTimes correctly", func() {
+			cloudProfileDeprecatedDate := metav1.NewTime(newExpiryDate.Add(12 * time.Hour))
+			cloudProfileExpiredDate := metav1.NewTime(newExpiryDate.Add(24 * time.Hour))
+			namespacedCloudProfileDeprecatedDate := metav1.NewTime(newExpiryDate.Add(48 * time.Hour))
+
+			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationDeprecated,
+							StartTime:      &cloudProfileDeprecatedDate,
+						},
+						{
+							Classification: gardencorev1beta1.ClassificationExpired,
+							StartTime:      &cloudProfileExpiredDate,
+						},
+					},
+				},
+			}
+			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationDeprecated,
+							StartTime:      &namespacedCloudProfileDeprecatedDate,
+						},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically("~", 48*time.Hour, time.Second))
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationSupported},
+						{Classification: gardencorev1beta1.ClassificationDeprecated, StartTime: &namespacedCloudProfileDeprecatedDate},
+						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &namespacedCloudProfileDeprecatedDate},
+					},
+				},
+			}))
 		})
 
 		It("should set observedGeneration correctly", func() {
@@ -427,15 +675,13 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			))
 		})
 
-		It("should merge MachineImages correctly", func() {
+		It("should merge MachineImages correctly and ignore an additional ExpirationDate set", func() {
 			newExpiryDate := metav1.NewTime(time.Now().Truncate(time.Second))
 			namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 				{
 					Name: "test-image",
 					Versions: []gardencorev1beta1.MachineImageVersion{
-						// override existing version with new expiration date
 						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0.0", ExpirationDate: &newExpiryDate}},
-						// add new version
 						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.1.2"}},
 					},
 				},
@@ -452,12 +698,22 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
 			Expect(updated.Status.CloudProfileSpec.MachineImages).To(HaveLen(1))
 			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Name).To(Equal("test-image"))
-			versions := updated.Status.CloudProfileSpec.MachineImages[0].Versions
-			Expect(versions).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-				"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{Version: "1.0.0", ExpirationDate: &newExpiryDate, Classification: nil, Lifecycle: nil}),
-			}), MatchFields(IgnoreExtras, Fields{
-				"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{Version: "1.1.2", ExpirationDate: nil, Classification: nil, Lifecycle: nil}),
-			})))
+			Expect(updated.Status.CloudProfileSpec.MachineImages[0].Versions).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{
+						Version: "1.0.0",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{Classification: gardencorev1beta1.ClassificationSupported},
+						},
+					}),
+					"CRI":                      Equal([]gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}),
+					"Architectures":            ConsistOf("amd64"),
+					"KubeletVersionConstraint": Equal(new("==1.30.0")),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"ExpirableVersion": Equal(gardencorev1beta1.ExpirableVersion{Version: "1.1.2"}),
+				}),
+			))
 		})
 
 		It("should merge MachineImages with overridden updateStrategy correctly", func() {
@@ -853,7 +1109,15 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 
 					expectedSpec := cloudProfile.Spec.DeepCopy()
 
-					expectedSpec.MachineImages[1].Versions[1].ExpirationDate = &expirationDate
+					expectedSpec.MachineImages[1].Versions[1].Lifecycle = []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+						// {
+						// 	Classification: gardencorev1beta1.ClassificationExpired,
+						// 	StartTime:      &expirationDate,
+						// },
+					}
 					expectedSpec.MachineImages[1].Versions = append(expectedSpec.MachineImages[1].Versions, gardencorev1beta1.MachineImageVersion{
 						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.0"},
 						Architectures:    []string{"amd64"},
@@ -865,7 +1129,15 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						"architecture": {"amd64"},
 					}})
 					expectedSpec.VolumeTypes = append(expectedSpec.VolumeTypes, gardencorev1beta1.VolumeType{Name: "volume-d"})
-					expectedSpec.Kubernetes.Versions[1].ExpirationDate = &expirationDate
+					expectedSpec.Kubernetes.Versions[1].Lifecycle = []gardencorev1beta1.LifecycleStage{
+						{
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+						// {
+						// 	Classification: gardencorev1beta1.ClassificationExpired,
+						// 	StartTime:      &expirationDate,
+						// },
+					}
 
 					Expect(namespacedCloudProfile.Status.CloudProfileSpec).To(Equal(*expectedSpec))
 				})

--- a/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
+++ b/pkg/controllermanager/controller/namespacedcloudprofile/reconciler_test.go
@@ -217,7 +217,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{{Version: "1.0.0"}}))
 		})
 
-		It("should ignore ExpirationDate set only in NamespacedCloudProfile", func() {
+		It("should migrate ExpirationDate set only in NamespacedCloudProfile", func() {
 			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
 				{Version: "1.0.0", ExpirationDate: &newExpiryDate},
 			}
@@ -236,14 +236,41 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 					Version: "1.0.0",
 					Lifecycle: []gardencorev1beta1.LifecycleStage{
 						{Classification: gardencorev1beta1.ClassificationSupported},
+						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newExpiryDate},
 					},
 				},
 			}))
 		})
 
-		FIt("should merge Kubernetes versions ExpirationDates correctly", func() {
-			cloudProfileExpiryDate := metav1.NewTime(newExpiryDate.Add(24 * time.Hour))
-			newLaterExpiryDate := metav1.NewTime(newExpiryDate.Add(48 * time.Hour))
+		It("should migrate legacy Classification set in NamespacedCloudProfile", func() {
+			classification := gardencorev1beta1.ClassificationPreview
+			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+				{Version: "1.0.0", Classification: &classification},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile.DeepCopy())).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).ToNot(HaveOccurred())
+
+			updated := &gardencorev1beta1.NamespacedCloudProfile{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: namespacedCloudProfileName, Namespace: namespaceName}, updated)).To(Succeed())
+			Expect(updated.Status.CloudProfileSpec.Kubernetes.Versions).To(Equal([]gardencorev1beta1.ExpirableVersion{
+				{
+					Version: "1.0.0",
+					Lifecycle: []gardencorev1beta1.LifecycleStage{
+						{Classification: gardencorev1beta1.ClassificationPreview},
+					},
+				},
+			}))
+		})
+
+		It("should merge Kubernetes versions ExpirationDates correctly", func() {
+			firstExpiryDate := metav1.NewTime(time.Now().Add(24 * time.Hour).Truncate(time.Second))
+			cloudProfileExpiryDate := metav1.NewTime(firstExpiryDate.Add(24 * time.Hour))
+			newLaterExpiryDate := metav1.NewTime(firstExpiryDate.Add(48 * time.Hour))
 
 			cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
 				{Version: "1.0.0", ExpirationDate: &cloudProfileExpiryDate},
@@ -251,7 +278,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 				{Version: "3.0.0"},
 			}
 			namespacedCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
-				{Version: "1.0.0", ExpirationDate: &newExpiryDate},
+				{Version: "1.0.0", ExpirationDate: &firstExpiryDate},
 				{Version: "2.0.0", ExpirationDate: &newLaterExpiryDate},
 			}
 
@@ -259,7 +286,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			Expect(fakeClient.Create(ctx, namespacedCloudProfile.DeepCopy())).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: namespacedCloudProfileName, Namespace: namespaceName}})
-			Expect(result.RequeueAfter).To(BeNumerically("~", newExpiryDate.Sub(time.Now()), time.Second))
+			Expect(result.RequeueAfter).To(BeNumerically("~", firstExpiryDate.Sub(time.Now()), time.Second))
 			Expect(err).ToNot(HaveOccurred())
 
 			updated := &gardencorev1beta1.NamespacedCloudProfile{}
@@ -269,7 +296,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 					Version: "1.0.0",
 					Lifecycle: []gardencorev1beta1.LifecycleStage{
 						{Classification: gardencorev1beta1.ClassificationSupported},
-						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newExpiryDate},
+						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &firstExpiryDate},
 					},
 				},
 				{
@@ -279,12 +306,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newLaterExpiryDate},
 					},
 				},
-				{
-					Version: "3.0.0",
-					Lifecycle: []gardencorev1beta1.LifecycleStage{
-						{Classification: gardencorev1beta1.ClassificationSupported},
-					},
-				},
+				{Version: "3.0.0"},
 			}))
 		})
 
@@ -675,7 +697,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 			))
 		})
 
-		It("should merge MachineImages correctly and ignore an additional ExpirationDate set", func() {
+		It("should merge MachineImages correctly and migrate an additional ExpirationDate", func() {
 			newExpiryDate := metav1.NewTime(time.Now().Truncate(time.Second))
 			namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 				{
@@ -704,6 +726,7 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						Version: "1.0.0",
 						Lifecycle: []gardencorev1beta1.LifecycleStage{
 							{Classification: gardencorev1beta1.ClassificationSupported},
+							{Classification: gardencorev1beta1.ClassificationExpired, StartTime: &newExpiryDate},
 						},
 					}),
 					"CRI":                      Equal([]gardencorev1beta1.CRI{{Name: "containerd", ContainerRuntimes: nil}}),
@@ -1113,10 +1136,10 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						{
 							Classification: gardencorev1beta1.ClassificationSupported,
 						},
-						// {
-						// 	Classification: gardencorev1beta1.ClassificationExpired,
-						// 	StartTime:      &expirationDate,
-						// },
+						{
+							Classification: gardencorev1beta1.ClassificationExpired,
+							StartTime:      &expirationDate,
+						},
 					}
 					expectedSpec.MachineImages[1].Versions = append(expectedSpec.MachineImages[1].Versions, gardencorev1beta1.MachineImageVersion{
 						ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.0"},
@@ -1133,10 +1156,10 @@ var _ = Describe("NamespacedCloudProfile Reconciler", func() {
 						{
 							Classification: gardencorev1beta1.ClassificationSupported,
 						},
-						// {
-						// 	Classification: gardencorev1beta1.ClassificationExpired,
-						// 	StartTime:      &expirationDate,
-						// },
+						{
+							Classification: gardencorev1beta1.ClassificationExpired,
+							StartTime:      &expirationDate,
+						},
 					}
 
 					Expect(namespacedCloudProfile.Status.CloudProfileSpec).To(Equal(*expectedSpec))

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -781,7 +781,7 @@ func shouldKubernetesVersionBeUpdated(kubernetesVersion string, autoUpdate bool,
 		return true, updateReason, true, nil
 	}
 
-	if v1beta1helper.CurrentLifecycleClassification(version) == gardencorev1beta1.ClassificationExpired {
+	if v1beta1helper.VersionIsExpired(version) {
 		updateReason = "Kubernetes version expired - force update required"
 		return true, updateReason, true, nil
 	}
@@ -846,7 +846,7 @@ func shouldMachineImageVersionBeUpdated(shootMachineImage *gardencorev1beta1.Sho
 		return true, updateReason, true
 	}
 
-	if v1beta1helper.CurrentLifecycleClassification(machineImage.Versions[versionIndex].ExpirableVersion) == gardencorev1beta1.ClassificationExpired {
+	if v1beta1helper.VersionIsExpired(machineImage.Versions[versionIndex].ExpirableVersion) {
 		updateReason = fmt.Sprintf("Machine image version expired - force update required (image update strategy: %s)", *machineImage.UpdateStrategy)
 		return true, updateReason, true
 	}

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -1227,7 +1227,7 @@ func getRemovedMachineImageVersions(namespacedCloudProfile, oldNamespacedCloudPr
 func validateShootForRemovedKubernetesVersions(channel chan error, shoot *gardencorev1beta1.Shoot, removedKubernetesVersions sets.Set[string], parentCloudProfileKubernetesVersions map[string]gardencorev1beta1.ExpirableVersion, namespacedCloudProfile *core.NamespacedCloudProfile) {
 	shootKubernetesVersion := shoot.Spec.Kubernetes.Version
 	if removedKubernetesVersions.Has(shootKubernetesVersion) {
-		if v1beta1helper.CurrentLifecycleClassification(parentCloudProfileKubernetesVersions[shootKubernetesVersion]) == gardencorev1beta1.ClassificationExpired {
+		if v1beta1helper.VersionIsExpired(parentCloudProfileKubernetesVersions[shootKubernetesVersion]) {
 			channel <- fmt.Errorf("unable to delete Kubernetes version %q from NamespacedCloudProfile '%s/%s' - version with extended expiration date is still in use by shoot '%s/%s'", shootKubernetesVersion, namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, shoot.Namespace, shoot.Name)
 		}
 	}
@@ -1246,7 +1246,7 @@ func validateShootWorkersForRemovedMachineImageVersions(channel chan error, shoo
 
 		if removedMachineImageVersions[worker.Machine.Image.Name].Has(*worker.Machine.Image.Version) {
 			parentVersion, exists := parentCloudProfileMachineImageVersions[worker.Machine.Image.Name][*worker.Machine.Image.Version]
-			if !exists || v1beta1helper.CurrentLifecycleClassification(parentVersion.ExpirableVersion) == gardencorev1beta1.ClassificationExpired {
+			if !exists || v1beta1helper.VersionIsExpired(parentVersion.ExpirableVersion) {
 				channel <- fmt.Errorf("unable to delete Machine image version '%s/%s' from NamespacedCloudProfile '%s/%s' - version is still in use by shoot '%s/%s' by worker %q", worker.Machine.Image.Name, *worker.Machine.Image.Version, namespacedCloudProfile.Namespace, namespacedCloudProfile.Name, shoot.Namespace, shoot.Name, worker.Name)
 			}
 		}

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -242,7 +242,7 @@ func (c *validationContext) validateKubernetesVersionOverrides(attr admission.At
 		if newVersion.ExpirationDate == nil {
 			return fmt.Errorf("specified version '%s' does not set expiration date", newVersion.Version)
 		}
-		if attr.GetOperation() == admission.Update && gardencorehelper.CurrentLifecycleClassification(newVersion) == gardencore.ClassificationExpired {
+		if attr.GetOperation() == admission.Update && gardencorehelper.VersionIsExpired(newVersion) {
 			if override, exists := currentVersionsMerged[newVersion.Version]; !exists || !override.ExpirationDate.Equal(newVersion.ExpirationDate) {
 				return fmt.Errorf("expiration date for version %q is in the past", newVersion.Version)
 			}
@@ -320,7 +320,7 @@ func (c *validationContext) validateMachineImageOverrides(ctx context.Context, a
 						}
 					}
 
-					if attr.GetOperation() == admission.Update && gardencorehelper.CurrentLifecycleClassification(imageVersion.ExpirableVersion) == gardencore.ClassificationExpired {
+					if attr.GetOperation() == admission.Update && gardencorehelper.VersionIsExpired(imageVersion.ExpirableVersion) {
 						var (
 							override gardencore.MachineImageVersion
 							exists   bool

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -16,11 +16,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/ptr"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/plugin/pkg/namespacedcloudprofile/validator"
 )
 
@@ -286,6 +289,7 @@ var _ = Describe("Admission", func() {
 			})
 
 			It("should fail if the latest Kubernetes version has an expiration date", func() {
+				parentCloudProfile.Spec.Kubernetes.Versions[0] = gardencorev1beta1.ExpirableVersion{Version: "1.30.0", Classification: ptr.To(gardencorev1beta1.ClassificationExpired)}
 				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
 
 				namespacedCloudProfile.Spec.Kubernetes = &gardencore.KubernetesSettings{Versions: []gardencore.ExpirableVersion{
@@ -574,24 +578,6 @@ var _ = Describe("Admission", func() {
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
-			It("should fail for creating a NamespacedCloudProfile that overrides an existing MachineImage version without specifying an expiration date", func() {
-				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
-					{Name: "test-image", Versions: []gardencorev1beta1.MachineImageVersion{
-						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.2.0"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}},
-						{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0.0"}, CRI: []gardencorev1beta1.CRI{{Name: "containerd"}}},
-					}},
-				}
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
-
-				namespacedCloudProfile.Spec.MachineImages = []gardencore.MachineImage{
-					{Name: "test-image", Versions: []gardencore.MachineImageVersion{{ExpirableVersion: gardencore.ExpirableVersion{Version: "1.0.0"}}}},
-				}
-
-				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("expiration date for version \"1.0.0\" must be set")))
-			})
-
 			DescribeTable("should fail for creating a NamespacedCloudProfile that overrides an existing MachineImage version and specifies classification/cri/arch/flavors/kubeletVersionConstraint/inPlaceUpdates", func(parentUsesCapabilities bool) {
 				var additionalMatcher types.GomegaMatcher
 				if parentUsesCapabilities {
@@ -842,6 +828,8 @@ var _ = Describe("Admission", func() {
 			)
 
 			BeforeEach(func() {
+				DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
+
 				parentCloudProfileName = "cloudprofile1"
 				namespacedCloudProfileName = "namespaced-profile"
 				namespaceName = "garden-test"
@@ -1005,7 +993,7 @@ var _ = Describe("Admission", func() {
 			})
 
 			Context("machine image validation", func() {
-				It("should allow an empty list of machine images", func() {
+				FIt("should allow an empty list of machine images", func() {
 					namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{}
 
 					errorList := ValidateSimulatedNamespacedCloudProfileStatus(parentCloudProfile, namespacedCloudProfile)

--- a/plugin/pkg/namespacedcloudprofile/validator/validator_suite_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/validator_suite_test.go
@@ -9,9 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/apiserver/features"
 )
 
 func TestValidator(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "AdmissionPlugin NamespacedCloudProfile Validator Suite")
 }

--- a/plugin/pkg/shoot/mutator/admission.go
+++ b/plugin/pkg/shoot/mutator/admission.go
@@ -425,7 +425,7 @@ func defaultKubernetesVersion(constraints []gardencorev1beta1.ExpirableVersion, 
 func findLatestSupportedVersion(constraints []gardencorev1beta1.ExpirableVersion, major, minor *uint64) *semver.Version {
 	var latestVersion *semver.Version
 	for _, versionConstraint := range constraints {
-		if v1beta1helper.CurrentLifecycleClassification(versionConstraint) != gardencorev1beta1.ClassificationSupported {
+		if !v1beta1helper.VersionIsSupported(versionConstraint) {
 			continue
 		}
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1286,7 +1286,7 @@ func validateKubernetesVersionConstraints(a admission.Attributes, constraints []
 		// Disallow usage of an expired Kubernetes version on Shoot creation and new worker pool creation
 		// Updating an existing worker to a higher (ensured by validation) expired Kubernetes version is necessary for consecutive maintenance force updates
 		if a.GetOperation() == admission.Create || isNewWorkerPool {
-			if !v1beta1helper.CurrentLifecycleClassification(versionConstraint).IsActive() {
+			if !v1beta1helper.VersionIsActive(versionConstraint) {
 				continue
 			}
 		}
@@ -1573,9 +1573,9 @@ func validateMachineImagesConstraints(a admission.Attributes, constraints []gard
 			for _, machineVersion := range machineImage.Versions {
 				machineImageVersion := fmt.Sprintf("%s:%s", machineImage.Name, machineVersion.Version)
 
-				if v1beta1helper.CurrentLifecycleClassification(machineVersion.ExpirableVersion).IsActive() {
+				if v1beta1helper.VersionIsActive(machineVersion.ExpirableVersion) {
 					activeMachineImageVersions.Insert(machineImageVersion)
-				} else if a.GetOperation() == admission.Update && !isNewWorkerPool && v1beta1helper.CurrentLifecycleClassification(machineVersion.ExpirableVersion) == gardencorev1beta1.ClassificationExpired {
+				} else if a.GetOperation() == admission.Update && !isNewWorkerPool && v1beta1helper.VersionIsExpired(machineVersion.ExpirableVersion) {
 					// An already expired machine image version is a viable machine image version for the worker pool if-and-only-if:
 					//  - this is an update call (no new Shoot creation)
 					//  - updates an existing worker pool (not for a new worker pool)

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
@@ -5,6 +5,8 @@
 package cloudprofile_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -26,6 +28,7 @@ var _ = DescribeTableSubtree("CloudProfile controller tests", func(isCapabilitie
 
 	BeforeEach(func() {
 		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.CloudProfileCapabilities, true))
+		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
 		var CapabilityDefinition []gardencorev1beta1.CapabilityDefinition
 		if isCapabilitiesCloudProfile {
 			CapabilityDefinition = []gardencorev1beta1.CapabilityDefinition{
@@ -146,35 +149,174 @@ var _ = DescribeTableSubtree("CloudProfile controller tests", func(isCapabilitie
 				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
 			}).Should(BeNotFoundError())
 		})
-	})
 
-	Context("shoots referencing the CloudProfile", func() {
-		JustBeforeEach(func() {
-			By("Ensure finalizer got added")
+		It("should patch the status versions from the CloudProfile spec", func() {
+			By("Ensure status versions got patched")
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)).To(Succeed())
-				g.Expect(cloudProfile.Finalizers).To(ConsistOf("gardener"))
-			}).Should(Succeed())
 
-			By("Delete CloudProfile")
-			Expect(testClient.Delete(ctx, cloudProfile)).To(Succeed())
+				g.Expect(cloudProfile.Status.Kubernetes).To(Equal(&gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.2.3",
+							Classification: gardencorev1beta1.ClassificationSupported,
+						},
+					},
+				}))
+
+				g.Expect(cloudProfile.Status.MachineImages).To(Equal([]gardencorev1beta1.MachineImageStatus{
+					{
+						Name: "some-image",
+						Versions: []gardencorev1beta1.ExpirableVersionStatus{
+							{
+								Version:        "4.5.6",
+								Classification: gardencorev1beta1.ClassificationSupported,
+							},
+						},
+					},
+				}))
+			}).Should(Succeed())
 		})
 
-		It("should add the finalizer and not release it on deletion since there still is a referencing shoot", func() {
-			By("Ensure CloudProfile is not released")
-			Consistently(func() error {
-				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
-			}).Should(Succeed())
-		})
-
-		It("should add the finalizer and release it on deletion after the shoot got deleted", func() {
-			By("Delete Shoot")
-			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
-
-			By("Ensure CloudProfile is released")
+		It("should patch the status versions after the CloudProfile spec changed with old classification", func() {
+			By("Update CloudProfile spec")
 			Eventually(func() error {
-				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
-			}).Should(BeNotFoundError())
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile); err != nil {
+					return err
+				}
+
+				cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+					{
+						Version:        "1.2.4",
+						Classification: new(gardencorev1beta1.ClassificationDeprecated),
+					},
+				}
+				cloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "5.6.7",
+									Classification: new(gardencorev1beta1.ClassificationPreview),
+								},
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, cloudProfile)
+			}).Should(Succeed())
+
+			By("Ensure status versions got patched")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)).To(Succeed())
+
+				g.Expect(cloudProfile.Status.Kubernetes).To(Equal(&gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.2.4",
+							Classification: gardencorev1beta1.ClassificationDeprecated,
+						},
+					},
+				}))
+
+				g.Expect(cloudProfile.Status.MachineImages).To(Equal([]gardencorev1beta1.MachineImageStatus{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.ExpirableVersionStatus{
+							{
+								Version:        "5.6.7",
+								Classification: gardencorev1beta1.ClassificationPreview,
+							},
+						},
+					},
+				}))
+			}).Should(Succeed())
+		})
+
+		It("should patch the status versions after the CloudProfile spec changed with new classification", func() {
+			var (
+				now    = time.Now()
+				future = &metav1.Time{Time: now.Add(24 * time.Hour)}
+				past   = &metav1.Time{Time: now.Add(-24 * time.Hour)}
+			)
+
+			By("Update CloudProfile spec")
+			Eventually(func() error {
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile); err != nil {
+					return err
+				}
+
+				cloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+					{
+						Version: "1.2.4",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+								StartTime:      past,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+				}
+				cloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "5.6.7",
+									Lifecycle: []gardencorev1beta1.LifecycleStage{
+										{
+											Classification: gardencorev1beta1.ClassificationPreview,
+										},
+										{
+											Classification: gardencorev1beta1.ClassificationSupported,
+											StartTime:      past,
+										},
+										{
+											Classification: gardencorev1beta1.ClassificationDeprecated,
+											StartTime:      future,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, cloudProfile)
+			}).Should(Succeed())
+
+			By("Ensure status versions got patched")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)).To(Succeed())
+
+				g.Expect(cloudProfile.Status.Kubernetes).To(Equal(&gardencorev1beta1.KubernetesStatus{
+					Versions: []gardencorev1beta1.ExpirableVersionStatus{
+						{
+							Version:        "1.2.4",
+							Classification: gardencorev1beta1.ClassificationPreview,
+						},
+					},
+				}))
+
+				g.Expect(cloudProfile.Status.MachineImages).To(Equal([]gardencorev1beta1.MachineImageStatus{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.ExpirableVersionStatus{
+							{
+								Version:        "5.6.7",
+								Classification: gardencorev1beta1.ClassificationSupported,
+							},
+						},
+					},
+				}))
+			}).Should(Succeed())
 		})
 	})
 },

--- a/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
+++ b/test/integration/controllermanager/namespacedcloudprofile/namespacedcloudprofile_test.go
@@ -36,6 +36,7 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 
 	BeforeEach(func() {
 		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.CloudProfileCapabilities, true))
+		DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
 		var capabilityDefinitions []gardencorev1beta1.CapabilityDefinition
 		if isCapabilitiesCloudProfile {
 			capabilityDefinitions = []gardencorev1beta1.CapabilityDefinition{
@@ -378,6 +379,344 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile controller tests", func(isC
 					gardencorev1beta1.ExpirableVersion{Version: "1.3.0"},
 					gardencorev1beta1.ExpirableVersion{Version: "1.4.0"},
 				))
+			}).Should(Succeed())
+		})
+
+		It("should update the NamespacedCloudProfile status on CloudProfile spec update with old classification", func() {
+			deprecated := gardencorev1beta1.ClassificationDeprecated
+			preview := gardencorev1beta1.ClassificationPreview
+
+			By("Update parent CloudProfile spec")
+			Eventually(func() error {
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(parentCloudProfile), parentCloudProfile); err != nil {
+					return err
+				}
+
+				parentCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+					{
+						Version:        "1.2.4",
+						Classification: &deprecated,
+					},
+				}
+				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        "5.6.7",
+									Classification: &preview,
+								},
+								CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+								Architectures:     []string{"amd64"},
+								CapabilityFlavors: imageFlavors,
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, parentCloudProfile)
+			}).Should(Succeed())
+
+			By("Ensure status versions got patched")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+
+				g.Expect(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions).To(ContainElement(
+					gardencorev1beta1.ExpirableVersion{
+						Version:        "1.2.4",
+						Classification: &deprecated,
+					},
+				))
+
+				var machineImage *gardencorev1beta1.MachineImage
+				for i := range namespacedCloudProfile.Status.CloudProfileSpec.MachineImages {
+					if namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i].Name == "some-other-image" {
+						machineImage = &namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i]
+						break
+					}
+				}
+
+				g.Expect(machineImage).ToNot(BeNil())
+				if machineImage == nil {
+					return
+				}
+
+				g.Expect(machineImage.Versions).To(ContainElement(gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version:        "5.6.7",
+						Classification: &preview,
+					},
+					CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+					Architectures:     []string{"amd64"},
+					CapabilityFlavors: imageFlavors,
+				}))
+			}).Should(Succeed())
+		})
+
+		It("should update the NamespacedCloudProfile status on CloudProfile spec update with new classification", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
+
+			var (
+				now    = time.Now()
+				future = &metav1.Time{Time: now.Add(24 * time.Hour)}
+				past   = &metav1.Time{Time: now.Add(-24 * time.Hour)}
+			)
+
+			By("Update parent CloudProfile spec")
+			Eventually(func() error {
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(parentCloudProfile), parentCloudProfile); err != nil {
+					return err
+				}
+
+				parentCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+					{
+						Version: "1.2.4",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+								StartTime:      past,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+				}
+				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-other-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "5.6.7",
+									Lifecycle: []gardencorev1beta1.LifecycleStage{
+										{
+											Classification: gardencorev1beta1.ClassificationPreview,
+										},
+										{
+											Classification: gardencorev1beta1.ClassificationSupported,
+											StartTime:      past,
+										},
+										{
+											Classification: gardencorev1beta1.ClassificationDeprecated,
+											StartTime:      future,
+										},
+									},
+								},
+								CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+								Architectures:     []string{"amd64"},
+								CapabilityFlavors: imageFlavors,
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, parentCloudProfile)
+			}).Should(Succeed())
+
+			By("Ensure status versions got patched")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+
+				g.Expect(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions).To(ContainElement(
+					gardencorev1beta1.ExpirableVersion{
+						Version: "1.2.4",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+								StartTime:      past,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+				))
+
+				var machineImage *gardencorev1beta1.MachineImage
+				for i := range namespacedCloudProfile.Status.CloudProfileSpec.MachineImages {
+					if namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i].Name == "some-other-image" {
+						machineImage = &namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i]
+						break
+					}
+				}
+
+				g.Expect(machineImage).ToNot(BeNil())
+				if machineImage == nil {
+					return
+				}
+
+				g.Expect(machineImage.Versions).To(ContainElement(gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "5.6.7",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      past,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationDeprecated,
+								StartTime:      future,
+							},
+						},
+					},
+					CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+					Architectures:     []string{"amd64"},
+					CapabilityFlavors: imageFlavors,
+				}))
+			}).Should(Succeed())
+		})
+
+		It("should merge lifecycle classifications when the first override stage has no start time", func() {
+			DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VersionClassificationLifecycle, true))
+
+			var (
+				now    = time.Now()
+				future = &metav1.Time{Time: now.Add(24 * time.Hour)}
+			)
+
+			By("Update parent CloudProfile spec")
+			Eventually(func() error {
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(parentCloudProfile), parentCloudProfile); err != nil {
+					return err
+				}
+
+				parentCloudProfile.Spec.Kubernetes.Versions = []gardencorev1beta1.ExpirableVersion{
+					{
+						Version: "1.2.3",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+				}
+				parentCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "4.5.6",
+									Lifecycle: []gardencorev1beta1.LifecycleStage{
+										{
+											Classification: gardencorev1beta1.ClassificationPreview,
+										},
+										{
+											Classification: gardencorev1beta1.ClassificationSupported,
+											StartTime:      future,
+										},
+									},
+								},
+								CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+								Architectures:     []string{"amd64"},
+								CapabilityFlavors: imageFlavors,
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, parentCloudProfile)
+			}).Should(Succeed())
+
+			By("Update NamespacedCloudProfile spec")
+			Eventually(func() error {
+				if err := testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile); err != nil {
+					return err
+				}
+
+				namespacedCloudProfile.Spec.Kubernetes = &gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{
+						{
+							Version: "1.2.3",
+							Lifecycle: []gardencorev1beta1.LifecycleStage{
+								{
+									Classification: gardencorev1beta1.ClassificationPreview,
+								},
+							},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version: "4.5.6",
+									Lifecycle: []gardencorev1beta1.LifecycleStage{
+										{
+											Classification: gardencorev1beta1.ClassificationPreview,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				return testClient.Update(ctx, namespacedCloudProfile)
+			}).Should(Succeed())
+
+			By("Ensure status versions got patched")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(namespacedCloudProfile), namespacedCloudProfile)).To(Succeed())
+
+				g.Expect(namespacedCloudProfile.Status.CloudProfileSpec.Kubernetes.Versions).To(ContainElement(
+					gardencorev1beta1.ExpirableVersion{
+						Version: "1.2.3",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+				))
+
+				var machineImage *gardencorev1beta1.MachineImage
+				for i := range namespacedCloudProfile.Status.CloudProfileSpec.MachineImages {
+					if namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i].Name == "some-image" {
+						machineImage = &namespacedCloudProfile.Status.CloudProfileSpec.MachineImages[i]
+						break
+					}
+				}
+
+				g.Expect(machineImage).ToNot(BeNil())
+				if machineImage == nil {
+					return
+				}
+
+				g.Expect(machineImage.Versions).To(ContainElement(gardencorev1beta1.MachineImageVersion{
+					ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+						Version: "4.5.6",
+						Lifecycle: []gardencorev1beta1.LifecycleStage{
+							{
+								Classification: gardencorev1beta1.ClassificationPreview,
+							},
+							{
+								Classification: gardencorev1beta1.ClassificationSupported,
+								StartTime:      future,
+							},
+						},
+					},
+					CRI:               []gardencorev1beta1.CRI{{Name: "containerd"}},
+					Architectures:     []string{"amd64"},
+					CapabilityFlavors: imageFlavors,
+				}))
 			}).Should(Succeed())
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**  
/area ops-productivity usability  
/kind api-change

What this PR does / why we need it:
Implements the GEP-32 controller logic for the `NamespacedCloudProfile`.
This is a **stacked PR of #14311**, separated by an empty commit.

I'm aware that here are some tests failing, and I have to look into this again.
But I think this is still reviewable.

I updated the wording consistently: 
**legacy classifications** refer to the deprecated fields e.g.: `expirationDate`/`classification`.
**lifecycle classifications** are the newly introduced lifecycle stages.



For more information refer to the umbrealla issue:

**Which issue(s) this PR fixes:**  
Part of 
- [ ] https://github.com/gardener/gardener/issues/12256
