### PR TITLE
Deploy `ControlPlane` extension after `kube-apiserver` during shoot deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go
@@ -233,22 +233,6 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(scaleETCD),
 		})
-		// Redeploy the control plane to make sure all components that depend on the cloud provider secret
-		// are restarted in case it has changed.
-		deployControlPlane = g.Add(flow.Task{
-			Name:         "Deploying Shoot control plane",
-			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources || !controlPlaneDeploymentNeeded,
-			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, ensureShootClusterIdentity),
-		})
-		waitUntilControlPlaneReady = g.Add(flow.Task{
-			Name: "Waiting until Shoot control plane has been reconciled",
-			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return botanist.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
-			}),
-			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources || !controlPlaneDeploymentNeeded,
-			Dependencies: flow.NewTaskIDs(deployControlPlane),
-		})
 		deployKubeAPIServer = g.Add(flow.Task{
 			Name: "Deploying Kubernetes API server",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
@@ -260,7 +244,6 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 				deployETCD,
 				waitUntilEtcdReady,
 				waitUntilKubeAPIServerServiceIsReady,
-				waitUntilControlPlaneReady,
 			),
 		})
 		scaleUpKubeAPIServer = g.Add(flow.Task{
@@ -301,6 +284,22 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Fn:           botanist.Shoot.Components.ControlPlane.ResourceManager.Wait,
 			SkipIf:       !cleanupShootResources,
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+		// Redeploy the control plane to make sure all components that depend on the cloud provider secret
+		// are restarted in case it has changed.
+		deployControlPlane = g.Add(flow.Task{
+			Name:         "Deploying Shoot control plane",
+			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources || !controlPlaneDeploymentNeeded,
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady),
+		})
+		waitUntilControlPlaneReady = g.Add(flow.Task{
+			Name: "Waiting until Shoot control plane has been reconciled",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				return botanist.Shoot.Components.Extensions.ControlPlane.Wait(ctx)
+			}),
+			SkipIf:       botanist.Shoot.IsWorkerless || !cleanupShootResources || !controlPlaneDeploymentNeeded,
+			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		deployGardenerAccess = g.Add(flow.Task{
 			Name:         "Deploying Gardener shoot access resources",
@@ -348,7 +347,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Name:         "Waiting until kube-controller-manager is active",
 			Fn:           flow.TaskFn(botanist.WaitForKubeControllerManagerToBeActive).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       !cleanupShootResources || !kubeControllerManagerDeploymentFound,
-			Dependencies: flow.NewTaskIDs(initializeShootClients, cleanupWebhooks, deployControlPlane, deployKubeControllerManager),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, cleanupWebhooks, deployKubeControllerManager),
 		})
 		cleanExtendedAPIs = g.Add(flow.Task{
 			Name:         "Cleaning extended API groups",
@@ -360,7 +359,7 @@ func (r *Reconciler) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		syncPointReadyForCleanup = flow.NewTaskIDs(
 			initializeShootClients,
 			cleanExtendedAPIs,
-			deployControlPlane,
+			waitUntilControlPlaneReady,
 			deployKubeControllerManager,
 			waitForControllersToBeActive,
 		)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Aligns the deletion flow with the reconciliation flow (changed in #8162):
`deployControlPlane` now runs after `waitUntilGardenerResourceManagerReady` instead of before `deployKubeAPIServer`.

Earlier, the dependency to the `controlplane` reconciliation potentially blocked the shoot deletion if service account tokens (managed by GRM) were expired.

_Deadlock sequence:_
1. Service Account tokens are expired, incl. the one from GRM.
2. Shoot deletion is triggered.
3. Gardener waits for a successful `controlplane` reconciliation.
4. The provider extension fails to reconcile the controlplane resource because several components, such as the `CSI` controllers and the `cloud-controller-manager`, are crash-looping due to expired tokens.
5. Re-bootstraping of GRM, which would lead to token renewal, does not happen because of the erroneous `controlplane` resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Provider injection of cloud-provider-config into the `kube-apiserver` deployment is no longer needed since #8087, so there is no reason to block `kube-apiserver` or `gardener-resource-manager` on the `controlplane` extension being reconciled.

/cc @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
7. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The shoot deletion flow was changed to deploy the control-plane after the `kube-apiserver` and `gardener-resource-manager`. In the past, a cyclic dependency between the `controlplane` reconciliation and the `gardener-resource-manager` potentially blocked the shoot deletion.
```
