### PR TITLE
Align `customverbauthorizer` subject handling with RBAC subject types

### DIFF
--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -315,24 +315,27 @@ func mustCheckProjectMembers(oldMembers, members []core.ProjectMember, owner *rb
 	return !oldNonServiceAccounts.Equal(newNonServiceAccounts)
 }
 
-type humanMembership struct {
+// membership is a data structure representing project member with one of its roles.
+// Project members with multiple roles can create a membership for each role.
+// Members with no roles associated, can create a membership with empty role.
+type membership struct {
 	member string
 	role   string
 }
 
-func findNonServiceAccountsWithRoles(members []core.ProjectMember) sets.Set[humanMembership] {
-	result := sets.New[humanMembership]()
+func findNonServiceAccountsWithRoles(members []core.ProjectMember) sets.Set[membership] {
+	result := sets.New[membership]()
 
 	for _, member := range members {
 		if !isServiceAccountSubject(member.Subject) {
 			memberKey := memberSubjectKey(member.Subject)
 			// Create a unique key that includes both subject and roles
 			for _, role := range member.Roles {
-				result.Insert(humanMembership{member: memberKey, role: role})
+				result.Insert(membership{member: memberKey, role: role})
 			}
 			// If no roles are specified, still create an entry with empty role
 			if len(member.Roles) == 0 {
-				result.Insert(humanMembership{member: memberKey, role: ""})
+				result.Insert(membership{member: memberKey, role: ""})
 			}
 		}
 	}
@@ -357,7 +360,7 @@ func memberSubjectKey(subject rbacv1.Subject) string {
 	return subject.Kind + subject.Name
 }
 
-func removeEntriesWithMember(set sets.Set[humanMembership], member string) {
+func removeEntriesWithMember(set sets.Set[membership], member string) {
 	for membership := range set {
 		if membership.member == member {
 			set.Delete(membership)

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -344,8 +344,13 @@ func isServiceAccountSubject(subject rbacv1.Subject) bool {
 	// Service account groups, e.g. (subject.Kind == "Group" && strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountGroupPrefix))
 	// are not considered as service account subjects, otherwise it would allow project admins to manage also service account groups
 	// which is not allowed (see docs/usage/project/projects.md#user-access-management).
-	return subject.APIGroup == "" && subject.Kind == rbacv1.ServiceAccountKind ||
-		subject.APIGroup == rbacv1.GroupName && subject.Kind == rbacv1.UserKind && strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountUsernamePrefix)
+	var (
+		isServiceAccount              = subject.APIGroup == "" && subject.Kind == rbacv1.ServiceAccountKind
+		isServiceAccountAsUserSubject = subject.APIGroup == rbacv1.GroupName && subject.Kind == rbacv1.UserKind &&
+			strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountUsernamePrefix)
+	)
+
+	return isServiceAccount || isServiceAccountAsUserSubject
 }
 
 func memberSubjectKey(subject rbacv1.Subject) string {

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -304,15 +304,15 @@ func mustCheckProjectMembers(oldMembers, members []core.ProjectMember, owner *rb
 		return false
 	}
 
-	var oldHumanUsers, newHumanUsers = findHumanUsersWithRoles(oldMembers), findHumanUsersWithRoles(members)
+	var oldNonServiceAccounts, newNonServiceAccounts = findNonServiceAccountsWithRoles(oldMembers), findNonServiceAccountsWithRoles(members)
 	// Remove owner subject from `members` list to always allow it to be added
-	if owner != nil && isHumanUser(*owner) {
-		ownerKey := humanMemberKey(*owner)
-		removeEntriesWithMember(oldHumanUsers, ownerKey)
-		removeEntriesWithMember(newHumanUsers, ownerKey)
+	if owner != nil && !isServiceAccountSubject(*owner) {
+		ownerKey := memberSubjectKey(*owner)
+		removeEntriesWithMember(oldNonServiceAccounts, ownerKey)
+		removeEntriesWithMember(newNonServiceAccounts, ownerKey)
 	}
 
-	return !oldHumanUsers.Equal(newHumanUsers)
+	return !oldNonServiceAccounts.Equal(newNonServiceAccounts)
 }
 
 type humanMembership struct {
@@ -320,12 +320,12 @@ type humanMembership struct {
 	role   string
 }
 
-func findHumanUsersWithRoles(members []core.ProjectMember) sets.Set[humanMembership] {
+func findNonServiceAccountsWithRoles(members []core.ProjectMember) sets.Set[humanMembership] {
 	result := sets.New[humanMembership]()
 
 	for _, member := range members {
-		if isHumanUser(member.Subject) {
-			memberKey := humanMemberKey(member.Subject)
+		if !isServiceAccountSubject(member.Subject) {
+			memberKey := memberSubjectKey(member.Subject)
 			// Create a unique key that includes both subject and roles
 			for _, role := range member.Roles {
 				result.Insert(humanMembership{member: memberKey, role: role})
@@ -340,11 +340,15 @@ func findHumanUsersWithRoles(members []core.ProjectMember) sets.Set[humanMembers
 	return result
 }
 
-func isHumanUser(subject rbacv1.Subject) bool {
-	return subject.Kind == rbacv1.UserKind && !strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountUsernamePrefix)
+func isServiceAccountSubject(subject rbacv1.Subject) bool {
+	// Service account groups, e.g. (subject.Kind == "Group" && strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountGroupPrefix))
+	// are not considered as service account subjects, otherwise it would allow project admins to manage also service account groups
+	// which is not allowed (see docs/usage/project/projects.md#user-access-management).
+	return subject.APIGroup == "" && subject.Kind == rbacv1.ServiceAccountKind ||
+		subject.APIGroup == rbacv1.GroupName && subject.Kind == rbacv1.UserKind && strings.HasPrefix(subject.Name, serviceaccount.ServiceAccountUsernamePrefix)
 }
 
-func humanMemberKey(subject rbacv1.Subject) string {
+func memberSubjectKey(subject rbacv1.Subject) string {
 	return subject.Kind + subject.Name
 }
 

--- a/plugin/pkg/global/customverbauthorizer/admission_test.go
+++ b/plugin/pkg/global/customverbauthorizer/admission_test.go
@@ -42,7 +42,7 @@ var _ = Describe("customverbauthorizer", func() {
 			admissionHandler    *CustomVerbAuthorizer
 			coreInformerFactory gardencoreinformers.SharedInformerFactory
 
-			userInfo            = &user.DefaultInfo{Name: "foo"}
+			userInfo            user.Info
 			authorizeAttributes authorizer.AttributesRecord
 		)
 
@@ -52,6 +52,7 @@ var _ = Describe("customverbauthorizer", func() {
 			admissionHandler.AssignReadyFunc(func() bool { return true })
 			coreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
 			admissionHandler.SetCoreInformerFactory(coreInformerFactory)
+			userInfo = &user.DefaultInfo{Name: "foo"}
 		})
 
 		Context("Projects", func() {
@@ -69,16 +70,14 @@ var _ = Describe("customverbauthorizer", func() {
 				authorizeAttributes = authorizer.AttributesRecord{
 					User:            userInfo,
 					APIGroup:        "core.gardener.cloud",
-					Namespace:       project.Namespace,
 					Name:            project.Name,
 					ResourceRequest: true,
+					Resource:        "projects",
 				}
-
-				authorizeAttributes.Resource = "projects"
 			})
 
 			It("should do nothing because the resource is not Project", func() {
-				attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), project.Namespace, project.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), "", project.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 				err := admissionHandler.Validate(ctx, attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -89,7 +88,7 @@ var _ = Describe("customverbauthorizer", func() {
 				})
 
 				It("should always allow creating a project without whitelist tolerations", func() {
-					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
@@ -101,7 +100,7 @@ var _ = Describe("customverbauthorizer", func() {
 					It("should allow creating a project with whitelist tolerations", func() {
 						project.Spec.Tolerations = &core.ProjectTolerations{Whitelist: []core.Toleration{{Key: "foo"}}}
 
-						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
@@ -110,7 +109,7 @@ var _ = Describe("customverbauthorizer", func() {
 						oldProject := project.DeepCopy()
 						project.Spec.Tolerations.Whitelist = append(project.Spec.Tolerations.Whitelist, core.Toleration{Key: "bar"})
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
@@ -119,7 +118,7 @@ var _ = Describe("customverbauthorizer", func() {
 						oldProject := project.DeepCopy()
 						project.Spec.Tolerations.Whitelist = nil
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
@@ -132,7 +131,7 @@ var _ = Describe("customverbauthorizer", func() {
 					It("should forbid creating a project with whitelist tolerations", func() {
 						project.Spec.Tolerations = &core.ProjectTolerations{Whitelist: []core.Toleration{{Key: "foo"}}}
 
-						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
@@ -141,7 +140,7 @@ var _ = Describe("customverbauthorizer", func() {
 						oldProject := project.DeepCopy()
 						project.Spec.Tolerations.Whitelist = append(project.Spec.Tolerations.Whitelist, core.Toleration{Key: "bar"})
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 
@@ -150,7 +149,7 @@ var _ = Describe("customverbauthorizer", func() {
 						oldProject := project.DeepCopy()
 						project.Spec.Tolerations.Whitelist = nil
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 					})
 				})
@@ -162,9 +161,16 @@ var _ = Describe("customverbauthorizer", func() {
 				})
 
 				var (
+					owner                       rbacv1.Subject
+					projectMembersWithHumans    []core.ProjectMember
+					projectMembersWithoutHumans []core.ProjectMember
+				)
+
+				BeforeEach(func() {
 					owner = rbacv1.Subject{
-						Kind: rbacv1.UserKind,
-						Name: "owner",
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.UserKind,
+						Name:     "owner",
 					}
 					projectMembersWithHumans = []core.ProjectMember{
 						{
@@ -172,46 +178,47 @@ var _ = Describe("customverbauthorizer", func() {
 						},
 						{
 							Subject: rbacv1.Subject{
-								Kind: rbacv1.UserKind,
-								Name: "foo",
+								APIGroup: rbacv1.GroupName,
+								Kind:     rbacv1.UserKind,
+								Name:     "foo",
 							},
 						},
 						{
 							Subject: rbacv1.Subject{
-								Kind: rbacv1.GroupKind,
-								Name: "bar",
+								APIGroup: rbacv1.GroupName,
+								Kind:     rbacv1.GroupKind,
+								Name:     "bar",
 							},
 						},
 					}
 					projectMembersWithoutHumans = []core.ProjectMember{
 						{
 							Subject: rbacv1.Subject{
-								Kind: rbacv1.ServiceAccountKind,
-								Name: "foo",
+								APIGroup: "",
+								Kind:     rbacv1.ServiceAccountKind,
+								Name:     "foo",
 							},
 						},
 						{
 							Subject: rbacv1.Subject{
-								Kind: rbacv1.UserKind,
-								Name: servieaccount.ServiceAccountUsernamePrefix + "foo:bar",
+								APIGroup: rbacv1.GroupName,
+								Kind:     rbacv1.UserKind,
+								Name:     servieaccount.ServiceAccountUsernamePrefix + "foo:bar",
 							},
 						},
 					}
-				)
-
-				BeforeEach(func() {
 					project.Spec.Owner = &owner
 				})
 
 				It("should always allow creating a project without members", func() {
-					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
 				It("should always allow creating a project with only owner as member", func() {
 					project.Spec.Owner = &owner
 					project.Spec.Members = []core.ProjectMember{{Subject: owner}}
-					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+					attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
@@ -220,7 +227,7 @@ var _ = Describe("customverbauthorizer", func() {
 					oldProject := project.DeepCopy()
 					project.Spec.Members = append(projectMembersWithHumans, projectMembersWithoutHumans...)
 
-					attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+					attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 					Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 				})
 
@@ -232,22 +239,22 @@ var _ = Describe("customverbauthorizer", func() {
 					Context("CREATE", func() {
 						It("should allow creating a project with human members if creator=owner", func() {
 							project.Spec.Members = projectMembersWithHumans
-							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project without human members if creator=owner", func() {
 							project.Spec.Members = projectMembersWithoutHumans
-							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with owner plus additional human members", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 					})
@@ -258,7 +265,7 @@ var _ = Describe("customverbauthorizer", func() {
 							oldProject := project.DeepCopy()
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
@@ -267,7 +274,7 @@ var _ = Describe("customverbauthorizer", func() {
 							oldProject := project.DeepCopy()
 							project.Spec.Members = projectMembersWithoutHumans
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 					})
@@ -282,57 +289,74 @@ var _ = Describe("customverbauthorizer", func() {
 						It("should allow creating a project without human members if owner=nil (meaning creator=owner)", func() {
 							project.Spec.Owner = nil
 							project.Spec.Members = projectMembersWithoutHumans
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with owner plus additional human members if creator=owner", func() {
-							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+							project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow creating a project with human members if owner=nil (meaning creator=owner)", func() {
 							project.Spec.Owner = nil
 							project.Spec.Members = projectMembersWithHumans
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should forbid creating a project with human members if creator!=owner", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = projectMembersWithHumans
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 
 						It("should forbid creating a project with owner plus additional human members if creator!=owner", func() {
 							project.Spec.Owner = &owner
 							project.Spec.Members = append([]core.ProjectMember{{Subject: owner}}, projectMembersWithHumans...)
-							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+						})
+
+						It("should forbid creating a project with group members if creator!=owner", func() {
+							project.Spec.Owner = &owner
+							project.Spec.Members = []core.ProjectMember{{Subject: rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: "baz"}}}
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+						})
+
+						It("should forbid creating a project with owner plus additional group members if creator!=owner", func() {
+							project.Spec.Owner = &owner
+							project.Spec.Members = []core.ProjectMember{
+								{Subject: owner},
+								{Subject: rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: "baz"}},
+							}
+							attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 					})
 
 					Context("UPDATE", func() {
 						It("should allow to add human users (user=owner)", func() {
-							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+							project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
 							project.Spec.Members = projectMembersWithoutHumans
 							oldProject := project.DeepCopy()
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
 						It("should allow to remove human users (user=owner)", func() {
-							project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+							project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
 							project.Spec.Members = projectMembersWithHumans
 							oldProject := project.DeepCopy()
 							project.Spec.Members = projectMembersWithoutHumans
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 						})
 
@@ -342,7 +366,7 @@ var _ = Describe("customverbauthorizer", func() {
 							oldProject := project.DeepCopy()
 							project.Spec.Members = append(projectMembersWithoutHumans, projectMembersWithHumans...)
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 
@@ -352,7 +376,27 @@ var _ = Describe("customverbauthorizer", func() {
 							oldProject := project.DeepCopy()
 							project.Spec.Members = projectMembersWithoutHumans
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+						})
+
+						It("should forbid to add groups (user!=owner)", func() {
+							project.Spec.Owner = &owner
+							project.Spec.Members = projectMembersWithoutHumans
+							oldProject := project.DeepCopy()
+							project.Spec.Members = append(projectMembersWithoutHumans, core.ProjectMember{Subject: rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: "baz"}})
+
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
+						})
+
+						It("should forbid to remove groups (user!=owner)", func() {
+							project.Spec.Owner = &owner
+							project.Spec.Members = []core.ProjectMember{{Subject: rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: "baz"}}}
+							oldProject := project.DeepCopy()
+							project.Spec.Members = []core.ProjectMember{}
+
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 
@@ -361,8 +405,9 @@ var _ = Describe("customverbauthorizer", func() {
 							project.Spec.Members = []core.ProjectMember{
 								{
 									Subject: rbacv1.Subject{
-										Kind: rbacv1.UserKind,
-										Name: "test-user",
+										APIGroup: rbacv1.GroupName,
+										Kind:     rbacv1.UserKind,
+										Name:     "test-user",
 									},
 									Roles: []string{"viewer"},
 								},
@@ -371,7 +416,7 @@ var _ = Describe("customverbauthorizer", func() {
 							// Only change the roles, keep the subject the same
 							project.Spec.Members[0].Roles = []string{"admin"}
 
-							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+							attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 							Expect(admissionHandler.Validate(ctx, attrs, nil)).NotTo(Succeed())
 						})
 					})
@@ -381,8 +426,8 @@ var _ = Describe("customverbauthorizer", func() {
 			Context("owner configuration", func() {
 				Context("CREATE", func() {
 					It("should allow setting the owner", func() {
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
-						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
+						attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 				})
@@ -393,52 +438,52 @@ var _ = Describe("customverbauthorizer", func() {
 					})
 
 					It("should succeed without owner change", func() {
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
 						oldProject := project.DeepCopy()
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow changing the owner for owner", func() {
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: userInfo.Name}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: userInfo.GetName()}
 						oldProject := project.DeepCopy()
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "new-owner"}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: "new-owner"}
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should allow changing the owner for uam user", func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionAllow, "", nil)
 
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "old-owner"}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: "old-owner"}
 						oldProject := project.DeepCopy()
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "new-owner"}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: "new-owner"}
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 					})
 
 					It("should deny changing the owner", func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
 
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "old-owner"}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: "old-owner"}
 						oldProject := project.DeepCopy()
 						project.Spec.Owner.Name = "new-owner"
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("not allowed to manage owner")))
 					})
 
 					It("should deny unsetting the owner", func() {
 						auth.EXPECT().Authorize(ctx, authorizeAttributes).Return(authorizer.DecisionDeny, "", nil)
 
-						project.Spec.Owner = &rbacv1.Subject{Kind: rbacv1.UserKind, Name: "owner"}
+						project.Spec.Owner = &rbacv1.Subject{APIGroup: rbacv1.GroupName, Kind: rbacv1.UserKind, Name: "owner"}
 						oldProject := project.DeepCopy()
 						project.Spec.Owner = nil
 
-						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						attrs = admission.NewAttributesRecord(project, oldProject, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
 						Expect(admissionHandler.Validate(ctx, attrs, nil)).To(MatchError(ContainSubstring("not allowed to manage owner")))
 					})
 				})


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/area robustness
/area user-management
/kind enhancement

**What this PR does / why we need it**:
Align `customverbauthorizer` subject handling with RBAC subject types

Update the member classification logic to properly account for all non-service-account subject kinds. Improve test coverage and ensure test fixtures use fully-qualified RBAC subjects.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @timuthy @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Align `customverbauthorizer` subject handling with RBAC subject types.
```