### PR TITLE
provider-local: run machine pods with AppArmor/seccomp unconfined

### DIFF
--- a/pkg/provider-local/machine-provider/node/Dockerfile
+++ b/pkg/provider-local/machine-provider/node/Dockerfile
@@ -18,7 +18,12 @@ RUN rm -f /etc/systemd/system/kubelet.service && \
 # kubelets) get their own cgroup namespace. Without this, nested kubelets see the host's cgroup
 # hierarchy and fail to manage cgroups properly. This is the same adjustment that kind.sh performs
 # at cluster creation time for KinD nodes.
-RUN jq '.linux.namespaces += [{"type": "cgroup"}]' /etc/containerd/cri-base.json > /tmp/cri-base.json && \
+#
+# Also run containers unconfined (no seccomp, no AppArmor) so that processes started by the
+# machine node's containerd (e.g. the cilium-cli host-netns DaemonSet used for encryption tests)
+# are not restricted. Without this, the runtime default seccomp profile and the host's AppArmor
+# profile are inherited by nested containers.
+RUN jq '.linux.namespaces += [{"type": "cgroup"}] | .linux.seccomp = {} | .process.apparmorProfile = "unconfined"' /etc/containerd/cri-base.json > /tmp/cri-base.json && \
     mv /tmp/cri-base.json /etc/containerd/cri-base.json
 
 # copy containerd hosts configurations for local registry mirrors


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind test

**What this PR does / why we need it**:
With a kind update the AppArmor profile has apparently changed and Cilium connection tests are failing. The tests do tcpdumps that became unkillable. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
provider-local: configure machine node containerd to run nested containers with seccomp and AppArmor unconfined, fixing unkillable processes in deeply nested CI environments 
```
