### PR TITLE
[GEP-36]`gardenlet`: add controller for updating control plane endpoints

### DIFF
--- a/charts/gardener/operator/files/crd-extensions.yaml
+++ b/charts/gardener/operator/files/crd-extensions.yaml
@@ -406,6 +406,11 @@ spec:
                         description: ClusterType defines the type of cluster.
                         type: string
                       type: array
+                    continuousEndpointUpdate:
+                      description: |-
+                        ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously
+                        updated with healthy/valid control plane endpoints.
+                      type: boolean
                     kind:
                       description: Kind is the resource kind, for example "OperatingSystemConfig".
                       type: string

--- a/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
+++ b/dev-setup/extensions/provider-local/components/controllerregistration/controllerregistration.yaml
@@ -26,6 +26,7 @@ spec:
       type: local
     - kind: SelfHostedShootExposure
       type: local
+      continuousEndpointUpdate: true
     - kind: Worker
       type: local
     - kind: Extension

--- a/dev-setup/extensions/provider-local/components/extension/extension.yaml
+++ b/dev-setup/extensions/provider-local/components/extension/extension.yaml
@@ -37,3 +37,4 @@ spec:
     type: local
   - kind: SelfHostedShootExposure
     type: local
+    continuousEndpointUpdate: true

--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -734,6 +734,7 @@ build:
             - pkg/gardenlet/controller/shoot
             - pkg/gardenlet/controller/shoot/care
             - pkg/gardenlet/controller/shoot/lease
+            - pkg/gardenlet/controller/shoot/selfhostedshootexposure
             - pkg/gardenlet/controller/shoot/shoot
             - pkg/gardenlet/controller/shoot/shoot/helper
             - pkg/gardenlet/controller/shoot/state

--- a/dev-setup/skaffold-seed.yaml
+++ b/dev-setup/skaffold-seed.yaml
@@ -252,6 +252,7 @@ build:
             - pkg/gardenlet/controller/shoot
             - pkg/gardenlet/controller/shoot/care
             - pkg/gardenlet/controller/shoot/lease
+            - pkg/gardenlet/controller/shoot/selfhostedshootexposure
             - pkg/gardenlet/controller/shoot/shoot
             - pkg/gardenlet/controller/shoot/shoot/helper
             - pkg/gardenlet/controller/shoot/state

--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -3105,6 +3105,18 @@ boolean
 <p>ClusterCompatibility defines the compatibility of this resource with different cluster types.<br />If compatibility is not specified, it will be defaulted to 'shoot'.<br />This field can only be set for resources of kind "Extension".</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>continuousEndpointUpdate</code></br>
+<em>
+boolean
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously<br />updated with healthy/valid control plane endpoints.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -527,6 +527,10 @@ Please refer to [GEP-0022: Improved Usage of the `ShootState` API](https://githu
 
 This reconciler watches for the `extensionsv1alpha1.Worker` resource in the control plane namespace of the `Shoot` and if its `status.inPlaceUpdates.workerPoolToHashMap` has changed, it requeues the corresponding `Shoot`. A worker pool is removed from `status.inPlaceUpdates.pendingWorkersRollouts.manualInPlaceUpdate` field in the `Shoot` if the hash of the worker pool in the `Shoot` spec and the `Worker` status field matches. This indicates that all the nodes of that worker pool are successfully updated and are no longer pending manual in-place updates.
 
+### [`SelfHostedShootExposure` Reconciler](../../pkg/gardenlet/controller/shoot/selfhostedshootexposure)
+
+This reconciler only runs in `gardenlet`s responsible for a self-hosted `Shoot` and keeps its API server exposure in sync with the control-plane `Node`s. Depending on `spec.provider.workers[].controlPlane.exposure`, it either maintains the `SelfHostedShootExposure` extension resource's endpoints and updates the external `DNSRecord` from the reported ingress (extension-based exposure), or points the external `DNSRecord` directly at the control-plane node addresses (DNS-based exposure). When the mechanism is switched or exposure is removed, it updates the `DNSRecord` a final time and deletes the obsolete `SelfHostedShootExposure`. Please refer to [GEP-0036: Self-Hosted Shoot Exposure](https://github.com/gardener/enhancements/tree/main/geps/0036-self-hosted-shoot-exposure) for more details.
+
 ### [`TokenRequestor` Controller For `ServiceAccount`s](../../pkg/controller/tokenrequestor)
 
 The `gardenlet` uses an instance of the `TokenRequestor` controller which initially was developed in the context of the `gardener-resource-manager`, please read [this document](resource-manager.md#tokenrequestor-controller) for further information.

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -529,7 +529,10 @@ This reconciler watches for the `extensionsv1alpha1.Worker` resource in the cont
 
 ### [`SelfHostedShootExposure` Reconciler](../../pkg/gardenlet/controller/shoot/selfhostedshootexposure)
 
-This reconciler only runs in `gardenlet`s responsible for a self-hosted `Shoot` and keeps its API server exposure in sync with the control-plane `Node`s. Depending on `spec.provider.workers[].controlPlane.exposure`, it either maintains the `SelfHostedShootExposure` extension resource's endpoints and updates the external `DNSRecord` from the reported ingress (extension-based exposure), or points the external `DNSRecord` directly at the control-plane node addresses (DNS-based exposure). When the mechanism is switched or exposure is removed, it updates the `DNSRecord` a final time and deletes the obsolete `SelfHostedShootExposure`. Please refer to [GEP-0036: Self-Hosted Shoot Exposure](https://github.com/gardener/enhancements/tree/main/geps/0036-self-hosted-shoot-exposure) for more details.
+This reconciler only runs in `gardenlet`s responsible for a self-hosted `Shoot` and keeps its API server exposure in sync with the control-plane `Node`s.
+Depending on `spec.provider.workers[].controlPlane.exposure`, it either maintains the `SelfHostedShootExposure` extension resource's endpoints and updates the external `DNSRecord` from the reported ingress (extension-based exposure), or points the external `DNSRecord` directly at the control-plane node addresses (DNS-based exposure).
+When the mechanism is switched or exposure is removed, it updates the `DNSRecord` a final time and deletes the obsolete `SelfHostedShootExposure`.
+Please refer to [GEP-0036: Self-Hosted Shoot Exposure](https://github.com/gardener/enhancements/tree/main/geps/0036-self-hosted-shoot-exposure) for more details.
 
 ### [`TokenRequestor` Controller For `ServiceAccount`s](../../pkg/controller/tokenrequestor)
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -529,7 +529,8 @@ This reconciler watches for the `extensionsv1alpha1.Worker` resource in the cont
 
 ### [`SelfHostedShootExposure` Reconciler](../../pkg/gardenlet/controller/shoot/selfhostedshootexposure)
 
-This reconciler only runs in `gardenlet`s responsible for a self-hosted `Shoot` and keeps its API server exposure in sync with the control-plane `Node`s.
+This reconciler only runs if `gardenlet` is responsible for a self-hosted `Shoot`.
+It keeps its API server exposure in sync with the control-plane `Node`s.
 Depending on `spec.provider.workers[].controlPlane.exposure`, it either maintains the `SelfHostedShootExposure` extension resource's endpoints and updates the external `DNSRecord` from the reported ingress (extension-based exposure), or points the external `DNSRecord` directly at the control-plane node addresses (DNS-based exposure).
 When the mechanism is switched or exposure is removed, it updates the `DNSRecord` a final time and deletes the obsolete `SelfHostedShootExposure`.
 Please refer to [GEP-0036: Self-Hosted Shoot Exposure](https://github.com/gardener/enhancements/tree/main/geps/0036-self-hosted-shoot-exposure) for more details.

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -437,3 +437,16 @@ Due to technical reasons, exceptions apply for different reconcile flows, for ex
 - The garden reconciliation doesn't distinguish between `AfterKubeAPIServer` and `AfterWorker`.
 - The seed reconciliation completely ignores the `lifecycle` field.
 - The lifecycle value `AfterWorker` is only available during `reconcile`. When specified, the extension resource will be reconciled after the workers are deployed. This is useful for extensions that want to deploy a workload in the shoot control plane and want to wait for the workload to run and get ready on a node. During shoot creation the extension will start its reconciliation before the first workers have joined the cluster, they will become available at some later point.
+
+#### `SelfHostedShootExposure` Endpoint Update
+
+For `ControllerResource`s of kind `SelfHostedShootExposure`, the `continuousEndpointUpdate` field controls whether `gardenlet` continuously keeps the `SelfHostedShootExposure` resource's endpoints in sync with the self-hosted shoot's control-plane node addresses (for extension-based exposure). It defaults to `true`. It does not affect DNS-based exposure, whose `DNSRecord` is always kept in sync.
+
+```yaml
+    ...
+    kind: SelfHostedShootExposure
+    type: foo
+    continuousEndpointUpdate: false
+```
+
+This field has no effect for other `kind` values and may not be set on them.

--- a/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
+++ b/example/operator/10-crd-operator.gardener.cloud_extensions.yaml
@@ -406,6 +406,11 @@ spec:
                         description: ClusterType defines the type of cluster.
                         type: string
                       type: array
+                    continuousEndpointUpdate:
+                      description: |-
+                        ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously
+                        updated with healthy/valid control plane endpoints.
+                      type: boolean
                     kind:
                       description: Kind is the resource kind, for example "OperatingSystemConfig".
                       type: string

--- a/pkg/api/core/v1beta1/helper/controllerregistration.go
+++ b/pkg/api/core/v1beta1/helper/controllerregistration.go
@@ -7,7 +7,10 @@ package helper
 import (
 	"strings"
 
+	"k8s.io/utils/ptr"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 // IsResourceSupported returns true if a given combination of kind/type is part of a controller resources list.
@@ -19,4 +22,17 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 	}
 
 	return false
+}
+
+// ContinuousEndpointUpdateEnabled returns whether the SelfHostedShootExposure controller registered for the given
+// extension type opts into continuous endpoint updates. Defaults to the API default (true).
+func ContinuousEndpointUpdateEnabled(registrations []gardencorev1beta1.ControllerRegistration, extensionType string) bool {
+	for _, reg := range registrations {
+		for _, res := range reg.Spec.Resources {
+			if res.Kind == extensionsv1alpha1.SelfHostedShootExposureResource && strings.EqualFold(res.Type, extensionType) {
+				return ptr.Deref(res.ContinuousEndpointUpdate, true)
+			}
+		}
+	}
+	return true
 }

--- a/pkg/api/core/v1beta1/helper/controllerregistration.go
+++ b/pkg/api/core/v1beta1/helper/controllerregistration.go
@@ -29,7 +29,7 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 func ContinuousEndpointUpdateEnabled(registrations []gardencorev1beta1.ControllerRegistration, extensionType string) bool {
 	for _, reg := range registrations {
 		for _, res := range reg.Spec.Resources {
-			if res.Kind == extensionsv1alpha1.SelfHostedShootExposureResource && strings.EqualFold(res.Type, extensionType) {
+			if res.Kind == extensionsv1alpha1.SelfHostedShootExposureResource && res.Type == extensionType {
 				return ptr.Deref(res.ContinuousEndpointUpdate, true)
 			}
 		}

--- a/pkg/api/core/v1beta1/helper/controllerregistration_test.go
+++ b/pkg/api/core/v1beta1/helper/controllerregistration_test.go
@@ -51,4 +51,59 @@ var _ = Describe("Helper", func() {
 			false,
 		),
 	)
+
+	DescribeTable("#ContinuousEndpointUpdateEnabled",
+		func(registrations []gardencorev1beta1.ControllerRegistration, extensionType string, expected bool) {
+			Expect(ContinuousEndpointUpdateEnabled(registrations, extensionType)).To(Equal(expected))
+		},
+		Entry("no registrations defaults to true (not-yet-synced must not silently disable)",
+			nil,
+			"local",
+			true,
+		),
+		Entry("no matching registration defaults to true",
+			[]gardencorev1beta1.ControllerRegistration{{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "foo", Type: "bar"},
+					},
+				},
+			}},
+			"local",
+			true,
+		),
+		Entry("matching registration with field unset defaults to true",
+			[]gardencorev1beta1.ControllerRegistration{{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "SelfHostedShootExposure", Type: "local"},
+					},
+				},
+			}},
+			"local",
+			true,
+		),
+		Entry("matching registration with field explicitly set to false",
+			[]gardencorev1beta1.ControllerRegistration{{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "SelfHostedShootExposure", Type: "local", ContinuousEndpointUpdate: new(false)},
+					},
+				},
+			}},
+			"local",
+			false,
+		),
+		Entry("type lookup is case-insensitive",
+			[]gardencorev1beta1.ControllerRegistration{{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{Kind: "SelfHostedShootExposure", Type: "Local", ContinuousEndpointUpdate: new(false)},
+					},
+				},
+			}},
+			"local",
+			false,
+		),
+	)
 })

--- a/pkg/api/core/v1beta1/helper/controllerregistration_test.go
+++ b/pkg/api/core/v1beta1/helper/controllerregistration_test.go
@@ -94,16 +94,5 @@ var _ = Describe("Helper", func() {
 			"local",
 			false,
 		),
-		Entry("type lookup is case-insensitive",
-			[]gardencorev1beta1.ControllerRegistration{{
-				Spec: gardencorev1beta1.ControllerRegistrationSpec{
-					Resources: []gardencorev1beta1.ControllerResource{
-						{Kind: "SelfHostedShootExposure", Type: "Local", ContinuousEndpointUpdate: new(false)},
-					},
-				},
-			}},
-			"local",
-			false,
-		),
 	)
 })

--- a/pkg/api/core/v1beta1/helper/shoot.go
+++ b/pkg/api/core/v1beta1/helper/shoot.go
@@ -622,11 +622,38 @@ func HasManagedInfrastructure(shoot *gardencorev1beta1.Shoot) bool {
 	return shoot.Spec.CredentialsBindingName != nil || shoot.Spec.SecretBindingName != nil
 }
 
+// ControlPlaneExposureForShoot returns the control plane exposure configuration for the shoot,
+// or nil if the shoot is not self-hosted or the control plane worker pool is not configured with an exposure.
+func ControlPlaneExposureForShoot(shoot *gardencorev1beta1.Shoot) *gardencorev1beta1.Exposure {
+	pool := ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)
+	if pool == nil || pool.ControlPlane == nil {
+		return nil
+	}
+	return pool.ControlPlane.Exposure
+}
+
 // HasExtensionExposure returns true if the shoot's control plane is configured to use a
 // SelfHostedShootExposure extension object to expose the API server.
 func HasExtensionExposure(shoot *gardencorev1beta1.Shoot) bool {
-	pool := ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers)
-	return pool != nil && pool.ControlPlane.Exposure != nil && pool.ControlPlane.Exposure.Extension != nil
+	exposure := ControlPlaneExposureForShoot(shoot)
+	return exposure != nil && exposure.Extension != nil
+}
+
+// HasDNSExposure returns true if the shoot's control plane is configured to be exposed directly via DNS, i.e. the
+// external DNSRecord points at the control-plane node addresses without an exposure extension in between.
+func HasDNSExposure(shoot *gardencorev1beta1.Shoot) bool {
+	exposure := ControlPlaneExposureForShoot(shoot)
+	return exposure != nil && exposure.DNS != nil
+}
+
+// SelfHostedShootExposureExtensionType returns the exposure extension type configured for the shoot,
+// defaulting to the provider type when it is not configured.
+func SelfHostedShootExposureExtensionType(shoot *gardencorev1beta1.Shoot) string {
+	exposure := ControlPlaneExposureForShoot(shoot)
+	if exposure == nil || exposure.Extension == nil {
+		return shoot.Spec.Provider.Type
+	}
+	return ptr.Deref(exposure.Extension.Type, shoot.Spec.Provider.Type)
 }
 
 // ControlPlaneWorkerPoolForShoot returns the worker pool running the control plane in case the shoot is self-hosted.

--- a/pkg/api/core/v1beta1/helper/shoot_test.go
+++ b/pkg/api/core/v1beta1/helper/shoot_test.go
@@ -1695,6 +1695,85 @@ var _ = Describe("Helper", func() {
 		})
 	})
 
+	Describe("#ControlPlaneExposureForShoot", func() {
+		It("should return nil when shoot has no control plane worker pool", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{{}}}}}
+			Expect(ControlPlaneExposureForShoot(shoot)).To(BeNil())
+		})
+
+		It("should return nil when the control plane worker pool has no Exposure", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+			}}}}
+			Expect(ControlPlaneExposureForShoot(shoot)).To(BeNil())
+		})
+
+		It("should return the Exposure when it is set", func() {
+			exposure := &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}}
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: exposure}},
+			}}}}
+			Expect(ControlPlaneExposureForShoot(shoot)).To(BeIdenticalTo(exposure))
+		})
+	})
+
+	Describe("#HasDNSExposure", func() {
+		It("should return false when shoot has no exposure", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}},
+			}}}}
+			Expect(HasDNSExposure(shoot)).To(BeFalse())
+		})
+
+		It("should return false for extension-based exposure", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: &gardencorev1beta1.Exposure{Extension: &gardencorev1beta1.ExtensionExposure{Type: new("local")}}}},
+			}}}}
+			Expect(HasDNSExposure(shoot)).To(BeFalse())
+		})
+
+		It("should return true for DNS-based exposure", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+				{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}}}},
+			}}}}
+			Expect(HasDNSExposure(shoot)).To(BeTrue())
+		})
+	})
+
+	Describe("#SelfHostedShootExposureExtensionType", func() {
+		It("should default to the provider type when no exposure is configured", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{
+				Type:    "local",
+				Workers: []gardencorev1beta1.Worker{{ControlPlane: &gardencorev1beta1.WorkerControlPlane{}}},
+			}}}
+			Expect(SelfHostedShootExposureExtensionType(shoot)).To(Equal("local"))
+		})
+
+		It("should default to the provider type for DNS-based exposure (no extension)", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{
+				Type:    "local",
+				Workers: []gardencorev1beta1.Worker{{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}}}}},
+			}}}
+			Expect(SelfHostedShootExposureExtensionType(shoot)).To(Equal("local"))
+		})
+
+		It("should default to the provider type when the extension type is unset", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{
+				Type:    "local",
+				Workers: []gardencorev1beta1.Worker{{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: &gardencorev1beta1.Exposure{Extension: &gardencorev1beta1.ExtensionExposure{}}}}},
+			}}}
+			Expect(SelfHostedShootExposureExtensionType(shoot)).To(Equal("local"))
+		})
+
+		It("should return the configured extension type", func() {
+			shoot := &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{
+				Type:    "local",
+				Workers: []gardencorev1beta1.Worker{{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: &gardencorev1beta1.Exposure{Extension: &gardencorev1beta1.ExtensionExposure{Type: new("custom-lb")}}}}},
+			}}}
+			Expect(SelfHostedShootExposureExtensionType(shoot)).To(Equal("custom-lb"))
+		})
+	})
+
 	Describe("#ControlPlaneWorkerPoolForShoot", func() {
 		It("should return nil because shoot has no workers", func() {
 			shoot := &gardencorev1beta1.Shoot{}

--- a/pkg/api/core/validation/controllerregistration.go
+++ b/pkg/api/core/validation/controllerregistration.go
@@ -114,6 +114,10 @@ func ValidateControllerResources(resources []core.ControllerResource, clusterTyp
 		}
 		resourceKindToType[resource.Kind] = resource.Type
 
+		if resource.Kind != extensionsv1alpha1.SelfHostedShootExposureResource && resource.ContinuousEndpointUpdate != nil {
+			allErrs = append(allErrs, field.Forbidden(idxPath.Child("continuousEndpointUpdate"), fmt.Sprintf("field must not be set when kind != %s", extensionsv1alpha1.SelfHostedShootExposureResource)))
+		}
+
 		if resource.Kind != extensionsv1alpha1.ExtensionResource {
 			if len(resource.AutoEnable) > 0 {
 				allErrs = append(allErrs, field.Forbidden(idxPath.Child("autoEnable"), fmt.Sprintf("field must not be set when kind != %s", extensionsv1alpha1.ExtensionResource)))

--- a/pkg/api/core/validation/controllerregistration_test.go
+++ b/pkg/api/core/validation/controllerregistration_test.go
@@ -347,6 +347,40 @@ var _ = Describe("validation", func() {
 			}))))
 		})
 
+		It("should allow setting continuousEndpointUpdate for kind SelfHostedShootExposure", func() {
+			resources = []core.ControllerResource{{
+				Kind:                     extensionsv1alpha1.SelfHostedShootExposureResource,
+				Type:                     "arbitrary",
+				ContinuousEndpointUpdate: new(true),
+			}}
+
+			errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		DescribeTable("should forbid setting continuousEndpointUpdate for invalid kind",
+			func(kind string) {
+				resources = []core.ControllerResource{{
+					Kind:                     kind,
+					Type:                     "arbitrary",
+					ContinuousEndpointUpdate: new(true),
+				}}
+
+				errorList := ValidateControllerResources(resources, validModes, fldPath)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("resources[0].continuousEndpointUpdate"),
+				}))))
+			},
+
+			Entry("Extension", extensionsv1alpha1.ExtensionResource),
+			Entry("OperatingSystemConfig", extensionsv1alpha1.OperatingSystemConfigResource),
+			Entry("Infrastructure", extensionsv1alpha1.InfrastructureResource),
+			Entry("Worker", extensionsv1alpha1.WorkerResource),
+		)
+
 		It("should allow setting valid autoEnable modes", func() {
 			resources[0].Kind = "Extension"
 			resources[0].AutoEnable = []core.ClusterType{core.ClusterTypeShoot, core.ClusterTypeSeed}

--- a/pkg/api/extensions/v1alpha1/helper/dnsrecord.go
+++ b/pkg/api/extensions/v1alpha1/helper/dnsrecord.go
@@ -5,8 +5,13 @@
 package helper
 
 import (
+	"fmt"
 	"net"
+	"slices"
 
+	corev1 "k8s.io/api/core/v1"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
@@ -27,4 +32,89 @@ func GetDNSRecordTTL(ttl *int64) int64 {
 		return *ttl
 	}
 	return 120
+}
+
+// DNSValuesFromIngress computes the values and record type for a DNSRecord from the given LoadBalancerIngress entries,
+// as reported by an exposure extension. IPs are preferred over hostnames (CNAME); the IPs of the first configured IP
+// family with at least one match are used.
+func DNSValuesFromIngress(ingress []corev1.LoadBalancerIngress, ipFamilies []gardencorev1beta1.IPFamily) ([]string, extensionsv1alpha1.DNSRecordType, error) {
+	if len(ingress) == 0 {
+		return nil, "", fmt.Errorf("exposure has no ingress yet")
+	}
+
+	var ips, hostnames []string
+	for _, i := range ingress {
+		if i.IP != "" {
+			ips = append(ips, i.IP)
+		}
+		if i.Hostname != "" {
+			hostnames = append(hostnames, i.Hostname)
+		}
+	}
+
+	for _, family := range ipFamilies {
+		recordType := IPFamilyToDNSRecordType(family)
+		values := slices.DeleteFunc(slices.Clone(ips), func(ip string) bool {
+			return GetDNSRecordType(ip) != recordType
+		})
+		if len(values) > 0 {
+			return values, recordType, nil
+		}
+	}
+
+	switch {
+	case len(ips) > 0:
+		return nil, "", fmt.Errorf("none of the IP addresses %v match a configured IP family %v", ips, ipFamilies)
+	case len(hostnames) > 0:
+		return hostnames[:1], extensionsv1alpha1.DNSRecordTypeCNAME, nil
+	default:
+		return nil, "", fmt.Errorf("ingress has neither IPs nor hostnames")
+	}
+}
+
+// DNSValuesFromNodes computes the values and record type for a DNSRecord from the given node addresses: each node
+// contributes its first address in the order of addressTypePreference (first family with at least one match wins).
+func DNSValuesFromNodes(nodes []corev1.Node, ipFamilies []gardencorev1beta1.IPFamily, addressTypePreference ...corev1.NodeAddressType) ([]string, extensionsv1alpha1.DNSRecordType, error) {
+	for i := range nodes {
+		if len(nodes[i].Status.Addresses) == 0 {
+			return nil, "", fmt.Errorf("node %q has no addresses", nodes[i].Name)
+		}
+	}
+
+	for _, family := range ipFamilies {
+		recordType := IPFamilyToDNSRecordType(family)
+
+		var values []string
+		for _, node := range nodes {
+			if address := preferredAddress(node.Status.Addresses, recordType, addressTypePreference); address != "" {
+				values = append(values, address)
+			}
+		}
+
+		if len(values) > 0 {
+			return values, recordType, nil
+		}
+	}
+
+	return nil, "", fmt.Errorf("no node address of types %v matches a configured IP family %v", addressTypePreference, ipFamilies)
+}
+
+// IPFamilyToDNSRecordType maps a Gardener IP family to the corresponding DNSRecord type.
+func IPFamilyToDNSRecordType(family gardencorev1beta1.IPFamily) extensionsv1alpha1.DNSRecordType {
+	if family == gardencorev1beta1.IPFamilyIPv6 {
+		return extensionsv1alpha1.DNSRecordTypeAAAA
+	}
+	return extensionsv1alpha1.DNSRecordTypeA
+}
+
+// preferredAddress returns the first address of the given record type in the order of addressTypePreference, or "".
+func preferredAddress(addresses []corev1.NodeAddress, recordType extensionsv1alpha1.DNSRecordType, addressTypePreference []corev1.NodeAddressType) string {
+	for _, addressType := range addressTypePreference {
+		for _, address := range addresses {
+			if address.Type == addressType && GetDNSRecordType(address.Address) == recordType {
+				return address.Address
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/api/extensions/v1alpha1/helper/dnsrecord.go
+++ b/pkg/api/extensions/v1alpha1/helper/dnsrecord.go
@@ -43,12 +43,12 @@ func DNSValuesFromIngress(ingress []corev1.LoadBalancerIngress, ipFamilies []gar
 	}
 
 	var ips, hostnames []string
-	for _, i := range ingress {
-		if i.IP != "" {
-			ips = append(ips, i.IP)
+	for _, ingress := range ingress {
+		if ingress.IP != "" {
+			ips = append(ips, ingress.IP)
 		}
-		if i.Hostname != "" {
-			hostnames = append(hostnames, i.Hostname)
+		if ingress.Hostname != "" {
+			hostnames = append(hostnames, ingress.Hostname)
 		}
 	}
 
@@ -75,9 +75,9 @@ func DNSValuesFromIngress(ingress []corev1.LoadBalancerIngress, ipFamilies []gar
 // DNSValuesFromNodes computes the values and record type for a DNSRecord from the given node addresses: each node
 // contributes its first address in the order of addressTypePreference (first family with at least one match wins).
 func DNSValuesFromNodes(nodes []corev1.Node, ipFamilies []gardencorev1beta1.IPFamily, addressTypePreference ...corev1.NodeAddressType) ([]string, extensionsv1alpha1.DNSRecordType, error) {
-	for i := range nodes {
-		if len(nodes[i].Status.Addresses) == 0 {
-			return nil, "", fmt.Errorf("node %q has no addresses", nodes[i].Name)
+	for _, node := range nodes {
+		if len(node.Status.Addresses) == 0 {
+			return nil, "", fmt.Errorf("node %q has no addresses", node.Name)
 		}
 	}
 

--- a/pkg/api/extensions/v1alpha1/helper/dnsrecord_test.go
+++ b/pkg/api/extensions/v1alpha1/helper/dnsrecord_test.go
@@ -7,12 +7,20 @@ package helper_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/gardener/gardener/pkg/api/extensions/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 var _ = Describe("Helper", func() {
+	var (
+		ipv4 = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}
+		ipv6 = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
+	)
+
 	DescribeTable("#GetDNSRecordType",
 		func(address string, expected extensionsv1alpha1.DNSRecordType) {
 			Expect(GetDNSRecordType(address)).To(Equal(expected))
@@ -31,4 +39,133 @@ var _ = Describe("Helper", func() {
 		Entry("nil value", nil, int64(120)),
 		Entry("non-nil value", new(int64(300)), int64(300)),
 	)
+
+	Describe("#DNSValuesFromIngress", func() {
+		It("should prefer IPs over hostnames", func() {
+			ingress := []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}, {Hostname: "lb.example.com"}}
+
+			values, recordType, err := DNSValuesFromIngress(ingress, ipv4)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(values).To(ConsistOf("1.2.3.4"))
+		})
+
+		It("should fall back to a single hostname (CNAME) when no IPs are present", func() {
+			ingress := []corev1.LoadBalancerIngress{{Hostname: "lb-1.example.com"}, {Hostname: "lb-2.example.com"}}
+
+			values, recordType, err := DNSValuesFromIngress(ingress, ipv4)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeCNAME))
+			// CNAME records must have a single value.
+			Expect(values).To(Equal([]string{"lb-1.example.com"}))
+		})
+
+		It("should select the IPs of the first configured IP family with a match", func() {
+			ingress := []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}, {IP: "fd12::1"}}
+
+			values, recordType, err := DNSValuesFromIngress(ingress, []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6, gardencorev1beta1.IPFamilyIPv4})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeAAAA))
+			Expect(values).To(ConsistOf("fd12::1"))
+		})
+
+		It("should error on empty ingress with a distinct message", func() {
+			_, _, err := DNSValuesFromIngress(nil, ipv4)
+			Expect(err).To(MatchError("exposure has no ingress yet"))
+		})
+
+		It("should error when ingress entries have neither IP nor hostname", func() {
+			_, _, err := DNSValuesFromIngress([]corev1.LoadBalancerIngress{{}}, ipv4)
+			Expect(err).To(MatchError(ContainSubstring("neither IPs nor hostnames")))
+		})
+
+		It("should error when IPs match no configured IP family, even if hostnames are present", func() {
+			_, _, err := DNSValuesFromIngress([]corev1.LoadBalancerIngress{{IP: "1.2.3.4", Hostname: "lb.example.com"}}, ipv6)
+			Expect(err).To(MatchError(ContainSubstring("configured IP family")))
+		})
+	})
+
+	Describe("#DNSValuesFromNodes", func() {
+		node := func(name string, addresses ...corev1.NodeAddress) corev1.Node {
+			return corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Status:     corev1.NodeStatus{Addresses: addresses},
+			}
+		}
+		externalIP := func(address string) corev1.NodeAddress {
+			return corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address}
+		}
+		internalIP := func(address string) corev1.NodeAddress {
+			return corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: address}
+		}
+
+		It("should pick each node's first address in the given type order (internal-first)", func() {
+			nodes := []corev1.Node{
+				node("cp-1", externalIP("1.2.3.4"), internalIP("10.0.0.1")),
+				node("cp-2", externalIP("1.2.3.5")),
+			}
+
+			values, recordType, err := DNSValuesFromNodes(nodes, ipv4, corev1.NodeInternalIP, corev1.NodeExternalIP)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(values).To(Equal([]string{"10.0.0.1", "1.2.3.5"}))
+		})
+
+		It("should pick each node's first address in the given type order (external-first)", func() {
+			nodes := []corev1.Node{
+				node("cp-1", externalIP("1.2.3.4"), internalIP("10.0.0.1")),
+				node("cp-2", internalIP("10.0.0.2")),
+			}
+
+			values, recordType, err := DNSValuesFromNodes(nodes, ipv4, corev1.NodeExternalIP, corev1.NodeInternalIP)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(values).To(Equal([]string{"1.2.3.4", "10.0.0.2"}))
+		})
+
+		It("should select the first IP family with at least one matching address", func() {
+			nodes := []corev1.Node{
+				node("cp-1", internalIP("10.0.0.1")),
+				node("cp-2", internalIP("fd12::1")),
+			}
+
+			values, recordType, err := DNSValuesFromNodes(nodes, []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6}, corev1.NodeInternalIP)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(values).To(Equal([]string{"10.0.0.1"}))
+		})
+
+		It("should ignore addresses that are no IP of the family, e.g. hostnames", func() {
+			nodes := []corev1.Node{
+				node("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalDNS, Address: "internal.dns"}, externalIP("1.2.3.4")),
+			}
+
+			values, recordType, err := DNSValuesFromNodes(nodes, ipv4, corev1.NodeInternalDNS, corev1.NodeExternalIP)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(values).To(Equal([]string{"1.2.3.4"}))
+		})
+
+		It("should error if a node has no addresses", func() {
+			_, _, err := DNSValuesFromNodes([]corev1.Node{node("cp-1")}, ipv4, corev1.NodeInternalIP)
+			Expect(err).To(MatchError(ContainSubstring(`node "cp-1" has no addresses`)))
+		})
+
+		It("should error if no address of the given types matches a configured IP family", func() {
+			_, _, err := DNSValuesFromNodes([]corev1.Node{node("cp-1", internalIP("10.0.0.1"))}, ipv6, corev1.NodeInternalIP, corev1.NodeExternalIP)
+			Expect(err).To(MatchError(ContainSubstring("configured IP family")))
+		})
+
+		It("should error if no node address is of the given types", func() {
+			_, _, err := DNSValuesFromNodes([]corev1.Node{node("cp-1", internalIP("10.0.0.1"))}, ipv4, corev1.NodeExternalIP)
+			Expect(err).To(MatchError(ContainSubstring("configured IP family")))
+		})
+	})
 })

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -84,6 +84,9 @@ type ControllerResource struct {
 	// If compatibility is not specified, it will be defaulted to 'shoot'.
 	// This field can only be set for resources of kind "Extension".
 	ClusterCompatibility []ClusterType
+	// ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously
+	// updated with healthy/valid control plane endpoints.
+	ContinuousEndpointUpdate *bool
 }
 
 // DeploymentRef contains information about `ControllerDeployment` references.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -839,6 +839,9 @@ const (
 	// LabelWorkerPoolGardenerNodeAgentSecretName is the name of the secret used by the gardener node agent
 	LabelWorkerPoolGardenerNodeAgentSecretName = "worker.gardener.cloud/gardener-node-agent-secret-name"
 
+	// LabelNodeRoleControlPlane is a label key marking a node as a control-plane node.
+	LabelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
+
 	// LabelUpdateRestriction is a constant for a label key that indicates
 	// that a resource must be only updated by the gardenlet.
 	LabelUpdateRestriction = "gardener.cloud/update-restriction"

--- a/pkg/apis/core/v1beta1/defaults_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/defaults_controllerregistration.go
@@ -29,6 +29,10 @@ func SetDefaults_ControllerResource(obj *ControllerResource) {
 			obj.Lifecycle = &ControllerResourceLifecycle{}
 		}
 	}
+
+	if obj.Kind == "SelfHostedShootExposure" && obj.ContinuousEndpointUpdate == nil {
+		obj.ContinuousEndpointUpdate = new(true)
+	}
 }
 
 // SetDefaults_ControllerResourceLifecycle sets default values for ControllerResourceLifecycle objects.

--- a/pkg/apis/core/v1beta1/defaults_controllerregistration_test.go
+++ b/pkg/apis/core/v1beta1/defaults_controllerregistration_test.go
@@ -30,6 +30,10 @@ var _ = Describe("ControllerRegistration defaulting", func() {
 						Kind: "Extension",
 						Type: "extension-foo",
 					},
+					{
+						Kind: "SelfHostedShootExposure",
+						Type: "provider-foo",
+					},
 				},
 				Deployment: &ControllerRegistrationDeployment{
 					DeploymentRefs: []DeploymentRef{{
@@ -143,6 +147,36 @@ var _ = Describe("ControllerRegistration defaulting", func() {
 
 				Expect(obj.Spec.Resources[1].ClusterCompatibility).To(ConsistOf(ClusterType("seed")))
 			})
+		})
+
+		Context("kind == SelfHostedShootExposure", func() {
+			BeforeEach(func() {
+				obj.Spec.Resources = append(obj.Spec.Resources, ControllerResource{
+					Kind: "SelfHostedShootExposure",
+					Type: "provider-foo",
+				})
+			})
+
+			It("should default ContinuousEndpointUpdate to true", func() {
+				SetObjectDefaults_ControllerRegistration(obj)
+
+				Expect(obj.Spec.Resources[2].ContinuousEndpointUpdate).To(PointTo(BeTrue()))
+			})
+
+			It("should not overwrite ContinuousEndpointUpdate", func() {
+				obj.Spec.Resources[2].ContinuousEndpointUpdate = new(false)
+
+				SetObjectDefaults_ControllerRegistration(obj)
+
+				Expect(obj.Spec.Resources[2].ContinuousEndpointUpdate).To(PointTo(BeFalse()))
+			})
+		})
+
+		It("should not default ContinuousEndpointUpdate", func() {
+			SetObjectDefaults_ControllerRegistration(obj)
+
+			Expect(obj.Spec.Resources[0].ContinuousEndpointUpdate).To(BeNil())
+			Expect(obj.Spec.Resources[1].ContinuousEndpointUpdate).To(BeNil())
 		})
 	})
 

--- a/pkg/apis/core/v1beta1/generated.pb.go
+++ b/pkg/apis/core/v1beta1/generated.pb.go
@@ -3289,6 +3289,16 @@ func (m *ControllerResource) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.ContinuousEndpointUpdate != nil {
+		i--
+		if *m.ContinuousEndpointUpdate {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
+	}
 	if len(m.ClusterCompatibility) > 0 {
 		for iNdEx := len(m.ClusterCompatibility) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.ClusterCompatibility[iNdEx])
@@ -14630,6 +14640,9 @@ func (m *ControllerResource) Size() (n int) {
 			n += 1 + l + sovGenerated(uint64(l))
 		}
 	}
+	if m.ContinuousEndpointUpdate != nil {
+		n += 2
+	}
 	return n
 }
 
@@ -19172,6 +19185,7 @@ func (this *ControllerResource) String() string {
 		`WorkerlessSupported:` + valueToStringGenerated(this.WorkerlessSupported) + `,`,
 		`AutoEnable:` + fmt.Sprintf("%v", this.AutoEnable) + `,`,
 		`ClusterCompatibility:` + fmt.Sprintf("%v", this.ClusterCompatibility) + `,`,
+		`ContinuousEndpointUpdate:` + valueToStringGenerated(this.ContinuousEndpointUpdate) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -30033,6 +30047,27 @@ func (m *ControllerResource) Unmarshal(dAtA []byte) error {
 			}
 			m.ClusterCompatibility = append(m.ClusterCompatibility, ClusterType(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContinuousEndpointUpdate", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			b := bool(v != 0)
+			m.ContinuousEndpointUpdate = &b
 		default:
 			iNdEx = preIndex
 			skippy, err := skipGenerated(dAtA[iNdEx:])

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -871,6 +871,11 @@ message ControllerResource {
   // This field can only be set for resources of kind "Extension".
   // +optional
   repeated string clusterCompatibility = 9;
+
+  // ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously
+  // updated with healthy/valid control plane endpoints.
+  // +optional
+  optional bool continuousEndpointUpdate = 10;
 }
 
 // ControllerResourceLifecycle defines the lifecycle of a controller resource.

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -97,6 +97,10 @@ type ControllerResource struct {
 	// This field can only be set for resources of kind "Extension".
 	// +optional
 	ClusterCompatibility []ClusterType `json:"clusterCompatibility,omitempty" protobuf:"bytes,9,rep,name=clusterCompatibility,casttype=ClusterType"`
+	// ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously
+	// updated with healthy/valid control plane endpoints.
+	// +optional
+	ContinuousEndpointUpdate *bool `json:"continuousEndpointUpdate,omitempty" protobuf:"varint,10,opt,name=continuousEndpointUpdate"`
 }
 
 // DeploymentRef contains information about `ControllerDeployment` references.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3508,6 +3508,7 @@ func autoConvert_v1beta1_ControllerResource_To_core_ControllerResource(in *Contr
 	out.WorkerlessSupported = (*bool)(unsafe.Pointer(in.WorkerlessSupported))
 	out.AutoEnable = *(*[]core.ClusterType)(unsafe.Pointer(&in.AutoEnable))
 	out.ClusterCompatibility = *(*[]core.ClusterType)(unsafe.Pointer(&in.ClusterCompatibility))
+	out.ContinuousEndpointUpdate = (*bool)(unsafe.Pointer(in.ContinuousEndpointUpdate))
 	return nil
 }
 
@@ -3525,6 +3526,7 @@ func autoConvert_core_ControllerResource_To_v1beta1_ControllerResource(in *core.
 	out.WorkerlessSupported = (*bool)(unsafe.Pointer(in.WorkerlessSupported))
 	out.AutoEnable = *(*[]ClusterType)(unsafe.Pointer(&in.AutoEnable))
 	out.ClusterCompatibility = *(*[]ClusterType)(unsafe.Pointer(&in.ClusterCompatibility))
+	out.ContinuousEndpointUpdate = (*bool)(unsafe.Pointer(in.ContinuousEndpointUpdate))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1599,6 +1599,11 @@ func (in *ControllerResource) DeepCopyInto(out *ControllerResource) {
 		*out = make([]ClusterType, len(*in))
 		copy(*out, *in)
 	}
+	if in.ContinuousEndpointUpdate != nil {
+		in, out := &in.ContinuousEndpointUpdate, &out.ContinuousEndpointUpdate
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1611,6 +1611,11 @@ func (in *ControllerResource) DeepCopyInto(out *ControllerResource) {
 		*out = make([]ClusterType, len(*in))
 		copy(*out, *in)
 	}
+	if in.ContinuousEndpointUpdate != nil {
+		in, out := &in.ContinuousEndpointUpdate, &out.ContinuousEndpointUpdate
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apiserver/openapi/openapi_generated.go
+++ b/pkg/apiserver/openapi/openapi_generated.go
@@ -3427,6 +3427,13 @@ func schema_pkg_apis_core_v1beta1_ControllerResource(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"continuousEndpointUpdate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ContinuousEndpointUpdate indicates whether the extension requires the SelfHostedShootExposure endpoints to be continuously updated with healthy/valid control plane endpoints.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"kind", "type"},
 			},

--- a/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure.go
+++ b/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure.go
@@ -42,10 +42,10 @@ type Values struct {
 type SelfHostedShootExposure struct {
 	log    logr.Logger
 	client client.Client
+	clock  clock.PassiveClock
 	Values *Values
 
 	// exposed for testing
-	Clock               clock.PassiveClock
 	WaitInterval        time.Duration
 	WaitSevereThreshold time.Duration
 	WaitTimeout         time.Duration
@@ -56,18 +56,19 @@ type SelfHostedShootExposure struct {
 	Ingress []corev1.LoadBalancerIngress
 }
 
-// New creates a new SelfHostedShootExposure component with the default clock and wait settings.
+// New creates a new SelfHostedShootExposure component with the default wait settings.
 func New(
 	log logr.Logger,
 	c client.Client,
+	clock clock.PassiveClock,
 	values *Values,
 ) *SelfHostedShootExposure {
 	return &SelfHostedShootExposure{
 		log:    log,
 		client: c,
+		clock:  clock,
 		Values: values,
 
-		Clock:               &clock.RealClock{},
 		WaitInterval:        5 * time.Second,
 		WaitSevereThreshold: 30 * time.Second,
 		WaitTimeout:         5 * time.Minute,
@@ -86,7 +87,7 @@ func New(
 func (s *SelfHostedShootExposure) Deploy(ctx context.Context) error {
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, s.exposure, func() error {
 		metav1.SetMetaDataAnnotation(&s.exposure.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-		metav1.SetMetaDataAnnotation(&s.exposure.ObjectMeta, v1beta1constants.GardenerTimestamp, s.Clock.Now().UTC().Format(time.RFC3339Nano))
+		metav1.SetMetaDataAnnotation(&s.exposure.ObjectMeta, v1beta1constants.GardenerTimestamp, s.clock.Now().UTC().Format(time.RFC3339Nano))
 
 		s.exposure.Spec = extensionsv1alpha1.SelfHostedShootExposureSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure.go
+++ b/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure.go
@@ -42,7 +42,7 @@ type Values struct {
 type SelfHostedShootExposure struct {
 	log    logr.Logger
 	client client.Client
-	clock  clock.PassiveClock
+	clock  clock.Clock
 	Values *Values
 
 	// exposed for testing
@@ -60,7 +60,7 @@ type SelfHostedShootExposure struct {
 func New(
 	log logr.Logger,
 	c client.Client,
-	clock clock.PassiveClock,
+	clock clock.Clock,
 	values *Values,
 ) *SelfHostedShootExposure {
 	return &SelfHostedShootExposure{

--- a/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure_test.go
+++ b/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure_test.go
@@ -78,8 +78,7 @@ var _ = Describe("SelfHostedShootExposure", func() {
 			},
 		}
 
-		deployer = New(logr.Discard(), c, values)
-		deployer.Clock = fakeClock
+		deployer = New(logr.Discard(), c, fakeClock, values)
 		deployer.WaitInterval = time.Millisecond
 		deployer.WaitSevereThreshold = 250 * time.Millisecond
 		deployer.WaitTimeout = 500 * time.Millisecond

--- a/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure_test.go
+++ b/pkg/component/extensions/selfhostedshootexposure/selfhostedshootexposure_test.go
@@ -36,7 +36,7 @@ var _ = Describe("SelfHostedShootExposure", func() {
 		ctx context.Context
 		c   client.Client
 
-		fakeClock *testclock.FakePassiveClock
+		fakeClock *testclock.FakeClock
 		now       time.Time
 
 		values   *Values
@@ -48,7 +48,7 @@ var _ = Describe("SelfHostedShootExposure", func() {
 	BeforeEach(func() {
 		ctx = context.TODO()
 		now = time.Date(2026, 05, 18, 0, 0, 0, 0, time.UTC)
-		fakeClock = testclock.NewFakePassiveClock(now)
+		fakeClock = testclock.NewFakeClock(now)
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())

--- a/pkg/gardenadm/botanist/dnsrecord.go
+++ b/pkg/gardenadm/botanist/dnsrecord.go
@@ -7,10 +7,10 @@ package botanist
 import (
 	"context"
 	"fmt"
-	"slices"
+
+	corev1 "k8s.io/api/core/v1"
 
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/api/extensions/v1alpha1/helper"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 )
@@ -25,7 +25,7 @@ func (b *GardenadmBotanist) DeployBootstrapDNSRecord(ctx context.Context) error 
 		return err
 	}
 
-	machineAddr, err := PreferredAddress(machine.Status.Addresses)
+	machineAddr, err := PreferredNodeAddress(machine.Status.Addresses)
 	if err != nil {
 		return fmt.Errorf("failed getting preferred address for machine %q: %w", machine.Name, err)
 	}
@@ -57,82 +57,15 @@ func (b *GardenadmBotanist) RestoreExternalDNSRecord(ctx context.Context) error 
 }
 
 func (b *GardenadmBotanist) externalDNSRecordValues(ctx context.Context) ([]string, extensionsv1alpha1.DNSRecordType, error) {
+	ipFamilies := b.Shoot.GetInfo().Spec.Networking.IPFamilies
+
 	if b.Shoot.HasExtensionExposure() {
-		return b.extensionExposureDNSRecordValues()
+		return extensionsv1alpha1helper.DNSValuesFromIngress(b.Shoot.Components.Extensions.SelfHostedShootExposure.Ingress, ipFamilies)
 	}
-	return b.nodeAddressDNSRecordValues(ctx)
-}
 
-func (b *GardenadmBotanist) extensionExposureDNSRecordValues() ([]string, extensionsv1alpha1.DNSRecordType, error) {
-	ingress := b.Shoot.Components.Extensions.SelfHostedShootExposure.Ingress
-	if len(ingress) == 0 {
-		return nil, "", fmt.Errorf("SelfHostedShootExposure has no ingress yet")
-	}
-	// Prefer IPs over hostnames
-	var ips, hostnames []string
-	for _, i := range ingress {
-		if i.IP != "" {
-			ips = append(ips, i.IP)
-			continue
-		}
-		if i.Hostname != "" {
-			hostnames = append(hostnames, i.Hostname)
-		}
-	}
-	switch {
-	case len(ips) > 0:
-		filtered, recordType, ok := filterByIPFamily(ips, b.Shoot.GetInfo().Spec.Networking.IPFamilies)
-		if !ok {
-			return nil, "", fmt.Errorf("SelfHostedShootExposure ingress IPs %v do not match any configured IP family", ips)
-		}
-		return filtered, recordType, nil
-	case len(hostnames) > 0:
-		return hostnames, extensionsv1alpha1.DNSRecordTypeCNAME, nil
-	default:
-		return nil, "", fmt.Errorf("SelfHostedShootExposure ingress has neither IP(s) nor hostname(s)")
-	}
-}
-
-func (b *GardenadmBotanist) nodeAddressDNSRecordValues(ctx context.Context) ([]string, extensionsv1alpha1.DNSRecordType, error) {
 	nodes, err := b.ListControlPlaneNodes(ctx)
 	if err != nil {
 		return nil, "", err
 	}
-
-	addresses := make([]string, 0, len(nodes))
-	for _, node := range nodes {
-		addr, err := PreferredAddress(node.Status.Addresses)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed getting preferred address for node %q: %w", node.Name, err)
-		}
-		addresses = append(addresses, addr)
-	}
-
-	filtered, recordType, ok := filterByIPFamily(addresses, b.Shoot.GetInfo().Spec.Networking.IPFamilies)
-	if !ok {
-		return nil, "", fmt.Errorf("control plane node addresses %v do not match any configured IP family", addresses)
-	}
-	return filtered, recordType, nil
-}
-
-// filterByIPFamily returns the subset of addresses matching the first IP family in ipFamilies that has at least one
-// match, along with its DNS record type. The bool is false if no family matches.
-func filterByIPFamily(addresses []string, ipFamilies []gardencorev1beta1.IPFamily) ([]string, extensionsv1alpha1.DNSRecordType, bool) {
-	for _, family := range ipFamilies {
-		recordType := ipFamilyToDNSRecordType(family)
-		filtered := slices.DeleteFunc(slices.Clone(addresses), func(addr string) bool {
-			return extensionsv1alpha1helper.GetDNSRecordType(addr) != recordType
-		})
-		if len(filtered) > 0 {
-			return filtered, recordType, true
-		}
-	}
-	return nil, "", false
-}
-
-func ipFamilyToDNSRecordType(family gardencorev1beta1.IPFamily) extensionsv1alpha1.DNSRecordType {
-	if family == gardencorev1beta1.IPFamilyIPv6 {
-		return extensionsv1alpha1.DNSRecordTypeAAAA
-	}
-	return extensionsv1alpha1.DNSRecordTypeA
+	return extensionsv1alpha1helper.DNSValuesFromNodes(nodes, ipFamilies, corev1.NodeInternalIP, corev1.NodeExternalIP)
 }

--- a/pkg/gardenadm/botanist/dnsrecord_test.go
+++ b/pkg/gardenadm/botanist/dnsrecord_test.go
@@ -96,6 +96,20 @@ var _ = Describe("DNSRecord", func() {
 		b.Shoot.SetInfo(shoot)
 	}
 
+	// healthyControlPlaneNode returns a control-plane Node that passes health.CheckNode with the given addresses.
+	healthyControlPlaneNode := func(name string, addresses ...corev1.NodeAddress) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+				Addresses:  addresses,
+			},
+		}
+	}
+
 	Describe("#RestoreExternalDNSRecord", func() {
 		It("should fail if there are no control plane nodes", func(ctx SpecContext) {
 			node := &corev1.Node{
@@ -111,98 +125,64 @@ var _ = Describe("DNSRecord", func() {
 			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("no control plane nodes found"))
 		})
 
-		It("should fail if the control plane node doesn't have any addresses", func(ctx SpecContext) {
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: controlPlaneWorkerPoolName + "-1",
-					Labels: map[string]string{
-						"node-role.kubernetes.io/control-plane": "",
-					},
-				},
-			}
+		It("should fail if a control plane node has no addresses", func(ctx SpecContext) {
+			node := healthyControlPlaneNode(controlPlaneWorkerPoolName + "-1")
 			Expect(fakeClient.Create(ctx, node)).To(Succeed())
 
-			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("no addresses found in status")))
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("has no addresses")))
 		})
 
-		It("should fail if no node addresses match any configured IP family", func(ctx SpecContext) {
+		It("should fail if no node address matches the configured IP family", func(ctx SpecContext) {
 			shoot := b.Shoot.GetInfo()
 			shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv6}
 			b.Shoot.SetInfo(shoot)
 
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: controlPlaneWorkerPoolName + "-1",
-					Labels: map[string]string{
-						"node-role.kubernetes.io/control-plane": "",
-					},
-				},
-				Status: corev1.NodeStatus{
-					Addresses: []corev1.NodeAddress{{
-						Type:    corev1.NodeInternalIP,
-						Address: "10.0.0.1",
-					}},
-				},
-			}
+			node := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"})
 			Expect(fakeClient.Create(ctx, node)).To(Succeed())
 
-			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("do not match any configured IP family")))
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("configured IP family")))
 		})
 
-		It("should set the correct values and restore the DNSRecord", func(ctx SpecContext) {
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: controlPlaneWorkerPoolName + "-1",
-					Labels: map[string]string{
-						"node-role.kubernetes.io/control-plane": "",
-					},
-				},
-				Status: corev1.NodeStatus{
-					Addresses: []corev1.NodeAddress{{
-						Type:    corev1.NodeInternalIP,
-						Address: "10.0.0.1",
-					}},
-				},
-			}
+		It("should set the preferred (internal first) addresses and restore the DNSRecord", func(ctx SpecContext) {
+			// The internal address is preferred so the record stays resolvable within the cluster network even when
+			// the nodes have no externally routable addresses.
+			node1 := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-1",
+				corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+			)
+			node2 := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-2", corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "1.2.3.5"})
 
-			node2 := node.DeepCopy()
-			node2.Name = controlPlaneWorkerPoolName + "-2"
-			node2.Status.Addresses[0].Address = "10.0.0.2"
-
-			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+			Expect(fakeClient.Create(ctx, node1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, node2)).To(Succeed())
 
 			externalDNSRecord.EXPECT().SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
-			externalDNSRecord.EXPECT().SetValues([]string{node.Status.Addresses[0].Address, node2.Status.Addresses[0].Address})
+			externalDNSRecord.EXPECT().SetValues([]string{"10.0.0.1", "1.2.3.5"})
 			externalDNSRecord.EXPECT().Restore(gomock.Any(), gomock.Any()).Return(nil)
 			externalDNSRecord.EXPECT().Wait(gomock.Any()).Return(nil)
 
 			Expect(b.RestoreExternalDNSRecord(ctx)).To(Succeed())
 		})
 
-		It("should filter dual-stack node addresses to the first IP family", func(ctx SpecContext) {
+		It("should include unhealthy control plane nodes (restore is a one-shot at bootstrap)", func(ctx SpecContext) {
+			node := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"})
+			node.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}
+			Expect(fakeClient.Create(ctx, node)).To(Succeed())
+
+			externalDNSRecord.EXPECT().SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			externalDNSRecord.EXPECT().SetValues([]string{"10.0.0.1"})
+			externalDNSRecord.EXPECT().Restore(gomock.Any(), gomock.Any()).Return(nil)
+			externalDNSRecord.EXPECT().Wait(gomock.Any()).Return(nil)
+
+			Expect(b.RestoreExternalDNSRecord(ctx)).To(Succeed())
+		})
+
+		It("should filter dual-stack addresses to the first IP family", func(ctx SpecContext) {
 			shoot := b.Shoot.GetInfo()
 			shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4, gardencorev1beta1.IPFamilyIPv6}
 			b.Shoot.SetInfo(shoot)
 
-			node1 := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   controlPlaneWorkerPoolName + "-1",
-					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
-				},
-				Status: corev1.NodeStatus{
-					Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}},
-				},
-			}
-			node2 := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   controlPlaneWorkerPoolName + "-2",
-					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
-				},
-				Status: corev1.NodeStatus{
-					Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "fd12::1"}},
-				},
-			}
+			node1 := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"})
+			node2 := healthyControlPlaneNode(controlPlaneWorkerPoolName+"-2", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "fd12::1"})
 			Expect(fakeClient.Create(ctx, node1)).To(Succeed())
 			Expect(fakeClient.Create(ctx, node2)).To(Succeed())
 
@@ -220,13 +200,13 @@ var _ = Describe("DNSRecord", func() {
 			})
 
 			It("should fail if SelfHostedShootExposure has no ingress yet", func(ctx SpecContext) {
-				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("SelfHostedShootExposure has no ingress yet"))
+				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("exposure has no ingress yet"))
 			})
 
 			It("should fail if all ingress entries have neither IP nor hostname", func(ctx SpecContext) {
 				selfHostedShootExposure.Ingress = []corev1.LoadBalancerIngress{{IP: "", Hostname: ""}}
 
-				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError("SelfHostedShootExposure ingress has neither IP(s) nor hostname(s)"))
+				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("neither IPs nor hostnames")))
 			})
 
 			It("should use IPs when available", func(ctx SpecContext) {
@@ -305,7 +285,7 @@ var _ = Describe("DNSRecord", func() {
 					{IP: "10.0.0.1"},
 				}
 
-				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("do not match any configured IP family")))
+				Expect(b.RestoreExternalDNSRecord(ctx)).To(MatchError(ContainSubstring("configured IP family")))
 			})
 		})
 	})

--- a/pkg/gardenadm/botanist/dnsrecord_test.go
+++ b/pkg/gardenadm/botanist/dnsrecord_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -43,7 +44,7 @@ var _ = Describe("DNSRecord", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		externalDNSRecord = mockdnsrecord.NewMockInterface(ctrl)
-		selfHostedShootExposure = selfhostedshootexposure.New(logr.Discard(), fakeClient, &selfhostedshootexposure.Values{})
+		selfHostedShootExposure = selfhostedshootexposure.New(logr.Discard(), fakeClient, clock.RealClock{}, &selfhostedshootexposure.Values{})
 
 		b = &GardenadmBotanist{
 			Botanist: &botanistpkg.Botanist{

--- a/pkg/gardenadm/botanist/machines.go
+++ b/pkg/gardenadm/botanist/machines.go
@@ -36,10 +36,11 @@ func (b *GardenadmBotanist) GetMachineByIndex(index int) (*machinev1alpha1.Machi
 	return &b.controlPlaneMachines[index], nil
 }
 
-// addressTypePreference when retrieving the SSH Address of a node/machine. Higher value means higher priority.
+// addressTypePreference when picking a node/machine address. Higher value means higher priority.
 // Unknown address types have the lowest priority (0).
 var addressTypePreference = map[corev1.NodeAddressType]int{
-	// internal names have priority, as we jump via a bastion host
+	// internal names have priority: they are reachable from within the cluster network even when nodes have no
+	// externally routable addresses (and for SSH we jump via a bastion host)
 	corev1.NodeInternalIP:  5,
 	corev1.NodeInternalDNS: 4,
 	corev1.NodeExternalIP:  3,
@@ -48,9 +49,9 @@ var addressTypePreference = map[corev1.NodeAddressType]int{
 	corev1.NodeHostName: 1,
 }
 
-// PreferredAddress returns the preferred address of the given node/machine addresses based on addressTypePreference.
-// If the node/machine has no addresses, an error is returned.
-func PreferredAddress(addresses []corev1.NodeAddress) (string, error) {
+// PreferredNodeAddress returns the preferred address of the given node/machine addresses based on
+// addressTypePreference (prefer internal and IP to external and DNS). Returns an error if no addresses are given.
+func PreferredNodeAddress(addresses []corev1.NodeAddress) (string, error) {
 	if len(addresses) == 0 {
 		return "", fmt.Errorf("no addresses found in status")
 	}

--- a/pkg/gardenadm/botanist/machines_test.go
+++ b/pkg/gardenadm/botanist/machines_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("Machines", func() {
-	Describe("#PreferredAddress", func() {
+	Describe("#PreferredNodeAddress", func() {
 		var addresses []corev1.NodeAddress
 
 		BeforeEach(func() {
@@ -21,12 +21,12 @@ var _ = Describe("Machines", func() {
 		})
 
 		It("should return error if no addresses are present", func() {
-			Expect(PreferredAddress(addresses)).Error().To(MatchError(ContainSubstring("no addresses found")))
+			Expect(PreferredNodeAddress(addresses)).Error().To(MatchError(ContainSubstring("no addresses found")))
 		})
 
 		It("should return the only address present", func() {
 			addresses = []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}}
-			Expect(PreferredAddress(addresses)).To(Equal("1.2.3.4"))
+			Expect(PreferredNodeAddress(addresses)).To(Equal("1.2.3.4"))
 		})
 
 		It("should return the address with the highest preference", func() {
@@ -35,7 +35,7 @@ var _ = Describe("Machines", func() {
 				{Type: corev1.NodeHostName, Address: "host.local"},
 				{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
 			}
-			Expect(PreferredAddress(addresses)).To(Equal("10.0.0.2"))
+			Expect(PreferredNodeAddress(addresses)).To(Equal("10.0.0.2"))
 		})
 
 		It("should prefer InternalDNS over ExternalIP", func() {
@@ -43,12 +43,12 @@ var _ = Describe("Machines", func() {
 				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
 				{Type: corev1.NodeInternalDNS, Address: "internal.dns"},
 			}
-			Expect(PreferredAddress(addresses)).To(Equal("internal.dns"))
+			Expect(PreferredNodeAddress(addresses)).To(Equal("internal.dns"))
 		})
 
 		It("should return unknown type if only unknown is present", func() {
 			addresses = []corev1.NodeAddress{{Type: "UnknownType", Address: "unknown.addr"}}
-			Expect(PreferredAddress(addresses)).To(Equal("unknown.addr"))
+			Expect(PreferredNodeAddress(addresses)).To(Equal("unknown.addr"))
 		})
 
 		It("should prefer known type over unknown type", func() {
@@ -56,7 +56,7 @@ var _ = Describe("Machines", func() {
 				{Type: "UnknownType", Address: "unknown.addr"},
 				{Type: corev1.NodeExternalDNS, Address: "external.dns"},
 			}
-			Expect(PreferredAddress(addresses)).To(Equal("external.dns"))
+			Expect(PreferredNodeAddress(addresses)).To(Equal("external.dns"))
 		})
 	})
 })

--- a/pkg/gardenadm/botanist/ssh.go
+++ b/pkg/gardenadm/botanist/ssh.go
@@ -34,7 +34,7 @@ func (b *GardenadmBotanist) ConnectToControlPlaneMachine(ctx context.Context) er
 		return err
 	}
 
-	machineAddr, err := PreferredAddress(machine.Status.Addresses)
+	machineAddr, err := PreferredNodeAddress(machine.Status.Addresses)
 	if err != nil {
 		return fmt.Errorf("failed getting preferred address for machine %q: %w", machine.Name, err)
 	}

--- a/pkg/gardenlet/controller/add.go
+++ b/pkg/gardenlet/controller/add.go
@@ -135,7 +135,7 @@ func AddToManager(
 		}
 	}
 
-	if err := shoot.AddToManager(ctx, mgr, gardenCluster, seedCluster, seedClientSet, shootClientMap, *cfg, identity, gardenClusterIdentity, healthManager, seedName(cfg)); err != nil {
+	if err := shoot.AddToManager(ctx, mgr, gardenCluster, seedCluster, seedClientSet, shootClientMap, *cfg, identity, gardenClusterIdentity, healthManager, seedName(cfg), selfHostedShoot); err != nil {
 		return fmt.Errorf("failed adding Shoot controller: %w", err)
 	}
 

--- a/pkg/gardenlet/controller/shoot/add.go
+++ b/pkg/gardenlet/controller/shoot/add.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/care"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/lease"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/selfhostedshootexposure"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/state"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/status"
@@ -39,6 +41,7 @@ func AddToManager(
 	gardenClusterIdentity string,
 	healthManager healthz.Manager,
 	seedName string,
+	selfHostedShoot *gardencorev1beta1.Shoot,
 ) error {
 	// The ShootState reconciler is only enabled when:
 	// (a) the gardenlet is responsible for a self-hosted shoot (we always want ShootStates for such clusters in the
@@ -100,6 +103,12 @@ func AddToManager(
 	if gardenletutils.IsResponsibleForSelfHostedShoot() {
 		if err := lease.AddToManager(mgr, gardenCluster, seedClientSet.RESTClient(), healthManager, nil); err != nil {
 			return fmt.Errorf("failed adding lease reconciler: %w", err)
+		}
+
+		if err := (&selfhostedshootexposure.Reconciler{
+			ShootKey: client.ObjectKeyFromObject(selfHostedShoot),
+		}).AddToManager(mgr, gardenCluster); err != nil {
+			return fmt.Errorf("failed adding selfhostedshootexposure reconciler: %w", err)
 		}
 	}
 

--- a/pkg/gardenlet/controller/shoot/care/health.go
+++ b/pkg/gardenlet/controller/shoot/care/health.go
@@ -237,24 +237,9 @@ func (h *Health) getAllExtensionConditions(ctx context.Context) ([]healthchecker
 		return nil, nil, nil, nil, err
 	}
 
-	// Fetch ControllerRegistrations by getting each one referenced by the scoped installations.
-	// This avoids a global list, which is not permitted for the shoot gardenlet in self-hosted mode.
-	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
-	seen := sets.New[string]()
-	for _, inst := range controllerInstallations.Items {
-		name := inst.Spec.RegistrationRef.Name
-		if seen.Has(name) {
-			continue
-		}
-		seen.Insert(name)
-		reg := gardencorev1beta1.ControllerRegistration{}
-		if err := h.gardenClient.Get(ctx, client.ObjectKey{Name: name}, &reg); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, nil, nil, nil, err
-			}
-			continue
-		}
-		controllerRegistrations.Items = append(controllerRegistrations.Items, reg)
+	controllerRegistrations, err := gardenerutils.GetControllerRegistrationsForInstallations(ctx, h.gardenClient, controllerInstallations)
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	var (

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure
+
+import (
+	"context"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "self-hosted-shoot-exposure"
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Cluster) error {
+	if r.GardenClient == nil {
+		r.GardenClient = gardenCluster.GetClient()
+	}
+	if r.RuntimeClient == nil {
+		r.RuntimeClient = mgr.GetClient()
+	}
+	if r.Clock == nil {
+		r.Clock = clock.RealClock{}
+	}
+
+	// NOTE: ControllerRegistrations are intentionally not watched. A self-hosted gardenlet may not List/Watch them
+	// (RBAC, hence endpointUpdatesEnabled fetches them by name, indirectly via ControllerInstallations).
+	return builder.
+		ControllerManagedBy(mgr).
+		// Only one Shoot is managed, and every Node event enqueues the same key, so there is nothing to parallelize.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		Named(ControllerName).
+		WatchesRawSource(source.Kind[client.Object](mgr.GetCache(),
+			&corev1.Node{},
+			r.EventHandler(),
+			r.NodePredicate(),
+		)).
+		// Watch the Shoot so switching the exposure mechanism (or omitting exposure) reconciles without a Node event.
+		WatchesRawSource(source.Kind[client.Object](gardenCluster.GetCache(),
+			&gardencorev1beta1.Shoot{},
+			r.EventHandler(),
+			shootExposureChangePredicate(),
+		)).
+		// Watch the SelfHostedShootExposure for ingress changes by the exposure extension (e.g. a rotated LB IP).
+		WatchesRawSource(source.Kind[client.Object](mgr.GetCache(),
+			&extensionsv1alpha1.SelfHostedShootExposure{},
+			r.EventHandler(),
+			exposureIngressChangePredicate(),
+		)).
+		Complete(r)
+}
+
+// EventHandler returns a handler that enqueues the configured shoot key for every relevant Node event.
+func (r *Reconciler) EventHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
+		return []reconcile.Request{{NamespacedName: r.ShootKey}}
+	})
+}
+
+// NodePredicate triggers on control-plane Node events relevant to exposure: create/delete of a control-plane Node,
+// gaining/losing the control-plane label (after registration), and address or health-verdict changes on one.
+func (r *Reconciler) NodePredicate() predicate.Predicate {
+	isControlPlane := func(obj client.Object) bool {
+		_, ok := obj.GetLabels()[nodeRoleControlPlaneLabel]
+		return ok
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isControlPlane(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isControlPlane(e.Object) },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok1 := e.ObjectOld.(*corev1.Node)
+			newNode, ok2 := e.ObjectNew.(*corev1.Node)
+			if !ok1 || !ok2 {
+				return true
+			}
+			// React only if the node is (or was) a control-plane node. A label-membership change always matters;
+			// otherwise only address or health-verdict changes do.
+			oldCP, newCP := isControlPlane(oldNode), isControlPlane(newNode)
+			if !oldCP && !newCP {
+				return false
+			}
+			if oldCP != newCP || !slices.Equal(oldNode.Status.Addresses, newNode.Status.Addresses) {
+				return true
+			}
+			return (health.CheckNode(oldNode) == nil) != (health.CheckNode(newNode) == nil)
+		},
+	}
+}
+
+// exposureIngressChangePredicate triggers only when the ingress reported by the exposure extension changes.
+func exposureIngressChangePredicate() predicate.Predicate {
+	ingressOf := func(obj client.Object) []corev1.LoadBalancerIngress {
+		if exposure, ok := obj.(*extensionsv1alpha1.SelfHostedShootExposure); ok {
+			return exposure.Status.Ingress
+		}
+		return nil
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return false },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !apiequality.Semantic.DeepEqual(ingressOf(e.ObjectOld), ingressOf(e.ObjectNew))
+		},
+	}
+}
+
+// shootExposureChangePredicate triggers only when the control-plane exposure configuration changes (or the Shoot first
+// appears), so an unrelated Shoot update does not enqueue a reconcile.
+func shootExposureChangePredicate() predicate.Predicate {
+	exposureOf := func(obj client.Object) *gardencorev1beta1.Exposure {
+		shoot, ok := obj.(*gardencorev1beta1.Shoot)
+		if !ok {
+			return nil
+		}
+		if pool := v1beta1helper.ControlPlaneWorkerPoolForShoot(shoot.Spec.Provider.Workers); pool != nil && pool.ControlPlane != nil {
+			return pool.ControlPlane.Exposure
+		}
+		return nil
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(_ event.CreateEvent) bool { return true },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+		GenericFunc: func(_ event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !apiequality.Semantic.DeepEqual(exposureOf(e.ObjectOld), exposureOf(e.ObjectNew))
+		},
+	}
+}

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add.go
@@ -5,7 +5,6 @@
 package selfhostedshootexposure
 
 import (
-	"context"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,11 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
@@ -36,8 +35,8 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 	if r.GardenClient == nil {
 		r.GardenClient = gardenCluster.GetClient()
 	}
-	if r.RuntimeClient == nil {
-		r.RuntimeClient = mgr.GetClient()
+	if r.ShootClient == nil {
+		r.ShootClient = mgr.GetClient()
 	}
 	if r.Clock == nil {
 		r.Clock = clock.RealClock{}
@@ -47,41 +46,34 @@ func (r *Reconciler) AddToManager(mgr manager.Manager, gardenCluster cluster.Clu
 	// (RBAC, hence endpointUpdatesEnabled fetches them by name, indirectly via ControllerInstallations).
 	return builder.
 		ControllerManagedBy(mgr).
-		// Only one Shoot is managed, and every Node event enqueues the same key, so there is nothing to parallelize.
+		// Only one Shoot is managed, so there is nothing to parallelize.
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Named(ControllerName).
 		WatchesRawSource(source.Kind[client.Object](mgr.GetCache(),
 			&corev1.Node{},
-			r.EventHandler(),
+			&handler.EnqueueRequestForObject{},
 			r.NodePredicate(),
 		)).
 		// Watch the Shoot so switching the exposure mechanism (or omitting exposure) reconciles without a Node event.
 		WatchesRawSource(source.Kind[client.Object](gardenCluster.GetCache(),
 			&gardencorev1beta1.Shoot{},
-			r.EventHandler(),
-			shootExposureChangePredicate(),
+			&handler.EnqueueRequestForObject{},
+			r.ShootExposureChangePredicate(),
 		)).
 		// Watch the SelfHostedShootExposure for ingress changes by the exposure extension (e.g. a rotated LB IP).
 		WatchesRawSource(source.Kind[client.Object](mgr.GetCache(),
 			&extensionsv1alpha1.SelfHostedShootExposure{},
-			r.EventHandler(),
-			exposureIngressChangePredicate(),
+			&handler.EnqueueRequestForObject{},
+			r.ExposureIngressChangePredicate(),
 		)).
 		Complete(r)
-}
-
-// EventHandler returns a handler that enqueues the configured shoot key for every relevant Node event.
-func (r *Reconciler) EventHandler() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, _ client.Object) []reconcile.Request {
-		return []reconcile.Request{{NamespacedName: r.ShootKey}}
-	})
 }
 
 // NodePredicate triggers on control-plane Node events relevant to exposure: create/delete of a control-plane Node,
 // gaining/losing the control-plane label (after registration), and address or health-verdict changes on one.
 func (r *Reconciler) NodePredicate() predicate.Predicate {
 	isControlPlane := func(obj client.Object) bool {
-		_, ok := obj.GetLabels()[nodeRoleControlPlaneLabel]
+		_, ok := obj.GetLabels()[v1beta1constants.LabelNodeRoleControlPlane]
 		return ok
 	}
 	return predicate.Funcs{
@@ -92,7 +84,7 @@ func (r *Reconciler) NodePredicate() predicate.Predicate {
 			oldNode, ok1 := e.ObjectOld.(*corev1.Node)
 			newNode, ok2 := e.ObjectNew.(*corev1.Node)
 			if !ok1 || !ok2 {
-				return true
+				return false
 			}
 			// React only if the node is (or was) a control-plane node. A label-membership change always matters;
 			// otherwise only address or health-verdict changes do.
@@ -108,8 +100,8 @@ func (r *Reconciler) NodePredicate() predicate.Predicate {
 	}
 }
 
-// exposureIngressChangePredicate triggers only when the ingress reported by the exposure extension changes.
-func exposureIngressChangePredicate() predicate.Predicate {
+// ExposureIngressChangePredicate triggers only when the ingress reported by the exposure extension changes.
+func (r *Reconciler) ExposureIngressChangePredicate() predicate.Predicate {
 	ingressOf := func(obj client.Object) []corev1.LoadBalancerIngress {
 		if exposure, ok := obj.(*extensionsv1alpha1.SelfHostedShootExposure); ok {
 			return exposure.Status.Ingress
@@ -126,9 +118,9 @@ func exposureIngressChangePredicate() predicate.Predicate {
 	}
 }
 
-// shootExposureChangePredicate triggers only when the control-plane exposure configuration changes (or the Shoot first
+// ShootExposureChangePredicate triggers only when the control-plane exposure configuration changes (or the Shoot first
 // appears), so an unrelated Shoot update does not enqueue a reconcile.
-func shootExposureChangePredicate() predicate.Predicate {
+func (r *Reconciler) ShootExposureChangePredicate() predicate.Predicate {
 	exposureOf := func(obj client.Object) *gardencorev1beta1.Exposure {
 		shoot, ok := obj.(*gardencorev1beta1.Shoot)
 		if !ok {

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add_test.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/selfhostedshootexposure"
+)
+
+var _ = Describe("NodePredicate", func() {
+	const controlPlaneLabel = "node-role.kubernetes.io/control-plane"
+
+	var p predicate.Predicate
+
+	node := func(controlPlane bool, ready bool, addresses ...corev1.NodeAddress) *corev1.Node {
+		n := &corev1.Node{Status: corev1.NodeStatus{Addresses: addresses}}
+		if controlPlane {
+			n.Labels = map[string]string{controlPlaneLabel: ""}
+		}
+		status := corev1.ConditionFalse
+		if ready {
+			status = corev1.ConditionTrue
+		}
+		n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: status}}
+		return n
+	}
+	ip := func(address string) corev1.NodeAddress {
+		return corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: address}
+	}
+
+	BeforeEach(func() {
+		p = (&Reconciler{}).NodePredicate()
+	})
+
+	Describe("Create/Delete", func() {
+		It("should accept a control-plane node and reject a worker node", func() {
+			cp, worker := node(true, true, ip("10.0.0.1")), node(false, true, ip("10.0.0.2"))
+
+			Expect(p.Create(event.CreateEvent{Object: cp})).To(BeTrue())
+			Expect(p.Create(event.CreateEvent{Object: worker})).To(BeFalse())
+			Expect(p.Delete(event.DeleteEvent{Object: cp})).To(BeTrue())
+			Expect(p.Delete(event.DeleteEvent{Object: worker})).To(BeFalse())
+		})
+	})
+
+	Describe("Update", func() {
+		It("should accept a promotion (label added after registration)", func() {
+			// Same Ready node, only the control-plane label is added — the regression case.
+			Expect(p.Update(event.UpdateEvent{
+				ObjectOld: node(false, true, ip("10.0.0.1")),
+				ObjectNew: node(true, true, ip("10.0.0.1")),
+			})).To(BeTrue())
+		})
+
+		It("should accept a demotion (label removed)", func() {
+			Expect(p.Update(event.UpdateEvent{
+				ObjectOld: node(true, true, ip("10.0.0.1")),
+				ObjectNew: node(false, true, ip("10.0.0.1")),
+			})).To(BeTrue())
+		})
+
+		It("should accept an address change on a control-plane node", func() {
+			Expect(p.Update(event.UpdateEvent{
+				ObjectOld: node(true, true, ip("10.0.0.1")),
+				ObjectNew: node(true, true, ip("10.0.0.2")),
+			})).To(BeTrue())
+		})
+
+		It("should accept a health-verdict change on a control-plane node", func() {
+			Expect(p.Update(event.UpdateEvent{
+				ObjectOld: node(true, true, ip("10.0.0.1")),
+				ObjectNew: node(true, false, ip("10.0.0.1")),
+			})).To(BeTrue())
+		})
+
+		It("should reject an irrelevant change on a control-plane node", func() {
+			old := node(true, true, ip("10.0.0.1"))
+			updated := node(true, true, ip("10.0.0.1"))
+			updated.Annotations = map[string]string{"foo": "bar"}
+
+			Expect(p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated})).To(BeFalse())
+		})
+
+		It("should reject any change on a node that is not a control-plane node before or after", func() {
+			Expect(p.Update(event.UpdateEvent{
+				ObjectOld: node(false, true, ip("10.0.0.1")),
+				ObjectNew: node(false, false, ip("10.0.0.2")),
+			})).To(BeFalse())
+		})
+
+		It("should accept updates with non-Node objects (defensive)", func() {
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "x"}}})).To(BeTrue())
+		})
+	})
+})

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add_test.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/add_test.go
@@ -12,11 +12,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/selfhostedshootexposure"
 )
 
 var _ = Describe("NodePredicate", func() {
-	const controlPlaneLabel = "node-role.kubernetes.io/control-plane"
+	const controlPlaneLabel = v1beta1constants.LabelNodeRoleControlPlane
 
 	var p predicate.Predicate
 
@@ -96,8 +99,89 @@ var _ = Describe("NodePredicate", func() {
 			})).To(BeFalse())
 		})
 
-		It("should accept updates with non-Node objects (defensive)", func() {
-			Expect(p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "x"}}})).To(BeTrue())
+		It("should reject updates with non-Node objects", func() {
+			Expect(p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "x"}}})).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("ShootExposureChangePredicate", func() {
+	var p predicate.Predicate
+
+	shoot := func(exposure *gardencorev1beta1.Exposure) *gardencorev1beta1.Shoot {
+		return &gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+			{ControlPlane: &gardencorev1beta1.WorkerControlPlane{Exposure: exposure}},
+		}}}}
+	}
+	dnsExposure := &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}}
+	extensionExposure := &gardencorev1beta1.Exposure{Extension: &gardencorev1beta1.ExtensionExposure{Type: new("local")}}
+
+	BeforeEach(func() {
+		p = (&Reconciler{}).ShootExposureChangePredicate()
+	})
+
+	It("should accept creates so the initial state is reconciled", func() {
+		Expect(p.Create(event.CreateEvent{Object: shoot(dnsExposure)})).To(BeTrue())
+	})
+
+	It("should reject deletes", func() {
+		Expect(p.Delete(event.DeleteEvent{Object: shoot(dnsExposure)})).To(BeFalse())
+	})
+
+	It("should reject generic events", func() {
+		Expect(p.Generic(event.GenericEvent{Object: shoot(dnsExposure)})).To(BeFalse())
+	})
+
+	It("should accept an exposure mechanism switch", func() {
+		Expect(p.Update(event.UpdateEvent{ObjectOld: shoot(extensionExposure), ObjectNew: shoot(dnsExposure)})).To(BeTrue())
+	})
+
+	It("should accept exposure being removed", func() {
+		Expect(p.Update(event.UpdateEvent{ObjectOld: shoot(extensionExposure), ObjectNew: shoot(nil)})).To(BeTrue())
+	})
+
+	It("should reject an unrelated Shoot update", func() {
+		old, updated := shoot(extensionExposure), shoot(extensionExposure)
+		updated.Labels = map[string]string{"foo": "bar"}
+		Expect(p.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: updated})).To(BeFalse())
+	})
+})
+
+var _ = Describe("ExposureIngressChangePredicate", func() {
+	var p predicate.Predicate
+
+	exposure := func(ingress ...corev1.LoadBalancerIngress) *extensionsv1alpha1.SelfHostedShootExposure {
+		return &extensionsv1alpha1.SelfHostedShootExposure{Status: extensionsv1alpha1.SelfHostedShootExposureStatus{Ingress: ingress}}
+	}
+
+	BeforeEach(func() {
+		p = (&Reconciler{}).ExposureIngressChangePredicate()
+	})
+
+	It("should reject creates, deletes and generic events", func() {
+		Expect(p.Create(event.CreateEvent{Object: exposure()})).To(BeFalse())
+		Expect(p.Delete(event.DeleteEvent{Object: exposure()})).To(BeFalse())
+		Expect(p.Generic(event.GenericEvent{Object: exposure()})).To(BeFalse())
+	})
+
+	It("should accept an ingress change", func() {
+		Expect(p.Update(event.UpdateEvent{
+			ObjectOld: exposure(corev1.LoadBalancerIngress{IP: "1.2.3.4"}),
+			ObjectNew: exposure(corev1.LoadBalancerIngress{IP: "1.2.3.5"}),
+		})).To(BeTrue())
+	})
+
+	It("should accept the ingress first appearing", func() {
+		Expect(p.Update(event.UpdateEvent{
+			ObjectOld: exposure(),
+			ObjectNew: exposure(corev1.LoadBalancerIngress{IP: "1.2.3.4"}),
+		})).To(BeTrue())
+	})
+
+	It("should reject an update that does not change the ingress", func() {
+		Expect(p.Update(event.UpdateEvent{
+			ObjectOld: exposure(corev1.LoadBalancerIngress{IP: "1.2.3.4"}),
+			ObjectNew: exposure(corev1.LoadBalancerIngress{IP: "1.2.3.4"}),
+		})).To(BeFalse())
 	})
 })

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/api/extensions/v1alpha1/helper"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/component"
+	extensionsselfhostedshootexposure "github.com/gardener/gardener/pkg/component/extensions/selfhostedshootexposure"
+	"github.com/gardener/gardener/pkg/extensions"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+const nodeRoleControlPlaneLabel = "node-role.kubernetes.io/control-plane"
+
+// Reconciler keeps the SelfHostedShootExposure endpoints (or the external DNSRecord values in DNS-only setups) in
+// sync with the self-hosted shoot's control-plane Node addresses.
+type Reconciler struct {
+	GardenClient  client.Client
+	RuntimeClient client.Client
+	ShootKey      types.NamespacedName
+	Clock         clock.PassiveClock
+}
+
+// Reconcile recomputes the control-plane endpoints from the current Node state and patches the SelfHostedShootExposure
+// resource or the external DNSRecord accordingly.
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx).WithName(ControllerName)
+
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := r.GardenClient.Get(ctx, r.ShootKey, shoot); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed getting Shoot: %w", err)
+	}
+
+	if v1beta1helper.HasExtensionExposure(shoot) {
+		// Extension-based exposure: some extensions opt out of continuously updated endpoints via the ControllerRegistration.
+		enabled, err := r.endpointUpdatesEnabled(ctx, shoot)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if !enabled {
+			log.V(1).Info("Endpoint updates disabled by ControllerRegistration")
+			return reconcile.Result{}, nil
+		}
+
+		return reconcile.Result{}, r.reconcileExtensionExposure(ctx, log, shoot)
+	}
+
+	if v1beta1helper.HasDNSExposure(shoot) {
+		// DNS-based exposure: the external DNSRecord points directly at the control-plane nodes' (preferably external) addresses.
+		return reconcile.Result{}, r.reconcileDNSExposure(ctx, log, shoot)
+	}
+
+	// Exposure is omitted. If it was previously extension-based: point the external
+	// DNSRecord at the control-plane nodes, then delete the SelfHostedShootExposure. Otherwise: do nothing.
+	return reconcile.Result{}, r.reconcileExposureDisabled(ctx, log, shoot)
+}
+
+func (r *Reconciler) reconcileDNSExposure(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
+	nodes, err := r.listControlPlaneNodes(ctx)
+	if err != nil {
+		return err
+	}
+	// Steady-state DNS exposure: the record tracks the healthy nodes' preferably external addresses (erroring keeps the last good values).
+	if err := r.updateExternalDNSRecordFromNodes(ctx, log, shoot, health.FilterHealthyNodes(nodes), corev1.NodeExternalIP, corev1.NodeInternalIP); err != nil {
+		return err
+	}
+	// Remove a SelfHostedShootExposure left over from a previous extension-based exposure (switch).
+	return r.deleteExposureIfExists(ctx, log, shoot)
+}
+
+// reconcileExposureDisabled performs the switch-off handoff for extension-based exposure to unmanaged.
+func (r *Reconciler) reconcileExposureDisabled(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
+	exposure, err := r.getExposure(ctx, shoot)
+	if err != nil || exposure == nil {
+		return err
+	}
+	if exposure.DeletionTimestamp != nil {
+		// Deletion already in flight; the final DNSRecord update was done on the reconcile that issued it.
+		return nil
+	}
+
+	// Bootstrap address semantics: keep the record resolvable within the cluster network after the handoff.
+	nodes, err := r.listControlPlaneNodes(ctx)
+	if err != nil {
+		return err
+	}
+	if err := r.updateExternalDNSRecordFromNodes(ctx, log, shoot, nodes, corev1.NodeInternalIP, corev1.NodeExternalIP); err != nil {
+		return err
+	}
+
+	log.Info("Control plane exposure disabled, deleting SelfHostedShootExposure after final external DNSRecord update")
+	return extensions.DeleteExtensionObject(ctx, r.RuntimeClient, exposure)
+}
+
+// updateExternalDNSRecordFromNodes computes the DNSRecord values from the given nodes (in the given address-type
+// preference order) and patches the external DNSRecord.
+func (r *Reconciler) updateExternalDNSRecordFromNodes(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot, nodes []corev1.Node, addressTypePreference ...corev1.NodeAddressType) error {
+	values, recordType, err := extensionsv1alpha1helper.DNSValuesFromNodes(nodes, shoot.Spec.Networking.IPFamilies, addressTypePreference...)
+	if err != nil {
+		return err
+	}
+	return r.patchExternalDNSRecord(ctx, log, shoot, values, recordType)
+}
+
+// getExposure returns the shoot's SelfHostedShootExposure, or nil if it does not exist.
+func (r *Reconciler) getExposure(ctx context.Context, shoot *gardencorev1beta1.Shoot) (*extensionsv1alpha1.SelfHostedShootExposure, error) {
+	exposure := &extensionsv1alpha1.SelfHostedShootExposure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shoot.Name,
+			Namespace: v1beta1helper.ControlPlaneNamespaceForShoot(shoot),
+		},
+	}
+	if err := r.RuntimeClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return exposure, nil
+}
+
+// deleteExposureIfExists deletes the shoot's SelfHostedShootExposure if present (idempotent), used when exposure is no
+// longer extension-based.
+func (r *Reconciler) deleteExposureIfExists(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
+	exposure, err := r.getExposure(ctx, shoot)
+	if err != nil || exposure == nil || exposure.DeletionTimestamp != nil {
+		return err
+	}
+	log.Info("Deleting SelfHostedShootExposure left over from a previous extension-based exposure")
+	return extensions.DeleteExtensionObject(ctx, r.RuntimeClient, exposure)
+}
+
+// patchExternalDNSRecord keeps the shoot's external DNSRecord in sync with the desired values and record type.
+func (r *Reconciler) patchExternalDNSRecord(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot, values []string, recordType extensionsv1alpha1.DNSRecordType) error {
+	slices.Sort(values)
+
+	dnsRecord := &extensionsv1alpha1.DNSRecord{}
+	key := types.NamespacedName{
+		Name:      shoot.Name + "-" + v1beta1constants.DNSRecordExternalName,
+		Namespace: v1beta1helper.ControlPlaneNamespaceForShoot(shoot),
+	}
+	if err := r.RuntimeClient.Get(ctx, key, dnsRecord); err != nil {
+		return fmt.Errorf("failed getting external DNSRecord %q: %w", key, err)
+	}
+
+	if dnsRecord.Spec.RecordType == recordType && slices.Equal(dnsRecord.Spec.Values, values) {
+		log.V(1).Info("External DNSRecord already up-to-date", "recordType", recordType, "values", values)
+		return nil
+	}
+
+	patch := client.MergeFrom(dnsRecord.DeepCopy())
+	dnsRecord.Spec.Values = values
+	dnsRecord.Spec.RecordType = recordType
+	metav1.SetMetaDataAnnotation(&dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+	if err := r.RuntimeClient.Patch(ctx, dnsRecord, patch); err != nil {
+		return fmt.Errorf("failed patching external DNSRecord %q: %w", key, err)
+	}
+
+	log.Info("Updated external DNSRecord", "recordType", recordType, "values", values)
+	return nil
+}
+
+func (r *Reconciler) endpointUpdatesEnabled(ctx context.Context, shoot *gardencorev1beta1.Shoot) (bool, error) {
+	controllerInstallations := &gardencorev1beta1.ControllerInstallationList{}
+	if err := r.GardenClient.List(ctx, controllerInstallations, client.MatchingFields{
+		core.ShootRefName:      shoot.Name,
+		core.ShootRefNamespace: shoot.Namespace,
+	}); err != nil {
+		return false, fmt.Errorf("failed listing ControllerInstallations: %w", err)
+	}
+
+	registrations, err := gardenerutils.GetControllerRegistrationsForInstallations(ctx, r.GardenClient, controllerInstallations)
+	if err != nil {
+		return false, fmt.Errorf("failed getting ControllerRegistrations: %w", err)
+	}
+
+	return v1beta1helper.ContinuousEndpointUpdateEnabled(registrations.Items, v1beta1helper.SelfHostedShootExposureExtensionType(shoot)), nil
+}
+
+func (r *Reconciler) listControlPlaneNodes(ctx context.Context) ([]corev1.Node, error) {
+	nodes := &corev1.NodeList{}
+	if err := r.RuntimeClient.List(ctx, nodes, client.MatchingLabels{nodeRoleControlPlaneLabel: ""}); err != nil {
+		return nil, fmt.Errorf("failed listing control-plane nodes: %w", err)
+	}
+	return nodes.Items, nil
+}
+
+func (r *Reconciler) reconcileExtensionExposure(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
+	nodes, err := r.listControlPlaneNodes(ctx)
+	if err != nil {
+		return err
+	}
+
+	endpoints, err := gardenerutils.ControlPlaneEndpointsFromNodes(nodes)
+	if err != nil {
+		return err
+	}
+
+	values := &extensionsselfhostedshootexposure.Values{
+		Name:      shoot.Name,
+		Namespace: v1beta1helper.ControlPlaneNamespaceForShoot(shoot),
+		Type:      v1beta1helper.SelfHostedShootExposureExtensionType(shoot),
+		Endpoints: endpoints,
+	}
+	if v1beta1helper.HasManagedInfrastructure(shoot) {
+		values.CredentialsRef = &corev1.ObjectReference{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+			Name:       v1beta1constants.SecretNameCloudProvider,
+			Namespace:  values.Namespace,
+		}
+	}
+
+	c := extensionsselfhostedshootexposure.New(log, r.RuntimeClient, values)
+	if r.Clock != nil {
+		c.Clock = r.Clock
+	}
+
+	existing, err := r.getExposure(ctx, shoot)
+	if err != nil {
+		return err
+	}
+
+	if existing != nil && health.CheckExtensionObject(existing) == nil &&
+		existing.Spec.Type == values.Type &&
+		apiequality.Semantic.DeepEqual(existing.Spec.Endpoints, values.Endpoints) {
+		c.Ingress = existing.Status.Ingress
+	} else if err := component.OpWait(c).Deploy(ctx); err != nil {
+		return err
+	}
+
+	dnsValues, recordType, err := extensionsv1alpha1helper.DNSValuesFromIngress(c.Ingress, shoot.Spec.Networking.IPFamilies)
+	if err != nil {
+		return err
+	}
+	return r.patchExternalDNSRecord(ctx, log, shoot, dnsValues, recordType)
+}

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
@@ -45,7 +45,7 @@ type Reconciler struct {
 // Reconcile recomputes the control-plane endpoints from the current Node state and patches the SelfHostedShootExposure
 // resource or the external DNSRecord accordingly.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-	log := logf.FromContext(ctx).WithName(ControllerName)
+	log := logf.FromContext(ctx)
 
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := r.GardenClient.Get(ctx, r.ShootKey, shoot); err != nil {
@@ -235,8 +235,7 @@ func (r *Reconciler) reconcileExtensionExposure(ctx context.Context, log logr.Lo
 		}
 	}
 
-	c := extensionsselfhostedshootexposure.New(log, r.ShootClient, values)
-	c.Clock = r.Clock
+	c := extensionsselfhostedshootexposure.New(log, r.ShootClient, r.Clock, values)
 
 	existing, err := r.getExposure(ctx, shoot)
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler.go
@@ -33,15 +33,13 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
-const nodeRoleControlPlaneLabel = "node-role.kubernetes.io/control-plane"
-
 // Reconciler keeps the SelfHostedShootExposure endpoints (or the external DNSRecord values in DNS-only setups) in
 // sync with the self-hosted shoot's control-plane Node addresses.
 type Reconciler struct {
-	GardenClient  client.Client
-	RuntimeClient client.Client
-	ShootKey      types.NamespacedName
-	Clock         clock.PassiveClock
+	GardenClient client.Client
+	ShootClient  client.Client
+	ShootKey     types.NamespacedName
+	Clock        clock.Clock
 }
 
 // Reconcile recomputes the control-plane endpoints from the current Node state and patches the SelfHostedShootExposure
@@ -61,7 +59,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		// Extension-based exposure: some extensions opt out of continuously updated endpoints via the ControllerRegistration.
 		enabled, err := r.endpointUpdatesEnabled(ctx, shoot)
 		if err != nil {
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("failed checking whether continuous endpoint updates are enabled: %w", err)
 		}
 		if !enabled {
 			log.V(1).Info("Endpoint updates disabled by ControllerRegistration")
@@ -84,11 +82,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 func (r *Reconciler) reconcileDNSExposure(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
 	nodes, err := r.listControlPlaneNodes(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed reconciling DNS-based exposure: %w", err)
 	}
 	// Steady-state DNS exposure: the record tracks the healthy nodes' preferably external addresses (erroring keeps the last good values).
 	if err := r.updateExternalDNSRecordFromNodes(ctx, log, shoot, health.FilterHealthyNodes(nodes), corev1.NodeExternalIP, corev1.NodeInternalIP); err != nil {
-		return err
+		return fmt.Errorf("failed reconciling DNS-based exposure: %w", err)
 	}
 	// Remove a SelfHostedShootExposure left over from a previous extension-based exposure (switch).
 	return r.deleteExposureIfExists(ctx, log, shoot)
@@ -108,14 +106,14 @@ func (r *Reconciler) reconcileExposureDisabled(ctx context.Context, log logr.Log
 	// Bootstrap address semantics: keep the record resolvable within the cluster network after the handoff.
 	nodes, err := r.listControlPlaneNodes(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed disabling control plane exposure: %w", err)
 	}
 	if err := r.updateExternalDNSRecordFromNodes(ctx, log, shoot, nodes, corev1.NodeInternalIP, corev1.NodeExternalIP); err != nil {
-		return err
+		return fmt.Errorf("failed disabling control plane exposure: %w", err)
 	}
 
 	log.Info("Control plane exposure disabled, deleting SelfHostedShootExposure after final external DNSRecord update")
-	return extensions.DeleteExtensionObject(ctx, r.RuntimeClient, exposure)
+	return extensions.DeleteExtensionObject(ctx, r.ShootClient, exposure)
 }
 
 // updateExternalDNSRecordFromNodes computes the DNSRecord values from the given nodes (in the given address-type
@@ -136,11 +134,11 @@ func (r *Reconciler) getExposure(ctx context.Context, shoot *gardencorev1beta1.S
 			Namespace: v1beta1helper.ControlPlaneNamespaceForShoot(shoot),
 		},
 	}
-	if err := r.RuntimeClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure); err != nil {
+	if err := r.ShootClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed getting SelfHostedShootExposure: %w", err)
 	}
 	return exposure, nil
 }
@@ -153,7 +151,7 @@ func (r *Reconciler) deleteExposureIfExists(ctx context.Context, log logr.Logger
 		return err
 	}
 	log.Info("Deleting SelfHostedShootExposure left over from a previous extension-based exposure")
-	return extensions.DeleteExtensionObject(ctx, r.RuntimeClient, exposure)
+	return extensions.DeleteExtensionObject(ctx, r.ShootClient, exposure)
 }
 
 // patchExternalDNSRecord keeps the shoot's external DNSRecord in sync with the desired values and record type.
@@ -165,7 +163,7 @@ func (r *Reconciler) patchExternalDNSRecord(ctx context.Context, log logr.Logger
 		Name:      shoot.Name + "-" + v1beta1constants.DNSRecordExternalName,
 		Namespace: v1beta1helper.ControlPlaneNamespaceForShoot(shoot),
 	}
-	if err := r.RuntimeClient.Get(ctx, key, dnsRecord); err != nil {
+	if err := r.ShootClient.Get(ctx, key, dnsRecord); err != nil {
 		return fmt.Errorf("failed getting external DNSRecord %q: %w", key, err)
 	}
 
@@ -178,7 +176,7 @@ func (r *Reconciler) patchExternalDNSRecord(ctx context.Context, log logr.Logger
 	dnsRecord.Spec.Values = values
 	dnsRecord.Spec.RecordType = recordType
 	metav1.SetMetaDataAnnotation(&dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-	if err := r.RuntimeClient.Patch(ctx, dnsRecord, patch); err != nil {
+	if err := r.ShootClient.Patch(ctx, dnsRecord, patch); err != nil {
 		return fmt.Errorf("failed patching external DNSRecord %q: %w", key, err)
 	}
 
@@ -205,7 +203,7 @@ func (r *Reconciler) endpointUpdatesEnabled(ctx context.Context, shoot *gardenco
 
 func (r *Reconciler) listControlPlaneNodes(ctx context.Context) ([]corev1.Node, error) {
 	nodes := &corev1.NodeList{}
-	if err := r.RuntimeClient.List(ctx, nodes, client.MatchingLabels{nodeRoleControlPlaneLabel: ""}); err != nil {
+	if err := r.ShootClient.List(ctx, nodes, client.MatchingLabels{v1beta1constants.LabelNodeRoleControlPlane: ""}); err != nil {
 		return nil, fmt.Errorf("failed listing control-plane nodes: %w", err)
 	}
 	return nodes.Items, nil
@@ -214,12 +212,12 @@ func (r *Reconciler) listControlPlaneNodes(ctx context.Context) ([]corev1.Node, 
 func (r *Reconciler) reconcileExtensionExposure(ctx context.Context, log logr.Logger, shoot *gardencorev1beta1.Shoot) error {
 	nodes, err := r.listControlPlaneNodes(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed reconciling extension-based exposure: %w", err)
 	}
 
 	endpoints, err := gardenerutils.ControlPlaneEndpointsFromNodes(nodes)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed reconciling extension-based exposure: %w", err)
 	}
 
 	values := &extensionsselfhostedshootexposure.Values{
@@ -237,14 +235,12 @@ func (r *Reconciler) reconcileExtensionExposure(ctx context.Context, log logr.Lo
 		}
 	}
 
-	c := extensionsselfhostedshootexposure.New(log, r.RuntimeClient, values)
-	if r.Clock != nil {
-		c.Clock = r.Clock
-	}
+	c := extensionsselfhostedshootexposure.New(log, r.ShootClient, values)
+	c.Clock = r.Clock
 
 	existing, err := r.getExposure(ctx, shoot)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed reconciling extension-based exposure: %w", err)
 	}
 
 	if existing != nil && health.CheckExtensionObject(existing) == nil &&
@@ -252,12 +248,12 @@ func (r *Reconciler) reconcileExtensionExposure(ctx context.Context, log logr.Lo
 		apiequality.Semantic.DeepEqual(existing.Spec.Endpoints, values.Endpoints) {
 		c.Ingress = existing.Status.Ingress
 	} else if err := component.OpWait(c).Deploy(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed reconciling extension-based exposure: %w", err)
 	}
 
 	dnsValues, recordType, err := extensionsv1alpha1helper.DNSValuesFromIngress(c.Ingress, shoot.Spec.Networking.IPFamilies)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed reconciling extension-based exposure: %w", err)
 	}
 	return r.patchExternalDNSRecord(ctx, log, shoot, dnsValues, recordType)
 }

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler_test.go
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot/selfhostedshootexposure"
+)
+
+var _ = Describe("Reconciler", func() {
+	const shootName = "my-shoot"
+
+	var (
+		ctx = context.Background()
+
+		gardenClient  client.Client
+		runtimeClient client.Client
+		runtimeScheme *runtime.Scheme
+		reconciler    *Reconciler
+
+		shoot     *gardencorev1beta1.Shoot
+		dnsRecord *extensionsv1alpha1.DNSRecord
+
+		// controlPlaneNode returns a healthy control-plane Node with the given addresses.
+		controlPlaneNode = func(name string, addresses ...corev1.NodeAddress) *corev1.Node {
+			return &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   name,
+					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					Addresses:  addresses,
+				},
+			}
+		}
+		externalIP = func(address string) corev1.NodeAddress {
+			return corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address}
+		}
+	)
+
+	BeforeEach(func() {
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: "garden-project"},
+			Spec: gardencorev1beta1.ShootSpec{
+				Provider: gardencorev1beta1.Provider{
+					Type: "local",
+					Workers: []gardencorev1beta1.Worker{{
+						Name: "control-plane",
+						ControlPlane: &gardencorev1beta1.WorkerControlPlane{
+							// DNS-based exposure (Extension is nil).
+							Exposure: &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}},
+						},
+					}},
+				},
+				Networking: &gardencorev1beta1.Networking{
+					IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				},
+			},
+		}
+
+		// The external DNSRecord already exists (created during bootstrapping), the controller only keeps it in sync.
+		dnsRecord = &extensionsv1alpha1.DNSRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName + "-" + v1beta1constants.DNSRecordExternalName,
+				Namespace: metav1.NamespaceSystem,
+			},
+		}
+
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(shoot).Build()
+
+		runtimeScheme = runtime.NewScheme()
+		Expect(kubernetes.AddSeedSchemeToScheme(runtimeScheme)).To(Succeed())
+		Expect(extensionsv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
+		runtimeClient = fakeclient.NewClientBuilder().WithScheme(runtimeScheme).Build()
+
+		reconciler = &Reconciler{
+			GardenClient:  gardenClient,
+			RuntimeClient: runtimeClient,
+			ShootKey:      client.ObjectKeyFromObject(shoot),
+			Clock:         testclock.NewFakeClock(time.Now()),
+		}
+	})
+
+	It("should do nothing if the Shoot is gone", func() {
+		Expect(gardenClient.Delete(ctx, shoot)).To(Succeed())
+
+		Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+	})
+
+	It("should do nothing if the control plane exposure is not configured", func() {
+		shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = nil
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(shoot).Build()
+		reconciler.GardenClient = gardenClient
+
+		Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+	})
+
+	Context("DNS-based exposure", func() {
+		It("should patch the external DNSRecord with the sorted external node addresses", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.5")))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-2", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			// Equal (not ConsistOf) on purpose: the values must be sorted so equal node sets don't cause unnecessary updates.
+			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4", "1.2.3.5"}))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should not patch the DNSRecord when it is already up-to-date", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			dnsRecord.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeA
+			dnsRecord.Spec.Values = []string{"1.2.3.4"}
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			// No reconcile annotation means the no-op guard skipped the patch entirely.
+			Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+		})
+
+		It("should fall back to a node's internal address if it has no external one (e.g. local setups)", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(Equal([]string{"10.0.0.1"}))
+		})
+
+		It("should ignore the addresses of unhealthy nodes", func() {
+			unhealthy := controlPlaneNode("cp-2", externalIP("1.2.3.5"))
+			unhealthy.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, unhealthy)).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4"}))
+		})
+
+		It("should fail if no healthy node has a usable address", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeHostName, Address: "cp-1"}))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(MatchError(ContainSubstring("matches a configured IP family")))
+		})
+
+		It("should delete a SelfHostedShootExposure left over from a previous extension-based exposure", func() {
+			leftover := &extensionsv1alpha1.SelfHostedShootExposure{
+				ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: metav1.NamespaceSystem},
+			}
+			Expect(runtimeClient.Create(ctx, leftover)).To(Succeed())
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4"}))
+
+			err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(leftover), leftover)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "orphaned SelfHostedShootExposure must be deleted")
+		})
+	})
+
+	Context("extension-based exposure", func() {
+		const exposureType = "local"
+
+		var (
+			fakeClock             *testclock.FakeClock
+			endpointUpdateEnabled *bool
+		)
+
+		BeforeEach(func() {
+			fakeClock = testclock.NewFakeClock(time.Now())
+			// defaulting to true
+			endpointUpdateEnabled = nil
+
+			shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = &gardencorev1beta1.Exposure{
+				Extension: &gardencorev1beta1.ExtensionExposure{Type: new(exposureType)},
+			}
+
+			// The runtime client simulates the exposure extension controller: the moment a SelfHostedShootExposure is
+			// created/patched with the reconcile operation annotation, it stamps a successful status with an ingress so
+			// the component's Wait succeeds on its first poll.
+			stampExposureReady := func(ctx context.Context, c client.WithWatch, obj client.Object) error {
+				exposure, ok := obj.(*extensionsv1alpha1.SelfHostedShootExposure)
+				if !ok {
+					return nil
+				}
+				if err := c.Get(ctx, client.ObjectKeyFromObject(exposure), exposure); err != nil {
+					return err
+				}
+				if _, hasOp := exposure.Annotations[v1beta1constants.GardenerOperation]; !hasOp {
+					return nil
+				}
+
+				withoutOp := exposure.DeepCopy()
+				delete(exposure.Annotations, v1beta1constants.GardenerOperation)
+				if err := c.Patch(ctx, exposure, client.MergeFrom(withoutOp)); err != nil {
+					return err
+				}
+
+				beforeStatus := exposure.DeepCopy()
+				exposure.Status.ObservedGeneration = exposure.Generation
+				exposure.Status.LastError = nil
+				exposure.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:           gardencorev1beta1.LastOperationTypeReconcile,
+					State:          gardencorev1beta1.LastOperationStateSucceeded,
+					LastUpdateTime: metav1.NewTime(fakeClock.Now().UTC().Add(time.Second)),
+				}
+				exposure.Status.Ingress = []corev1.LoadBalancerIngress{{IP: "5.6.7.8"}}
+				return c.Status().Patch(ctx, exposure, client.MergeFrom(beforeStatus))
+			}
+
+			runtimeClient = fakeclient.NewClientBuilder().
+				WithScheme(runtimeScheme).
+				WithStatusSubresource(&extensionsv1alpha1.SelfHostedShootExposure{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if err := c.Create(ctx, obj, opts...); err != nil {
+							return err
+						}
+						return stampExposureReady(ctx, c, obj)
+					},
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+							return err
+						}
+						return stampExposureReady(ctx, c, obj)
+					},
+				}).
+				Build()
+		})
+
+		JustBeforeEach(func() {
+			controllerRegistration := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider-local"},
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{{
+						Kind:                     extensionsv1alpha1.SelfHostedShootExposureResource,
+						Type:                     exposureType,
+						ContinuousEndpointUpdate: endpointUpdateEnabled,
+					}},
+				},
+			}
+			// The controller derives the ControllerRegistration from the shoot's ControllerInstallations.
+			controllerInstallation := &gardencorev1beta1.ControllerInstallation{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider-local"},
+				Spec: gardencorev1beta1.ControllerInstallationSpec{
+					RegistrationRef: corev1.ObjectReference{Name: controllerRegistration.Name},
+					ShootRef:        &corev1.ObjectReference{Name: shoot.Name, Namespace: shoot.Namespace},
+				},
+			}
+
+			gardenClient = fakeclient.NewClientBuilder().
+				WithScheme(kubernetes.GardenScheme).
+				WithObjects(shoot, controllerRegistration, controllerInstallation).
+				WithIndex(&gardencorev1beta1.ControllerInstallation{}, core.ShootRefName, func(o client.Object) []string {
+					if ref := o.(*gardencorev1beta1.ControllerInstallation).Spec.ShootRef; ref != nil {
+						return []string{ref.Name}
+					}
+					return nil
+				}).
+				WithIndex(&gardencorev1beta1.ControllerInstallation{}, core.ShootRefNamespace, func(o client.Object) []string {
+					if ref := o.(*gardencorev1beta1.ControllerInstallation).Spec.ShootRef; ref != nil {
+						return []string{ref.Namespace}
+					}
+					return nil
+				}).
+				Build()
+
+			reconciler = &Reconciler{
+				GardenClient:  gardenClient,
+				RuntimeClient: runtimeClient,
+				ShootKey:      client.ObjectKeyFromObject(shoot),
+				Clock:         fakeClock,
+			}
+		})
+
+		It("should deploy the SelfHostedShootExposure and patch the DNSRecord from its ingress", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			// The exposure resource was created carrying the control-plane node endpoints (all addresses, the extension
+			// decides which to use).
+			exposure := &extensionsv1alpha1.SelfHostedShootExposure{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)).To(Succeed())
+			Expect(exposure.Spec.Type).To(Equal(exposureType))
+			Expect(exposure.Spec.Endpoints).To(HaveLen(1))
+			Expect(exposure.Spec.Endpoints[0].NodeName).To(Equal("cp-1"))
+
+			// The DNSRecord was updated from the extension-reported ingress, not from the node addresses.
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(updated.Spec.Values).To(Equal([]string{"5.6.7.8"}))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should reuse the reported ingress without re-triggering the extension when endpoints are unchanged", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			// An already-reconciled exposure targeting the same endpoints, reporting a distinct ingress.
+			exposure := &extensionsv1alpha1.SelfHostedShootExposure{
+				ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: metav1.NamespaceSystem},
+				Spec: extensionsv1alpha1.SelfHostedShootExposureSpec{
+					DefaultSpec: extensionsv1alpha1.DefaultSpec{Type: exposureType},
+					Endpoints: []extensionsv1alpha1.ControlPlaneEndpoint{
+						{NodeName: "cp-1", Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}}},
+					},
+				},
+			}
+			Expect(runtimeClient.Create(ctx, exposure)).To(Succeed())
+			exposure.Status.ObservedGeneration = exposure.Generation
+			exposure.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile, State: gardencorev1beta1.LastOperationStateSucceeded}
+			exposure.Status.Ingress = []corev1.LoadBalancerIngress{{IP: "9.9.9.9"}}
+			Expect(runtimeClient.Status().Update(ctx, exposure)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			// The DNSRecord was set from the pre-existing ingress (9.9.9.9); a re-trigger would have stamped 5.6.7.8.
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(Equal([]string{"9.9.9.9"}))
+		})
+
+		When("the extension opted out of endpoint updates via the ControllerRegistration", func() {
+			BeforeEach(func() {
+				endpointUpdateEnabled = new(false)
+			})
+
+			It("should not deploy the SelfHostedShootExposure nor touch the DNSRecord", func() {
+				Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+				Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+				Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+				exposure := &extensionsv1alpha1.SelfHostedShootExposure{}
+				err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "SelfHostedShootExposure must not be created")
+
+				updated := &extensionsv1alpha1.DNSRecord{}
+				Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+				Expect(updated.Spec.Values).To(BeEmpty())
+				Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+			})
+		})
+	})
+
+	Context("exposure switch-off (disable transition)", func() {
+		BeforeEach(func() {
+			// Exposure is omitted; a SelfHostedShootExposure from the prior extension-based setup may still exist.
+			shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = nil
+			gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(shoot).Build()
+			reconciler.GardenClient = gardenClient
+		})
+
+		It("should flip the DNSRecord to the node addresses and delete the SelfHostedShootExposure", func() {
+			exposure := &extensionsv1alpha1.SelfHostedShootExposure{
+				ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: metav1.NamespaceSystem},
+			}
+			Expect(runtimeClient.Create(ctx, exposure)).To(Succeed())
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			// The record still points at the old extension ingress.
+			dnsRecord.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeA
+			dnsRecord.Spec.Values = []string{"5.6.7.8"}
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			// The DNSRecord was flipped to the control-plane node addresses one last time.
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(Equal([]string{"10.0.0.1"}))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+
+			// The SelfHostedShootExposure was deleted, leaving the record to the operator.
+			err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "SelfHostedShootExposure must be deleted")
+		})
+
+		It("should do nothing when no SelfHostedShootExposure exists (DNS-based or never managed)", func() {
+			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+
+			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.Values).To(BeEmpty())
+			Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
+		})
+	})
+})

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler_test.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/reconciler_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Reconciler", func() {
 		ctx = context.Background()
 
 		gardenClient  client.Client
-		runtimeClient client.Client
+		shootClient   client.Client
 		runtimeScheme *runtime.Scheme
 		reconciler    *Reconciler
 
@@ -93,13 +93,13 @@ var _ = Describe("Reconciler", func() {
 		runtimeScheme = runtime.NewScheme()
 		Expect(kubernetes.AddSeedSchemeToScheme(runtimeScheme)).To(Succeed())
 		Expect(extensionsv1alpha1.AddToScheme(runtimeScheme)).To(Succeed())
-		runtimeClient = fakeclient.NewClientBuilder().WithScheme(runtimeScheme).Build()
+		shootClient = fakeclient.NewClientBuilder().WithScheme(runtimeScheme).Build()
 
 		reconciler = &Reconciler{
-			GardenClient:  gardenClient,
-			RuntimeClient: runtimeClient,
-			ShootKey:      client.ObjectKeyFromObject(shoot),
-			Clock:         testclock.NewFakeClock(time.Now()),
+			GardenClient: gardenClient,
+			ShootClient:  shootClient,
+			ShootKey:     client.ObjectKeyFromObject(shoot),
+			Clock:        testclock.NewFakeClock(time.Now()),
 		}
 	})
 
@@ -119,14 +119,14 @@ var _ = Describe("Reconciler", func() {
 
 	Context("DNS-based exposure", func() {
 		It("should patch the external DNSRecord with the sorted external node addresses", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.5")))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-2", externalIP("1.2.3.4")))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.5")))).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-2", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
 			// Equal (not ConsistOf) on purpose: the values must be sorted so equal node sets don't cause unnecessary updates.
 			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4", "1.2.3.5"}))
@@ -134,47 +134,47 @@ var _ = Describe("Reconciler", func() {
 		})
 
 		It("should not patch the DNSRecord when it is already up-to-date", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
 			dnsRecord.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeA
 			dnsRecord.Spec.Values = []string{"1.2.3.4"}
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			// No reconcile annotation means the no-op guard skipped the patch entirely.
 			Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 		})
 
 		It("should fall back to a node's internal address if it has no external one (e.g. local setups)", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(Equal([]string{"10.0.0.1"}))
 		})
 
 		It("should ignore the addresses of unhealthy nodes", func() {
 			unhealthy := controlPlaneNode("cp-2", externalIP("1.2.3.5"))
 			unhealthy.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, unhealthy)).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(shootClient.Create(ctx, unhealthy)).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4"}))
 		})
 
 		It("should fail if no healthy node has a usable address", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeHostName, Address: "cp-1"}))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeHostName, Address: "cp-1"}))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
 			Expect(err).To(MatchError(ContainSubstring("matches a configured IP family")))
@@ -184,17 +184,17 @@ var _ = Describe("Reconciler", func() {
 			leftover := &extensionsv1alpha1.SelfHostedShootExposure{
 				ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: metav1.NamespaceSystem},
 			}
-			Expect(runtimeClient.Create(ctx, leftover)).To(Succeed())
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, leftover)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(Equal([]string{"1.2.3.4"}))
 
-			err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(leftover), leftover)
+			err := shootClient.Get(ctx, client.ObjectKeyFromObject(leftover), leftover)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "orphaned SelfHostedShootExposure must be deleted")
 		})
 	})
@@ -249,7 +249,7 @@ var _ = Describe("Reconciler", func() {
 				return c.Status().Patch(ctx, exposure, client.MergeFrom(beforeStatus))
 			}
 
-			runtimeClient = fakeclient.NewClientBuilder().
+			shootClient = fakeclient.NewClientBuilder().
 				WithScheme(runtimeScheme).
 				WithStatusSubresource(&extensionsv1alpha1.SelfHostedShootExposure{}).
 				WithInterceptorFuncs(interceptor.Funcs{
@@ -307,38 +307,38 @@ var _ = Describe("Reconciler", func() {
 				Build()
 
 			reconciler = &Reconciler{
-				GardenClient:  gardenClient,
-				RuntimeClient: runtimeClient,
-				ShootKey:      client.ObjectKeyFromObject(shoot),
-				Clock:         fakeClock,
+				GardenClient: gardenClient,
+				ShootClient:  shootClient,
+				ShootKey:     client.ObjectKeyFromObject(shoot),
+				Clock:        fakeClock,
 			}
 		})
 
 		It("should deploy the SelfHostedShootExposure and patch the DNSRecord from its ingress", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			// The exposure resource was created carrying the control-plane node endpoints (all addresses, the extension
 			// decides which to use).
 			exposure := &extensionsv1alpha1.SelfHostedShootExposure{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)).To(Succeed())
 			Expect(exposure.Spec.Type).To(Equal(exposureType))
 			Expect(exposure.Spec.Endpoints).To(HaveLen(1))
 			Expect(exposure.Spec.Endpoints[0].NodeName).To(Equal("cp-1"))
 
 			// The DNSRecord was updated from the extension-reported ingress, not from the node addresses.
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
 			Expect(updated.Spec.Values).To(Equal([]string{"5.6.7.8"}))
 			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
 		})
 
 		It("should reuse the reported ingress without re-triggering the extension when endpoints are unchanged", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			// An already-reconciled exposure targeting the same endpoints, reporting a distinct ingress.
 			exposure := &extensionsv1alpha1.SelfHostedShootExposure{
@@ -350,17 +350,17 @@ var _ = Describe("Reconciler", func() {
 					},
 				},
 			}
-			Expect(runtimeClient.Create(ctx, exposure)).To(Succeed())
+			Expect(shootClient.Create(ctx, exposure)).To(Succeed())
 			exposure.Status.ObservedGeneration = exposure.Generation
 			exposure.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile, State: gardencorev1beta1.LastOperationStateSucceeded}
 			exposure.Status.Ingress = []corev1.LoadBalancerIngress{{IP: "9.9.9.9"}}
-			Expect(runtimeClient.Status().Update(ctx, exposure)).To(Succeed())
+			Expect(shootClient.Status().Update(ctx, exposure)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			// The DNSRecord was set from the pre-existing ingress (9.9.9.9); a re-trigger would have stamped 5.6.7.8.
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(Equal([]string{"9.9.9.9"}))
 		})
 
@@ -370,17 +370,17 @@ var _ = Describe("Reconciler", func() {
 			})
 
 			It("should not deploy the SelfHostedShootExposure nor touch the DNSRecord", func() {
-				Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
-				Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+				Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+				Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 				Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 				exposure := &extensionsv1alpha1.SelfHostedShootExposure{}
-				err := runtimeClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)
+				err := shootClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)
 				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "SelfHostedShootExposure must not be created")
 
 				updated := &extensionsv1alpha1.DNSRecord{}
-				Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+				Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 				Expect(updated.Spec.Values).To(BeEmpty())
 				Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 			})
@@ -399,34 +399,34 @@ var _ = Describe("Reconciler", func() {
 			exposure := &extensionsv1alpha1.SelfHostedShootExposure{
 				ObjectMeta: metav1.ObjectMeta{Name: shootName, Namespace: metav1.NamespaceSystem},
 			}
-			Expect(runtimeClient.Create(ctx, exposure)).To(Succeed())
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
+			Expect(shootClient.Create(ctx, exposure)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))).To(Succeed())
 			// The record still points at the old extension ingress.
 			dnsRecord.Spec.RecordType = extensionsv1alpha1.DNSRecordTypeA
 			dnsRecord.Spec.Values = []string{"5.6.7.8"}
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			// The DNSRecord was flipped to the control-plane node addresses one last time.
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(Equal([]string{"10.0.0.1"}))
 			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
 
 			// The SelfHostedShootExposure was deleted, leaving the record to the operator.
-			err := runtimeClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure)
+			err := shootClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "SelfHostedShootExposure must be deleted")
 		})
 
 		It("should do nothing when no SelfHostedShootExposure exists (DNS-based or never managed)", func() {
-			Expect(runtimeClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
-			Expect(runtimeClient.Create(ctx, dnsRecord)).To(Succeed())
+			Expect(shootClient.Create(ctx, controlPlaneNode("cp-1", externalIP("1.2.3.4")))).To(Succeed())
+			Expect(shootClient.Create(ctx, dnsRecord)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, reconcile.Request{})).To(Equal(reconcile.Result{}))
 
 			updated := &extensionsv1alpha1.DNSRecord{}
-			Expect(runtimeClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
 			Expect(updated.Spec.Values).To(BeEmpty())
 			Expect(updated.Annotations).NotTo(HaveKey(v1beta1constants.GardenerOperation))
 		})

--- a/pkg/gardenlet/controller/shoot/selfhostedshootexposure/selfhostedshootexposure_suite_test.go
+++ b/pkg/gardenlet/controller/shoot/selfhostedshootexposure/selfhostedshootexposure_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSelfHostedShootExposure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet Controller Shoot SelfHostedShootExposure Suite")
+}

--- a/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
+++ b/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
@@ -12,9 +12,9 @@ import (
 
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	extensionsselfhostedshootexposure "github.com/gardener/gardener/pkg/component/extensions/selfhostedshootexposure"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // DefaultSelfHostedShootExposure creates the default deployer for the SelfHostedShootExposure resource.
@@ -58,16 +58,9 @@ func (b *Botanist) DeploySelfHostedShootExposure(ctx context.Context) error {
 		return fmt.Errorf("failed listing control plane nodes: %w", err)
 	}
 
-	endpoints := make([]extensionsv1alpha1.ControlPlaneEndpoint, 0, len(nodes))
-	for _, node := range nodes {
-		if len(node.Status.Addresses) == 0 {
-			return fmt.Errorf("node %q has no addresses", node.Name)
-		}
-		nodeCopy := node.DeepCopy()
-		endpoints = append(endpoints, extensionsv1alpha1.ControlPlaneEndpoint{
-			NodeName:  nodeCopy.Name,
-			Addresses: nodeCopy.Status.Addresses,
-		})
+	endpoints, err := gardenerutils.ControlPlaneEndpointsFromNodes(nodes)
+	if err != nil {
+		return err
 	}
 
 	b.Shoot.Components.Extensions.SelfHostedShootExposure.Values.Endpoints = endpoints

--- a/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
+++ b/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
@@ -60,7 +60,7 @@ func (b *Botanist) DeploySelfHostedShootExposure(ctx context.Context) error {
 
 	endpoints, err := gardenerutils.ControlPlaneEndpointsFromNodes(nodes)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed computing control plane endpoints: %w", err)
 	}
 
 	b.Shoot.Components.Extensions.SelfHostedShootExposure.Values.Endpoints = endpoints

--- a/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
+++ b/pkg/gardenlet/operation/botanist/selfhostedshootexposure.go
@@ -46,6 +46,7 @@ func (b *Botanist) DefaultSelfHostedShootExposure() *extensionsselfhostedshootex
 	return extensionsselfhostedshootexposure.New(
 		b.Logger,
 		b.SeedClientSet.Client(),
+		b.Clock,
 		values,
 	)
 }

--- a/pkg/utils/gardener/controllerregistration.go
+++ b/pkg/utils/gardener/controllerregistration.go
@@ -5,14 +5,43 @@
 package gardener
 
 import (
+	"context"
 	"slices"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
+
+// GetControllerRegistrationsForInstallations returns the distinct ControllerRegistrations referenced by the given
+// ControllerInstallations, fetched by name (a global List is not permitted for a self-hosted shoot's gardenlet, RBAC).
+func GetControllerRegistrationsForInstallations(ctx context.Context, reader client.Reader, controllerInstallations *gardencorev1beta1.ControllerInstallationList) (*gardencorev1beta1.ControllerRegistrationList, error) {
+	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
+	seen := sets.New[string]()
+
+	for _, controllerInstallation := range controllerInstallations.Items {
+		name := controllerInstallation.Spec.RegistrationRef.Name
+		if seen.Has(name) {
+			continue
+		}
+		seen.Insert(name)
+
+		controllerRegistration := gardencorev1beta1.ControllerRegistration{}
+		if err := reader.Get(ctx, client.ObjectKey{Name: name}, &controllerRegistration); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		controllerRegistrations.Items = append(controllerRegistrations.Items, controllerRegistration)
+	}
+
+	return controllerRegistrations, nil
+}
 
 func extensionEnabledForCluster(clusterType gardencorev1beta1.ClusterType, resource gardencorev1beta1.ControllerResource, disabledExtensions sets.Set[string]) bool {
 	return resource.Kind == extensionsv1alpha1.ExtensionResource &&

--- a/pkg/utils/gardener/controllerregistration_test.go
+++ b/pkg/utils/gardener/controllerregistration_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var _ = Describe("#GetControllerRegistrationsForInstallations", func() {
+	var (
+		ctx        = context.Background()
+		fakeClient client.Client
+
+		installations *gardencorev1beta1.ControllerInstallationList
+	)
+
+	registration := func(name string) *gardencorev1beta1.ControllerRegistration {
+		return &gardencorev1beta1.ControllerRegistration{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+	installation := func(registrationName string) gardencorev1beta1.ControllerInstallation {
+		return gardencorev1beta1.ControllerInstallation{Spec: gardencorev1beta1.ControllerInstallationSpec{
+			RegistrationRef: corev1.ObjectReference{Name: registrationName},
+		}}
+	}
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		installations = &gardencorev1beta1.ControllerInstallationList{}
+	})
+
+	It("should return the distinct ControllerRegistrations referenced by the installations", func() {
+		Expect(fakeClient.Create(ctx, registration("reg-a"))).To(Succeed())
+		Expect(fakeClient.Create(ctx, registration("reg-b"))).To(Succeed())
+		installations.Items = []gardencorev1beta1.ControllerInstallation{installation("reg-a"), installation("reg-b")}
+
+		result, err := GetControllerRegistrationsForInstallations(ctx, fakeClient, installations)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Items).To(HaveLen(2))
+		Expect(result.Items[0].Name).To(Equal("reg-a"))
+		Expect(result.Items[1].Name).To(Equal("reg-b"))
+	})
+
+	It("should deduplicate registrations referenced by multiple installations", func() {
+		Expect(fakeClient.Create(ctx, registration("reg-a"))).To(Succeed())
+		installations.Items = []gardencorev1beta1.ControllerInstallation{installation("reg-a"), installation("reg-a")}
+
+		result, err := GetControllerRegistrationsForInstallations(ctx, fakeClient, installations)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Items).To(HaveLen(1))
+		Expect(result.Items[0].Name).To(Equal("reg-a"))
+	})
+
+	It("should skip references to non-existing ControllerRegistrations", func() {
+		Expect(fakeClient.Create(ctx, registration("reg-a"))).To(Succeed())
+		installations.Items = []gardencorev1beta1.ControllerInstallation{installation("reg-a"), installation("gone")}
+
+		result, err := GetControllerRegistrationsForInstallations(ctx, fakeClient, installations)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Items).To(HaveLen(1))
+		Expect(result.Items[0].Name).To(Equal("reg-a"))
+	})
+
+	It("should return an empty list when there are no installations", func() {
+		result, err := GetControllerRegistrationsForInstallations(ctx, fakeClient, installations)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Items).To(BeEmpty())
+	})
+
+	It("should propagate non-NotFound errors", func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return fmt.Errorf("fake error")
+			},
+		}).Build()
+		installations.Items = []gardencorev1beta1.ControllerInstallation{installation("reg-a")}
+
+		_, err := GetControllerRegistrationsForInstallations(ctx, fakeClient, installations)
+		Expect(err).To(MatchError(ContainSubstring("fake error")))
+	})
+})

--- a/pkg/utils/gardener/selfhostedshootexposure.go
+++ b/pkg/utils/gardener/selfhostedshootexposure.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+// ControlPlaneEndpointsFromNodes builds the list of ControlPlaneEndpoints for a SelfHostedShootExposure resource from
+// the given control plane nodes. The extension controller may choose which addresses to use, so all are included.
+// Returns an error if there are no healthy nodes or if a node has no addresses.
+func ControlPlaneEndpointsFromNodes(nodes []corev1.Node) ([]extensionsv1alpha1.ControlPlaneEndpoint, error) {
+	healthy := health.FilterHealthyNodes(nodes)
+	if len(healthy) == 0 {
+		return nil, fmt.Errorf("no healthy control plane nodes found")
+	}
+
+	endpoints := make([]extensionsv1alpha1.ControlPlaneEndpoint, 0, len(healthy))
+	for i := range healthy {
+		node := &healthy[i]
+		if len(node.Status.Addresses) == 0 {
+			return nil, fmt.Errorf("node %q has no addresses", node.Name)
+		}
+		nodeCopy := node.DeepCopy()
+		endpoints = append(endpoints, extensionsv1alpha1.ControlPlaneEndpoint{
+			NodeName:  nodeCopy.Name,
+			Addresses: nodeCopy.Status.Addresses,
+		})
+	}
+
+	return endpoints, nil
+}

--- a/pkg/utils/gardener/selfhostedshootexposure_test.go
+++ b/pkg/utils/gardener/selfhostedshootexposure_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardener_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+var _ = Describe("SelfHostedShootExposure", func() {
+	var (
+		// healthyNode returns a node that passes health.CheckNode (Ready, no pressure) with the given addresses.
+		healthyNode = func(name string, addresses ...corev1.NodeAddress) corev1.Node {
+			return corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+					Addresses:  addresses,
+				},
+			}
+		}
+		// unhealthyNode returns a node that fails health.CheckNode (NotReady).
+		unhealthyNode = func(name string, addresses ...corev1.NodeAddress) corev1.Node {
+			n := healthyNode(name, addresses...)
+			n.Status.Conditions = []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}
+			return n
+		}
+		externalIP = func(address string) corev1.NodeAddress {
+			return corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: address}
+		}
+		internalIP = func(address string) corev1.NodeAddress {
+			return corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: address}
+		}
+	)
+
+	Describe("#ControlPlaneEndpointsFromNodes", func() {
+		It("should build endpoints from healthy nodes with all their addresses", func() {
+			nodes := []corev1.Node{
+				healthyNode("cp-1", externalIP("1.2.3.4"), internalIP("10.0.0.1")),
+				healthyNode("cp-2", externalIP("1.2.3.5")),
+			}
+
+			endpoints, err := ControlPlaneEndpointsFromNodes(nodes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoints).To(ConsistOf(
+				extensionsv1alpha1.ControlPlaneEndpoint{NodeName: "cp-1", Addresses: []corev1.NodeAddress{externalIP("1.2.3.4"), internalIP("10.0.0.1")}},
+				extensionsv1alpha1.ControlPlaneEndpoint{NodeName: "cp-2", Addresses: []corev1.NodeAddress{externalIP("1.2.3.5")}},
+			))
+		})
+
+		It("should drop unhealthy nodes when at least one node is healthy", func() {
+			nodes := []corev1.Node{
+				unhealthyNode("cp-1", internalIP("10.0.0.1")),
+				healthyNode("cp-2", internalIP("10.0.0.2")),
+			}
+
+			endpoints, err := ControlPlaneEndpointsFromNodes(nodes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoints).To(ConsistOf(
+				extensionsv1alpha1.ControlPlaneEndpoint{NodeName: "cp-2", Addresses: []corev1.NodeAddress{internalIP("10.0.0.2")}},
+			))
+		})
+
+		It("should return an error if no node is healthy (keeping the last good endpoints)", func() {
+			_, err := ControlPlaneEndpointsFromNodes([]corev1.Node{unhealthyNode("cp-1", internalIP("10.0.0.1"))})
+			Expect(err).To(MatchError(ContainSubstring("no healthy control plane nodes found")))
+		})
+
+		It("should return an error if there are no nodes", func() {
+			_, err := ControlPlaneEndpointsFromNodes(nil)
+			Expect(err).To(MatchError(ContainSubstring("no healthy control plane nodes found")))
+		})
+
+		It("should return an error if a node has no addresses", func() {
+			_, err := ControlPlaneEndpointsFromNodes([]corev1.Node{healthyNode("cp-1")})
+			Expect(err).To(MatchError(ContainSubstring(`node "cp-1" has no addresses`)))
+		})
+	})
+})

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -720,8 +720,10 @@ func ComputeRequiredExtensionsForShoot(shoot *gardencorev1beta1.Shoot, seed *gar
 				requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.ContainerRuntimeResource, cr.Type))
 			}
 		}
-		if pool.ControlPlane != nil && pool.ControlPlane.Exposure != nil {
-			requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.SelfHostedShootExposureResource, *pool.ControlPlane.Exposure.Extension.Type))
+		if pool.ControlPlane != nil && pool.ControlPlane.Exposure != nil && pool.ControlPlane.Exposure.Extension != nil {
+			// Exposure.Extension.Type is optional and defaults to .spec.provider.type, so resolve it via the helper
+			// rather than dereferencing it directly (which would panic when the type is not set).
+			requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.SelfHostedShootExposureResource, v1beta1helper.SelfHostedShootExposureExtensionType(shoot)))
 		}
 	}
 

--- a/pkg/utils/kubernetes/health/node.go
+++ b/pkg/utils/kubernetes/health/node.go
@@ -6,6 +6,7 @@ package health
 
 import (
 	"context"
+	"slices"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,4 +96,11 @@ func IsNodePreservedAndUnhealthy(node corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+// FilterHealthyNodes returns the subset of nodes that are considered healthy according to CheckNode.
+func FilterHealthyNodes(nodes []corev1.Node) []corev1.Node {
+	return slices.DeleteFunc(slices.Clone(nodes), func(node corev1.Node) bool {
+		return CheckNode(&node) != nil
+	})
 }

--- a/pkg/utils/kubernetes/health/node_test.go
+++ b/pkg/utils/kubernetes/health/node_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
@@ -74,5 +75,34 @@ var _ = Describe("Node", func() {
 				false,
 			),
 		)
+	})
+
+	Describe("FilterHealthyNodes", func() {
+		node := func(name string, conditions ...corev1.NodeCondition) corev1.Node {
+			return corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Status:     corev1.NodeStatus{Conditions: conditions},
+			}
+		}
+
+		It("should keep healthy nodes and drop unhealthy ones", func() {
+			nodes := []corev1.Node{
+				node("not-ready", corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionFalse}),
+				node("pressured",
+					corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					corev1.NodeCondition{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+				),
+				node("healthy", corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue}),
+			}
+
+			result := health.FilterHealthyNodes(nodes)
+
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Name).To(Equal("healthy"))
+		})
+
+		It("should return an empty slice when no nodes are healthy", func() {
+			Expect(health.FilterHealthyNodes(nil)).To(BeEmpty())
+		})
 	})
 })

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -306,7 +306,7 @@ func addMetaDataLabelsShoot(shoot *core.Shoot, controllerRegistrations []*garden
 		if pool.Machine.Image != nil {
 			metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionOperatingSystemConfigTypePrefix+pool.Machine.Image.Name, "true")
 		}
-		if pool.ControlPlane != nil && pool.ControlPlane.Exposure != nil {
+		if pool.ControlPlane != nil && pool.ControlPlane.Exposure != nil && pool.ControlPlane.Exposure.Extension != nil {
 			metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionSelfHostedShootExposureTypePrefix+*pool.ControlPlane.Exposure.Extension.Type, "true")
 		}
 	}

--- a/plugin/pkg/global/extensionlabels/admission_test.go
+++ b/plugin/pkg/global/extensionlabels/admission_test.go
@@ -492,6 +492,17 @@ var _ = Describe("ExtensionLabels tests", func() {
 			Expect(shoot.ObjectMeta.Labels).To(HaveKeyWithValue("selfhostedshootexposure.extensions.gardener.cloud/"+providerType, "true"))
 		})
 
+		It("should not add a self-hosted shoot exposure label for DNS-based exposure", func() {
+			shoot.Spec.Provider.Workers[0].ControlPlane = &core.WorkerControlPlane{
+				Exposure: &core.Exposure{DNS: &core.DNSExposure{}},
+			}
+
+			attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("Shoot").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
+
+			Expect(shoot.ObjectMeta.Labels).NotTo(HaveKey(HavePrefix("selfhostedshootexposure.extensions.gardener.cloud/")))
+		})
+
 		Context("Workerless Shoot", func() {
 			BeforeEach(func() {
 				shoot = &core.Shoot{

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -320,7 +320,7 @@ func (e *ExtensionValidator) validateShoot(kindToExtensions map[string][]extensi
 
 		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.OperatingSystemConfigResource, worker.Machine.Image.Name, fmt.Sprintf("%s operating system type", message), field.NewPath("spec", "provider", "workers").Index(i).Child("machine", "image", "name")})
 
-		if worker.ControlPlane != nil && worker.ControlPlane.Exposure != nil {
+		if worker.ControlPlane != nil && worker.ControlPlane.Exposure != nil && worker.ControlPlane.Exposure.Extension != nil {
 			requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.SelfHostedShootExposureResource, *worker.ControlPlane.Exposure.Extension.Type, fmt.Sprintf("%s self hosted shoot exposure type", message), field.NewPath("spec", "provider", "workers").Index(i).Child("controlPlane", "exposure", "type")})
 		}
 	}

--- a/test/e2e/gardenadm/managedinfra/gardenadm.go
+++ b/test/e2e/gardenadm/managedinfra/gardenadm.go
@@ -5,10 +5,7 @@
 package managedinfra
 
 import (
-	"context"
-	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -45,23 +42,16 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 		const (
 			shootName   = "root"
 			technicalID = "shoot--garden--" + shootName
-			localPort   = 6443
 		)
 
 		var (
 			session *gexec.Session
 
 			kubeconfigOutputFile string
-
-			portForwardCtx    context.Context
-			cancelPortForward context.CancelFunc
 		)
 
 		BeforeAll(func() {
 			DeferCleanup(test.WithTempFile("", "kubeconfig", nil, &kubeconfigOutputFile))
-
-			portForwardCtx, cancelPortForward = context.WithCancel(context.Background())
-			DeferCleanup(func() { cancelPortForward() })
 		})
 
 		AfterAll(func(ctx SpecContext) {
@@ -197,7 +187,7 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 			kubeconfigSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kubeconfig", Namespace: technicalID}}
 			Eventually(ctx, Object(kubeconfigSecret)).Should(HaveField("Data", HaveKey("kubeconfig")))
 
-			kubeconfig = strings.ReplaceAll(string(kubeconfigSecret.Data["kubeconfig"]), "api.root.garden.external.local.gardener.cloud", fmt.Sprintf("localhost:%d", localPort))
+			kubeconfig = string(kubeconfigSecret.Data["kubeconfig"])
 		}, SpecTimeout(time.Minute))
 
 		var (
@@ -206,20 +196,12 @@ var _ = Describe("gardenadm managed infrastructure scenario tests", Label("garde
 		)
 
 		It("should connect to the shoot", func(ctx SpecContext) {
-			By("Forward port to control plane machine pod")
-			fw, err := kubernetes.SetupPortForwarder(portForwardCtx, RuntimeClient.RESTConfig(), technicalID, machinePodName(ctx, technicalID, 0), localPort, 443)
-			Expect(err).NotTo(HaveOccurred())
-
-			go func() {
-				if err := fw.ForwardPorts(); err != nil {
-					Fail("Error forwarding ports: " + err.Error())
-				}
-			}()
-
-			Eventually(fw.Ready()).Should(BeClosed())
-
 			By("Create client set")
-			Eventually(func() error {
+			// The control plane is exposed via the SelfHostedShootExposure LoadBalancer (provisioned by
+			// cloud-controller-manager-local), so the kubeconfig's server address is reachable directly from the
+			// host and we can connect without port-forwarding to the machine pod.
+			Eventually(ctx, func() error {
+				var err error
 				shootClientSet, err = kubernetes.NewClientFromBytes([]byte(kubeconfig),
 					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 					kubernetes.WithDisabledCachedClient(),

--- a/test/integration/gardenlet/shoot/selfhostedshootexposure/selfhostedshootexposure_suite_test.go
+++ b/test/integration/gardenlet/shoot/selfhostedshootexposure/selfhostedshootexposure_suite_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/rest"
+	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/gardener/gardener/pkg/api/indexer"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/shoot/selfhostedshootexposure"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils"
+	gardenerenvtest "github.com/gardener/gardener/test/envtest"
+)
+
+func TestSelfHostedShootExposure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Integration Gardenlet Shoot SelfHostedShootExposure Suite")
+}
+
+const (
+	testID = "shoot-selfhostedshootexposure-controller-test"
+	// shootName is fixed because the controller is configured with a single ShootKey at startup.
+	shootName = "root"
+)
+
+var (
+	ctx       = context.Background()
+	log       logr.Logger
+	fakeClock *testclock.FakeClock
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+
+	testRunID string
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultConsistentlyDuration(time.Second)
+
+	By("Start test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		Environment: &envtest.Environment{
+			CRDInstallOptions: envtest.CRDInstallOptions{
+				Paths: []string{
+					filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_dnsrecords.yaml"),
+					filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_selfhostedshootexposures.yaml"),
+				},
+			},
+			ErrorIfCRDPathMissing: true,
+		},
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{
+				"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator,ShootMutator",
+			},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("Stop test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	testSchemeBuilder := runtime.NewSchemeBuilder(
+		kubernetes.AddGardenSchemeToScheme,
+		kubernetes.AddSeedSchemeToScheme,
+	)
+	testScheme := runtime.NewScheme()
+	Expect(testSchemeBuilder.AddToScheme(testScheme)).To(Succeed())
+
+	By("Create test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	testRunID = utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+
+	By("Ensure garden Namespace exists (self-hosted shoots must live in the garden namespace)")
+	Expect(testClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.GardenNamespace}})).To(Or(Succeed(), MatchError(apierrors.IsAlreadyExists, "already exists")))
+
+	By("Ensure kube-system Namespace exists (control-plane namespace of a self-hosted shoot)")
+	Expect(testClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}})).To(Or(Succeed(), MatchError(apierrors.IsAlreadyExists, "already exists")))
+
+	By("Setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:  testScheme,
+		Metrics: metricsserver.Options{BindAddress: "0"},
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: new(true),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Register field indexes the controller lists ControllerInstallations by")
+	Expect(indexer.AddControllerInstallationShootRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())
+	Expect(indexer.AddControllerInstallationShootRefNamespace(ctx, mgr.GetFieldIndexer())).To(Succeed())
+
+	fakeClock = testclock.NewFakeClock(time.Now().Round(time.Second))
+
+	By("Register controller")
+	Expect((&selfhostedshootexposure.Reconciler{
+		ShootKey: client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: shootName},
+		Clock:    fakeClock,
+	}).AddToManager(mgr, mgr)).To(Succeed())
+
+	By("Start manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("Stop manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/gardenlet/shoot/selfhostedshootexposure/selfhostedshootexposure_test.go
+++ b/test/integration/gardenlet/shoot/selfhostedshootexposure/selfhostedshootexposure_test.go
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package selfhostedshootexposure_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("SelfHostedShootExposure controller tests", func() {
+	const exposureType = "local"
+
+	var (
+		shoot         *gardencorev1beta1.Shoot
+		dnsRecord     *extensionsv1alpha1.DNSRecord
+		dnsRecordName = shootName + "-" + v1beta1constants.DNSRecordExternalName
+	)
+
+	// controlPlaneNode returns a healthy control-plane Node with the given addresses.
+	controlPlaneNode := func(name string, addresses ...corev1.NodeAddress) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   name,
+				Labels: map[string]string{"node-role.kubernetes.io/control-plane": "", testID: testRunID},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+				Addresses:  addresses,
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: v1beta1constants.GardenNamespace,
+				Labels:    map[string]string{testID: testRunID},
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				CloudProfileName: new("cloudprofile1"),
+				Region:           "europe-central-1",
+				Provider: gardencorev1beta1.Provider{
+					Type: exposureType,
+					Workers: []gardencorev1beta1.Worker{{
+						Name:    "control-plane",
+						Minimum: 1,
+						Maximum: 1,
+						Machine: gardencorev1beta1.Machine{
+							Type:  "large",
+							Image: &gardencorev1beta1.ShootMachineImage{Name: "some-image", Version: new("1.0.0")},
+						},
+						ControlPlane: &gardencorev1beta1.WorkerControlPlane{},
+					}},
+				},
+				Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.31.1"},
+				Networking: &gardencorev1beta1.Networking{
+					Type:       new("foo-networking"),
+					Services:   new("10.0.0.0/16"),
+					Pods:       new("10.1.0.0/16"),
+					IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4},
+				},
+			},
+		}
+
+		// The external DNSRecord already exists (created during bootstrapping); the controller only keeps it in sync.
+		dnsRecord = &extensionsv1alpha1.DNSRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dnsRecordName,
+				Namespace: metav1.NamespaceSystem,
+				Labels:    map[string]string{testID: testRunID},
+			},
+			Spec: extensionsv1alpha1.DNSRecordSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{Type: exposureType},
+				SecretRef:   corev1.SecretReference{Name: "dnsrecord-secret", Namespace: metav1.NamespaceSystem},
+				Name:        "api.root.example.com",
+				RecordType:  extensionsv1alpha1.DNSRecordTypeA,
+				// A stale bootstrap value the controller is expected to overwrite.
+				Values: []string{"9.9.9.9"},
+			},
+		}
+	})
+
+	// createNode/createShoot/createDNSRecord create the object and register cleanup.
+	createNode := func(n *corev1.Node) {
+		ExpectWithOffset(1, testClient.Create(ctx, n)).To(Succeed())
+		DeferCleanup(func() {
+			ExpectWithOffset(1, testClient.Delete(ctx, n)).To(Or(Succeed(), BeNotFoundError()))
+		})
+	}
+	createShoot := func() {
+		ExpectWithOffset(1, testClient.Create(ctx, shoot)).To(Succeed())
+		DeferCleanup(func() {
+			ExpectWithOffset(1, testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+		})
+	}
+	createDNSRecord := func() {
+		ExpectWithOffset(1, testClient.Create(ctx, dnsRecord)).To(Succeed())
+		DeferCleanup(func() {
+			ExpectWithOffset(1, testClient.Delete(ctx, dnsRecord)).To(Or(Succeed(), BeNotFoundError()))
+		})
+	}
+
+	dnsRecordValues := func() func() []string {
+		return func() []string {
+			updated := &extensionsv1alpha1.DNSRecord{}
+			if err := testClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated); err != nil {
+				return nil
+			}
+			return updated.Spec.Values
+		}
+	}
+
+	Context("DNS-based exposure", func() {
+		BeforeEach(func() {
+			shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = &gardencorev1beta1.Exposure{DNS: &gardencorev1beta1.DNSExposure{}}
+		})
+
+		It("should keep the external DNSRecord in sync with the control-plane node external addresses", func() {
+			createNode(controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}))
+			createDNSRecord()
+			createShoot()
+
+			Eventually(dnsRecordValues()).Should(ConsistOf("1.2.3.4"))
+
+			updated := &extensionsv1alpha1.DNSRecord{}
+			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(dnsRecord), updated)).To(Succeed())
+			Expect(updated.Spec.RecordType).To(Equal(extensionsv1alpha1.DNSRecordTypeA))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+		})
+
+		It("should delete a SelfHostedShootExposure left over from a previous extension-based exposure", func() {
+			createNode(controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}))
+			createDNSRecord()
+			leftover := createExposure()
+			createShoot()
+
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(leftover), leftover)
+			}).Should(BeNotFoundError(), "orphaned SelfHostedShootExposure should be deleted")
+			Eventually(dnsRecordValues()).Should(ConsistOf("1.2.3.4"))
+		})
+	})
+
+	Context("extension-based exposure", func() {
+		BeforeEach(func() {
+			shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = &gardencorev1beta1.Exposure{
+				Extension: &gardencorev1beta1.ExtensionExposure{Type: new(exposureType)},
+			}
+		})
+
+		It("should propagate ingress changes reported by the extension to the DNSRecord", func() {
+			createNode(controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))
+			createDNSRecord()
+			exposure := createExposure()
+			stampExposureIngress(exposure, "172.18.0.10")
+			createShoot()
+
+			Eventually(dnsRecordValues()).Should(ConsistOf("172.18.0.10"))
+
+			stampExposureIngress(exposure, "172.18.0.11")
+			Eventually(dnsRecordValues()).Should(ConsistOf("172.18.0.11"))
+		})
+	})
+
+	Context("extension-based exposure with continuousEndpointUpdate disabled", func() {
+		BeforeEach(func() {
+			shoot.Spec.Provider.Workers[0].ControlPlane.Exposure = &gardencorev1beta1.Exposure{
+				Extension: &gardencorev1beta1.ExtensionExposure{Type: new(exposureType)},
+			}
+			createControllerRegistrationAndInstallation(new(false))
+		})
+
+		It("should neither deploy a SelfHostedShootExposure nor touch the DNSRecord", func() {
+			createNode(controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))
+			createDNSRecord()
+			createShoot()
+
+			exposure := &extensionsv1alpha1.SelfHostedShootExposure{}
+			Consistently(func() error {
+				return testClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: shootName}, exposure)
+			}).Should(BeNotFoundError(), "SelfHostedShootExposure must not be created")
+			// The DNSRecord keeps its bootstrap value untouched.
+			Expect(dnsRecordValues()()).To(ConsistOf("9.9.9.9"))
+		})
+	})
+
+	Context("exposure disabled (switch-off handoff)", func() {
+		It("should point the DNSRecord at the node addresses and delete the SelfHostedShootExposure", func() {
+			// Exposure is omitted, but a SelfHostedShootExposure from the prior extension-based setup still exists.
+			createNode(controlPlaneNode("cp-1", corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}))
+			createDNSRecord()
+			exposure := createExposure()
+			createShoot()
+
+			Eventually(dnsRecordValues()).Should(ConsistOf("10.0.0.1"))
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure)
+			}).Should(BeNotFoundError(), "SelfHostedShootExposure should be deleted after the final DNSRecord update")
+		})
+	})
+})
+
+// createExposure creates a SelfHostedShootExposure in the control-plane namespace of the test shoot (registering
+// cleanup, since the controller is expected to delete it) and returns it.
+func createExposure() *extensionsv1alpha1.SelfHostedShootExposure {
+	exposure := &extensionsv1alpha1.SelfHostedShootExposure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shootName,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{testID: testRunID},
+		},
+		Spec: extensionsv1alpha1.SelfHostedShootExposureSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{Type: "local"},
+			Port:        443,
+			Endpoints: []extensionsv1alpha1.ControlPlaneEndpoint{
+				{NodeName: "cp-1", Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}}},
+			},
+		},
+	}
+	ExpectWithOffset(1, testClient.Create(ctx, exposure)).To(Succeed())
+	DeferCleanup(func() {
+		ExpectWithOffset(1, testClient.Delete(ctx, exposure)).To(Or(Succeed(), BeNotFoundError()))
+	})
+	return exposure
+}
+
+// stampExposureIngress marks the SelfHostedShootExposure as successfully reconciled with the given ingress IP.
+func stampExposureIngress(exposure *extensionsv1alpha1.SelfHostedShootExposure, ip string) {
+	ExpectWithOffset(1, testClient.Get(ctx, client.ObjectKeyFromObject(exposure), exposure)).To(Succeed())
+	patch := client.MergeFrom(exposure.DeepCopy())
+	exposure.Status.ObservedGeneration = exposure.Generation
+	exposure.Status.LastOperation = &gardencorev1beta1.LastOperation{
+		Type:           gardencorev1beta1.LastOperationTypeReconcile,
+		State:          gardencorev1beta1.LastOperationStateSucceeded,
+		LastUpdateTime: metav1.Now(),
+	}
+	exposure.Status.Ingress = []corev1.LoadBalancerIngress{{IP: ip}}
+	ExpectWithOffset(1, testClient.Status().Patch(ctx, exposure, patch)).To(Succeed())
+}
+
+// createControllerRegistrationAndInstallation registers a provider-local ControllerRegistration declaring the
+// SelfHostedShootExposure resource (with the given continuousEndpointUpdate value) and a ControllerInstallation
+// referencing the test shoot, and registers cleanup.
+func createControllerRegistrationAndInstallation(continuousEndpointUpdate *bool) {
+	registration := &gardencorev1beta1.ControllerRegistration{
+		ObjectMeta: metav1.ObjectMeta{Name: "provider-local-" + testRunID, Labels: map[string]string{testID: testRunID}},
+		Spec: gardencorev1beta1.ControllerRegistrationSpec{
+			Resources: []gardencorev1beta1.ControllerResource{{
+				Kind:                     extensionsv1alpha1.SelfHostedShootExposureResource,
+				Type:                     "local",
+				ContinuousEndpointUpdate: continuousEndpointUpdate,
+			}},
+		},
+	}
+	ExpectWithOffset(1, testClient.Create(ctx, registration)).To(Succeed())
+	DeferCleanup(func() {
+		ExpectWithOffset(1, testClient.Delete(ctx, registration)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	installation := &gardencorev1beta1.ControllerInstallation{
+		ObjectMeta: metav1.ObjectMeta{Name: "provider-local-" + testRunID, Labels: map[string]string{testID: testRunID}},
+		Spec: gardencorev1beta1.ControllerInstallationSpec{
+			RegistrationRef: corev1.ObjectReference{Name: registration.Name},
+			SeedRef:         &corev1.ObjectReference{Name: "seed"},
+			ShootRef:        &corev1.ObjectReference{Name: shootName, Namespace: v1beta1constants.GardenNamespace},
+		},
+	}
+	ExpectWithOffset(1, testClient.Create(ctx, installation)).To(Succeed())
+	DeferCleanup(func() {
+		ExpectWithOffset(1, testClient.Delete(ctx, installation)).To(Or(Succeed(), BeNotFoundError()))
+	})
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/area networking
/kind enhancement
/kind api-change

**What this PR does / why we need it**:

This implements the `gardenlet` controller from [GEP-36](https://github.com/gardener/gardener/issues/13602) (Self-Hosted Shoot Exposure) that keeps a self-hosted shoot's API server exposure in sync with the state of its control-plane nodes.

Depending on the shoot's `spec.provider.workers[].controlPlane.exposure` configuration, the controller (which runs only on self-hosted gardenlets) reconciles on control-plane `Node` and `Shoot` changes:

- **Extension-based exposure** (`exposure.extension`): it maintains the `SelfHostedShootExposure` extension resource's endpoints from the healthy control-plane nodes, waits for the extension to report its ingress in `.status.ingress`, and updates the shoot's external `DNSRecord` accordingly. The (re-)deploy is skipped when the endpoints are unchanged and the extension already reconciled successfully.
- **DNS-based exposure** (`exposure.dns`): it updates the external `DNSRecord` directly with the control-plane nodes' external addresses — no extension involved.
- **Switching / disabling exposure**: on a mechanism switch or when exposure is removed, it deletes the now-obsolete `SelfHostedShootExposure` and updates the `DNSRecord` one last time with the control-plane node addresses (using the same address preference as at bootstrapping), then leaves it to the operator.

Additionally, this PR:

- Adds a `continuousEndpointUpdate` field to `ControllerResource` (only valid for kind `SelfHostedShootExposure`) so an exposure extension can opt out of having its endpoints continuously updated. It defaults to `true`.
- Extracts the control-plane address / DNS-value / exposure-endpoint helpers shared between `gardenadm` and the new controller, and reuses them in the existing `gardenadm` external-`DNSRecord` and shoot-care controller code (removing duplicated logic).
- Fixes a nil-pointer dereference for DNS-based exposure in the `extensionlabels` and `extensionvalidation` admission plugins and in `ComputeRequiredExtensionsForShoot`: these paths assumed `controlPlane.exposure.extension` is always set, whereas DNS-based exposure leaves it unset and requires no extension at all.

**Which issue(s) this PR fixes**:
Part of [☂️ GEP-36](https://github.com/gardener/gardener/issues/13602) (Self-Hosted Shoot Exposure).
Fixes #

**Special notes for your reviewer**:

- The nil-pointer dereference fixed in the admission plugins / `ComputeRequiredExtensionsForShoot` is a latent bug in the already-merged GEP-36 API code; it only becomes reachable now that DNS-based exposure (with an unset `exposure.extension`) exists. The integration test in this PR surfaces it.
- A self-hosted gardenlet may not `List`/`Watch` `ControllerRegistration`s (RBAC), so `continuousEndpointUpdate` is resolved by listing the shoot's `ControllerInstallation`s (by field index) and fetching the referenced `ControllerRegistration`s by name; this helper is shared with the shoot-care health check.
- Covered by unit tests and an envtest integration test (`test/integration/gardenlet/shoot/selfhostedshootexposure`).

**Release note**:

(probably optional for the GEP?)
```other operator
Self-hosted shoot clusters now keep their API server exposure (the `SelfHostedShootExposure` endpoints for extension-based exposure, or the external `DNSRecord` for DNS-based exposure) continuously in sync with the control-plane node state. A new `continuousEndpointUpdate` field on `ControllerRegistration` resources of kind `SelfHostedShootExposure` allows an exposure extension to opt out of continuous endpoint updates (defaults to `true`).
