### PR TITLE
gardenadm: support cilium shoots in dev-setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ gardenadm:
 	BUILD_OUTPUT_FILE=./bin/ BUILD_PACKAGES=./cmd/gardenadm $(MAKE) build
 # gardenadm-{up,down}
 gardenadm-%: export SKAFFOLD_FILENAME = $(DEV_SETUP)/skaffold-gardenadm.yaml
+gardenadm-%: export NETWORK_PROVIDER ?=
 gardenadm-up gardenadm-down: $(SKAFFOLD) $(KUBECTL)
 	$(DEV_SETUP)/gardenadm.sh $(subst gardenadm-,,$@)
 

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -10,7 +10,19 @@ COMMAND="${1:-up}"
 VALID_COMMANDS=("up" "down")
 
 SCENARIO="${SCENARIO:-unmanaged-infra}"
+NETWORK_PROVIDER="${NETWORK_PROVIDER:-calico}"
 VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect" "connect-kind")
+
+skaffold_profiles() {
+  profiles=(
+    "${SCENARIO}"
+  )
+  if [[ "$NETWORK_PROVIDER" == "cilium" ]]; then
+    profiles+=("${SCENARIO}-cilium")
+  fi
+  printf -v joined '%s,' "${profiles[@]}"
+  echo "${joined%,}"
+}
 
 # For unmanaged-infra and connect scenarios, there is no cluster to detect the node platform from.
 # Default to the local machine's architecture.
@@ -43,13 +55,13 @@ case "$COMMAND" in
       # Prepare resources and generate manifests.
       # The manifests are copied to the unmanaged-infra machine pods or can be passed to the `--config-dir` flag of `gardenadm bootstrap`.
       skaffold build \
-        -p "$SCENARIO" \
+        -p "$(skaffold_profiles)" \
         -m gardenadm,provider-local \
         -q \
         --cache-artifacts="$($(dirname "$0")/get-skaffold-cache-artifacts.sh gardenadm)" \
         |\
       skaffold render \
-        -p "$SCENARIO" \
+        -p "$(skaffold_profiles)" \
         -m provider-local \
         -o "$(dirname "$0")/gardenadm/resources/generated/$SCENARIO/manifests.yaml" \
         --build-artifacts \

--- a/dev-setup/gardenadm.sh
+++ b/dev-setup/gardenadm.sh
@@ -13,16 +13,18 @@ SCENARIO="${SCENARIO:-unmanaged-infra}"
 NETWORK_PROVIDER="${NETWORK_PROVIDER:-calico}"
 VALID_SCENARIOS=("unmanaged-infra" "managed-infra" "connect" "connect-kind")
 
-skaffold_profiles() {
-  profiles=(
-    "${SCENARIO}"
+function skaffold_profiles() {
+  local profiles=(
+    "-p ${SCENARIO}"
   )
   if [[ "$NETWORK_PROVIDER" == "cilium" ]]; then
-    profiles+=("${SCENARIO}-cilium")
+    profiles+=("-p ${SCENARIO}-cilium")
   fi
-  printf -v joined '%s,' "${profiles[@]}"
-  echo "${joined%,}"
+  # print array as space separated string so we can directly use it in the skaffold flags
+  echo "${profiles[*]}"
 }
+
+SKAFFOLD_PROFILES=$(skaffold_profiles)
 
 # For unmanaged-infra and connect scenarios, there is no cluster to detect the node platform from.
 # Default to the local machine's architecture.
@@ -55,13 +57,13 @@ case "$COMMAND" in
       # Prepare resources and generate manifests.
       # The manifests are copied to the unmanaged-infra machine pods or can be passed to the `--config-dir` flag of `gardenadm bootstrap`.
       skaffold build \
-        -p "$(skaffold_profiles)" \
+        ${SKAFFOLD_PROFILES} \
         -m gardenadm,provider-local \
         -q \
         --cache-artifacts="$($(dirname "$0")/get-skaffold-cache-artifacts.sh gardenadm)" \
         |\
       skaffold render \
-        -p "$(skaffold_profiles)" \
+        ${SKAFFOLD_PROFILES} \
         -m provider-local \
         -o "$(dirname "$0")/gardenadm/resources/generated/$SCENARIO/manifests.yaml" \
         --build-artifacts \

--- a/dev-setup/gardenadm/resources/components/cilium/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/components/cilium/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-shoot.yaml

--- a/dev-setup/gardenadm/resources/components/cilium/patch-shoot.yaml
+++ b/dev-setup/gardenadm/resources/components/cilium/patch-shoot.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: root
+  namespace: garden
+spec:
+  networking:
+    type: cilium

--- a/dev-setup/gardenadm/resources/overlays/managed-infra-cilium/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/managed-infra-cilium/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../managed-infra/
+
+components:
+- ../../components/cilium
+

--- a/dev-setup/gardenadm/resources/overlays/unmanaged-infra-cilium/kustomization.yaml
+++ b/dev-setup/gardenadm/resources/overlays/unmanaged-infra-cilium/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../unmanaged-infra/
+
+components:
+- ../../components/cilium
+

--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -1181,8 +1181,18 @@ profiles:
         value: local-skaffold/machine-controller-manager-provider-local
       - op: remove
         path: /build/artifacts/4
+  - name: unmanaged-infra-cilium
+    manifests:
+      kustomize:
+        paths:
+          - dev-setup/gardenadm/resources/overlays/unmanaged-infra-cilium
   - name: managed-infra
     manifests:
       kustomize:
         paths:
           - dev-setup/gardenadm/resources/overlays/managed-infra
+  - name: managed-infra-cilium
+    manifests:
+      kustomize:
+        paths:
+          - dev-setup/gardenadm/resources/overlays/managed-infra-cilium


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Support running Cilium self hosted shoots in the local setup.
Introduce new Skaffold profiles "managed-infra-cilium" and "unmanaged-infra-cilium" which patch the self hosted shoot to use `networking.type=cilium`.

To use this one can use `make NETWORK_PROVIDER=cilium gardenadm-up`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/hackathon/issues/46

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Support cilium self hosted shoots in local setup
```
