### PR TITLE
 Label `VirtualServices` requiring basic authentication with the `istio-basic-auth-server` that configures them

### DIFF
--- a/dev-setup/skaffold-gardenadm.yaml
+++ b/dev-setup/skaffold-gardenadm.yaml
@@ -946,6 +946,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/proxy
+            - pkg/component/networking/istiobasicauthserver
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/prometheus/shoot

--- a/dev-setup/skaffold-operator.yaml
+++ b/dev-setup/skaffold-operator.yaml
@@ -1066,6 +1066,7 @@ build:
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/kubernetes/apiserver/constants
             - pkg/component/kubernetes/proxy
+            - pkg/component/networking/istiobasicauthserver
             - pkg/component/nodemanagement/machinecontrollermanager
             - pkg/component/observability/monitoring/alertmanager
             - pkg/component/observability/monitoring/prometheus/shoot

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -540,6 +540,8 @@ const (
 	LabelObservability = "observability"
 	// LabelBasicAuthSecretName is a constant for a label used on virtual services to include the referenced secret into the istio-basic-auth-server for basic auth.
 	LabelBasicAuthSecretName = "reference.gardener.cloud/basic-auth-secret-name"
+	// LabelBasicAuthServerName is a constant for a label used on virtual services to associate them with a specific istio-basic-auth-server instance.
+	LabelBasicAuthServerName = "reference.gardener.cloud/basic-auth-server-name"
 
 	// LabelExtensionExtensionTypePrefix is used to prefix extension label for extension types.
 	LabelExtensionExtensionTypePrefix = "extensions.extensions.gardener.cloud/"

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver.go
@@ -179,7 +179,7 @@ func (i *istioBasicAuthServer) calculateConfiguration(
 	error,
 ) {
 	virtualServiceList := &istionetworkingv1beta1.VirtualServiceList{}
-	if err := i.client.List(ctx, virtualServiceList, client.InNamespace(i.namespace), client.HasLabels{v1beta1constants.LabelBasicAuthSecretName}); err != nil {
+	if err := i.client.List(ctx, virtualServiceList, client.InNamespace(i.namespace), client.MatchingLabels{v1beta1constants.LabelBasicAuthServerName: i.getPrefix() + name}); err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to list virtual services: %w", err)
 	}
 
@@ -300,6 +300,19 @@ func (i *istioBasicAuthServer) getPrefix() string {
 	}
 
 	return ""
+}
+
+// BasicAuthLabels returns the labels that associate a VirtualService with its configuring istio-basic-auth-server.
+func BasicAuthLabels(isGardenCluster bool, secretName string) map[string]string {
+	basicAuthServerName := v1beta1constants.DeploymentNameIstioBasicAuthServer
+	if isGardenCluster {
+		basicAuthServerName = operatorv1alpha1.VirtualGardenNamePrefix + basicAuthServerName
+	}
+
+	return map[string]string{
+		v1beta1constants.LabelBasicAuthSecretName: secretName,
+		v1beta1constants.LabelBasicAuthServerName: basicAuthServerName,
+	}
 }
 
 func (i *istioBasicAuthServer) getLabels() map[string]string {

--- a/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
+++ b/pkg/component/networking/istiobasicauthserver/istiobasicauthserver_test.go
@@ -454,13 +454,23 @@ status: {}
 		})
 
 		Context("With secrets present", func() {
-			BeforeEach(func() {
+			createVirtualServices := func(basicAuthServerName string) {
 				Expect(c.Create(ctx, dummyVirtualService.DeepCopy())).To(Succeed())
-				Expect(c.Create(ctx, realVirtualService1.DeepCopy())).To(Succeed())
-				Expect(c.Create(ctx, realVirtualService2.DeepCopy())).To(Succeed())
-			})
+
+				vs1 := realVirtualService1.DeepCopy()
+				vs1.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
+				Expect(c.Create(ctx, vs1)).To(Succeed())
+
+				vs2 := realVirtualService2.DeepCopy()
+				vs2.Labels["reference.gardener.cloud/basic-auth-server-name"] = basicAuthServerName
+				Expect(c.Create(ctx, vs2)).To(Succeed())
+			}
 
 			Context("Shoot or Seed", func() {
+				BeforeEach(func() {
+					createVirtualServices("istio-basic-auth-server")
+				})
+
 				It("should successfully deploy the resources", func() {
 					testManifests(false, []prefixToSecretMapping{
 						{prefix1, secret1},
@@ -472,6 +482,7 @@ status: {}
 
 			Context("Garden", func() {
 				BeforeEach(func() {
+					createVirtualServices("virtual-garden-istio-basic-auth-server")
 					values.IsGardenCluster = true
 					values.SigningCA = "ca-virtual-garden-istio-basic-auth-server"
 					values.IstioIngressGatewayNamespace = "virtual-garden-istio-ingress"

--- a/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
+++ b/pkg/component/observability/monitoring/alertmanager/alertmanager_test.go
@@ -363,6 +363,7 @@ var _ = Describe("Alertmanager", func() {
 					"role":         "monitoring",
 					"alertmanager": name,
 					"reference.gardener.cloud/basic-auth-secret-name": "foo",
+					"reference.gardener.cloud/basic-auth-server-name": "istio-basic-auth-server",
 				},
 			},
 			Spec: istionetworkingv1alpha3.VirtualService{

--- a/pkg/component/observability/monitoring/alertmanager/istio_resources.go
+++ b/pkg/component/observability/monitoring/alertmanager/istio_resources.go
@@ -17,6 +17,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/istiobasicauthserver"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/istio"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -87,7 +88,7 @@ func (a *alertManager) istioResources(ctx context.Context) ([]client.Object, err
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: a.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(a.getLabels(), map[string]string{v1beta1constants.LabelBasicAuthSecretName: a.values.ExternalExposure.AuthSecretName}),
+		utils.MergeStringMaps(a.getLabels(), istiobasicauthserver.BasicAuthLabels(a.values.ExternalExposure.IsGardenCluster, a.values.ExternalExposure.AuthSecretName)),
 		[]string{a.values.ExternalExposure.IstioIngressGatewayNamespace},
 		[]string{a.values.ExternalExposure.Host},
 		gatewayName,

--- a/pkg/component/observability/monitoring/prometheus/istio_resources.go
+++ b/pkg/component/observability/monitoring/prometheus/istio_resources.go
@@ -17,6 +17,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+	"github.com/gardener/gardener/pkg/component/networking/istiobasicauthserver"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/istio"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -92,7 +93,7 @@ func (p *prometheus) istioResources(ctx context.Context) ([]client.Object, error
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(p.getLabels(), map[string]string{v1beta1constants.LabelBasicAuthSecretName: p.values.Ingress.AuthSecretName}),
+		utils.MergeStringMaps(p.getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.Ingress.IsGardenCluster, p.values.Ingress.AuthSecretName)),
 		[]string{p.values.Ingress.IstioIngressGatewayNamespace},
 		[]string{p.values.Ingress.Host},
 		gatewayName,

--- a/pkg/component/observability/monitoring/prometheus/prometheus_test.go
+++ b/pkg/component/observability/monitoring/prometheus/prometheus_test.go
@@ -489,6 +489,7 @@ honor_labels: true`
 					"role": "monitoring",
 					"name": name,
 					"reference.gardener.cloud/basic-auth-secret-name": "foo",
+					"reference.gardener.cloud/basic-auth-server-name": "istio-basic-auth-server",
 				},
 			},
 			Spec: istionetworkingv1alpha3.VirtualService{

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -32,6 +32,7 @@ import (
 	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/networking/istiobasicauthserver"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -868,7 +869,7 @@ func (p *plutono) getIstioResources(ctx context.Context) ([]client.Object, error
 	virtualService := &istionetworkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: p.namespace}}
 	if err := istio.VirtualServiceForTLSTermination(
 		virtualService,
-		utils.MergeStringMaps(getLabels(), map[string]string{v1beta1constants.LabelBasicAuthSecretName: credentialsSecretName}),
+		utils.MergeStringMaps(getLabels(), istiobasicauthserver.BasicAuthLabels(p.values.IsGardenCluster, credentialsSecretName)),
 		[]string{p.values.IstioIngressGatewayNamespace},
 		[]string{p.values.IngressHost},
 		gatewayName,

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -570,6 +570,13 @@ metadata:
 					secretName = `observability-ingress-users`
 				}
 				out += secretName + `
+    reference.gardener.cloud/basic-auth-server-name: `
+				if values.IsGardenCluster {
+					out += `virtual-garden-istio-basic-auth-server`
+				} else {
+					out += `istio-basic-auth-server`
+				}
+				out += `
   name: `
 				if values.IsGardenCluster {
 					out += `virtual-garden-plutono-garden`


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Basic authentication for observability ingress is currently configured solely based on the `reference.gardener.cloud/basic-auth-secret-name` label. Virtual services receive such label, creating the relationship between the ingress and the secret. Upon reconciliation, the `gardener-operator` and `gardenlet` list `VirtualServices` with such label and deploy the corresponding `istio-basic-auth-server` pods for `Garden` and `Seed` ingress, respectively.

However, in setups where the garden and seed clusters are the same, the `istio-basic-auth-servers` deployed by the `gardener-operator` and by the `gardenlet` end up configuring basic authentication for both `Garden` and `Seed` resources,  causing each server to mount ingress secrets from both contexts.

```
> k -n garden get pod virtual-garden-istio-basic-auth-server-c8b5bf69c-xp689 -o json | jq -r '.spec.volumes[].secret.secretName' | sort | uniq | grep observability
observability-ingress-0da36eb1
seed-observability-ingress-0da36eb1
> k -n garden get pod istio-basic-auth-server-754bbfc77d-x6rv8 -o json | jq -r '.spec.volumes[].secret.secretName' | sort | uniq | grep observability
observability-ingress-0da36eb1
seed-observability-ingress-0da36eb1
```

This PR proposes a new `reference.gardener.cloud/basic-auth-server-name` label on `VirtualServices` to reference the `istio-basic-auth-server` that configures such `VirtualService`'s authentication. This way, `VirtualServices` managed by the `gardener-operator` are labeled as

    reference.gardener.cloud/basic-auth-server-name: virtual-garden-istio-basic-auth-server

and `VirtualServices` managed by the `gardenlet` with

    reference.gardener.cloud/basic-auth-server-name: istio-basic-auth-server

This makes `VirtualServices` with basic authentication from the `Garden` and `Seed` resources distinguishable. The new label is used during `Garden` and `Seed` resource reconciliation to correctly configure the `istio-basic-auth-servers`. The new behaviour can be verified by checking the secrets each `istio-basic-auth-server` mounts:

```
> k -n garden get pod virtual-garden-istio-basic-auth-server-6b5554d988-h9fg4 -o json | jq -r '.spec.volumes[].secret.secretName' | sort | uniq | grep observability
observability-ingress-0da36eb1
> k -n garden get pod istio-basic-auth-server-7468658775-gzl62 -o json | jq -r '.spec.volumes[].secret.secretName' | sort | uniq | grep observability
seed-observability-ingress-0da36eb1
```

**Special notes for your reviewer**:

/cc @ScheererJ @istvanballok @rickardsjp @chrkl 

**Release note**:

```other operator
`VirtualServices` with basic authentication are now labeled with `reference.gardener.cloud/basic-auth-server-name` to reference the `istio-basic-auth-server` that configures them.
```
