### PR TITLE
Deprecate `github.com/gardener/gardener/extensions/pkg/terraformer` package

### DIFF
--- a/extensions/pkg/terraformer/chart.go
+++ b/extensions/pkg/terraformer/chart.go
@@ -11,6 +11,8 @@ import (
 )
 
 // TerraformFiles contains all files necessary for initializing a Terraformer.
+//
+// Deprecated: This type is deprecated and will be removed after v1.154 has been released.
 type TerraformFiles struct {
 	Main      string
 	Variables string
@@ -27,6 +29,8 @@ func nonEmptyFileContent(release *chartrenderer.RenderedChart, filename string) 
 }
 
 // ExtractTerraformFiles extracts TerraformFiles from the given RenderedChart.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 //
 // It errors if a file is not contained in the chart.
 func ExtractTerraformFiles(release *chartrenderer.RenderedChart) (*TerraformFiles, error) {

--- a/extensions/pkg/terraformer/chart.go
+++ b/extensions/pkg/terraformer/chart.go
@@ -29,10 +29,9 @@ func nonEmptyFileContent(release *chartrenderer.RenderedChart, filename string) 
 }
 
 // ExtractTerraformFiles extracts TerraformFiles from the given RenderedChart.
+// It errors if a file is not contained in the chart.
 //
 // Deprecated: This function is deprecated and will be removed after v1.154 has been released.
-//
-// It errors if a file is not contained in the chart.
 func ExtractTerraformFiles(release *chartrenderer.RenderedChart) (*TerraformFiles, error) {
 	main, err := nonEmptyFileContent(release, MainKey)
 	if err != nil {

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -82,6 +82,8 @@ func (t *terraformer) SetLogLevel(level string) Terraformer {
 
 // InitializerConfig is the configuration about the location and naming of the resources the
 // Terraformer expects.
+//
+// Deprecated: This type is deprecated and will be removed after v1.154 has been released.
 type InitializerConfig struct {
 	// Namespace is the namespace where all the resources required for the Terraformer shall be
 	// deployed.
@@ -145,6 +147,8 @@ func createOrUpdateConfigMap(ctx context.Context, c client.Client, namespace, na
 
 // CreateOrUpdateConfigurationConfigMap creates or updates the Terraform configuration ConfigMap
 // with the given main and variables content.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func CreateOrUpdateConfigurationConfigMap(ctx context.Context, c client.Client, namespace, name, main, variables string, ownerRef *metav1.OwnerReference) (*corev1.ConfigMap, error) {
 	return createOrUpdateConfigMap(
 		ctx,
@@ -160,6 +164,8 @@ func CreateOrUpdateConfigurationConfigMap(ctx context.Context, c client.Client, 
 }
 
 // CreateOrUpdateTFVarsSecret creates or updates the Terraformer variables Secret with the given tfvars.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func CreateOrUpdateTFVarsSecret(ctx context.Context, c client.Client, namespace, name string, tfvars []byte, ownerRef *metav1.OwnerReference) (*corev1.Secret, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -191,6 +197,8 @@ func (f initializerFunc) Initialize(ctx context.Context, config *InitializerConf
 
 // DefaultInitializer is an Initializer that initializes the configuration, variables and state resources
 // based on the given main, variables and tfvars content and on the given InitializerConfig.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func DefaultInitializer(c client.Client, main, variables string, tfvars []byte, stateInitializer StateConfigMapInitializer) Initializer {
 	return initializerFunc(func(ctx context.Context, config *InitializerConfig, ownerRef *metav1.OwnerReference) error {
 		if _, err := CreateOrUpdateConfigurationConfigMap(ctx, c, config.Namespace, config.ConfigurationName, main, variables, ownerRef); err != nil {

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -22,12 +22,20 @@ import (
 
 const (
 	// MainKey is the key of the main.tf file inside the configuration ConfigMap.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	MainKey = "main.tf"
 	// VariablesKey is the key of the variables.tf file inside the configuration ConfigMap.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	VariablesKey = "variables.tf"
 	// TFVarsKey is the key of the terraform.tfvars file inside the variables Secret.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	TFVarsKey = "terraform.tfvars"
 	// StateKey is the key of the terraform.tfstate file inside the state ConfigMap.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	StateKey = "terraform.tfstate"
 )
 

--- a/extensions/pkg/terraformer/doc.go
+++ b/extensions/pkg/terraformer/doc.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package terraformer provides a client library for spawning Terraformer Pods
+// on seed clusters to execute Terraform scripts for infrastructure reconciliation.
+//
+// Deprecated: This package is deprecated and will be removed after v1.154 has been released.
+//
+// TODO(kon-angelo): Remove this package after v1.154 has been released.
+package terraformer

--- a/extensions/pkg/terraformer/doc.go
+++ b/extensions/pkg/terraformer/doc.go
@@ -6,6 +6,7 @@
 // on seed clusters to execute Terraform scripts for infrastructure reconciliation.
 //
 // Deprecated: This package is deprecated and will be removed after v1.154 has been released.
+// Instead, consider using plain SDK calls for infrastructure reconciliation.
 //
 // TODO(kon-angelo): Remove this package after v1.154 has been released.
 package terraformer

--- a/extensions/pkg/terraformer/raw_state.go
+++ b/extensions/pkg/terraformer/raw_state.go
@@ -33,6 +33,8 @@ func (t *terraformer) GetRawState(ctx context.Context) (*RawState, error) {
 }
 
 // UnmarshalRawState transform passed rawState to RawState struct. It tries to decode the state
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func UnmarshalRawState(rawState any) (*RawState, error) {
 	var rawData []byte
 

--- a/extensions/pkg/terraformer/raw_state.go
+++ b/extensions/pkg/terraformer/raw_state.go
@@ -16,6 +16,8 @@ import (
 )
 
 // Marshal transform RawState to []byte representation. It encodes the raw state data
+//
+// Deprecated: This method is deprecated and will be removed after v1.154 has been released.
 func (trs *RawState) Marshal() ([]byte, error) {
 	return json.Marshal(trs.encodeBase64())
 }

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -22,6 +22,8 @@ import (
 
 const (
 	// TerraformerFinalizer is the finalizer key set by the terraformer on the configmaps and secrets
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	TerraformerFinalizer = "gardener.cloud/terraformer"
 )
 
@@ -124,6 +126,8 @@ func (e *variablesNotFoundError) Error() string {
 }
 
 // IsVariablesNotFoundError returns true if the error indicates that not all variables have been found.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func IsVariablesNotFoundError(err error) bool {
 	switch err.(type) {
 	case *variablesNotFoundError:
@@ -178,12 +182,16 @@ func sniffJSONStateVersion(stateConfigMap []byte) (uint64, error) {
 }
 
 // Initialize implements StateConfigMapInitializer
+//
+// Deprecated: This method is deprecated and will be removed after v1.154 has been released.
 func (f StateConfigMapInitializerFunc) Initialize(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error {
 	return f(ctx, c, namespace, name, ownerRef)
 }
 
 // CreateState create terraform state config map and use empty state.
 // It does not create or update state ConfigMap if already exists,
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func CreateState(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
@@ -200,6 +208,8 @@ func CreateState(ctx context.Context, c client.Client, namespace, name string, o
 }
 
 // Initialize implements StateConfigMapInitializer
+//
+// Deprecated: This method is deprecated and will be removed after v1.154 has been released.
 func (cus CreateOrUpdateState) Initialize(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error {
 	if cus.State == nil {
 		return fmt.Errorf("missing state when creating or updating terraform state ConfigMap %s/%s", namespace, name)

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -26,8 +26,12 @@ import (
 
 const (
 	// LabelKeyName is a key for label on a Terraformer Pod indicating the Terraformer name.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	LabelKeyName = "terraformer.gardener.cloud/name"
 	// LabelKeyPurpose is a key for label on a Terraformer Pod indicating the Terraformer purpose.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	LabelKeyPurpose = "terraformer.gardener.cloud/purpose"
 )
 
@@ -124,8 +128,12 @@ func New(
 
 const (
 	// CommandApply is a constant for the "apply" command.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	CommandApply = "apply"
 	// CommandDestroy is a constant for the "destroy" command.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	CommandDestroy = "destroy"
 )
 

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -46,11 +46,15 @@ func (f factory) DefaultInitializer(c client.Client, main, variables string, tfV
 }
 
 // DefaultFactory returns the default factory.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func DefaultFactory() Factory {
 	return factory{}
 }
 
 // NewForConfig creates a new Terraformer and its dependencies from the given configuration.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func NewForConfig(
 	logger logr.Logger,
 	config *rest.Config,
@@ -80,6 +84,8 @@ func NewForConfig(
 // <image> name for the to-be-used Docker image. It returns a Terraformer interface with initialized
 // values for the namespace and the names which will be used for all the stored resources like
 // ConfigMaps/Secrets.
+//
+// Deprecated: This function is deprecated and will be removed after v1.154 has been released.
 func New(
 	logger logr.Logger,
 	c client.Client,

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -66,6 +66,8 @@ type terraformer struct {
 }
 
 // RawState represent the terraformer state's raw data
+//
+// Deprecated: This type is deprecated and will be removed after v1.154 has been released.
 type RawState struct {
 	Data     string `json:"data"`
 	Encoding string `json:"encoding"`
@@ -91,6 +93,8 @@ const (
 )
 
 // Terraformer is the Terraformer interface.
+//
+// Deprecated: This interface is deprecated and will be removed after v1.154 has been released.
 type Terraformer interface {
 	SetLogLevel(string) Terraformer
 	SetEnvVars(envVars ...corev1.EnvVar) Terraformer
@@ -116,11 +120,15 @@ type Terraformer interface {
 }
 
 // Initializer can initialize a Terraformer.
+//
+// Deprecated: This interface is deprecated and will be removed after v1.154 has been released.
 type Initializer interface {
 	Initialize(ctx context.Context, config *InitializerConfig, ownerRef *metav1.OwnerReference) error
 }
 
 // Factory is a factory that can produce Terraformer and Initializer.
+//
+// Deprecated: This interface is deprecated and will be removed after v1.154 has been released.
 type Factory interface {
 	NewForConfig(logger logr.Logger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
 	New(logger logr.Logger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
@@ -128,15 +136,21 @@ type Factory interface {
 }
 
 // StateConfigMapInitializer initialize terraformer state ConfigMap
+//
+// Deprecated: This interface is deprecated and will be removed after v1.154 has been released.
 type StateConfigMapInitializer interface {
 	Initialize(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error
 }
 
 // StateConfigMapInitializerFunc implements StateConfigMapInitializer
+//
+// Deprecated: This type is deprecated and will be removed after v1.154 has been released.
 type StateConfigMapInitializerFunc func(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error
 
 // CreateOrUpdateState implements StateConfigMapInitializer.
 // It use it field state for creating or updating the state ConfigMap
+//
+// Deprecated: This type is deprecated and will be removed after v1.154 has been released.
 type CreateOrUpdateState struct {
 	State *string
 }

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -77,18 +77,28 @@ const (
 	numberOfConfigResources = 3
 
 	// ConfigSuffix is the suffix used for the ConfigMap which stores the Terraform configuration and variables declaration.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	ConfigSuffix = ".tf-config"
 
 	// VariablesSuffix is the suffix used for the Secret which stores the Terraform variables definition.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	VariablesSuffix = ".tf-vars"
 
 	// StateSuffix is the suffix used for the ConfigMap which stores the Terraform state.
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	StateSuffix = ".tf-state"
 
 	// Base64Encoding denotes base64 encoding for the RawState.Data
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	Base64Encoding = "base64"
 
 	// NoneEncoding denotes none encoding for the RawState.Data
+	//
+	// Deprecated: This constant is deprecated and will be removed after v1.154 has been released.
 	NoneEncoding = "none"
 )
 


### PR DESCRIPTION
The terraformer library is deprecated in favor of flow-based reconciliation using direct cloud SDK calls. Provider extensions should migrate their infrastructure reconciliation away from Terraform/Terraformer.

All exported types, interfaces, and functions in the package are marked with // Deprecated: comments, and a package-level doc.go documents the deprecation with rationale and migration pointer.

The package is scheduled for removal after v1.154 has been released, respecting the 9-release deprecation window for extension-relevant functionality.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind technical-debt

**What this PR does / why we need it**:
Known providers have migrated away from using the terraformer library and thus it is considered mostly deprecated artifact. Let's reduce refactoring pains by removing the package in the near future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `github.com/gardener/gardener/extensions/pkg/terraformer` package is marked as deprecated now. Instead, consider using plain SDK calls for infrastructure reconciliation. The package removal is scheduled after Gardener v1.154 has been released.
```
