### PR TITLE
Configure `registry.local.gardener.cloud` as insecure in remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -271,6 +271,8 @@ spec:
           mkdir -p ~/go/src/github.com/gardener
           cd ~/go/src/github.com/gardener
           [ -d gardener/.git ] || git clone -q https://github.com/gardener/gardener
+          mkdir -p /etc/docker
+          echo '{"insecure-registries":["registry.local.gardener.cloud:5001"]}' > /etc/docker/daemon.json
           nice dockerd-entrypoint.sh 2>&1 | tee ~/.dockerd.log &
           until docker ps >/dev/null 2>&1; do sleep 1; done
 


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This is a leftover after the update of the remote local setup to DinD v29:

- https://github.com/gardener/gardener/pull/14644

Without this PR, pushing images to the local registry in the remote local setup will fail with `http: server gave HTTP response to HTTPS client`. This only occurs in pristine remote local setups where the image doesn't exist yet in the local registry. Because of this, this required configuration change wasn't detected during validation of the PR above.

Unfortunately, the specific Docker change between v26 and v29 that makes this change required couldn't be fully pinned down. 

**Special notes for your reviewer**:

/cc @istvanballok 

**Release note**:

```other developer
The local docker registry is configured as insecure in remote local setup.
```
