### PR TITLE
remote-setup: Fix field name in the Garden resource

### DIFF
--- a/dev-setup/garden/overlays/remote/garden.yaml.tmpl
+++ b/dev-setup/garden/overlays/remote/garden.yaml.tmpl
@@ -48,6 +48,6 @@ spec:
           # Enter subdomain of your primary domain e.g. "discovery.my-garden.my-domain.com"
           name: ""
           provider: primary
-      scheduler:
+      gardenerScheduler:
         # Required for the remote getting-started flow so shoots of different providers can be scheduled to the same seed.
         strategy: MinimalDistance


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
The field name in the Garden resource is `.spec.virtualCluster.gardener.gardenerScheduler`, not `.spec.virtualCluster.gardener.scheduler`.

**Which issue(s) this PR fixes**:
A follow-up after https://github.com/gardener/gardener/pull/14963

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
