### PR TITLE
Add iypetrov to the `gardener-reviewers-logging` group

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -38,6 +38,7 @@ aliases:
   - shreyas-s-rao
   - unmarshall
   gardener-reviewers-logging: # This group is primarily responsible for logging topics.
+  - iypetrov
   - nickytd
   - rrhubenov
   gardener-reviewers-machine-controller-manager: # This group is primarily responsible for the machine-controller-manager component.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind task

**What this PR does / why we need it**:
See https://github.com/gardener/org/issues/24

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/org/issues/24

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
