### PR TITLE
fix(logging): workaround for node-agent deadlock during Shoot purpose migration

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -26,6 +26,9 @@ const (
 	// UnitNameHealthCheckTimer is the name of the opentelemetry-collector timer.
 	UnitNameHealthCheckTimer = "opentelemetry-collector-healthcheck.timer"
 
+	// UnitNameAuthToken is the opentelemetry-collector checker that ensures the auth-token file exists before startup.
+	UnitNameAuthToken = "opentelemetry-collector-auth-token.path"
+
 	// PathDirectory is the path for the opentelemetry-collector's directory.
 	PathDirectory = "/var/lib/opentelemetry-collector"
 	// PathAuthToken is the path for the file containing opentelemetry-collector's authentication that gets
@@ -85,6 +88,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 	units = append(
 		units,
 		getOpenTelemetryCollectorUnit(),
+		getOpenTelemetryCollectorPathAuthTokenUnit(),
 		getOpenTelemetryCollectorHealthCheckUnit(),
 		getOpenTelemetryCollectorTimerUnit(),
 	)

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/component.go
@@ -85,6 +85,26 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		return nil, nil, err
 	}
 
+	// File dependencies for the opentelemetry-collector unit are expressed in two
+	// complementary ways, and it is worth being explicit about why:
+	//   - The `FilePaths` field on extensionsv1alpha1.Unit lists files that are
+	//     managed as part of the OperatingSystemConfig (config, CA cert, binary,
+	//     kubeconfig). The gardener-node-agent restarts the unit when any of
+	//     these managed files change.
+	//   - A systemd.path(5) unit (see getOpenTelemetryCollectorPathAuthTokenUnit)
+	//     waits for the auth-token file to appear on disk. The auth-token is not
+	//     part of the OSC `Files` list because it is provisioned at runtime by
+	//     another component, so `FilePaths` cannot express this dependency.
+	// A future refactor that unifies how resource dependencies are declared
+	// would make the overall picture easier to follow.
+	//
+	// As a consequence, the opentelemetry-collector service can be (re)started
+	// through four different mechanisms, which can be confusing while debugging:
+	//   - the path unit, when the auth-token file first appears,
+	//   - the healthcheck timer unit, which restarts the service on a failed probe,
+	//   - the gardener-node-agent, when any file listed in `FilePaths` changes,
+	//   - `Restart=always` in the service unit itself, on process exit.
+	// When investigating an unexpected restart, check all four sources.
 	units = append(
 		units,
 		getOpenTelemetryCollectorUnit(),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -131,7 +131,7 @@ func getOpenTelemetryCollectorPathAuthTokenUnit() extensionsv1alpha1.Unit {
 		Content: new(`[Unit]
 Description=Monitor the auth-token file for required for opentelemetry-collector
 [Install]
-WantedBy=multi-user.target
+WantedBy=paths.target
 [Path]
 Unit=` + UnitName + `
 PathExists=` + PathAuthToken + ``),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -134,7 +134,7 @@ Description=Monitor the auth-token file for required for opentelemetry-collector
 WantedBy=multi-user.target
 [Path]
 Unit=` + UnitName + `
-PathChanged=` + PathAuthToken + ``),
+PathExists=` + PathAuthToken + ``),
 		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -96,7 +96,7 @@ func getOpenTelemetryCollectorCAFile(ctx components.Context) extensionsv1alpha1.
 func getOpenTelemetryCollectorUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitName,
-		Command: new(extensionsv1alpha1.CommandStart),
+		Command: new(extensionsv1alpha1.CommandStop),
 		Enable:  new(true),
 		Content: new(`[Unit]
 Description=opentelemetry-collector daemon
@@ -119,6 +119,22 @@ Environment=KUBECONFIG=` + openTelemetryCollectorKubeconfigPath + `
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:]) GOMEMLIMIT=` + goMemLimit + `"
 ExecStartPre=/bin/sh -c "test -s ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/opentelemetry-collector --config=` + PathConfig),
+		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
+	}
+}
+
+func getOpenTelemetryCollectorPathAuthTokenUnit() extensionsv1alpha1.Unit {
+	return extensionsv1alpha1.Unit{
+		Name:    UnitNameAuthToken,
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
+Description=Monitor the auth-token file for required for opentelemetry-collector
+[Install]
+WantedBy=multi-user.target
+[Path]
+Unit=` + UnitName + `
+PathChanged=` + PathAuthToken + ``),
 		FilePaths: []string{PathConfig, PathCACert, openTelemetryCollectorBinaryPath, openTelemetryCollectorKubeconfigPath},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config.go
@@ -129,7 +129,7 @@ func getOpenTelemetryCollectorPathAuthTokenUnit() extensionsv1alpha1.Unit {
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
-Description=Monitor the auth-token file for required for opentelemetry-collector
+Description=Monitor the auth-token file required for opentelemetry-collector
 [Install]
 WantedBy=paths.target
 [Path]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -71,7 +71,7 @@ ExecStart=/opt/bin/opentelemetry-collector --config=` + PathConfig
 
 			otelDaemonUnit := extensionsv1alpha1.Unit{
 				Name:    UnitName,
-				Command: new(extensionsv1alpha1.CommandStart),
+				Command: new(extensionsv1alpha1.CommandStop),
 				Enable:  new(true),
 				Content: new(unitContent),
 			}
@@ -325,7 +325,26 @@ AccuracySec=1min
 Unit=opentelemetry-collector-healthcheck.service`),
 			}
 
-			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit, otelHealthCheckUnit, otelTimerUnit}
+			otelAuthTokenPathUnit := extensionsv1alpha1.Unit{
+				Name:    "opentelemetry-collector-auth-token.path",
+				Command: new(extensionsv1alpha1.CommandStart),
+				Enable:  new(true),
+				Content: new(`[Unit]
+Description=Monitor the auth-token file for required for opentelemetry-collector
+[Install]
+WantedBy=multi-user.target
+[Path]
+Unit=` + UnitName + `
+PathChanged=` + PathAuthToken),
+				FilePaths: []string{
+					"/var/lib/opentelemetry-collector/config/config",
+					"/var/lib/opentelemetry-collector/ca.crt",
+					"/opt/bin/opentelemetry-collector",
+					"/var/lib/opentelemetry-collector/kubeconfig",
+				},
+			}
+
+			expectedUnits := []extensionsv1alpha1.Unit{otelDaemonUnit, otelAuthTokenPathUnit, otelHealthCheckUnit, otelTimerUnit}
 
 			Expect(units).To(ConsistOf(expectedUnits))
 			Expect(files).To(ConsistOf(expectedFiles))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -332,7 +332,7 @@ Unit=opentelemetry-collector-healthcheck.service`),
 				Content: new(`[Unit]
 Description=Monitor the auth-token file for required for opentelemetry-collector
 [Install]
-WantedBy=multi-user.target
+WantedBy=paths.target
 [Path]
 Unit=` + UnitName + `
 PathExists=` + PathAuthToken),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -335,7 +335,7 @@ Description=Monitor the auth-token file for required for opentelemetry-collector
 WantedBy=multi-user.target
 [Path]
 Unit=` + UnitName + `
-PathChanged=` + PathAuthToken),
+PathExists=` + PathAuthToken),
 				FilePaths: []string{
 					"/var/lib/opentelemetry-collector/config/config",
 					"/var/lib/opentelemetry-collector/ca.crt",

--- a/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/opentelemetrycollector/config_test.go
@@ -330,7 +330,7 @@ Unit=opentelemetry-collector-healthcheck.service`),
 				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]
-Description=Monitor the auth-token file for required for opentelemetry-collector
+Description=Monitor the auth-token file required for opentelemetry-collector
 [Install]
 WantedBy=paths.target
 [Path]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/component.go
@@ -51,7 +51,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 			return nil, nil, err
 		}
 
-		units = append(units, getValitailUnit())
+		units = append(units, getValitailUnit(), getValitailPathAuthTokenUnit())
 		files = append(files, valitailConfigFile, getValitailCAFile(ctx), extensionsv1alpha1.File{
 			Path:        valitailBinaryPath,
 			Permissions: new(uint32(0755)),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -118,7 +118,7 @@ func getValitailPathAuthTokenUnit() extensionsv1alpha1.Unit {
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
-Description=Monitor the auth-token file for required for valitail
+Description=Monitor the auth-token file required for valitail
 [Install]
 WantedBy=paths.target
 [Path]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -123,7 +123,7 @@ Description=Monitor the auth-token file for required for valitail
 WantedBy=multi-user.target
 [Path]
 Unit=` + UnitName + `
-PathChanged=` + PathAuthToken),
+PathExists=` + PathAuthToken),
 		FilePaths: []string{PathConfig, PathCACert, valitailBinaryPath},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -86,7 +86,7 @@ func getValitailCAFile(ctx components.Context) extensionsv1alpha1.File {
 func getValitailUnit() extensionsv1alpha1.Unit {
 	return extensionsv1alpha1.Unit{
 		Name:    UnitName,
-		Command: new(extensionsv1alpha1.CommandStart),
+		Command: new(extensionsv1alpha1.CommandStop),
 		Enable:  new(true),
 		Content: new(`[Unit]
 Description=valitail daemon
@@ -108,6 +108,22 @@ EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname | tr [:upper:] [:lower:])"
 ExecStartPre=/bin/sh -c "test -s ` + PathAuthToken + `"
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/valitail -config.file=` + PathConfig),
+		FilePaths: []string{PathConfig, PathCACert, valitailBinaryPath},
+	}
+}
+
+func getValitailPathAuthTokenUnit() extensionsv1alpha1.Unit {
+	return extensionsv1alpha1.Unit{
+		Name:    "valitail-auth-token.path",
+		Command: new(extensionsv1alpha1.CommandStart),
+		Enable:  new(true),
+		Content: new(`[Unit]
+Description=Monitor the auth-token file for required for valitail
+[Install]
+WantedBy=multi-user.target
+[Path]
+Unit=` + UnitName + `
+PathChanged=` + PathAuthToken),
 		FilePaths: []string{PathConfig, PathCACert, valitailBinaryPath},
 	}
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config.go
@@ -120,7 +120,7 @@ func getValitailPathAuthTokenUnit() extensionsv1alpha1.Unit {
 		Content: new(`[Unit]
 Description=Monitor the auth-token file for required for valitail
 [Install]
-WantedBy=multi-user.target
+WantedBy=paths.target
 [Path]
 Unit=` + UnitName + `
 PathExists=` + PathAuthToken),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -261,7 +261,7 @@ scrape_configs:
 					Command: new(extensionsv1alpha1.CommandStart),
 					Enable:  new(true),
 					Content: new(`[Unit]
-Description=Monitor the auth-token file for required for valitail
+Description=Monitor the auth-token file required for valitail
 [Install]
 WantedBy=paths.target
 [Path]

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -266,7 +266,7 @@ Description=Monitor the auth-token file for required for valitail
 WantedBy=multi-user.target
 [Path]
 Unit=` + UnitName + `
-PathChanged=` + PathAuthToken),
+PathExists=` + PathAuthToken),
 					FilePaths: []string{
 						"/var/lib/valitail/config/config",
 						"/var/lib/valitail/ca.crt",

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -73,7 +73,7 @@ ExecStart=/opt/bin/valitail -config.file=` + PathConfig
 
 				valitailDaemonUnit := extensionsv1alpha1.Unit{
 					Name:    UnitName,
-					Command: new(extensionsv1alpha1.CommandStart),
+					Command: new(extensionsv1alpha1.CommandStop),
 					Enable:  new(true),
 					Content: new(unitContent),
 				}
@@ -256,7 +256,25 @@ scrape_configs:
 				expectedFiles = append(expectedFiles, valitailBinaryFile)
 				valitailDaemonUnit.FilePaths = append(valitailDaemonUnit.FilePaths, "/opt/bin/valitail")
 
-				expectedUnits := []extensionsv1alpha1.Unit{valitailDaemonUnit}
+				valitailAuthTokenPathUnit := extensionsv1alpha1.Unit{
+					Name:    "valitail-auth-token.path",
+					Command: new(extensionsv1alpha1.CommandStart),
+					Enable:  new(true),
+					Content: new(`[Unit]
+Description=Monitor the auth-token file for required for valitail
+[Install]
+WantedBy=multi-user.target
+[Path]
+Unit=` + UnitName + `
+PathChanged=` + PathAuthToken),
+					FilePaths: []string{
+						"/var/lib/valitail/config/config",
+						"/var/lib/valitail/ca.crt",
+						"/opt/bin/valitail",
+					},
+				}
+
+				expectedUnits := []extensionsv1alpha1.Unit{valitailDaemonUnit, valitailAuthTokenPathUnit}
 
 				Expect(units).To(ConsistOf(expectedUnits))
 				Expect(files).To(ConsistOf(expectedFiles))

--- a/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/valitail/config_test.go
@@ -263,7 +263,7 @@ scrape_configs:
 					Content: new(`[Unit]
 Description=Monitor the auth-token file for required for valitail
 [Install]
-WantedBy=multi-user.target
+WantedBy=paths.target
 [Path]
 Unit=` + UnitName + `
 PathExists=` + PathAuthToken),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
This PR introduces a [path unit](https://www.freedesktop.org/software/systemd/man/latest/systemd.path.html) for the logging agents, that checks if the `auth-token` file is created and if not it doesn't start the logging agent at all. It is good to mention that the pre check with `test -s` is not removed, because it is required, if the `auth-token` file is created, but empty.

**Which issue(s) this PR fixes**:
Fixes #15028

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`valitail` and `opentelemetry-collector` will not start at all, if `auth-token` file doesn't exist, instead of just failing.
```
