### PR TITLE
[GEP-33] Promote `CloudProfileCapabilities` feature gate to Beta

### DIFF
--- a/dev-setup/garden/base/garden.yaml
+++ b/dev-setup/garden/base/garden.yaml
@@ -55,7 +55,6 @@ spec:
       clusterIdentity: gardener-local
       gardenerAPIServer:
         featureGates:
-          CloudProfileCapabilities: true
           InPlaceNodeUpdates: true
           VersionClassificationLifecycle: true
           DisableNginxIngressInShoot: true

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -24,7 +24,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | InPlaceNodeUpdates             | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination            | `false` | `Alpha` | `1.114` | `1.143` |
 | IstioTLSTermination            | `true`  | `Beta`  | `1.144` |         |
-| CloudProfileCapabilities       | `false` | `Alpha` | `1.117` |         |
+| CloudProfileCapabilities       | `false` | `Alpha` | `1.117` | `1.144` |
+| CloudProfileCapabilities       | `true`  | `Beta`  | `1.145` |         |
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
 | VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -24,8 +24,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | InPlaceNodeUpdates             | `false` | `Alpha` | `1.113` |         |
 | IstioTLSTermination            | `false` | `Alpha` | `1.114` | `1.143` |
 | IstioTLSTermination            | `true`  | `Beta`  | `1.144` |         |
-| CloudProfileCapabilities       | `false` | `Alpha` | `1.117` | `1.144` |
-| CloudProfileCapabilities       | `true`  | `Beta`  | `1.145` |         |
+| CloudProfileCapabilities       | `false` | `Alpha` | `1.117` | `1.145` |
+| CloudProfileCapabilities       | `true`  | `Beta`  | `1.146` |         |
 | OpenTelemetryCollector         | `false` | `Alpha` | `1.124` | `1.135` |
 | OpenTelemetryCollector         | `true`  | `Beta`  | `1.136` |         |
 | VPAInPlaceUpdates              | `false` | `Alpha` | `1.133` | `1.137` |

--- a/example/30-cloudprofile.yaml
+++ b/example/30-cloudprofile.yaml
@@ -25,7 +25,7 @@ spec:
   #   machineType: # optional -> will use the machine with the lowest amount of CPUs
   #     name: n1-standard-2
   # ---
-  # machineCapabilities: # CloudProfileCapabilities feature gate enabled
+  # machineCapabilities:
   # - name: architecture
   #   values: [amd64,arm64]
   kubernetes:
@@ -50,7 +50,7 @@ spec:
           # architectures: # optional
           # - amd64
           # - arm64
-          # capabilityFlavors: # CloudProfileCapabilities feature gate enabled
+          # capabilityFlavors:
           # - architecture: [amd64]
           # - architecture: [arm64]
           # cri: # Even though gardener doesn't support docker CRI, gardener requires machine images to have the docker daemon installed. See https://github.com/gardener/gardener/issues/4673 for more information.
@@ -85,7 +85,7 @@ spec:
       #   minSize: 10Gi  # optional, either size or minSize must be configured
       usable: true
       # architecture: amd64 # optional
-      # capabilities: # CloudProfileCapabilities feature gate enabled
+      # capabilities:
       #   architecture: [amd64]
       # machineControllerManager:
       #   machineCreationTimeout: 20m # optional, can be overridden by shoot.spec.provider.workers.machineControllerManager.machineCreationTimeout if set there

--- a/pkg/api/core/validation/cloudprofile_test.go
+++ b/pkg/api/core/validation/cloudprofile_test.go
@@ -2337,6 +2337,8 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 				})
 
 				It("should fail to validate provided capabilities with disabled feature gate", func() {
+					DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.CloudProfileCapabilities, false))
+
 					cloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
 						{Name: "architecture", Values: []string{"amd64"}},
 					}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -39,7 +39,7 @@ const (
 	// will boot up successfully. Capabilities are also used to determine valid upgrade paths during automated maintenance operations.
 	// owner: @roncossek
 	// alpha: v1.117.0
-	// beta: v1.145.0
+	// beta: v1.146.0
 	CloudProfileCapabilities featuregate.Feature = "CloudProfileCapabilities"
 
 	// VersionClassificationLifecycle enables the features introduced by GEP-0032,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -39,6 +39,7 @@ const (
 	// will boot up successfully. Capabilities are also used to determine valid upgrade paths during automated maintenance operations.
 	// owner: @roncossek
 	// alpha: v1.117.0
+	// beta: v1.145.0
 	CloudProfileCapabilities featuregate.Feature = "CloudProfileCapabilities"
 
 	// VersionClassificationLifecycle enables the features introduced by GEP-0032,
@@ -162,7 +163,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DefaultSeccompProfile:          {Default: false, PreRelease: featuregate.Alpha},
 	InPlaceNodeUpdates:             {Default: false, PreRelease: featuregate.Alpha},
 	IstioTLSTermination:            {Default: true, PreRelease: featuregate.Beta},
-	CloudProfileCapabilities:       {Default: false, PreRelease: featuregate.Alpha},
+	CloudProfileCapabilities:       {Default: true, PreRelease: featuregate.Beta},
 	DoNotCopyBackupCredentials:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	OpenTelemetryCollector:         {Default: true, PreRelease: featuregate.Beta},
 	VictoriaLogsBackend:            {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area usability
/kind enhancement

**What this PR does / why we need it**:

Promotes the `CloudProfileCapabilities` feature gate from `Alpha` to `Beta` (default `true`) starting in `v1.145.0`. 

**Which issue(s) this PR fixes**:
Part of ☂️ #11301 

**Special notes for your reviewer**:
All open source provider-extensions implemented the required changes as referenced in the ☂️ -issue.

The validation guard in `pkg/api/core/validation/cloudprofile.go` (and the matching test assertion) is intentionally kept — it should only be removed on GA promotion when the gate becomes `LockToDefault`. Existing `DeferCleanup(test.WithFeatureGate(..., CloudProfileCapabilities, true))` calls in tests are left in place; this matches prior Beta promotions like `UseUnifiedHTTPProxyPort` (#14422) and `VPAInPlaceUpdates` (#14145).

**Release note**:
```noteworthy operator
The `CloudProfileCapabilities` feature gate has been promoted to `Beta` and is now enabled by default.
```
