### PR TITLE
Remove leftover `oidcConfig` example from `90-shoot.yaml`

### DIFF
--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -188,21 +188,6 @@ spec:
   #     SomeKubernetesFeature: true
   #   runtimeConfig:
   #     scheduling.k8s.io/v1alpha1: true
-  #   oidcConfig:
-  #     caBundle: |
-  #       -----BEGIN CERTIFICATE-----
-  #       Li4u
-  #       -----END CERTIFICATE-----
-  #     clientID: client-id
-  #     groupsClaim: groups-claim
-  #     groupsPrefix: groups-prefix
-  #     issuerURL: https://identity.example.com
-  #     usernameClaim: username-claim
-  #     usernamePrefix: username-prefix
-  #     signingAlgs: # See https://datatracker.ietf.org/doc/html/rfc7518#section-3.1 for the list of valid algorithms
-  #     - RS256
-  #     requiredClaims:
-  #       key: value
   #   structuredAuthentication:
   #     configMapName: name-of-configmap-containing-authentication-config
   #   structuredAuthorization:

--- a/example/operator/20-garden.yaml
+++ b/example/operator/20-garden.yaml
@@ -117,21 +117,6 @@ spec:
     #     SomeKubernetesFeature: true
     #   runtimeConfig:
     #     scheduling.k8s.io/v1alpha1: true
-    #   oidcConfig:
-    #     caBundle: |
-    #       -----BEGIN CERTIFICATE-----
-    #       Li4u
-    #       -----END CERTIFICATE-----
-    #     clientID: client-id
-    #     groupsClaim: groups-claim
-    #     groupsPrefix: groups-prefix
-    #     issuerURL: https://identity.example.com
-    #     usernameClaim: username-claim
-    #     usernamePrefix: username-prefix
-    #     signingAlgs: # See https://datatracker.ietf.org/doc/html/rfc7518#section-3.1 for the list of valid algorithms
-    #     - RS256
-    #     requiredClaims:
-    #       key: value
     #   structuredAuthentication:
     #     configMapName: name-of-configmap-containing-authentication-config
     #   structuredAuthorization:


### PR DESCRIPTION
**How to categorize this PR?**

/area documentation
/kind cleanup

**What this PR does / why we need it**:

In #14615 the inline `oidcConfig` on the shoot kube-apiserver was removed and only the structured authentication / authorization configuration is supported going forward. The commented-out `oidcConfig` example block in `example/90-shoot.yaml` was missed at that time and is still present, which is confusing for anyone using the example as a reference.

This PR removes that leftover block. The `structuredAuthentication` and `structuredAuthorization` examples right below it remain untouched.

**Which issue(s) this PR fixes**:

Follow-up to #14615.

**Special notes for your reviewer**:

/cc @timuthy @vicwicker

**Release note**:

```doc developer
NONE
```
