### PR TITLE
Forbid `k8s.io/utils/ptr.To` usages with a golangci-lint linter (forbidgo)

### DIFF
--- a/.golangci.yaml.in
+++ b/.golangci.yaml.in
@@ -6,6 +6,7 @@ linters:
     - embeddedstructfieldcheck
     - exptostd
     - depguard
+    - forbidigo
     - ginkgolinter
     - gocritic
     - importas
@@ -29,6 +30,10 @@ linters:
     embeddedstructfieldcheck:
       # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.
       forbid-mutex: true
+    forbidigo:
+      forbid:
+        - pattern: ^ptr\.To$
+          msg: "ptr.To shall no longer be used, please use the built-in new(T) instead. See https://github.com/gardener/gardener/pull/14872."
     gocritic:
       disable-all: true
       enabled-checks:

--- a/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/gardenlet/operation/botanist/kubeapiserverexposure_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
@@ -38,8 +37,8 @@ var _ = Describe("KubeAPIServerExposure", func() {
 				Config: &gardenletconfigv1alpha1.GardenletConfiguration{
 					SNI: &gardenletconfigv1alpha1.SNI{
 						Ingress: &gardenletconfigv1alpha1.SNIIngress{
-							Namespace:   ptr.To(v1beta1constants.DefaultSNIIngressNamespace),
-							ServiceName: ptr.To(v1beta1constants.DefaultSNIIngressServiceName),
+							Namespace:   new(v1beta1constants.DefaultSNIIngressNamespace),
+							ServiceName: new(v1beta1constants.DefaultSNIIngressServiceName),
 							Labels: map[string]string{
 								v1beta1constants.LabelApp: v1beta1constants.DefaultIngressGatewayAppLabelValue,
 								"istio":                   "ingressgateway",
@@ -73,7 +72,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 
 	Describe("#setAPIServerServiceClusterIPs", func() {
 		BeforeEach(func() {
-			botanist.Shoot.InternalClusterDomain = ptr.To("internal.foo.bar")
+			botanist.Shoot.InternalClusterDomain = new("internal.foo.bar")
 
 			By("Create secrets managed outside of this function for which secretsmanager.Get() will be called")
 			for _, name := range []string{
@@ -119,7 +118,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 		})
 
 		It("should not panic when ExternalClusterDomain is not nil", func() {
-			botanist.Shoot.ExternalClusterDomain = ptr.To("external.foo.bar")
+			botanist.Shoot.ExternalClusterDomain = new("external.foo.bar")
 
 			Expect(botanist.DefaultKubeAPIServerService().Deploy(context.TODO())).To(Succeed())
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/14872 adapted modenize suggestions.
`modernize newexpr` suggested replacing `k8s.io/utils/ptr.To` usages with the built-in `new(T)`.
https://github.com/gardener/gardener/pull/14872 adapted to this change but didn't enforced this with a linter.
New occurrences are being added to the gardener/gardener's code base.
PR authors receive annoying comments on their PRs about this - see https://github.com/gardener/gardener/pull/14991#discussion_r3386390883 and https://github.com/gardener/gardener/pull/14963#discussion_r3354037248.
Similar things should be enforced with a linter. Otherwise, it is always inconsistent in the codebase and it is a never endoing story to adapt these inconsistencies.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14872 .

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
