### PR TITLE
Always allow adding `machineType`s to `NamespacedCloudProfiles`

### DIFF
--- a/docs/concepts/apiserver-admission-plugins.md
+++ b/docs/concepts/apiserver-admission-plugins.md
@@ -134,7 +134,7 @@ This admission controller is defined in the generic API server library (`k8s.io/
 **Type**: Validating. **Enabled by default**: Yes.
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `NamespacedCloudProfile`s.
-It primarily validates if the referenced parent `CloudProfile` exists in the system. In addition, the admission controller ensures that the `NamespacedCloudProfile` only configures new machine types, and does not overwrite those from the parent `CloudProfile`.
+It primarily validates if the referenced parent `CloudProfile` exists in the system.
 
 ## `ProjectMutator`
 

--- a/plugin/pkg/namespacedcloudprofile/validator/admission.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission.go
@@ -148,9 +148,6 @@ func (v *ValidateNamespacedCloudProfile) Validate(ctx context.Context, a admissi
 		oldNamespacedCloudProfile: oldNamespacedCloudProfile,
 	}
 
-	if err := validationContext.validateMachineTypes(a); err != nil {
-		return err
-	}
 	if err := validationContext.validateKubernetesVersionOverrides(a); err != nil {
 		return err
 	}
@@ -192,37 +189,6 @@ type validationContext struct {
 	parentCloudProfile        *gardencorev1beta1.CloudProfile
 	namespacedCloudProfile    *gardencore.NamespacedCloudProfile
 	oldNamespacedCloudProfile *gardencore.NamespacedCloudProfile
-}
-
-func (c *validationContext) validateMachineTypes(a admission.Attributes) error {
-	if c.namespacedCloudProfile.Spec.MachineTypes == nil || c.parentCloudProfile.Spec.MachineTypes == nil {
-		return nil
-	}
-
-	for _, machineType := range c.namespacedCloudProfile.Spec.MachineTypes {
-		for _, parentMachineType := range c.parentCloudProfile.Spec.MachineTypes {
-			if parentMachineType.Name != machineType.Name {
-				continue
-			}
-			// If a machineType is already present in the NamespacedCloudProfile and just got added to the parent CloudProfile,
-			// it should still be allowed to remain in the NamespacedCloudProfile.
-			if a.GetOperation() == admission.Update && isMachineTypePresentInNamespacedCloudProfile(machineType, c.oldNamespacedCloudProfile) {
-				continue
-			}
-			return apierrors.NewBadRequest(fmt.Sprintf("NamespacedCloudProfile attempts to overwrite parent CloudProfile with machineType: %+v", machineType))
-		}
-	}
-
-	return nil
-}
-
-func isMachineTypePresentInNamespacedCloudProfile(machineType gardencore.MachineType, cloudProfile *gardencore.NamespacedCloudProfile) bool {
-	for _, cloudProfileMachineType := range cloudProfile.Spec.MachineTypes {
-		if cloudProfileMachineType.Name == machineType.Name {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *validationContext) validateKubernetesVersionOverrides(attr admission.Attributes) error {

--- a/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
+++ b/plugin/pkg/namespacedcloudprofile/validator/admission_test.go
@@ -391,60 +391,68 @@ var _ = Describe("Admission", func() {
 		})
 
 		Describe("machineType", func() {
-			It("should not allow creating a NamespacedCloudProfile that defines a machineType of the parent CloudProfile", func() {
-				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{machineType}
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
-
-				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
-
-				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(And(
-					ContainSubstring("NamespacedCloudProfile attempts to overwrite parent CloudProfile with machineType"),
-					ContainSubstring("my-machine"),
-				)))
-			})
-
-			It("should allow creating a NamespacedCloudProfile that defines a machineType of the parent CloudProfile if it was added to the NamespacedCloudProfile first", func() {
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
-
-				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
-
-				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
-
-				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{machineType}
-
-				attrs = admission.NewAttributesRecord(namespacedCloudProfile, namespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
-			})
-
-			It("should allow creating a NamespacedCloudProfile that defines a machineType of the parent CloudProfile if it was added to the NamespacedCloudProfile first but is changed and the parent changes", func() {
-				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
-
-				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
-
-				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
-
-				oldNamespacedCloudProfile := *namespacedCloudProfile.DeepCopy()
-				machineType.Usable = new(false)
-				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{machineType}
-
-				attrs = admission.NewAttributesRecord(namespacedCloudProfile, &oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
-
-				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
-			})
-
 			It("should allow creating a NamespacedCloudProfile that defines a different machineType than the parent CloudProfile", func() {
 				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
 
 				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{{Name: "my-other-machine", Architecture: new("amd64")}}
 
 				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should allow a same-named machineType when the NamespacedCloudProfile is created first and the parent CloudProfile gains the entry afterwards", func() {
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
+
+				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+
+				parentMachineType := machineType.DeepCopy()
+				parentMachineType.Usable = new(false)
+				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{*parentMachineType}
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Update(parentCloudProfile)).To(Succeed())
+
+				oldNamespacedCloudProfile := namespacedCloudProfile.DeepCopy()
+				namespacedCloudProfile.Generation++
+
+				attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should allow a same-named machineType when the parent CloudProfile already contains the entry and the NamespacedCloudProfile adds it afterwards with a differing spec", func() {
+				parentMachineType := machineType.DeepCopy()
+				parentMachineType.GPU = resource.MustParse("0")
+				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{*parentMachineType}
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+
+				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
+
+				attrs := admission.NewAttributesRecord(namespacedCloudProfile, nil, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+			})
+
+			It("should allow updates that add or mutate a NamespacedCloudProfile machineType colliding with the parent CloudProfile", func() {
+				parentCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{machineType}
+				Expect(coreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(parentCloudProfile)).To(Succeed())
+
+				oldNamespacedCloudProfile := namespacedCloudProfile.DeepCopy()
+				namespacedCloudProfile.Spec.MachineTypes = []gardencore.MachineType{machineTypeCore}
+				namespacedCloudProfile.Generation++
+
+				attrs := admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+
+				oldNamespacedCloudProfile = namespacedCloudProfile.DeepCopy()
+				namespacedCloudProfile.Spec.MachineTypes[0].Architecture = new("amd64")
+				namespacedCloudProfile.Generation++
+
+				attrs = admission.NewAttributesRecord(namespacedCloudProfile, oldNamespacedCloudProfile, gardencorev1beta1.Kind("NamespacedCloudProfile").WithVersion("version"), "", namespacedCloudProfile.Name, gardencorev1beta1.Resource("namespacedcloudprofile").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Removed check for pre-existing type in parent `CloudProfile`.
This adapts the behavior in both cases and removes the dependency to the parent `CloudProfile` content / resolves the timing race dependency for users.

Still requires users to have the according rbac permissions.

**Which issue(s) this PR fixes**:
`NamespacedCloudProfile` can be created with custom `machineType` until the same type is added to the parent `CloudProfile`, which is out of a user's control.

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
