### PR TITLE
Handle worker pool renames in `node-local-dns`

### DIFF
--- a/pkg/component/networking/nodelocaldns/mock/mocks.go
+++ b/pkg/component/networking/nodelocaldns/mock/mocks.go
@@ -118,6 +118,18 @@ func (mr *MockInterfaceMockRecorder) SetShootClientSet(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShootClientSet", reflect.TypeOf((*MockInterface)(nil).SetShootClientSet), arg0)
 }
 
+// SetWorkerPoolNames mocks base method.
+func (m *MockInterface) SetWorkerPoolNames(arg0 []string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetWorkerPoolNames", arg0)
+}
+
+// SetWorkerPoolNames indicates an expected call of SetWorkerPoolNames.
+func (mr *MockInterfaceMockRecorder) SetWorkerPoolNames(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerPoolNames", reflect.TypeOf((*MockInterface)(nil).SetWorkerPoolNames), arg0)
+}
+
 // Wait mocks base method.
 func (m *MockInterface) Wait(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/component/networking/nodelocaldns/nodelocaldns.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns.go
@@ -98,6 +98,7 @@ type Interface interface {
 	SetDNSServers([]string)
 	SetIPFamilies([]gardencorev1beta1.IPFamily)
 	SetShootClientSet(kubernetes.Interface)
+	SetWorkerPoolNames([]string)
 }
 
 // Values is a set of configuration values for the node-local-dns component.
@@ -124,6 +125,10 @@ type Values struct {
 	Log logr.Logger
 	// Workers is the group of workers for which node-local-dns is deployed.
 	Workers []gardencorev1beta1.Worker
+	// WorkerPoolNames is the set of worker pool names for which DaemonSets shall be rendered. It is computed by the
+	// botanist and may include pool names that are no longer in the shoot spec but for which nodes still exist (e.g.
+	// after a worker pool rename), so that the corresponding DaemonSets are kept around until the old nodes are gone.
+	WorkerPoolNames []string
 	// KubeProxyConfig is the kube-proxy configuration for the shoot.
 	KubeProxyConfig *gardencorev1beta1.KubeProxyConfig
 	// CustomDNSServerInNodeLocalDNS indicates whether server block support is enabled for node-local-dns.
@@ -206,7 +211,7 @@ func (n *nodeLocalDNS) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	data, err := registry.AddAllAndSerialize(n.computePoolResourcesData(serviceAccount, configMap, service)...)
+	data, err := registry.AddAllAndSerialize(n.computePoolResourcesData(serviceAccount, configMap, service, n.values.WorkerPoolNames)...)
 	if err != nil {
 		return err
 	}
@@ -381,6 +386,10 @@ func (n *nodeLocalDNS) SetIPFamilies(ipfamilies []gardencorev1beta1.IPFamily) {
 
 func (n *nodeLocalDNS) SetShootClientSet(set kubernetes.Interface) {
 	n.values.ShootClient = set.Client()
+}
+
+func (n *nodeLocalDNS) SetWorkerPoolNames(names []string) {
+	n.values.WorkerPoolNames = names
 }
 
 func (n *nodeLocalDNS) getIPVSAddress() (ipvsAddress string) {

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -236,6 +236,7 @@ var _ = Describe("NodeLocalDNS", func() {
 					Name: "worker-aaaa",
 				},
 			},
+			WorkerPoolNames:               []string{"worker-aaaa"},
 			CustomDNSServerInNodeLocalDNS: true,
 		}
 

--- a/pkg/component/networking/nodelocaldns/resources.go
+++ b/pkg/component/networking/nodelocaldns/resources.go
@@ -147,7 +147,7 @@ ip6.arpa:53 {
 	return serviceAccount, configMap, service, nil
 }
 
-func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAccount, configMap *corev1.ConfigMap, service *corev1.Service) (clientObjects []client.Object) {
+func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAccount, configMap *corev1.ConfigMap, service *corev1.Service, poolNames []string) (clientObjects []client.Object) {
 	var (
 		maxUnavailable       = intstr.FromString("10%")
 		hostPathFileOrCreate = corev1.HostPathFileOrCreate
@@ -156,10 +156,10 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 	)
 
 	clientObjects = []client.Object{serviceAccount, configMap, service}
-	for _, worker := range n.values.Workers {
+	for _, poolName := range poolNames {
 		daemonSet = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "node-local-dns-" + worker.Name,
+				Name:      "node-local-dns-" + poolName,
 				Namespace: metav1.NamespaceSystem,
 				Annotations: map[string]string{
 					// This annotation is required so that the new label selector that includes the worker's name,
@@ -183,11 +183,11 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 				},
 				RevisionHistoryLimit: new(int32(2)),
 				Selector: &metav1.LabelSelector{
-					MatchLabels: getPoolLabels(worker.Name),
+					MatchLabels: getPoolLabels(poolName),
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: utils.MergeStringMaps(getPoolLabels(worker.Name), map[string]string{
+						Labels: utils.MergeStringMaps(getPoolLabels(poolName), map[string]string{
 							v1beta1constants.LabelNetworkPolicyToDNS:    "allowed",
 							v1beta1constants.LabelNodeCriticalComponent: "true",
 						}),
@@ -218,7 +218,7 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 						},
 						NodeSelector: map[string]string{
 							v1beta1constants.LabelNodeLocalDNS: "true",
-							v1beta1constants.LabelWorkerPool:   worker.Name,
+							v1beta1constants.LabelWorkerPool:   poolName,
 						},
 						Containers: []corev1.Container{
 							{
@@ -411,7 +411,7 @@ func (n *nodeLocalDNS) computePoolResourcesData(serviceAccount *corev1.ServiceAc
 			vpaUpdateMode := vpaautoscalingv1.UpdateModeRecreate
 			vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "node-local-dns-" + worker.Name,
+					Name:      "node-local-dns-" + poolName,
 					Namespace: metav1.NamespaceSystem,
 				},
 				Spec: vpaautoscalingv1.VerticalPodAutoscalerSpec{

--- a/pkg/gardenlet/operation/botanist/nodelocaldns.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/imagevector"
@@ -79,6 +81,11 @@ func (b *Botanist) ReconcileNodeLocalDNS(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetIPFamilies(b.Shoot.GetInfo().Spec.Networking.IPFamilies)
 	b.Shoot.Components.SystemComponents.NodeLocalDNS.SetShootClientSet(b.ShootClientSet)
 	if b.Shoot.NodeLocalDNSEnabled {
+		poolNames, err := b.computeWorkerPoolNamesForNodeLocalDNS(ctx)
+		if err != nil {
+			return err
+		}
+		b.Shoot.Components.SystemComponents.NodeLocalDNS.SetWorkerPoolNames(poolNames)
 		return b.Shoot.Components.SystemComponents.NodeLocalDNS.Deploy(ctx)
 	}
 
@@ -124,6 +131,33 @@ func (b *Botanist) isNodeLocalDNSStillDesired(ctx context.Context) (bool, error)
 	return kubernetesutils.ResourcesExist(ctx, b.ShootClientSet.Client(), &corev1.NodeList{}, b.ShootClientSet.Client().Scheme(), client.MatchingLabels{
 		v1beta1constants.LabelNodeLocalDNS: strconv.FormatBool(true),
 	})
+}
+
+// computeWorkerPoolNamesForNodeLocalDNS returns the configured worker pool names augmented by names of pools that no
+// longer appear in the shoot spec but for which nodes still exist (e.g. after a worker pool has been renamed). This
+// ensures that the corresponding node-local-dns DaemonSets are kept around until the old nodes have been drained,
+// preventing DNS outages on those nodes.
+func (b *Botanist) computeWorkerPoolNamesForNodeLocalDNS(ctx context.Context) ([]string, error) {
+	pools := sets.New[string]()
+	for _, w := range b.Shoot.GetInfo().Spec.Provider.Workers {
+		pools.Insert(w.Name)
+	}
+
+	nodeList := &metav1.PartialObjectMetadataList{}
+	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+	if err := b.ShootClientSet.Client().List(ctx, nodeList); err != nil {
+		return nil, fmt.Errorf("failed to list nodes for stale worker pool detection: %w", err)
+	}
+
+	for _, node := range nodeList.Items {
+		poolName, ok := node.Labels[v1beta1constants.LabelWorkerPool]
+		if !ok || poolName == "" {
+			continue
+		}
+		pools.Insert(poolName)
+	}
+
+	return sets.List(pools), nil
 }
 
 // hasKubernetesVersionsBelowAndAbove134 checks if there are worker pools with Kubernetes versions below 1.34 and others with versions 1.34 or above.

--- a/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
+++ b/pkg/gardenlet/operation/botanist/nodelocaldns_test.go
@@ -119,6 +119,7 @@ var _ = Describe("NodeLocalDNS", func() {
 
 		It("should fail when the deploy function fails", func() {
 			nodelocaldns.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
+			nodelocaldns.EXPECT().SetWorkerPoolNames([]string{"worker-aaaa"})
 			nodelocaldns.EXPECT().Deploy(ctx).Return(fakeErr)
 
 			Expect(botanist.ReconcileNodeLocalDNS(ctx)).To(MatchError(fakeErr))
@@ -126,10 +127,35 @@ var _ = Describe("NodeLocalDNS", func() {
 
 		It("should successfully deploy when enabled", func() {
 			nodelocaldns.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
+			nodelocaldns.EXPECT().SetWorkerPoolNames([]string{"worker-aaaa"})
 			nodelocaldns.EXPECT().Deploy(ctx)
 
 			Expect(botanist.ReconcileNodeLocalDNS(ctx)).To(Succeed())
 		})
+
+		It("should include worker pool names of stale nodes (e.g. after a pool rename)", func() {
+			oldNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "old-node",
+					Labels: map[string]string{v1beta1constants.LabelWorkerPool: "worker-old"},
+				},
+			}
+			newNode := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "new-node",
+					Labels: map[string]string{v1beta1constants.LabelWorkerPool: "worker-aaaa"},
+				},
+			}
+			Expect(shootClient.Create(ctx, oldNode)).To(Succeed())
+			Expect(shootClient.Create(ctx, newNode)).To(Succeed())
+
+			nodelocaldns.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4})
+			nodelocaldns.EXPECT().SetWorkerPoolNames([]string{"worker-aaaa", "worker-old"})
+			nodelocaldns.EXPECT().Deploy(ctx)
+
+			Expect(botanist.ReconcileNodeLocalDNS(ctx)).To(Succeed())
+		})
+
 		It("should successfully deploy when enabled with ipfamily IPv6", func() {
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
@@ -145,6 +171,7 @@ var _ = Describe("NodeLocalDNS", func() {
 				},
 			})
 			nodelocaldns.EXPECT().SetIPFamilies([]gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6})
+			nodelocaldns.EXPECT().SetWorkerPoolNames([]string{})
 			nodelocaldns.EXPECT().Deploy(ctx)
 
 			Expect(botanist.ReconcileNodeLocalDNS(ctx)).To(Succeed())


### PR DESCRIPTION
## How to categorize this PR?

/area networking
/kind bug

## What this PR does / why we need it:

When a worker pool is renamed, nodes from the old pool may still exist for a while.
Previously, `node-local-dns` would immediately drop the DaemonSet for the old pool
name, leaving these nodes without DNS until they are terminated. If the iptables
cleanup also fails to run, those nodes are permanently broken.

Mirroring `kube-proxy`'s worker pool handling, the botanist now lists nodes in the
shoot before reconciling `node-local-dns` and augments the configured worker pool
names with any pool name that still has nodes but is no longer in the spec. The
component renders one DaemonSet per pool name it is told about, so the DaemonSet
for a renamed pool keeps running until its old nodes are gone.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

The stale-pool computation lives in the botanist (`computeWorkerPoolNamesForNodeLocalDNS`)
to stay consistent with `computeWorkerPoolsForKubeProxy`; the component itself just
renders DaemonSets for the pool names it is given via the new `SetWorkerPoolNames`
setter.

## Release note:
```operator
`node-local-dns` no longer drops DaemonSets for renamed worker pools while nodes
from the old pool still exist, preventing DNS outages on those nodes.
```