### PR TITLE
Visualize ignored MRs

### DIFF
--- a/docs/usage/shoot/shoot_status.md
+++ b/docs/usage/shoot/shoot_status.md
@@ -120,6 +120,13 @@ This constraint indicates that at least one worker pool with the update strategy
 The constraint is not added to `.status.constraints` if all such worker pools are already up-to-date.
 Once the user manually labels all the relevant nodes with `node.machine.sapcloud.io/selected-for-update` and the update process completes, the constraint will be automatically removed.
 
+**`HasIgnoredManagedResources`**:
+
+This constraint indicates that at least one `ManagedResource` in the Shoot's control plane namespace has been annotated with `resources.gardener.cloud/ignore=true`, meaning its reconciliation has been disabled.
+It will not be added to `.status.constraints` if no such `ManagedResource` exists.
+If it's visible, operators should be aware that the annotated resources may diverge from the desired state and should remove the annotation once the manual intervention is complete.
+
+
 ### Last Operation
 
 The Shoot status holds information about the last operation that is performed on the Shoot. The last operation field reflects overall progress and the tasks that are currently being executed. Allowed operation types are `Create`, `Reconcile`, `Delete`, `Migrate`, and `Restore`. Allowed operation states are `Processing`, `Succeeded`, `Error`, `Failed`, `Pending`, and `Aborted`. An operation in `Error` state is an operation that will be retried for a configurable amount of time (`controllers.shoot.retryDuration` field in `GardenletConfiguration`, defaults to `12h`). If the operation cannot complete successfully for the configured retry duration, it will be marked as `Failed`. An operation in `Failed` state is an operation that won't be retried automatically (to retry such an operation, see [Retry failed operation](../shoot-operations/shoot_operations.md#retry-failed-operation)).

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -2133,6 +2133,10 @@ const (
 	// ShootManualInPlaceWorkersUpdated is a constant for a condition type indicating that the Shoot cluster does not have
 	// any worker pools with update strategy "ManualInPlaceUpdate" and pending update.
 	ShootManualInPlaceWorkersUpdated ConditionType = "ManualInPlaceWorkersUpdated"
+	// ShootHasIgnoredManagedResources is a constant for a condition type indicating that one or more ManagedResources
+	// in the Shoot's control plane namespace in the seed have been annotated with resources.gardener.cloud/ignore=true,
+	// meaning their reconciliation has been disabled. Operators should be aware of such resources as they may diverge from the desired state.
+	ShootHasIgnoredManagedResources ConditionType = "HasIgnoredManagedResources"
 	// ShootReadyForMigration is a constant for a condition type indicating whether the Shoot can be migrated.
 	ShootReadyForMigration ConditionType = "ReadyForMigration"
 	// ShootDualStackNodesMigrationReady is a constant for a condition type indicating whether all nodes are migrated to dual-stack .

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -125,6 +125,15 @@ func (c *Constraint) constraintsChecks(
 	status, reason, message = c.checkIfManualInPlaceWorkersUpdated()
 	constraints.manualInPlaceWorkersUpdated = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.manualInPlaceWorkersUpdated, status, reason, message)
 
+	// Check whether any ManagedResources in the shoot's control plane namespace have been annotated with
+	// resources.gardener.cloud/ignore=true, which disables their reconciliation.
+	status, reason, message, err = c.checkIfManagedResourcesAreIgnored(ctx)
+	if err != nil {
+		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.hasIgnoredManagedResources, err)
+	} else {
+		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hasIgnoredManagedResources, status, reason, message)
+	}
+
 	// Now check constraints depending on the shoot's kube-apiserver to be up and running
 	shootClient, apiServerRunning, err := c.initializeShootClients()
 	if err != nil {
@@ -136,14 +145,14 @@ func (c *Constraint) constraintsChecks(
 
 		return filterOptionalConstraints(
 			[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources},
 		)
 	}
 	if !apiServerRunning {
 		// don't check constraints if API server has already been deleted or has not been created yet
 		return filterOptionalConstraints(
 			shootControlPlaneNotRunningConstraints(c.clock, constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied),
-			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated},
+			[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources},
 		)
 	}
 	c.shootClient = shootClient.Client()
@@ -166,7 +175,7 @@ func (c *Constraint) constraintsChecks(
 
 	return filterOptionalConstraints(
 		[]gardencorev1beta1.Condition{constraints.hibernationPossible, constraints.maintenancePreconditionsSatisfied},
-		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated},
+		[]gardencorev1beta1.Condition{constraints.caCertificateValiditiesAcceptable, constraints.crdsWithProblematicConversionWebhooks, constraints.manualInPlaceWorkersUpdated, constraints.hasIgnoredManagedResources},
 	)
 }
 
@@ -263,6 +272,37 @@ func (c *Constraint) checkIfManualInPlaceWorkersUpdated() (gardencorev1beta1.Con
 		"WorkerPoolsWithManualInPlaceUpdateStrategyPending",
 		fmt.Sprintf("Some worker pools in your Shoot with update strategy ManualInPlaceUpdate are pending update: %s",
 			strings.Join(c.shoot.GetInfo().Status.InPlaceUpdates.PendingWorkerUpdates.ManualInPlaceUpdate, ", "))
+}
+
+// checkIfManagedResourcesAreIgnored lists all ManagedResources in the shoot's control plane namespace and checks
+// whether any of them have the resources.gardener.cloud/ignore=true annotation set, which disables their reconciliation.
+func (c *Constraint) checkIfManagedResourcesAreIgnored(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, error) {
+	managedResourceList := &resourcesv1alpha1.ManagedResourceList{}
+	if err := c.seedClient.List(ctx, managedResourceList, client.InNamespace(c.shoot.ControlPlaneNamespace)); err != nil {
+		return "", "", "", fmt.Errorf("could not list ManagedResources in shoot namespace in seed to check for ignored resources: %w", err)
+	}
+
+	ignoredNames := sets.New[string]()
+	for _, mr := range managedResourceList.Items {
+		if value, ok := mr.GetAnnotations()[resourcesv1alpha1.Ignore]; ok {
+			if truthy, _ := strconv.ParseBool(value); truthy {
+				ignoredNames.Insert(mr.Name)
+			}
+		}
+	}
+
+	if ignoredNames.Len() > 0 {
+		return gardencorev1beta1.ConditionFalse,
+			"ManagedResourcesIgnored",
+			fmt.Sprintf("Some ManagedResources have been annotated with %s=true, meaning their reconciliation is disabled: %s",
+				resourcesv1alpha1.Ignore, strings.Join(sets.List(ignoredNames), ", ")),
+			nil
+	}
+
+	return gardencorev1beta1.ConditionTrue,
+		"NoManagedResourcesIgnored",
+		"No ManagedResources are annotated to be ignored.",
+		nil
 }
 
 // checkIfCRDsWithProblematicConversionWebhooksPresent checks whether there are CRDs with multiple stored versions and
@@ -453,6 +493,7 @@ type ShootConstraints struct {
 	caCertificateValiditiesAcceptable     gardencorev1beta1.Condition
 	crdsWithProblematicConversionWebhooks gardencorev1beta1.Condition
 	manualInPlaceWorkersUpdated           gardencorev1beta1.Condition
+	hasIgnoredManagedResources            gardencorev1beta1.Condition
 }
 
 // ConvertToSlice returns the shoot constraints as a slice.
@@ -463,6 +504,7 @@ func (g ShootConstraints) ConvertToSlice() []gardencorev1beta1.Condition {
 		g.caCertificateValiditiesAcceptable,
 		g.crdsWithProblematicConversionWebhooks,
 		g.manualInPlaceWorkersUpdated,
+		g.hasIgnoredManagedResources,
 	}
 }
 
@@ -474,6 +516,7 @@ func (g ShootConstraints) ConstraintTypes() []gardencorev1beta1.ConditionType {
 		g.caCertificateValiditiesAcceptable.Type,
 		g.crdsWithProblematicConversionWebhooks.Type,
 		g.manualInPlaceWorkersUpdated.Type,
+		g.hasIgnoredManagedResources.Type,
 	}
 }
 
@@ -486,5 +529,6 @@ func NewShootConstraints(clock clock.Clock, shoot *gardencorev1beta1.Shoot) Shoo
 		caCertificateValiditiesAcceptable:     v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
 		crdsWithProblematicConversionWebhooks: v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks),
 		manualInPlaceWorkersUpdated:           v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
+		hasIgnoredManagedResources:            v1beta1helper.GetOrInitConditionWithClock(clock, shoot.Status.Constraints, gardencorev1beta1.ShootHasIgnoredManagedResources),
 	}
 }

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -49,13 +49,19 @@ const (
 func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
 	hibernationConditions := make([]gardencorev1beta1.Condition, 0, len(conditions))
 	for _, cond := range conditions {
-		// During hibernation, these conditions are either not applicable or already computed before
-		// the hibernation guard, so we preserve their current value.
-		if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated ||
-			cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
-			hibernationConditions = append(hibernationConditions, cond)
-			continue
-		}
+        // Not applicable during hibernation — skip entirely.
+        if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated {
+                continue
+        }
+        // Optional constraint computed before the hibernation guard.
+        // Only preserve it if it's non-True (i.e. there are ignored MRs worth showing).
+        // When True, drop it — consistent with filterOptionalConstraints behaviour.
+        if cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
+                if cond.Status != gardencorev1beta1.ConditionTrue {
+                        hibernationConditions = append(hibernationConditions, cond)
+                }
+                continue
+        }
 		hibernationConditions = append(hibernationConditions, v1beta1helper.UpdatedConditionWithClock(clock, cond, gardencorev1beta1.ConditionTrue, "ConstraintNotChecked", "Shoot cluster has been hibernated."))
 	}
 	return hibernationConditions

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -49,19 +49,19 @@ const (
 func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
 	hibernationConditions := make([]gardencorev1beta1.Condition, 0, len(conditions))
 	for _, cond := range conditions {
-        // Not applicable during hibernation — skip entirely.
-        if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated {
-                continue
-        }
-        // Optional constraint computed before the hibernation guard.
-        // Only preserve it if it's non-True (i.e. there are ignored MRs worth showing).
-        // When True, drop it — consistent with filterOptionalConstraints behaviour.
-        if cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
-                if cond.Status != gardencorev1beta1.ConditionTrue {
-                        hibernationConditions = append(hibernationConditions, cond)
-                }
-                continue
-        }
+		// Not applicable during hibernation — skip entirely.
+		if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated {
+			continue
+		}
+		// Optional constraint computed before the hibernation guard.
+		// Only preserve it if it's non-True (i.e. there are ignored MRs worth showing).
+		// When True, drop it — consistent with filterOptionalConstraints behaviour.
+		if cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
+			if cond.Status != gardencorev1beta1.ConditionTrue {
+				hibernationConditions = append(hibernationConditions, cond)
+			}
+			continue
+		}
 		hibernationConditions = append(hibernationConditions, v1beta1helper.UpdatedConditionWithClock(clock, cond, gardencorev1beta1.ConditionTrue, "ConstraintNotChecked", "Shoot cluster has been hibernated."))
 	}
 	return hibernationConditions

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -137,15 +137,6 @@ func (c *Constraint) constraintsChecks(
 	status, reason, message = c.checkIfManualInPlaceWorkersUpdated()
 	constraints.manualInPlaceWorkersUpdated = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.manualInPlaceWorkersUpdated, status, reason, message)
 
-	// Check whether any ManagedResources in the shoot's control plane namespace have been annotated with
-	// resources.gardener.cloud/ignore=true, which disables their reconciliation.
-	status, reason, message, err = c.checkIfManagedResourcesAreIgnored(ctx)
-	if err != nil {
-		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.hasIgnoredManagedResources, err)
-	} else {
-		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hasIgnoredManagedResources, status, reason, message)
-	}
-
 	// Now check constraints depending on the shoot's kube-apiserver to be up and running
 	shootClient, apiServerRunning, err := c.initializeShootClients()
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -121,7 +121,7 @@ func (c *Constraint) constraintsChecks(
 	} else {
 		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hasIgnoredManagedResources, status, reason, message)
 	}
-	
+
 	if c.shoot.HibernationEnabled || c.shoot.GetInfo().Status.IsHibernated {
 		return shootHibernatedConstraints(c.clock, constraints.ConvertToSlice()...)
 	}

--- a/pkg/gardenlet/controller/shoot/care/constraints.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints.go
@@ -49,8 +49,11 @@ const (
 func shootHibernatedConstraints(clock clock.Clock, conditions ...gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
 	hibernationConditions := make([]gardencorev1beta1.Condition, 0, len(conditions))
 	for _, cond := range conditions {
-		// During hibernation, this condition will always be True, so we can skip it
-		if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated {
+		// During hibernation, these conditions are either not applicable or already computed before
+		// the hibernation guard, so we preserve their current value.
+		if cond.Type == gardencorev1beta1.ShootManualInPlaceWorkersUpdated ||
+			cond.Type == gardencorev1beta1.ShootHasIgnoredManagedResources {
+			hibernationConditions = append(hibernationConditions, cond)
 			continue
 		}
 		hibernationConditions = append(hibernationConditions, v1beta1helper.UpdatedConditionWithClock(clock, cond, gardencorev1beta1.ConditionTrue, "ConstraintNotChecked", "Shoot cluster has been hibernated."))
@@ -110,6 +113,15 @@ func (c *Constraint) constraintsChecks(
 	ctx context.Context,
 	constraints ShootConstraints,
 ) []gardencorev1beta1.Condition {
+	// Check whether any ManagedResources in the shoot's control plane namespace have been annotated with
+	// resources.gardener.cloud/ignore=true, which disables their reconciliation.
+	status, reason, message, err := c.checkIfManagedResourcesAreIgnored(ctx)
+	if err != nil {
+		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionUnknownErrorWithClock(c.clock, constraints.hasIgnoredManagedResources, err)
+	} else {
+		constraints.hasIgnoredManagedResources = v1beta1helper.UpdatedConditionWithClock(c.clock, constraints.hasIgnoredManagedResources, status, reason, message)
+	}
+	
 	if c.shoot.HibernationEnabled || c.shoot.GetInfo().Status.IsHibernated {
 		return shootHibernatedConstraints(c.clock, constraints.ConvertToSlice()...)
 	}

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -723,6 +723,62 @@ var _ = Describe("Constraints", func() {
 						WithMessageSubstrings("bar, baz, foo"),
 					))
 				})
+
+				Context("when shoot is hibernated", func() {
+					var hibernatedConstraint *Constraint
+
+					BeforeEach(func() {
+						shootPkg := &shootpkg.Shoot{
+							ControlPlaneNamespace: controlPlaneNamespace,
+							HibernationEnabled:    true,
+						}
+						shootPkg.SetInfo(shoot)
+
+						hibernatedConstraint = NewConstraint(
+							logr.Discard(),
+							shootPkg,
+							seedClient,
+							func() (kubernetes.Interface, bool, error) {
+								return fakekubernetes.NewClientSetBuilder().WithClient(shootClient).Build(), true, nil
+							},
+							clock,
+						)
+					})
+
+					It("should remove the constraint when there are no ignored ManagedResources", func() {
+						hibernatedShoot := &gardencorev1beta1.Shoot{
+							Status: gardencorev1beta1.ShootStatus{
+								Constraints: []gardencorev1beta1.Condition{
+									{Type: gardencorev1beta1.ShootHasIgnoredManagedResources, Status: gardencorev1beta1.ConditionTrue},
+								},
+							},
+						}
+						hibernatedConstraints := NewShootConstraints(testclock.NewFakeClock(time.Time{}), hibernatedShoot)
+
+						Expect(hibernatedConstraint.Check(ctx, hibernatedConstraints)).NotTo(ContainCondition(
+							OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+						))
+					})
+
+					It("should preserve the constraint when ManagedResources are ignored", func() {
+						mr := &resourcesv1alpha1.ManagedResource{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "foo",
+								Namespace: controlPlaneNamespace,
+								Annotations: map[string]string{
+									resourcesv1alpha1.Ignore: "true",
+								},
+							},
+						}
+						Expect(seedClient.Create(ctx, mr)).To(Succeed())
+
+						Expect(hibernatedConstraint.Check(ctx, constraints)).To(ContainCondition(
+							OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+							WithReason("ManagedResourcesIgnored"),
+							WithMessageSubstrings("foo"),
+						))
+					})
+				})				
 			})
 		})
 

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -778,7 +778,7 @@ var _ = Describe("Constraints", func() {
 							WithMessageSubstrings("foo"),
 						))
 					})
-				})				
+				})
 			})
 		})
 

--- a/pkg/gardenlet/controller/shoot/care/constraints_test.go
+++ b/pkg/gardenlet/controller/shoot/care/constraints_test.go
@@ -42,6 +42,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
@@ -495,6 +496,7 @@ var _ = Describe("Constraints", func() {
 							{Type: gardencorev1beta1.ShootMaintenancePreconditionsSatisfied},
 							{Type: gardencorev1beta1.ShootCRDsWithProblematicConversionWebhooks},
 							{Type: gardencorev1beta1.ShootManualInPlaceWorkersUpdated},
+							{Type: gardencorev1beta1.ShootHasIgnoredManagedResources},
 						},
 					},
 				}
@@ -675,6 +677,53 @@ var _ = Describe("Constraints", func() {
 					))
 				})
 			})
+
+			Context("#HasIgnoredManagedResources", func() {
+				It("should remove the constraint when no ManagedResources exist", func() {
+					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+					))
+				})
+
+				It("should remove the constraint when a ManagedResource has ignore=false", func() {
+					mr := &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "foo",
+							Namespace: controlPlaneNamespace,
+							Annotations: map[string]string{
+								resourcesv1alpha1.Ignore: "false",
+							},
+						},
+					}
+					Expect(seedClient.Create(ctx, mr)).To(Succeed())
+
+					Expect(constraint.Check(ctx, constraints)).NotTo(ContainCondition(
+						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+					))
+				})
+
+				It("should keep the constraint when ManagedResources are ignored during reconcile", func() {
+					for _, name := range []string{"foo", "bar", "baz"} {
+						mr := &resourcesv1alpha1.ManagedResource{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      name,
+								Namespace: controlPlaneNamespace,
+								Annotations: map[string]string{
+									resourcesv1alpha1.Ignore: "true",
+								},
+							},
+						}
+						Expect(seedClient.Create(ctx, mr)).To(Succeed())
+					}
+
+					Expect(constraint.Check(ctx, constraints)).To(ContainCondition(
+						OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+						WithStatus(gardencorev1beta1.ConditionProgressing),
+						WithReason("ManagedResourcesIgnored"),
+						WithMessageSubstrings("bar, baz, foo"),
+					))
+				})
+			})
 		})
 
 		Describe("#CheckIfCACertificateValiditiesAcceptable", func() {
@@ -757,6 +806,7 @@ var _ = Describe("Constraints", func() {
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 
@@ -777,6 +827,7 @@ var _ = Describe("Constraints", func() {
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionWithStatusAndMsg("Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 		})
@@ -791,6 +842,7 @@ var _ = Describe("Constraints", func() {
 					OfType("CACertificateValiditiesAcceptable"),
 					OfType("CRDsWithProblematicConversionWebhooks"),
 					OfType("ManualInPlaceWorkersUpdated"),
+					OfType("HasIgnoredManagedResources"),
 				))
 			})
 		})
@@ -805,6 +857,7 @@ var _ = Describe("Constraints", func() {
 					gardencorev1beta1.ConditionType("CACertificateValiditiesAcceptable"),
 					gardencorev1beta1.ConditionType("CRDsWithProblematicConversionWebhooks"),
 					gardencorev1beta1.ConditionType("ManualInPlaceWorkersUpdated"),
+					gardencorev1beta1.ConditionType("HasIgnoredManagedResources"),
 				))
 			})
 		})

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -680,6 +680,7 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
+		),		
 	)
 
 	return And(matcher, HaveLen(expectedLength))

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -680,7 +680,7 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
-		),		
+		),
 	)
 
 	return And(matcher, HaveLen(expectedLength))

--- a/pkg/gardenlet/controller/shoot/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/care/reconciler_test.go
@@ -652,7 +652,7 @@ func containConditionsInUnknownStatus(message string, isWorkerless bool) types.G
 }
 
 func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
-	var expectedLength = 6
+	var expectedLength = 7
 	matcher := And(
 		ContainCondition(
 			OfType(gardencorev1beta1.ShootHibernationPossible),
@@ -676,7 +676,10 @@ func containConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 			OfType(gardencorev1beta1.ShootManualInPlaceWorkersUpdated),
 			WithStatus(gardencorev1beta1.ConditionUnknown),
 			WithMessage(message),
-		),
+		), ContainCondition(
+			OfType(gardencorev1beta1.ShootHasIgnoredManagedResources),
+			WithStatus(gardencorev1beta1.ConditionUnknown),
+			WithMessage(message),
 	)
 
 	return And(matcher, HaveLen(expectedLength))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Gardener allows operators to stop `ManagedResource` reconciliation by annotating them with `resources.gardener.cloud/ignore=true`. However, there was no built-in visibility that a resource had been ignored, which could lead to confusion and wasted troubleshooting time when resources silently diverge from their desired state.

This PR introduces a new optional shoot constraint `HasIgnoredManagedResources` that surfaces this information in the shoot's `.status.constraints`. The gardenlet's shoot care controller checks all `ManagedResources` in the shoot's control plane namespace in the seed and sets the constraint to `False` if any of them carry the `resources.gardener.cloud/ignore=true` annotation, listing their names in sorted order. The constraint is omitted from the status entirely when no such resources exist.

**Which issue(s) this PR fixes**:
Fixes #13592

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A new optional shoot constraint `HasIgnoredManagedResources` has been introduced. It surfaces in `.status.constraints` when one or more `ManagedResource`s in the shoot's control plane namespace have been annotated with `resources.gardener.cloud/ignore=true`, listing their names so operators are immediately aware of resources whose reconciliation has been disabled.
```
