### PR TITLE
make documentation of hibernation more precise

### DIFF
--- a/docs/usage/shoot/shoot_hibernate.md
+++ b/docs/usage/shoot/shoot_hibernate.md
@@ -33,7 +33,7 @@ To scale up everything where it was before hibernation, Gardener doesn’t delet
 
 ## Hibernate Your Cluster Manually
 
-The `.spec.hibernation.enabled` field specifies whether the cluster needs to be hibernated or not. If the field is set to `true`, the cluster's desired state is to be hibernated. If it is set to `false` or not specified at all, the cluster's desired state is to be awakened.
+The `.spec.hibernation.enabled` field controls the **immediate** desired hibernation state of the cluster. Setting it to `true` triggers an immediate hibernation. Setting it to `false` or leaving it unset means the cluster's desired state is to be awakened.
 
 To hibernate your cluster, you can run the following `kubectl` command:
 ```
@@ -51,11 +51,13 @@ $ kubectl patch shoot -n $NAMESPACE $SHOOT_NAME -p '{"spec":{"hibernation":{"ena
 
 You can specify a hibernation schedule to automatically hibernate/wake up a cluster.
 
+The schedule controller works by **toggling** `.spec.hibernation.enabled` to `true` or `false` based on the cron expressions you define. This means `schedules` and `enabled` interact with each other — `enabled` is not an on/off switch for the schedule feature.
+
 Let's have a look into the following example:
 
 ```yaml
   hibernation:
-    enabled: false
+    enabled: false # Initial deployment of Shoot is in awaked state
     schedules:
     - start: "0 20 * * *" # Start hibernation every day at 8PM
       end: "0 6 * * *"    # Stop hibernation every day at 6AM

--- a/docs/usage/shoot/shoot_hibernate.md
+++ b/docs/usage/shoot/shoot_hibernate.md
@@ -57,7 +57,7 @@ Let's have a look into the following example:
 
 ```yaml
   hibernation:
-    enabled: false # Initial deployment of Shoot is in awaked state
+    enabled: false
     schedules:
     - start: "0 20 * * *" # Start hibernation every day at 8PM
       end: "0 6 * * *"    # Stop hibernation every day at 6AM

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -431,9 +431,7 @@ spec:
       emailReceivers:
       - john.doe@example.com
 # hibernation:
-#   # enabled controls the immediate desired hibernation state. Setting it to true triggers immediate hibernation;
-#   # false (or omitting it) triggers immediate wake-up. The schedule below works by toggling this field. 
-#   enabled: false
+#   enabled: false # enabled controls the immediate desired hibernation state.
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -431,6 +431,8 @@ spec:
       emailReceivers:
       - john.doe@example.com
 # hibernation:
+#   # enabled controls the immediate desired hibernation state. Setting it to true triggers immediate hibernation;
+#   # false (or omitting it) triggers immediate wake-up. The schedule below works by toggling this field. 
 #   enabled: false
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:

The current hibernation works like:

- spec.hibernation.enabled: Sets the immediate desired state (true = hibernate now, false = wake now)
- spec.hibernation.schedules: Defines when the hibernation schedule controller should toggle spec.hibernation.enabled

From my perspective this contains a significant misinterpretation risk. We initially misunderstood 'spec.hibernation.enabled' as a flag to "activate the schedule," but it actually triggers immediate hibernation/wake-up.

This PR makes this more precise in the documentation without changing the functionality itself to avoid issues with backwards compatibility. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
