### PR TITLE
Suppress false secretName deprecation warning for DNS providers synced from credentialsRef

### DIFF
--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -93,17 +93,24 @@ func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path) []string {
 	var warnings []string
 
 	for i, provider := range dns.Providers {
-		if provider.SecretName != nil {
-			providerPath := fldPath.Child("providers").Index(i)
-			warnings = append(warnings, fmt.Sprintf(
-				"you are setting the %s field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use %s instead.",
-				providerPath.Child("secretName").String(),
-				providerPath.Child("credentialsRef").String(),
-			))
+		if provider.SecretName == nil {
+			continue
 		}
+
+		providerPath := fldPath.Child("providers").Index(i)
+		warnings = append(warnings, DNSProviderSecretNameWarning(providerPath))
 	}
 
 	return warnings
+}
+
+// DNSProviderSecretNameWarning returns the warning for a deprecated DNS provider secretName field.
+func DNSProviderSecretNameWarning(providerPath *field.Path) string {
+	return fmt.Sprintf(
+		"you are setting the %s field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use %s instead.",
+		providerPath.Child("secretName").String(),
+		providerPath.Child("credentialsRef").String(),
+	)
 }
 
 // GetKubeAPIServerWarnings returns warnings for the given KubeAPIServerConfig.

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -7,6 +7,7 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -21,7 +22,7 @@ import (
 )
 
 // GetWarnings returns warnings for the given Shoot.
-func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRotationInterval time.Duration) []string {
+func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRotationInterval time.Duration, suppressedDNSProviderSecretNameWarningIndexes []int) []string {
 	if shoot == nil {
 		return nil
 	}
@@ -82,18 +83,18 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if shoot.Spec.DNS != nil {
-		warnings = append(warnings, GetDNSProviderWarnings(shoot.Spec.DNS, field.NewPath("spec", "dns"))...)
+		warnings = append(warnings, GetDNSProviderWarnings(shoot.Spec.DNS, field.NewPath("spec", "dns"), suppressedDNSProviderSecretNameWarningIndexes)...)
 	}
 
 	return warnings
 }
 
 // GetDNSProviderWarnings returns warnings for the given DNS configuration.
-func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path) []string {
+func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path, suppressedSecretNameWarningIndexes []int) []string {
 	var warnings []string
 
 	for i, provider := range dns.Providers {
-		if provider.SecretName == nil {
+		if provider.SecretName == nil || slices.Contains(suppressedSecretNameWarningIndexes, i) {
 			continue
 		}
 

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GetWarnings returns warnings for the given Shoot.
-func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRotationInterval time.Duration, suppressedDNSProviderSecretNameWarningIndexes []int) []string {
+func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRotationInterval time.Duration, ignoreWarningsForDNSIndexes []int) []string {
 	if shoot == nil {
 		return nil
 	}
@@ -83,18 +83,18 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	}
 
 	if shoot.Spec.DNS != nil {
-		warnings = append(warnings, GetDNSProviderWarnings(shoot.Spec.DNS, field.NewPath("spec", "dns"), suppressedDNSProviderSecretNameWarningIndexes)...)
+		warnings = append(warnings, GetDNSProviderWarnings(shoot.Spec.DNS, field.NewPath("spec", "dns"), ignoreWarningsForDNSIndexes)...)
 	}
 
 	return warnings
 }
 
 // GetDNSProviderWarnings returns warnings for the given DNS configuration.
-func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path, suppressedSecretNameWarningIndexes []int) []string {
+func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path, ignoreWarningsForDNSIndexes []int) []string {
 	var warnings []string
 
 	for i, provider := range dns.Providers {
-		if provider.SecretName == nil || slices.Contains(suppressedSecretNameWarningIndexes, i) {
+		if provider.SecretName == nil || slices.Contains(ignoreWarningsForDNSIndexes, i) {
 			continue
 		}
 

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -99,19 +99,14 @@ func GetDNSProviderWarnings(dns *core.DNS, fldPath *field.Path, ignoreWarningsFo
 		}
 
 		providerPath := fldPath.Child("providers").Index(i)
-		warnings = append(warnings, DNSProviderSecretNameWarning(providerPath))
+		warnings = append(warnings, fmt.Sprintf(
+			"you are setting the %s field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use %s instead.",
+			providerPath.Child("secretName").String(),
+			providerPath.Child("credentialsRef").String(),
+		))
 	}
 
 	return warnings
-}
-
-// DNSProviderSecretNameWarning returns the warning for a deprecated DNS provider secretName field.
-func DNSProviderSecretNameWarning(providerPath *field.Path) string {
-	return fmt.Sprintf(
-		"you are setting the %s field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use %s instead.",
-		providerPath.Child("secretName").String(),
-		providerPath.Child("credentialsRef").String(),
-	)
 }
 
 // GetKubeAPIServerWarnings returns warnings for the given KubeAPIServerConfig.

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -41,11 +41,11 @@ var _ = Describe("Warnings", func() {
 		})
 
 		It("should return nil when shoot is nil", func() {
-			Expect(GetWarnings(ctx, nil, nil, credentialsRotationInterval)).To(BeEmpty())
+			Expect(GetWarnings(ctx, nil, nil, credentialsRotationInterval, nil)).To(BeEmpty())
 		})
 
 		It("should return nil when shoot does not have any problematic configuration", func() {
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(BeEmpty())
 		})
 
 		Context("credentials rotation", func() {
@@ -55,11 +55,11 @@ var _ = Describe("Warnings", func() {
 
 			It("should not return a warning when credentials rotation is due in case shoot is too young", func() {
 				shoot.CreationTimestamp = metav1.Now()
-				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(BeEmpty())
+				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval, nil)).To(BeEmpty())
 			})
 
 			It("should return a warning when credentials rotation is due", func() {
-				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you should consider rotating the shoot credentials")))
+				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you should consider rotating the shoot credentials")))
 			})
 
 			DescribeTable("warnings for specific credentials rotations",
@@ -78,7 +78,7 @@ var _ = Describe("Warnings", func() {
 					mutateRotation(rotation)
 					shoot.Status.Credentials = &core.ShootCredentials{Rotation: rotation}
 
-					Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(matcher)
+					Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval, nil)).To(matcher)
 				},
 
 				Entry("ca nil", ContainElement(ContainSubstring("you should consider rotating the certificate authorities")), nil,
@@ -246,7 +246,7 @@ var _ = Describe("Warnings", func() {
 			shoot.Spec.Kubernetes.KubeControllerManager = &core.KubeControllerManagerConfig{
 				PodEvictionTimeout: &metav1.Duration{Duration: 2 * time.Minute},
 			}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeControllerManager.podEvictionTimeout field. The field does not have effect since Kubernetes 1.13 and is forbidden to be set starting from Kubernetes 1.33. Instead, use the spec.kubernetes.kubeAPIServer.(defaultNotReadyTolerationSeconds/defaultUnreachableTolerationSeconds) fields.")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(Equal("you are setting the spec.kubernetes.kubeControllerManager.podEvictionTimeout field. The field does not have effect since Kubernetes 1.13 and is forbidden to be set starting from Kubernetes 1.33. Instead, use the spec.kubernetes.kubeAPIServer.(defaultNotReadyTolerationSeconds/defaultUnreachableTolerationSeconds) fields.")))
 		})
 
 		It("should warn when maxEmptyBulkDelete is set for shoots using kubernetes < v1.33", func() {
@@ -254,27 +254,27 @@ var _ = Describe("Warnings", func() {
 			shoot.Spec.Kubernetes.ClusterAutoscaler = &core.ClusterAutoscaler{
 				MaxEmptyBulkDelete: new(int32(5)),
 			}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.33. The value is not used and will be set to nil. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(Equal("you are setting the spec.kubernetes.clusterAutoscaler.maxEmptyBulkDelete field. The field has been deprecated and is forbidden to be set starting from Kubernetes 1.33. The value is not used and will be set to nil. Instead, use the spec.kubernetes.clusterAutoscaler.maxScaleDownParallelism field.")))
 		})
 
 		It("should warn when rotate-etcd-encryption-key-start operation annotation is set", func() {
 			shoot.Annotations = map[string]string{
 				"gardener.cloud/operation": "rotate-etcd-encryption-key-start",
 			}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the operation annotation to rotate-etcd-encryption-key-start. This annotation has been deprecated and is forbidden to be set starting from Kubernetes 1.34. Instead, use the rotate-etcd-encryption-key annotation, which performs a full rotation of the ETCD encryption key.")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(Equal("you are setting the operation annotation to rotate-etcd-encryption-key-start. This annotation has been deprecated and is forbidden to be set starting from Kubernetes 1.34. Instead, use the rotate-etcd-encryption-key annotation, which performs a full rotation of the ETCD encryption key.")))
 		})
 
 		It("should warn when rotate-etcd-encryption-key-complete operation annotation is set", func() {
 			shoot.Annotations = map[string]string{
 				"gardener.cloud/operation": "rotate-etcd-encryption-key-complete",
 			}
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(Equal("you are setting the operation annotation to rotate-etcd-encryption-key-complete. This annotation has been deprecated and is forbidden to be set starting from Kubernetes 1.34. Instead, use the rotate-etcd-encryption-key annotation, which performs a full rotation of the ETCD encryption key.")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(Equal("you are setting the operation annotation to rotate-etcd-encryption-key-complete. This annotation has been deprecated and is forbidden to be set starting from Kubernetes 1.34. Instead, use the rotate-etcd-encryption-key annotation, which performs a full rotation of the ETCD encryption key.")))
 		})
 
 		DescribeTable("spec.secretBindingName",
 			func(secretBindingName *string, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.SecretBindingName = secretBindingName
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(matcher)
 			},
 
 			Entry("should return a warning when secretBindingName is set", new("my-secret-binding"),
@@ -286,18 +286,18 @@ var _ = Describe("Warnings", func() {
 			It("should not return a warning when cloudProfileName is set and the Kubernetes version is < v1.33", func() {
 				shoot.Spec.Kubernetes.Version = "1.32.3"
 				shoot.Spec.CloudProfileName = new("local-profile")
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(BeEmpty())
 			})
 
 			It("should return a warning when cloudProfileName is set and the Kubernetes version is >= v1.33", func() {
 				shoot.Spec.Kubernetes.Version = "1.33.1"
 				shoot.Spec.CloudProfileName = new("local-profile")
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you are setting the spec.cloudProfileName field. The field is deprecated")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you are setting the spec.cloudProfileName field. The field is deprecated")))
 			})
 
 			It("should not return a warning when cloudProfileName is empty and the Kubernetes version is >= v1.33", func() {
 				shoot.Spec.Kubernetes.Version = "1.33.1"
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(BeEmpty())
 			})
 		})
 
@@ -305,7 +305,7 @@ var _ = Describe("Warnings", func() {
 			It("should print a warning when addons are set", func() {
 				shoot.Spec.Addons = &core.Addons{}
 
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you are setting the spec.addons field. The field is deprecated and will be forbidden starting with Kubernetes 1.35.")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you are setting the spec.addons field. The field is deprecated and will be forbidden starting with Kubernetes 1.35.")))
 			})
 		})
 
@@ -316,7 +316,7 @@ var _ = Describe("Warnings", func() {
 					Enabled: new(true),
 					Mode:    new(core.ProxyModeIPVS),
 				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you are using IPVS mode for kube-proxy")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you are using IPVS mode for kube-proxy")))
 			})
 
 			It("should not print a warning when kube-proxy mode is set to 'IPVS' and the Kubernetes version is < v1.35", func() {
@@ -325,7 +325,7 @@ var _ = Describe("Warnings", func() {
 					Enabled: new(true),
 					Mode:    new(core.ProxyModeIPVS),
 				}
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(BeEmpty())
 			})
 
 			It("should print a warning when kube-proxy mode is switched to 'IPVS' for Kubernetes versions < 1.35", func() {
@@ -340,7 +340,7 @@ var _ = Describe("Warnings", func() {
 					Mode:    new(core.ProxyModeIPTables),
 				}
 
-				Expect(GetWarnings(ctx, shoot, oldShoot, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you have switched to IPVS mode for kube-proxy")))
+				Expect(GetWarnings(ctx, shoot, oldShoot, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you have switched to IPVS mode for kube-proxy")))
 			})
 		})
 
@@ -350,14 +350,14 @@ var _ = Describe("Warnings", func() {
 					KubeMaxPDVols: new("20"),
 				}
 
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you are setting the spec.kubernetes.kubeScheduler.kubeMaxPDVols field")))
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(ContainElement(ContainSubstring("you are setting the spec.kubernetes.kubeScheduler.kubeMaxPDVols field")))
 			})
 		})
 
 		DescribeTable("spec.kubernetes.kubeAPIServer.enableAnonymousAuthentication",
 			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(matcher)
 			},
 
 			Entry("should not return a warning when kubeAPIServerConfig is nil",
@@ -377,7 +377,7 @@ var _ = Describe("Warnings", func() {
 		DescribeTable("spec.kubernetes.kubeAPIServer.watchCacheSizes.default",
 			func(kubeAPIServerConfig *core.KubeAPIServerConfig, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.Kubernetes.KubeAPIServer = kubeAPIServerConfig
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(matcher)
 			},
 
 			Entry("should not return a warning when kubeAPIServerConfig is nil",
@@ -401,7 +401,7 @@ var _ = Describe("Warnings", func() {
 		DescribeTable("spec.dns.providers[].secretName",
 			func(dns *core.DNS, matcher gomegatypes.GomegaMatcher) {
 				shoot.Spec.DNS = dns
-				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(matcher)
+				Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, nil)).To(matcher)
 			},
 			Entry("should not return a warning when dns is nil",
 				nil,
@@ -415,25 +415,24 @@ var _ = Describe("Warnings", func() {
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: nil}}},
 				BeEmpty(),
 			),
-			Entry("should return a warning when secretName matches Secret credentialsRef",
-				&core.DNS{Providers: []core.DNSProvider{{
-					SecretName:     new("secret"),
-					CredentialsRef: dnsSecretCredentialsRef("secret"),
-				}}},
-				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
-			),
 			Entry("should return a warning when secretName is set",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
 				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
 			),
-			Entry("should return a warning when secretName does not match Secret credentialsRef",
-				&core.DNS{Providers: []core.DNSProvider{{
-					SecretName:     new("secret"),
-					CredentialsRef: dnsSecretCredentialsRef("other-secret"),
-				}}},
-				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
-			),
 		)
+
+		It("should not return a suppressed secretName warning", func() {
+			shoot.Spec.DNS = &core.DNS{
+				Providers: []core.DNSProvider{
+					{
+						SecretName:     new("synced-secret"),
+						CredentialsRef: dnsSecretCredentialsRef("synced-secret"),
+					},
+				},
+			}
+
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, []int{0})).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+		})
 	})
 
 	Describe("#GetKubeAPIServerWarnings", func() {
@@ -483,7 +482,7 @@ var _ = Describe("Warnings", func() {
 	Describe("#GetDNSProviderWarnings", func() {
 		DescribeTable("providers[].secretName",
 			func(dns *core.DNS, fldPath *field.Path, matcher gomegatypes.GomegaMatcher) {
-				Expect(GetDNSProviderWarnings(dns, fldPath)).To(matcher)
+				Expect(GetDNSProviderWarnings(dns, fldPath, nil)).To(matcher)
 			},
 
 			Entry("should not return a warning when dns.providers is nil",
@@ -501,32 +500,8 @@ var _ = Describe("Warnings", func() {
 				field.NewPath("spec", "dns"),
 				BeEmpty(),
 			),
-			Entry("should return a warning when secretName matches Secret credentialsRef",
-				&core.DNS{Providers: []core.DNSProvider{{
-					SecretName:     new("secret"),
-					CredentialsRef: dnsSecretCredentialsRef("secret"),
-				}}},
-				field.NewPath("spec", "dns"),
-				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
-			),
 			Entry("should return a warning when secretName is set for a single provider",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
-				field.NewPath("spec", "dns"),
-				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
-			),
-			Entry("should return a warning when secretName does not match Secret credentialsRef",
-				&core.DNS{Providers: []core.DNSProvider{{
-					SecretName:     new("secret"),
-					CredentialsRef: dnsSecretCredentialsRef("other-secret"),
-				}}},
-				field.NewPath("spec", "dns"),
-				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
-			),
-			Entry("should return a warning when secretName is set with WorkloadIdentity credentialsRef",
-				&core.DNS{Providers: []core.DNSProvider{{
-					SecretName:     new("secret"),
-					CredentialsRef: dnsWorkloadIdentityCredentialsRef("identity"),
-				}}},
 				field.NewPath("spec", "dns"),
 				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
 			),
@@ -578,6 +553,20 @@ var _ = Describe("Warnings", func() {
 				ContainElement(Equal("you are setting the custom.path.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use custom.path.providers[0].credentialsRef instead.")),
 			),
 		)
+
+		It("should not return warnings for suppressed provider indexes", func() {
+			dns := &core.DNS{
+				Providers: []core.DNSProvider{
+					{
+						SecretName:     new("synced-secret"),
+						CredentialsRef: dnsSecretCredentialsRef("synced-secret"),
+					},
+					{SecretName: new("secret")},
+				},
+			}
+
+			Expect(GetDNSProviderWarnings(dns, field.NewPath("spec", "dns"), []int{0})).To(ConsistOf(Equal("you are setting the spec.dns.providers[1].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[1].credentialsRef instead.")))
+		})
 	})
 })
 
@@ -585,14 +574,6 @@ func dnsSecretCredentialsRef(name string) *autoscalingv1.CrossVersionObjectRefer
 	return &autoscalingv1.CrossVersionObjectReference{
 		APIVersion: "v1",
 		Kind:       "Secret",
-		Name:       name,
-	}
-}
-
-func dnsWorkloadIdentityCredentialsRef(name string) *autoscalingv1.CrossVersionObjectReference {
-	return &autoscalingv1.CrossVersionObjectReference{
-		APIVersion: "security.gardener.cloud/v1alpha1",
-		Kind:       "WorkloadIdentity",
 		Name:       name,
 	}
 }

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -414,8 +415,22 @@ var _ = Describe("Warnings", func() {
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: nil}}},
 				BeEmpty(),
 			),
+			Entry("should return a warning when secretName matches Secret credentialsRef",
+				&core.DNS{Providers: []core.DNSProvider{{
+					SecretName:     new("secret"),
+					CredentialsRef: dnsSecretCredentialsRef("secret"),
+				}}},
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
 			Entry("should return a warning when secretName is set",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
+			Entry("should return a warning when secretName does not match Secret credentialsRef",
+				&core.DNS{Providers: []core.DNSProvider{{
+					SecretName:     new("secret"),
+					CredentialsRef: dnsSecretCredentialsRef("other-secret"),
+				}}},
 				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
 			),
 		)
@@ -486,8 +501,32 @@ var _ = Describe("Warnings", func() {
 				field.NewPath("spec", "dns"),
 				BeEmpty(),
 			),
+			Entry("should return a warning when secretName matches Secret credentialsRef",
+				&core.DNS{Providers: []core.DNSProvider{{
+					SecretName:     new("secret"),
+					CredentialsRef: dnsSecretCredentialsRef("secret"),
+				}}},
+				field.NewPath("spec", "dns"),
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
 			Entry("should return a warning when secretName is set for a single provider",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
+				field.NewPath("spec", "dns"),
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
+			Entry("should return a warning when secretName does not match Secret credentialsRef",
+				&core.DNS{Providers: []core.DNSProvider{{
+					SecretName:     new("secret"),
+					CredentialsRef: dnsSecretCredentialsRef("other-secret"),
+				}}},
+				field.NewPath("spec", "dns"),
+				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
+			),
+			Entry("should return a warning when secretName is set with WorkloadIdentity credentialsRef",
+				&core.DNS{Providers: []core.DNSProvider{{
+					SecretName:     new("secret"),
+					CredentialsRef: dnsWorkloadIdentityCredentialsRef("identity"),
+				}}},
 				field.NewPath("spec", "dns"),
 				ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")),
 			),
@@ -513,6 +552,26 @@ var _ = Describe("Warnings", func() {
 					Not(ContainElement(ContainSubstring("spec.dns.providers[0].secretName"))),
 				),
 			),
+			Entry("should return warnings for all providers with secretName",
+				&core.DNS{Providers: []core.DNSProvider{
+					{
+						SecretName:     new("synced-secret"),
+						CredentialsRef: dnsSecretCredentialsRef("synced-secret"),
+					},
+					{SecretName: new("secret")},
+					{CredentialsRef: dnsSecretCredentialsRef("credentials-secret")},
+					{
+						SecretName:     new("mismatched-secret"),
+						CredentialsRef: dnsSecretCredentialsRef("other-secret"),
+					},
+				}},
+				field.NewPath("spec", "dns"),
+				ConsistOf(
+					Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead."),
+					Equal("you are setting the spec.dns.providers[1].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[1].credentialsRef instead."),
+					Equal("you are setting the spec.dns.providers[3].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[3].credentialsRef instead."),
+				),
+			),
 			Entry("should use custom field path in warning message",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
 				field.NewPath("custom", "path"),
@@ -521,3 +580,19 @@ var _ = Describe("Warnings", func() {
 		)
 	})
 })
+
+func dnsSecretCredentialsRef(name string) *autoscalingv1.CrossVersionObjectReference {
+	return &autoscalingv1.CrossVersionObjectReference{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Name:       name,
+	}
+}
+
+func dnsWorkloadIdentityCredentialsRef(name string) *autoscalingv1.CrossVersionObjectReference {
+	return &autoscalingv1.CrossVersionObjectReference{
+		APIVersion: "security.gardener.cloud/v1alpha1",
+		Kind:       "WorkloadIdentity",
+		Name:       name,
+	}
+}

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -527,26 +527,6 @@ var _ = Describe("Warnings", func() {
 					Not(ContainElement(ContainSubstring("spec.dns.providers[0].secretName"))),
 				),
 			),
-			Entry("should return warnings for all providers with secretName",
-				&core.DNS{Providers: []core.DNSProvider{
-					{
-						SecretName:     new("synced-secret"),
-						CredentialsRef: dnsSecretCredentialsRef("synced-secret"),
-					},
-					{SecretName: new("secret")},
-					{CredentialsRef: dnsSecretCredentialsRef("credentials-secret")},
-					{
-						SecretName:     new("mismatched-secret"),
-						CredentialsRef: dnsSecretCredentialsRef("other-secret"),
-					},
-				}},
-				field.NewPath("spec", "dns"),
-				ConsistOf(
-					Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead."),
-					Equal("you are setting the spec.dns.providers[1].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[1].credentialsRef instead."),
-					Equal("you are setting the spec.dns.providers[3].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[3].credentialsRef instead."),
-				),
-			),
 			Entry("should use custom field path in warning message",
 				&core.DNS{Providers: []core.DNSProvider{{SecretName: new("secret")}}},
 				field.NewPath("custom", "path"),

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -431,7 +431,7 @@ var _ = Describe("Warnings", func() {
 				},
 			}
 
-			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, []int{0})).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval, []int{0})).To(BeEmpty())
 		})
 	})
 

--- a/pkg/api/seedmanagement/managedseedset/warnings.go
+++ b/pkg/api/seedmanagement/managedseedset/warnings.go
@@ -27,7 +27,7 @@ func GetWarnings(managedseedset *seedmanagement.ManagedSeedSet) []string {
 
 	if dns := managedseedset.Spec.ShootTemplate.Spec.DNS; dns != nil {
 		path := field.NewPath("spec", "shootTemplate", "spec", "dns")
-		warnings = append(warnings, shoot.GetDNSProviderWarnings(dns, path)...)
+		warnings = append(warnings, shoot.GetDNSProviderWarnings(dns, path, nil)...)
 	}
 
 	return warnings

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -41,11 +42,18 @@ type shootStrategy struct {
 	names.NameGenerator
 
 	credentialsRotationInterval time.Duration
+
+	dnsProviderSecretNameWarningSuppressions *sync.Map
 }
 
 // NewStrategy returns a new storage strategy for Shoots.
 func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
-	return shootStrategy{api.Scheme, names.SimpleNameGenerator, credentialsRotationInterval}
+	return shootStrategy{
+		ObjectTyper:                              api.Scheme,
+		NameGenerator:                            names.SimpleNameGenerator,
+		credentialsRotationInterval:              credentialsRotationInterval,
+		dnsProviderSecretNameWarningSuppressions: &sync.Map{},
+	}
 }
 
 // Strategy should implement rest.RESTCreateUpdateStrategy
@@ -55,7 +63,7 @@ func (shootStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 
 	newShoot.Generation = 1
@@ -63,10 +71,11 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
+	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
 }
 
-func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
+func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
 
@@ -79,6 +88,7 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 		newShoot.Annotations[v1beta1constants.GardenerMaintenanceOperation] = cleanUpOperation(op)
 	}
 
+	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
 
 	if mustIncreaseGeneration(oldShoot, newShoot) {
@@ -227,13 +237,16 @@ func capEventTTL(kubeAPIServer *core.KubeAPIServerConfig) {
 	}
 }
 
-func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+func (s shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	shoot := obj.(*core.Shoot)
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateShoot(shoot)...)
 	allErrs = append(allErrs, validation.ValidateForceDeletion(shoot, nil)...)
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
+	if len(allErrs) > 0 {
+		s.clearDNSProviderSecretNameWarningSuppressions(shoot)
+	}
 
 	return allErrs
 }
@@ -276,10 +289,15 @@ func (shootStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newShoot := newObj.(*core.Shoot)
 	oldShoot := oldObj.(*core.Shoot)
-	return validation.ValidateShootUpdate(newShoot, oldShoot)
+	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
+	if len(allErrs) > 0 {
+		s.clearDNSProviderSecretNameWarningSuppressions(newShoot)
+	}
+
+	return allErrs
 }
 
 func (shootStrategy) AllowUnconditionalUpdate() bool {
@@ -288,12 +306,63 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return shoot.GetWarnings(ctx, obj.(*core.Shoot), nil, s.credentialsRotationInterval)
+	newShoot := obj.(*core.Shoot)
+	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return shoot.GetWarnings(ctx, obj.(*core.Shoot), old.(*core.Shoot), s.credentialsRotationInterval)
+	newShoot := obj.(*core.Shoot)
+	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, old.(*core.Shoot), s.credentialsRotationInterval))
+}
+
+func (s shootStrategy) recordDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
+	s.clearDNSProviderSecretNameWarningSuppressions(shootObj)
+
+	if s.dnsProviderSecretNameWarningSuppressions == nil || shootObj.Spec.DNS == nil {
+		return
+	}
+
+	indices := sets.New[int]()
+	for i, provider := range shootObj.Spec.DNS.Providers {
+		if provider.SecretName == nil && isSecretDNSProviderCredentialsRef(provider.CredentialsRef) {
+			indices.Insert(i)
+		}
+	}
+	if indices.Len() > 0 {
+		s.dnsProviderSecretNameWarningSuppressions.Store(shootObj, indices)
+	}
+}
+
+func (s shootStrategy) clearDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return
+	}
+	s.dnsProviderSecretNameWarningSuppressions.Delete(shootObj)
+}
+
+func (s shootStrategy) suppressDNSProviderSecretNameWarnings(shootObj *core.Shoot, warnings []string) []string {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return warnings
+	}
+
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(shootObj)
+	if !ok {
+		return warnings
+	}
+
+	indices, ok := value.(sets.Set[int])
+	if !ok || indices.Len() == 0 {
+		return warnings
+	}
+
+	suppressedWarnings := sets.New[string]()
+	providersPath := field.NewPath("spec", "dns").Child("providers")
+	for index := range indices {
+		suppressedWarnings.Insert(shoot.DNSProviderSecretNameWarning(providersPath.Index(index)))
+	}
+
+	return slices.DeleteFunc(warnings, suppressedWarnings.Has)
 }
 
 type shootStatusStrategy struct {
@@ -470,7 +539,7 @@ func SyncDNSProviderCredentials(shoot *core.Shoot) {
 			continue
 		}
 
-		if provider.SecretName == nil && provider.CredentialsRef != nil && provider.CredentialsRef.APIVersion == "v1" && provider.CredentialsRef.Kind == "Secret" {
+		if provider.SecretName == nil && isSecretDNSProviderCredentialsRef(provider.CredentialsRef) {
 			shoot.Spec.DNS.Providers[idx].SecretName = &provider.CredentialsRef.Name
 			continue
 		}
@@ -480,4 +549,8 @@ func SyncDNSProviderCredentials(shoot *core.Shoot) {
 		// - both fields are set -> let the validation check if they are correct
 		// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
 	}
+}
+
+func isSecretDNSProviderCredentialsRef(credentialsRef *autoscalingv1.CrossVersionObjectReference) bool {
+	return credentialsRef != nil && credentialsRef.APIVersion == "v1" && credentialsRef.Kind == "Secret"
 }

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -41,11 +42,18 @@ type shootStrategy struct {
 	names.NameGenerator
 
 	credentialsRotationInterval time.Duration
+
+	dnsProviderSecretNameWarningSuppressions *sync.Map
 }
 
 // NewStrategy returns a new storage strategy for Shoots.
 func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
-	return shootStrategy{api.Scheme, names.SimpleNameGenerator, credentialsRotationInterval}
+	return shootStrategy{
+		ObjectTyper:                              api.Scheme,
+		NameGenerator:                            names.SimpleNameGenerator,
+		credentialsRotationInterval:              credentialsRotationInterval,
+		dnsProviderSecretNameWarningSuppressions: &sync.Map{},
+	}
 }
 
 // Strategy should implement rest.RESTCreateUpdateStrategy
@@ -55,7 +63,7 @@ func (shootStrategy) NamespaceScoped() bool {
 	return true
 }
 
-func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
+func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 
 	newShoot.Generation = 1
@@ -63,10 +71,11 @@ func (shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
+	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
 }
 
-func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
+func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
 
@@ -79,6 +88,7 @@ func (shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object
 		newShoot.Annotations[v1beta1constants.GardenerMaintenanceOperation] = cleanUpOperation(op)
 	}
 
+	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
 
 	if mustIncreaseGeneration(oldShoot, newShoot) {
@@ -218,6 +228,9 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 	allErrs = append(allErrs, validation.ValidateForceDeletion(shoot, nil)...)
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
+	if len(allErrs) > 0 {
+		s.clearDNSProviderSecretNameWarningSuppressions(shoot)
+	}
 
 	return allErrs
 }
@@ -260,10 +273,15 @@ func (shootStrategy) AllowCreateOnUpdate() bool {
 	return false
 }
 
-func (shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.Object) field.ErrorList {
 	newShoot := newObj.(*core.Shoot)
 	oldShoot := oldObj.(*core.Shoot)
-	return validation.ValidateShootUpdate(newShoot, oldShoot)
+	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
+	if len(allErrs) > 0 {
+		s.clearDNSProviderSecretNameWarningSuppressions(newShoot)
+	}
+
+	return allErrs
 }
 
 func (shootStrategy) AllowUnconditionalUpdate() bool {
@@ -272,12 +290,63 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return shoot.GetWarnings(ctx, obj.(*core.Shoot), nil, s.credentialsRotationInterval)
+	newShoot := obj.(*core.Shoot)
+	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return shoot.GetWarnings(ctx, obj.(*core.Shoot), old.(*core.Shoot), s.credentialsRotationInterval)
+	newShoot := obj.(*core.Shoot)
+	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, old.(*core.Shoot), s.credentialsRotationInterval))
+}
+
+func (s shootStrategy) recordDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
+	s.clearDNSProviderSecretNameWarningSuppressions(shootObj)
+
+	if s.dnsProviderSecretNameWarningSuppressions == nil || shootObj.Spec.DNS == nil {
+		return
+	}
+
+	indices := sets.New[int]()
+	for i, provider := range shootObj.Spec.DNS.Providers {
+		if provider.SecretName == nil && isSecretDNSProviderCredentialsRef(provider.CredentialsRef) {
+			indices.Insert(i)
+		}
+	}
+	if indices.Len() > 0 {
+		s.dnsProviderSecretNameWarningSuppressions.Store(shootObj, indices)
+	}
+}
+
+func (s shootStrategy) clearDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return
+	}
+	s.dnsProviderSecretNameWarningSuppressions.Delete(shootObj)
+}
+
+func (s shootStrategy) suppressDNSProviderSecretNameWarnings(shootObj *core.Shoot, warnings []string) []string {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return warnings
+	}
+
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(shootObj)
+	if !ok {
+		return warnings
+	}
+
+	indices, ok := value.(sets.Set[int])
+	if !ok || indices.Len() == 0 {
+		return warnings
+	}
+
+	suppressedWarnings := sets.New[string]()
+	providersPath := field.NewPath("spec", "dns").Child("providers")
+	for index := range indices {
+		suppressedWarnings.Insert(shoot.DNSProviderSecretNameWarning(providersPath.Index(index)))
+	}
+
+	return slices.DeleteFunc(warnings, suppressedWarnings.Has)
 }
 
 type shootStatusStrategy struct {
@@ -454,7 +523,7 @@ func SyncDNSProviderCredentials(shoot *core.Shoot) {
 			continue
 		}
 
-		if provider.SecretName == nil && provider.CredentialsRef != nil && provider.CredentialsRef.APIVersion == "v1" && provider.CredentialsRef.Kind == "Secret" {
+		if provider.SecretName == nil && isSecretDNSProviderCredentialsRef(provider.CredentialsRef) {
 			shoot.Spec.DNS.Providers[idx].SecretName = &provider.CredentialsRef.Name
 			continue
 		}
@@ -464,4 +533,8 @@ func SyncDNSProviderCredentials(shoot *core.Shoot) {
 		// - both fields are set -> let the validation check if they are correct
 		// - credentialsRef refer to WorkloadIdentity -> secretRef should stay unset
 	}
+}
+
+func isSecretDNSProviderCredentialsRef(credentialsRef *autoscalingv1.CrossVersionObjectReference) bool {
+	return credentialsRef != nil && credentialsRef.APIVersion == "v1" && credentialsRef.Kind == "Secret"
 }

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -46,6 +46,16 @@ type shootStrategy struct {
 	dnsProviderSecretNameWarningSuppressions *sync.Map
 }
 
+type dnsProviderSecretNameWarningSuppressionKey struct {
+	namespace       string
+	name            string
+	uid             string
+	resourceVersion string
+	generation      int64
+}
+
+const dnsProviderSecretNameWarningSuppressionTTL = time.Minute
+
 // NewStrategy returns a new storage strategy for Shoots.
 func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
 	return shootStrategy{
@@ -65,19 +75,21 @@ func (shootStrategy) NamespaceScoped() bool {
 
 func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	newShoot := obj.(*core.Shoot)
+	syncedDNSProviderIndexes := dnsProviderIndexesSyncedFromCredentialsRef(newShoot)
 
 	newShoot.Generation = 1
 	newShoot.Status = core.ShootStatus{}
 
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
-	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
+	s.storeDNSProviderSecretNameWarningSuppressions(newShoot, nil, syncedDNSProviderIndexes)
 }
 
 func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
+	syncedDNSProviderIndexes := dnsProviderIndexesSyncedFromCredentialsRef(newShoot)
 
 	newShoot.Status = oldShoot.Status // can only be changed by shoots/status subresource
 
@@ -88,7 +100,6 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 		newShoot.Annotations[v1beta1constants.GardenerMaintenanceOperation] = cleanUpOperation(op)
 	}
 
-	s.recordDNSProviderSecretNameWarningSuppressions(newShoot)
 	SyncDNSProviderCredentials(newShoot)
 
 	if mustIncreaseGeneration(oldShoot, newShoot) {
@@ -96,6 +107,8 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 	}
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
+
+	s.storeDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot, syncedDNSProviderIndexes)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -229,7 +242,7 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
 	if len(allErrs) > 0 {
-		s.clearDNSProviderSecretNameWarningSuppressions(shoot)
+		s.clearDNSProviderSecretNameWarningSuppressions(shoot, nil)
 	}
 
 	return allErrs
@@ -278,7 +291,7 @@ func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.
 	oldShoot := oldObj.(*core.Shoot)
 	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
 	if len(allErrs) > 0 {
-		s.clearDNSProviderSecretNameWarningSuppressions(newShoot)
+		s.clearDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot)
 	}
 
 	return allErrs
@@ -291,62 +304,84 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval))
+	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.consumeDNSProviderSecretNameWarningSuppressions(newShoot, nil))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return s.suppressDNSProviderSecretNameWarnings(newShoot, shoot.GetWarnings(ctx, newShoot, old.(*core.Shoot), s.credentialsRotationInterval))
+	oldShoot := old.(*core.Shoot)
+	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.consumeDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot))
 }
 
-func (s shootStrategy) recordDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
-	s.clearDNSProviderSecretNameWarningSuppressions(shootObj)
-
-	if s.dnsProviderSecretNameWarningSuppressions == nil || shootObj.Spec.DNS == nil {
+func (s shootStrategy) storeDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot, suppressedIndexes []int) {
+	if s.dnsProviderSecretNameWarningSuppressions == nil || len(suppressedIndexes) == 0 {
 		return
 	}
 
-	indices := sets.New[int]()
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
+	s.dnsProviderSecretNameWarningSuppressions.Store(key, slices.Clone(suppressedIndexes))
+
+	time.AfterFunc(dnsProviderSecretNameWarningSuppressionTTL, func() {
+		s.dnsProviderSecretNameWarningSuppressions.Delete(key)
+	})
+}
+
+func (s shootStrategy) clearDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot) {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return
+	}
+	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
+}
+
+func (s shootStrategy) consumeDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot) []int {
+	if s.dnsProviderSecretNameWarningSuppressions == nil {
+		return nil
+	}
+
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
+	if !ok {
+		return nil
+	}
+
+	indexes, ok := value.([]int)
+	if !ok {
+		return nil
+	}
+
+	return indexes
+}
+
+func dnsProviderIndexesSyncedFromCredentialsRef(shootObj *core.Shoot) []int {
+	if shootObj.Spec.DNS == nil {
+		return nil
+	}
+
+	var indexes []int
 	for i, provider := range shootObj.Spec.DNS.Providers {
 		if provider.SecretName == nil && isSecretDNSProviderCredentialsRef(provider.CredentialsRef) {
-			indices.Insert(i)
+			indexes = append(indexes, i)
 		}
 	}
-	if indices.Len() > 0 {
-		s.dnsProviderSecretNameWarningSuppressions.Store(shootObj, indices)
-	}
+
+	return indexes
 }
 
-func (s shootStrategy) clearDNSProviderSecretNameWarningSuppressions(shootObj *core.Shoot) {
-	if s.dnsProviderSecretNameWarningSuppressions == nil {
-		return
-	}
-	s.dnsProviderSecretNameWarningSuppressions.Delete(shootObj)
-}
-
-func (s shootStrategy) suppressDNSProviderSecretNameWarnings(shootObj *core.Shoot, warnings []string) []string {
-	if s.dnsProviderSecretNameWarningSuppressions == nil {
-		return warnings
+func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
+	uid := string(shootObj.UID)
+	resourceVersion := shootObj.ResourceVersion
+	if oldShoot != nil {
+		uid = string(oldShoot.UID)
+		resourceVersion = oldShoot.ResourceVersion
 	}
 
-	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(shootObj)
-	if !ok {
-		return warnings
+	return dnsProviderSecretNameWarningSuppressionKey{
+		namespace:       shootObj.Namespace,
+		name:            shootObj.Name,
+		uid:             uid,
+		resourceVersion: resourceVersion,
+		generation:      shootObj.Generation,
 	}
-
-	indices, ok := value.(sets.Set[int])
-	if !ok || indices.Len() == 0 {
-		return warnings
-	}
-
-	suppressedWarnings := sets.New[string]()
-	providersPath := field.NewPath("spec", "dns").Child("providers")
-	for index := range indices {
-		suppressedWarnings.Insert(shoot.DNSProviderSecretNameWarning(providersPath.Index(index)))
-	}
-
-	return slices.DeleteFunc(warnings, suppressedWarnings.Has)
 }
 
 type shootStatusStrategy struct {

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -43,7 +44,12 @@ type shootStrategy struct {
 
 	credentialsRotationInterval time.Duration
 
-	dnsProviderSecretNameWarningSuppressions *sync.Map
+	dnsProviderSecretNameWarningSuppressions *dnsProviderSecretNameWarningSuppressions
+}
+
+type dnsProviderSecretNameWarningSuppressions struct {
+	lock  sync.Mutex
+	cache *utilcache.LRUExpireCache
 }
 
 type dnsProviderSecretNameWarningSuppressionKey struct {
@@ -54,15 +60,20 @@ type dnsProviderSecretNameWarningSuppressionKey struct {
 	generation      int64
 }
 
-const dnsProviderSecretNameWarningSuppressionTTL = time.Minute
+const (
+	dnsProviderSecretNameWarningSuppressionCacheSize = 100
+	dnsProviderSecretNameWarningSuppressionTTL       = time.Minute
+)
 
 // NewStrategy returns a new storage strategy for Shoots.
 func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
 	return shootStrategy{
-		ObjectTyper:                              api.Scheme,
-		NameGenerator:                            names.SimpleNameGenerator,
-		credentialsRotationInterval:              credentialsRotationInterval,
-		dnsProviderSecretNameWarningSuppressions: &sync.Map{},
+		ObjectTyper:                 api.Scheme,
+		NameGenerator:               names.SimpleNameGenerator,
+		credentialsRotationInterval: credentialsRotationInterval,
+		dnsProviderSecretNameWarningSuppressions: &dnsProviderSecretNameWarningSuppressions{
+			cache: utilcache.NewLRUExpireCache(dnsProviderSecretNameWarningSuppressionCacheSize),
+		},
 	}
 }
 
@@ -83,7 +94,7 @@ func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
 	SyncDNSProviderCredentials(newShoot)
-	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, nil, ignoredDNSWarningIndexes)
 }
 
 func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
@@ -108,7 +119,7 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
 
-	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, oldShoot, ignoredDNSWarningIndexes)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -242,7 +253,7 @@ func (s shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Err
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(shoot)
+		s.deleteIgnoredDNSWarningIndexes(shoot, nil)
 	}
 
 	return allErrs
@@ -291,7 +302,7 @@ func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.
 	oldShoot := oldObj.(*core.Shoot)
 	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(newShoot)
+		s.deleteIgnoredDNSWarningIndexes(newShoot, oldShoot)
 	}
 
 	return allErrs
@@ -304,38 +315,46 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
+	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, nil))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
+	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, oldShoot))
 }
 
-func (s shootStrategy) storeIgnoredDNSWarnings(shootObj *core.Shoot, ignoredIndexes []int) {
+func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, ignoredIndexes []int) {
+	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
+	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
+
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
+	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
 	if len(ignoredIndexes) == 0 {
 		return
 	}
 
-	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
-	s.dnsProviderSecretNameWarningSuppressions.Store(key, ignoredIndexes)
-
-	time.AfterFunc(dnsProviderSecretNameWarningSuppressionTTL, func() {
-		s.dnsProviderSecretNameWarningSuppressions.Delete(key)
-	})
+	s.dnsProviderSecretNameWarningSuppressions.cache.Add(key, ignoredIndexes, dnsProviderSecretNameWarningSuppressionTTL)
 }
 
-func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj *core.Shoot) {
-	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
+func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) {
+	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
+	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
+
+	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
 }
 
-func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
-	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
+func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) []int {
+	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
+	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
+
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.cache.Get(key)
 	if !ok {
 		return nil
 	}
+	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
 
 	indexes, ok := value.([]int)
 	if !ok {
@@ -360,9 +379,13 @@ func getIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
 	return indexes
 }
 
-func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
+func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
 	uid := string(shootObj.UID)
 	resourceVersion := shootObj.ResourceVersion
+	if oldShoot != nil {
+		uid = string(oldShoot.UID)
+		resourceVersion = oldShoot.ResourceVersion
+	}
 
 	return dnsProviderSecretNameWarningSuppressionKey{
 		namespace:       shootObj.Namespace,

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -75,7 +75,7 @@ func (shootStrategy) NamespaceScoped() bool {
 
 func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	newShoot := obj.(*core.Shoot)
-	syncedDNSProviderIndexes := dnsProviderIndexesSyncedFromCredentialsRef(newShoot)
+	ignoredDNSWarningIndexes := getIgnoredDNSWarningIndexes(newShoot)
 
 	newShoot.Generation = 1
 	newShoot.Status = core.ShootStatus{}
@@ -83,13 +83,13 @@ func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
 	SyncDNSProviderCredentials(newShoot)
-	s.storeDNSProviderSecretNameWarningSuppressions(newShoot, nil, syncedDNSProviderIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, nil, ignoredDNSWarningIndexes)
 }
 
 func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
-	syncedDNSProviderIndexes := dnsProviderIndexesSyncedFromCredentialsRef(newShoot)
+	ignoredDNSWarningIndexes := getIgnoredDNSWarningIndexes(newShoot)
 
 	newShoot.Status = oldShoot.Status // can only be changed by shoots/status subresource
 
@@ -108,7 +108,7 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
 
-	s.storeDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot, syncedDNSProviderIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, oldShoot, ignoredDNSWarningIndexes)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -242,7 +242,7 @@ func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Error
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
 	if len(allErrs) > 0 {
-		s.clearDNSProviderSecretNameWarningSuppressions(shoot, nil)
+		s.deleteIgnoredDNSWarningIndexes(shoot, nil)
 	}
 
 	return allErrs
@@ -291,7 +291,7 @@ func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.
 	oldShoot := oldObj.(*core.Shoot)
 	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
 	if len(allErrs) > 0 {
-		s.clearDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot)
+		s.deleteIgnoredDNSWarningIndexes(newShoot, oldShoot)
 	}
 
 	return allErrs
@@ -304,42 +304,35 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.consumeDNSProviderSecretNameWarningSuppressions(newShoot, nil))
+	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, nil))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.consumeDNSProviderSecretNameWarningSuppressions(newShoot, oldShoot))
+	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, oldShoot))
 }
 
-func (s shootStrategy) storeDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot, suppressedIndexes []int) {
-	if s.dnsProviderSecretNameWarningSuppressions == nil || len(suppressedIndexes) == 0 {
+func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, ignoredIndexes []int) {
+	if len(ignoredIndexes) == 0 {
 		return
 	}
 
-	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
-	s.dnsProviderSecretNameWarningSuppressions.Store(key, slices.Clone(suppressedIndexes))
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
+	s.dnsProviderSecretNameWarningSuppressions.Store(key, ignoredIndexes)
 
 	time.AfterFunc(dnsProviderSecretNameWarningSuppressionTTL, func() {
 		s.dnsProviderSecretNameWarningSuppressions.Delete(key)
 	})
 }
 
-func (s shootStrategy) clearDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot) {
-	if s.dnsProviderSecretNameWarningSuppressions == nil {
-		return
-	}
-	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
+func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) {
+	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 }
 
-func (s shootStrategy) consumeDNSProviderSecretNameWarningSuppressions(shootObj, oldShoot *core.Shoot) []int {
-	if s.dnsProviderSecretNameWarningSuppressions == nil {
-		return nil
-	}
-
-	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
+func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) []int {
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 	if !ok {
 		return nil
 	}
@@ -352,7 +345,7 @@ func (s shootStrategy) consumeDNSProviderSecretNameWarningSuppressions(shootObj,
 	return indexes
 }
 
-func dnsProviderIndexesSyncedFromCredentialsRef(shootObj *core.Shoot) []int {
+func getIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
 	if shootObj.Spec.DNS == nil {
 		return nil
 	}
@@ -367,13 +360,9 @@ func dnsProviderIndexesSyncedFromCredentialsRef(shootObj *core.Shoot) []int {
 	return indexes
 }
 
-func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
+func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
 	uid := string(shootObj.UID)
 	resourceVersion := shootObj.ResourceVersion
-	if oldShoot != nil {
-		uid = string(oldShoot.UID)
-		resourceVersion = oldShoot.ResourceVersion
-	}
 
 	return dnsProviderSecretNameWarningSuppressionKey{
 		namespace:       shootObj.Namespace,

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -83,7 +83,7 @@ func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
 	SyncDNSProviderCredentials(newShoot)
-	s.storeIgnoredDNSWarnings(newShoot, nil, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
 }
 
 func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
@@ -108,7 +108,7 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
 
-	s.storeIgnoredDNSWarnings(newShoot, oldShoot, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -242,7 +242,7 @@ func (s shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Err
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(shoot, nil)
+		s.deleteIgnoredDNSWarningIndexes(shoot)
 	}
 
 	return allErrs
@@ -291,7 +291,7 @@ func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.
 	oldShoot := oldObj.(*core.Shoot)
 	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(newShoot, oldShoot)
+		s.deleteIgnoredDNSWarningIndexes(newShoot)
 	}
 
 	return allErrs
@@ -304,17 +304,17 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, nil))
+	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, oldShoot))
+	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
 }
 
-func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, _ *core.Shoot, ignoredIndexes []int) {
+func (s shootStrategy) storeIgnoredDNSWarnings(shootObj *core.Shoot, ignoredIndexes []int) {
 	if len(ignoredIndexes) == 0 {
 		return
 	}
@@ -327,11 +327,11 @@ func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, _ *core.Shoot, ignoredI
 	})
 }
 
-func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, _ *core.Shoot) {
+func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj *core.Shoot) {
 	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 }
 
-func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, _ *core.Shoot) []int {
+func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
 	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 	if !ok {
 		return nil

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -234,7 +234,7 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 	return !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec)
 }
 
-func (shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+func (s shootStrategy) Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	shoot := obj.(*core.Shoot)
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validation.ValidateShoot(shoot)...)
@@ -314,7 +314,7 @@ func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, oldShoot))
 }
 
-func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, ignoredIndexes []int) {
+func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, _ *core.Shoot, ignoredIndexes []int) {
 	if len(ignoredIndexes) == 0 {
 		return
 	}
@@ -327,11 +327,11 @@ func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, i
 	})
 }
 
-func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) {
+func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, _ *core.Shoot) {
 	s.dnsProviderSecretNameWarningSuppressions.Delete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 }
 
-func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) []int {
+func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, _ *core.Shoot) []int {
 	value, ok := s.dnsProviderSecretNameWarningSuppressions.LoadAndDelete(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 	if !ok {
 		return nil

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -93,7 +93,7 @@ func (s shootStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	gardenerutils.SyncCloudProfileFields(nil, newShoot)
 
 	SyncDNSProviderCredentials(newShoot)
-	s.storeIgnoredDNSWarnings(newShoot, nil, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
 }
 
 func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
@@ -118,7 +118,7 @@ func (s shootStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Obje
 
 	gardenerutils.SyncCloudProfileFields(oldShoot, newShoot)
 
-	s.storeIgnoredDNSWarnings(newShoot, oldShoot, ignoredDNSWarningIndexes)
+	s.storeIgnoredDNSWarnings(newShoot, ignoredDNSWarningIndexes)
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
@@ -252,7 +252,7 @@ func (s shootStrategy) Validate(_ context.Context, obj runtime.Object) field.Err
 	allErrs = append(allErrs, validation.ValidateFinalizersOnCreation(shoot.Finalizers, field.NewPath("metadata", "finalizers"))...)
 	allErrs = append(allErrs, validation.ValidateInPlaceUpdateStrategyOnCreation(shoot)...)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(shoot, nil)
+		s.deleteIgnoredDNSWarningIndexes(shoot)
 	}
 
 	return allErrs
@@ -301,7 +301,7 @@ func (s shootStrategy) ValidateUpdate(_ context.Context, newObj, oldObj runtime.
 	oldShoot := oldObj.(*core.Shoot)
 	allErrs := validation.ValidateShootUpdate(newShoot, oldShoot)
 	if len(allErrs) > 0 {
-		s.deleteIgnoredDNSWarningIndexes(newShoot, oldShoot)
+		s.deleteIgnoredDNSWarningIndexes(newShoot)
 	}
 
 	return allErrs
@@ -314,18 +314,18 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 // WarningsOnCreate returns warnings to the client performing a create.
 func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, nil))
+	return shoot.GetWarnings(ctx, newShoot, nil, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
 func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
-	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot, oldShoot))
+	return shoot.GetWarnings(ctx, newShoot, oldShoot, s.credentialsRotationInterval, s.loadIgnoredDNSWarningIndexes(newShoot))
 }
 
-func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, ignoredIndexes []int) {
-	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
+func (s shootStrategy) storeIgnoredDNSWarnings(shootObj *core.Shoot, ignoredIndexes []int) {
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
 	if len(ignoredIndexes) == 0 {
 		s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
 		return
@@ -336,12 +336,12 @@ func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, i
 	s.dnsProviderSecretNameWarningSuppressions.cache.Add(key, ignoredIndexes, dnsProviderSecretNameWarningSuppressionTTL)
 }
 
-func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) {
-	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
+func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj *core.Shoot) {
+	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 }
 
-func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) []int {
-	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
+func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
+	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
 	value, ok := s.dnsProviderSecretNameWarningSuppressions.cache.Get(key)
 	if !ok {
 		return nil
@@ -371,19 +371,12 @@ func getIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
 	return indexes
 }
 
-func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
-	uid := string(shootObj.UID)
-	resourceVersion := shootObj.ResourceVersion
-	if oldShoot != nil {
-		uid = string(oldShoot.UID)
-		resourceVersion = oldShoot.ResourceVersion
-	}
-
+func dnsProviderSecretNameWarningSuppressionKeyFor(shootObj *core.Shoot) dnsProviderSecretNameWarningSuppressionKey {
 	return dnsProviderSecretNameWarningSuppressionKey{
 		namespace:       shootObj.Namespace,
 		name:            shootObj.Name,
-		uid:             uid,
-		resourceVersion: resourceVersion,
+		uid:             string(shootObj.UID),
+		resourceVersion: shootObj.ResourceVersion,
 		generation:      shootObj.Generation,
 	}
 }

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -48,7 +47,7 @@ type shootStrategy struct {
 }
 
 type dnsProviderSecretNameWarningSuppressions struct {
-	lock  sync.Mutex
+	// No mutex here: LRUExpireCache guards every operation with its own lock.
 	cache *utilcache.LRUExpireCache
 }
 
@@ -326,29 +325,22 @@ func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 }
 
 func (s shootStrategy) storeIgnoredDNSWarnings(shootObj, oldShoot *core.Shoot, ignoredIndexes []int) {
-	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
-	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
-
 	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
-	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
 	if len(ignoredIndexes) == 0 {
+		s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
 		return
 	}
 
+	// Add overwrites an existing entry, so no Remove is needed first and the
+	// pair does not have to be atomic.
 	s.dnsProviderSecretNameWarningSuppressions.cache.Add(key, ignoredIndexes, dnsProviderSecretNameWarningSuppressionTTL)
 }
 
 func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) {
-	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
-	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
-
 	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot))
 }
 
 func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj, oldShoot *core.Shoot) []int {
-	s.dnsProviderSecretNameWarningSuppressions.lock.Lock()
-	defer s.dnsProviderSecretNameWarningSuppressions.lock.Unlock()
-
 	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj, oldShoot)
 	value, ok := s.dnsProviderSecretNameWarningSuppressions.cache.Get(key)
 	if !ok {

--- a/pkg/apiserver/registry/core/shoot/strategy.go
+++ b/pkg/apiserver/registry/core/shoot/strategy.go
@@ -43,12 +43,7 @@ type shootStrategy struct {
 
 	credentialsRotationInterval time.Duration
 
-	dnsProviderSecretNameWarningSuppressions *dnsProviderSecretNameWarningSuppressions
-}
-
-type dnsProviderSecretNameWarningSuppressions struct {
-	// No mutex here: LRUExpireCache guards every operation with its own lock.
-	cache *utilcache.LRUExpireCache
+	dnsProviderSecretNameWarningSuppressions *utilcache.LRUExpireCache
 }
 
 type dnsProviderSecretNameWarningSuppressionKey struct {
@@ -67,12 +62,10 @@ const (
 // NewStrategy returns a new storage strategy for Shoots.
 func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
 	return shootStrategy{
-		ObjectTyper:                 api.Scheme,
-		NameGenerator:               names.SimpleNameGenerator,
-		credentialsRotationInterval: credentialsRotationInterval,
-		dnsProviderSecretNameWarningSuppressions: &dnsProviderSecretNameWarningSuppressions{
-			cache: utilcache.NewLRUExpireCache(dnsProviderSecretNameWarningSuppressionCacheSize),
-		},
+		ObjectTyper:                              api.Scheme,
+		NameGenerator:                            names.SimpleNameGenerator,
+		credentialsRotationInterval:              credentialsRotationInterval,
+		dnsProviderSecretNameWarningSuppressions: utilcache.NewLRUExpireCache(dnsProviderSecretNameWarningSuppressionCacheSize),
 	}
 }
 
@@ -327,26 +320,26 @@ func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 func (s shootStrategy) storeIgnoredDNSWarnings(shootObj *core.Shoot, ignoredIndexes []int) {
 	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
 	if len(ignoredIndexes) == 0 {
-		s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
+		s.dnsProviderSecretNameWarningSuppressions.Remove(key)
 		return
 	}
 
 	// Add overwrites an existing entry, so no Remove is needed first and the
 	// pair does not have to be atomic.
-	s.dnsProviderSecretNameWarningSuppressions.cache.Add(key, ignoredIndexes, dnsProviderSecretNameWarningSuppressionTTL)
+	s.dnsProviderSecretNameWarningSuppressions.Add(key, ignoredIndexes, dnsProviderSecretNameWarningSuppressionTTL)
 }
 
 func (s shootStrategy) deleteIgnoredDNSWarningIndexes(shootObj *core.Shoot) {
-	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
+	s.dnsProviderSecretNameWarningSuppressions.Remove(dnsProviderSecretNameWarningSuppressionKeyFor(shootObj))
 }
 
 func (s shootStrategy) loadIgnoredDNSWarningIndexes(shootObj *core.Shoot) []int {
 	key := dnsProviderSecretNameWarningSuppressionKeyFor(shootObj)
-	value, ok := s.dnsProviderSecretNameWarningSuppressions.cache.Get(key)
+	value, ok := s.dnsProviderSecretNameWarningSuppressions.Get(key)
 	if !ok {
 		return nil
 	}
-	s.dnsProviderSecretNameWarningSuppressions.cache.Remove(key)
+	s.dnsProviderSecretNameWarningSuppressions.Remove(key)
 
 	indexes, ok := value.([]int)
 	if !ok {

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -166,6 +166,42 @@ var _ = Describe("Strategy", func() {
 				strategy.PrepareForCreate(ctx, shoot)
 				Expect(shoot.Spec.DNS.Providers[0].SecretName).To(BeNil())
 			})
+
+			It("should return a secretName warning when secretName was synced to credentialsRef", func() {
+				shoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+						DNS: &core.DNS{
+							Providers: []core.DNSProvider{{
+								SecretName: new("secret-1"),
+							}},
+						},
+					},
+				}
+
+				strategy.PrepareForCreate(ctx, shoot)
+				Expect(strategy.WarningsOnCreate(ctx, shoot)).To(ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")))
+			})
+
+			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
+				shoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+						DNS: &core.DNS{
+							Providers: []core.DNSProvider{{
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret-1",
+								},
+							}},
+						},
+					},
+				}
+
+				strategy.PrepareForCreate(ctx, shoot)
+				Expect(strategy.WarningsOnCreate(ctx, shoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+			})
 		})
 	})
 
@@ -747,6 +783,52 @@ var _ = Describe("Strategy", func() {
 				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
 				Expect(newShoot.Spec.DNS.Providers[0].SecretName).To(BeNil())
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation))
+			})
+
+			It("should return a secretName warning when secretName was synced to credentialsRef", func() {
+				oldShoot := &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+					},
+				}
+
+				newShoot := oldShoot.DeepCopy()
+				newShoot.Spec.DNS = &core.DNS{
+					Providers: []core.DNSProvider{{
+						SecretName: new("secret-1"),
+					}},
+				}
+
+				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).To(ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")))
+			})
+
+			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
+				oldShoot := &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+					},
+				}
+
+				newShoot := oldShoot.DeepCopy()
+				newShoot.Spec.DNS = &core.DNS{
+					Providers: []core.DNSProvider{{
+						CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+							APIVersion: "v1",
+							Kind:       "Secret",
+							Name:       "secret-1",
+						},
+					}},
+				}
+
+				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -165,6 +165,42 @@ var _ = Describe("Strategy", func() {
 				strategy.PrepareForCreate(ctx, shoot)
 				Expect(shoot.Spec.DNS.Providers[0].SecretName).To(BeNil())
 			})
+
+			It("should return a secretName warning when secretName was synced to credentialsRef", func() {
+				shoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+						DNS: &core.DNS{
+							Providers: []core.DNSProvider{{
+								SecretName: new("secret-1"),
+							}},
+						},
+					},
+				}
+
+				strategy.PrepareForCreate(ctx, shoot)
+				Expect(strategy.WarningsOnCreate(ctx, shoot)).To(ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")))
+			})
+
+			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
+				shoot := &core.Shoot{
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+						DNS: &core.DNS{
+							Providers: []core.DNSProvider{{
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret-1",
+								},
+							}},
+						},
+					},
+				}
+
+				strategy.PrepareForCreate(ctx, shoot)
+				Expect(strategy.WarningsOnCreate(ctx, shoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+			})
 		})
 	})
 
@@ -710,6 +746,52 @@ var _ = Describe("Strategy", func() {
 				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
 				Expect(newShoot.Spec.DNS.Providers[0].SecretName).To(BeNil())
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation))
+			})
+
+			It("should return a secretName warning when secretName was synced to credentialsRef", func() {
+				oldShoot := &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+					},
+				}
+
+				newShoot := oldShoot.DeepCopy()
+				newShoot.Spec.DNS = &core.DNS{
+					Providers: []core.DNSProvider{{
+						SecretName: new("secret-1"),
+					}},
+				}
+
+				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).To(ContainElement(Equal("you are setting the spec.dns.providers[0].secretName field. The field is deprecated and is forbidden to be set starting from Kubernetes 1.35. Use spec.dns.providers[0].credentialsRef instead.")))
+			})
+
+			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
+				oldShoot := &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 1,
+					},
+					Spec: core.ShootSpec{
+						Kubernetes: core.Kubernetes{Version: "1.34.0"},
+					},
+				}
+
+				newShoot := oldShoot.DeepCopy()
+				newShoot.Spec.DNS = &core.DNS{
+					Providers: []core.DNSProvider{{
+						CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+							APIVersion: "v1",
+							Kind:       "Secret",
+							Name:       "secret-1",
+						},
+					}},
+				}
+
+				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -184,6 +184,10 @@ var _ = Describe("Strategy", func() {
 
 			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
 				shoot := &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "shoot",
+						Namespace: "garden",
+					},
 					Spec: core.ShootSpec{
 						Kubernetes: core.Kubernetes{Version: "1.34.0"},
 						DNS: &core.DNS{
@@ -199,7 +203,7 @@ var _ = Describe("Strategy", func() {
 				}
 
 				strategy.PrepareForCreate(ctx, shoot)
-				Expect(strategy.WarningsOnCreate(ctx, shoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+				Expect(strategy.WarningsOnCreate(ctx, shoot.DeepCopy())).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})
@@ -772,7 +776,10 @@ var _ = Describe("Strategy", func() {
 			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
 				oldShoot := &core.Shoot{
 					ObjectMeta: metav1.ObjectMeta{
-						Generation: 1,
+						Name:            "shoot",
+						Namespace:       "garden",
+						ResourceVersion: "42",
+						Generation:      1,
 					},
 					Spec: core.ShootSpec{
 						Kubernetes: core.Kubernetes{Version: "1.34.0"},
@@ -791,7 +798,7 @@ var _ = Describe("Strategy", func() {
 				}
 
 				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot.DeepCopy(), oldShoot.DeepCopy())).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})

--- a/pkg/apiserver/registry/core/shoot/strategy_test.go
+++ b/pkg/apiserver/registry/core/shoot/strategy_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Strategy", func() {
 				}
 
 				strategy.PrepareForCreate(ctx, shoot)
-				Expect(strategy.WarningsOnCreate(ctx, shoot.DeepCopy())).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+				Expect(strategy.WarningsOnCreate(ctx, shoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})
@@ -775,12 +775,6 @@ var _ = Describe("Strategy", func() {
 
 			It("should not return a secretName warning when credentialsRef was synced to secretName", func() {
 				oldShoot := &core.Shoot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "shoot",
-						Namespace:       "garden",
-						ResourceVersion: "42",
-						Generation:      1,
-					},
 					Spec: core.ShootSpec{
 						Kubernetes: core.Kubernetes{Version: "1.34.0"},
 					},
@@ -798,7 +792,7 @@ var _ = Describe("Strategy", func() {
 				}
 
 				strategy.PrepareForUpdate(ctx, newShoot, oldShoot)
-				Expect(strategy.WarningsOnUpdate(ctx, newShoot.DeepCopy(), oldShoot.DeepCopy())).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
+				Expect(strategy.WarningsOnUpdate(ctx, newShoot, oldShoot)).NotTo(ContainElement(ContainSubstring("spec.dns.providers[0].secretName")))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind bug

**What this PR does / why we need it**:

`PrepareForCreate`/`PrepareForUpdate` in the Shoot strategy sync `spec.dns.providers[].secretName` from `credentialsRef`. Because the sync runs before `GetWarnings`, every Shoot using the recommended `credentialsRef` field saw the `secretName is deprecated` warning on each update, even though the user never set `secretName`.

Suppressing the warning whenever `credentialsRef` is set would also hide it from clients still submitting the deprecated field, so instead the strategy records which provider indexes had `secretName` written by the sync, and passes those indexes to `GetWarnings`. `GetDNSProviderWarnings` skips them, so the warning is never generated for those providers rather than generated and then filtered.

A user-supplied `secretName`, alone or alongside `credentialsRef`, still warns.

The indexes are carried between the mutation and the warning call in an `LRUExpireCache` bounded to 100 entries with a one minute TTL, keyed by namespace, name, UID, resourceVersion and generation.

**Which issue(s) this PR fixes**:
Fixes #14941

**Special notes for your reviewer**:

Review feedback so far is all applied: the `sync.Mutex` duplicating `LRUExpireCache`'s built-in lock is gone, the unused `oldShoot` parameters are removed, and the CLA is signed with `license/cla` green.

The switch from `sync.Map` to `LRUExpireCache` came from @marc1404's review of the unbounded map, which had no eviction path.

Verification: `go build ./pkg/apiserver/...` and `go test -race` on `pkg/apiserver/registry/core/shoot`, its `storage` subpackage and `pkg/api/core/shoot` all pass.

**Release note**:

```other operator
The false deprecation warning for `spec.dns.providers[].secretName` is no longer emitted for Shoots whose `secretName` is synced from `credentialsRef`. The warning still appears when the deprecated field is set by the user.
```
