### PR TITLE
Validate shoot network CIDR overlap during admission

### DIFF
--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -111,7 +111,7 @@ func validateOverlapWithReservedRanges(fldPath *field.Path, network, networkType
 }
 
 // ValidateShootNetworkDisjointedness validates that the given shoot network is disjoint.
-func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices *string, workerless bool) field.ErrorList {
+func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices *string) field.ErrorList {
 	var (
 		allErrs = field.ErrorList{}
 
@@ -119,38 +119,19 @@ func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPo
 		pathPods     = fldPath.Child("pods")
 	)
 
-	if shootPods != nil && shootServices != nil {
-		if NetworksIntersect(*shootPods, *shootServices) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot pod network intersects with shoot service network"))
-		}
+	// Validate Intersection: Pods <-> Services
+	if shootPods != nil && shootServices != nil && NetworksIntersect(*shootPods, *shootServices) {
+		allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot pod network intersects with shoot service network"))
+	}
 
-		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with shoot node network"))
-		}
+	// Validate Intersection: Pods <-> Nodes
+	if shootPods != nil && shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
+		allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with shoot node network"))
+	}
 
-		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
-		}
-	} else if shootPods != nil {
-		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with shoot node network"))
-		}
-
-		allErrs = append(allErrs, field.Required(pathServices, "shoot service network is required"))
-	} else if shootServices != nil {
-		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
-		}
-
-		if !workerless {
-			allErrs = append(allErrs, field.Required(pathPods, "shoot pod network is required"))
-		}
-	} else {
-		if !workerless {
-			allErrs = append(allErrs, field.Required(pathPods, "shoot pod network is required"))
-		}
-
-		allErrs = append(allErrs, field.Required(pathServices, "shoot service network is required"))
+	// Validate Intersection: Services <-> Nodes
+	if shootServices != nil && shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
+		allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
 	}
 
 	return allErrs

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -599,29 +599,9 @@ var _ = Describe("utils", func() {
 				&nodesCIDR,
 				&podsCIDR,
 				&servicesCIDR,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should fail due to missing fields", func() {
-			errorList := ValidateShootNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				false,
-			)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].services"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].pods"),
-			})),
-			))
 		})
 
 		It("should fail due to disjointedness of node, service and pod networks", func() {
@@ -636,7 +616,6 @@ var _ = Describe("utils", func() {
 				&nodesCIDR,
 				&podsCIDR,
 				&servicesCIDR,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -666,29 +645,9 @@ var _ = Describe("utils", func() {
 				&nodesCIDR,
 				&podsCIDR,
 				&servicesCIDR,
-				false,
 			)
 
 			Expect(errorList).To(BeEmpty())
-		})
-
-		It("should fail due to missing fields", func() {
-			errorList := ValidateShootNetworkDisjointedness(
-				field.NewPath(""),
-				nil,
-				nil,
-				nil,
-				false,
-			)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].services"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("[].pods"),
-			})),
-			))
 		})
 
 		It("should fail due to disjointedness of node, service and pod networks", func() {
@@ -703,7 +662,6 @@ var _ = Describe("utils", func() {
 				&nodesCIDR,
 				&podsCIDR,
 				&servicesCIDR,
-				false,
 			)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -616,7 +616,6 @@ func authorize(ctx context.Context, a admission.Attributes, auth authorizer.Auth
 		Verb:            "update",
 		ResourceRequest: true,
 	})
-
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("could not authorize update request for shoot binding subresource: %+v", err.Error()))
 	}
@@ -830,6 +829,16 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 		return nil
 	}
 
+	if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
+		// validate network disjointedness within shoot network
+		allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
+			path,
+			c.shoot.Spec.Networking.Nodes,
+			c.shoot.Spec.Networking.Pods,
+			c.shoot.Spec.Networking.Services,
+		)...)
+	}
+
 	if c.seed != nil {
 		if c.shoot.Spec.Networking.Pods == nil && !workerless &&
 			slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
@@ -843,15 +852,6 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 		}
 
 		if slices.Contains(c.shoot.Spec.Networking.IPFamilies, core.IPFamilyIPv4) {
-			// validate network disjointedness within shoot network
-			allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
-				path,
-				c.shoot.Spec.Networking.Nodes,
-				c.shoot.Spec.Networking.Pods,
-				c.shoot.Spec.Networking.Services,
-				workerless,
-			)...)
-
 			// validate network disjointedness with seed networks if shoot is being (re)scheduled
 			if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
 				allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(
@@ -884,7 +884,6 @@ func (c *validationContext) validateShootNetworks(a admission.Attributes, worker
 			}
 		}
 	}
-
 	return allErrs
 }
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2298,21 +2298,6 @@ var _ = Describe("validator", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("should reject because shoot pods network is missing", func() {
-				shoot.Spec.Networking.Pods = nil
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
-
-				Expect(err).To(BeForbiddenError())
-			})
-
 			It("should not reject because shoot pods network is nil (workerless Shoot)", func() {
 				shoot.Spec.Provider.Workers = nil
 				shoot.Spec.Networking.Pods = nil
@@ -2327,40 +2312,6 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Validate(ctx, attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should reject because shoot services network is missing", func() {
-				shoot.Spec.Networking.Services = nil
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
-
-				Expect(err).To(BeForbiddenError())
-				Expect(err).To(MatchError(ContainSubstring("services is required, spec.networking.services")))
-			})
-
-			It("should reject because shoot services network is nil (workerless Shoot)", func() {
-				shoot.Spec.Provider.Workers = nil
-				shoot.Spec.Networking.Services = nil
-
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
-
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(ContainSubstring("services is required, spec.networking.services")))
-
 			})
 
 			It("should reject because shoot services network is nil (workerless Shoot, Ipv6)", func() {
@@ -2553,49 +2504,153 @@ var _ = Describe("validator", func() {
 				Expect(err).To(Not(HaveOccurred()))
 			})
 
-			It("should reject because the shoot service and the shoot node networks intersect", func() {
-				shoot.Spec.Networking.Services = shoot.Spec.Networking.Nodes
+			Context("with and without seed", func() {
+				var shootWithoutSeed core.Shoot
 
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+				BeforeEach(func() {
+					shootWithoutSeed = *shootBase.DeepCopy()
+					shootWithoutSeed.Spec.SeedName = nil
+				})
 
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
+				Describe("shoot pods network is missing", func() {
+					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+						s.Spec.Networking.Pods = nil
 
-				Expect(err).To(BeForbiddenError())
-			})
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
 
-			It("should reject because the shoot pod and the shoot node networks intersect", func() {
-				shoot.Spec.Networking.Pods = shoot.Spec.Networking.Nodes
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
 
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+						Expect(err).To(errorMatcher)
+					}
 
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
+					It("should reject with seed set", func() {
+						testFunc(shoot, BeForbiddenError())
+					})
+					It("should not reject without seed set", func() {
+						testFunc(shootWithoutSeed, Succeed())
+					})
+				})
 
-				Expect(err).To(BeForbiddenError())
-			})
+				Describe("shoot services network is missing", func() {
+					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+						s.Spec.Networking.Services = nil
 
-			It("should reject because the shoot pod and the shoot service networks intersect", func() {
-				shoot.Spec.Networking.Pods = shoot.Spec.Networking.Services
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
 
-				Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-				Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
 
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-				err := admissionHandler.Validate(ctx, attrs, nil)
+						Expect(err).To(errorMatcher)
+					}
+					It("should reject with seed set", func() {
+						testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
+					})
+					It("should not reject without seed set", func() {
+						testFunc(shootWithoutSeed, Succeed())
+					})
+				})
 
-				Expect(err).To(BeForbiddenError())
+				Describe("shoot services network is nil (workerless Shoot)", func() {
+					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+						s.Spec.Provider.Workers = nil
+						s.Spec.Networking.Services = nil
+
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
+
+						Expect(err).To(errorMatcher)
+					}
+					It("should reject with seed set", func() {
+						testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
+					})
+					It("should not reject without seed set", func() {
+						testFunc(shootWithoutSeed, Succeed())
+					})
+				})
+				Describe("shoot service and the shoot node networks intersect", func() {
+					testFunc := func(s core.Shoot) {
+						s.Spec.Networking.Services = s.Spec.Networking.Nodes
+
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
+
+						Expect(err).To(BeForbiddenError())
+					}
+					It("should reject with seed set", func() {
+						testFunc(shoot)
+					})
+					It("should reject without seed set", func() {
+						testFunc(shootWithoutSeed)
+					})
+				})
+
+				Describe("shoot pod and the shoot node networks intersect", func() {
+					testFunc := func(s core.Shoot) {
+						s.Spec.Networking.Pods = s.Spec.Networking.Nodes
+
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
+
+						Expect(err).To(BeForbiddenError())
+					}
+					It("should reject with seed set", func() {
+						testFunc(shoot)
+					})
+					It("should reject without seed set", func() {
+						testFunc(shootWithoutSeed)
+					})
+				})
+
+				Describe("shoot pod and shoot service networks intersect", func() {
+					testFunc := func(s core.Shoot) {
+						s.Spec.Networking.Pods = s.Spec.Networking.Services
+
+						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Validate(ctx, attrs, nil)
+
+						Expect(err).To(BeForbiddenError())
+					}
+
+					It("should reject with seed set", func() {
+						testFunc(shoot)
+					})
+					It("should reject without seed set", func() {
+						testFunc(shootWithoutSeed)
+					})
+				})
 			})
 		})
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -52,6 +52,7 @@ var _ = Describe("validator", func() {
 			credentialsBinding      securityv1alpha1.CredentialsBinding
 			project                 gardencorev1beta1.Project
 			shoot                   core.Shoot
+			shootWithoutSeed        core.Shoot
 			versionedShoot          gardencorev1beta1.Shoot
 
 			userInfo            = &user.DefaultInfo{Name: "foo"}
@@ -338,6 +339,8 @@ var _ = Describe("validator", func() {
 			secretBinding = secretBindingBase
 			credentialsBinding = credentialsBindingBase
 			shoot = *shootBase.DeepCopy()
+			shootWithoutSeed = *shootBase.DeepCopy()
+			shootWithoutSeed.Spec.SeedName = nil
 
 			admissionHandler, _ = New()
 			admissionHandler.SetAuthorizer(auth)
@@ -2504,152 +2507,143 @@ var _ = Describe("validator", func() {
 				Expect(err).To(Not(HaveOccurred()))
 			})
 
-			Context("with and without seed", func() {
-				var shootWithoutSeed core.Shoot
+			Describe("shoot pods network is missing", func() {
+				testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+					s.Spec.Networking.Pods = nil
 
-				BeforeEach(func() {
-					shootWithoutSeed = *shootBase.DeepCopy()
-					shootWithoutSeed.Spec.SeedName = nil
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(errorMatcher)
+				}
+
+				It("should reject with seed set", func() {
+					testFunc(shoot, BeForbiddenError())
 				})
-
-				Describe("shoot pods network is missing", func() {
-					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
-						s.Spec.Networking.Pods = nil
-
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
-
-						Expect(err).To(errorMatcher)
-					}
-
-					It("should reject with seed set", func() {
-						testFunc(shoot, BeForbiddenError())
-					})
-					It("should not reject without seed set", func() {
-						testFunc(shootWithoutSeed, Succeed())
-					})
+				It("should not reject without seed set", func() {
+					testFunc(shootWithoutSeed, Succeed())
 				})
+			})
 
-				Describe("shoot services network is missing", func() {
-					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
-						s.Spec.Networking.Services = nil
+			Describe("shoot services network is missing", func() {
+				testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+					s.Spec.Networking.Services = nil
 
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
 
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
 
-						Expect(err).To(errorMatcher)
-					}
-					It("should reject with seed set", func() {
-						testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
-					})
-					It("should not reject without seed set", func() {
-						testFunc(shootWithoutSeed, Succeed())
-					})
+					Expect(err).To(errorMatcher)
+				}
+				It("should reject with seed set", func() {
+					testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
 				})
-
-				Describe("shoot services network is nil (workerless Shoot)", func() {
-					testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
-						s.Spec.Provider.Workers = nil
-						s.Spec.Networking.Services = nil
-
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
-
-						Expect(err).To(errorMatcher)
-					}
-					It("should reject with seed set", func() {
-						testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
-					})
-					It("should not reject without seed set", func() {
-						testFunc(shootWithoutSeed, Succeed())
-					})
+				It("should not reject without seed set", func() {
+					testFunc(shootWithoutSeed, Succeed())
 				})
-				Describe("shoot service and the shoot node networks intersect", func() {
-					testFunc := func(s core.Shoot) {
-						s.Spec.Networking.Services = s.Spec.Networking.Nodes
+			})
 
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+			Describe("shoot services network is nil (workerless Shoot)", func() {
+				testFunc := func(s core.Shoot, errorMatcher types.GomegaMatcher) {
+					s.Spec.Provider.Workers = nil
+					s.Spec.Networking.Services = nil
 
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
 
-						Expect(err).To(BeForbiddenError())
-					}
-					It("should reject with seed set", func() {
-						testFunc(shoot)
-					})
-					It("should reject without seed set", func() {
-						testFunc(shootWithoutSeed)
-					})
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(errorMatcher)
+				}
+				It("should reject with seed set", func() {
+					testFunc(shoot, And(BeForbiddenError(), MatchError(ContainSubstring("services is required"))))
 				})
-
-				Describe("shoot pod and the shoot node networks intersect", func() {
-					testFunc := func(s core.Shoot) {
-						s.Spec.Networking.Pods = s.Spec.Networking.Nodes
-
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
-
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
-
-						Expect(err).To(BeForbiddenError())
-					}
-					It("should reject with seed set", func() {
-						testFunc(shoot)
-					})
-					It("should reject without seed set", func() {
-						testFunc(shootWithoutSeed)
-					})
+				It("should not reject without seed set", func() {
+					testFunc(shootWithoutSeed, Succeed())
 				})
+			})
+			Describe("shoot service and the shoot node networks intersect", func() {
+				testFunc := func(s core.Shoot) {
+					s.Spec.Networking.Services = s.Spec.Networking.Nodes
 
-				Describe("shoot pod and shoot service networks intersect", func() {
-					testFunc := func(s core.Shoot) {
-						s.Spec.Networking.Pods = s.Spec.Networking.Services
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
 
-						Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
-						Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
 
-						attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
-						err := admissionHandler.Validate(ctx, attrs, nil)
+					Expect(err).To(BeForbiddenError())
+				}
+				It("should reject with seed set", func() {
+					testFunc(shoot)
+				})
+				It("should reject without seed set", func() {
+					testFunc(shootWithoutSeed)
+				})
+			})
 
-						Expect(err).To(BeForbiddenError())
-					}
+			Describe("shoot pod and the shoot node networks intersect", func() {
+				testFunc := func(s core.Shoot) {
+					s.Spec.Networking.Pods = s.Spec.Networking.Nodes
 
-					It("should reject with seed set", func() {
-						testFunc(shoot)
-					})
-					It("should reject without seed set", func() {
-						testFunc(shootWithoutSeed)
-					})
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				}
+				It("should reject with seed set", func() {
+					testFunc(shoot)
+				})
+				It("should reject without seed set", func() {
+					testFunc(shootWithoutSeed)
+				})
+			})
+
+			Describe("shoot pod and shoot service networks intersect", func() {
+				testFunc := func(s core.Shoot) {
+					s.Spec.Networking.Pods = s.Spec.Networking.Services
+
+					Expect(coreInformerFactory.Core().V1beta1().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					Expect(coreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+					Expect(securityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer().GetStore().Add(&credentialsBinding)).To(Succeed())
+
+					attrs := admission.NewAttributesRecord(&s, nil, core.Kind("Shoot").WithVersion("version"), s.Namespace, s.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					err := admissionHandler.Validate(ctx, attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				}
+
+				It("should reject with seed set", func() {
+					testFunc(shoot)
+				})
+				It("should reject without seed set", func() {
+					testFunc(shootWithoutSeed)
 				})
 			})
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area usability
/kind enhancement

**What this PR does / why we need it**:
- Fix the existing validation logic to always check if Shoot CIDRs overlap even if the shoot is not yet scheduled on a seed.
- Remove the side effect from the `ValidateShootNetworkDisjointedness` function to also check if pod and service CIDR are required, as this was already checked in the admission code itself.
- Enhance readability for intersection validation

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/15024

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Validate shoot network overlap during admission and not during scheduling
```
