### PR TITLE
[GEP-33] Allow capability CloudProfile revert when NamespacedCloudprofiles use multiple architecture

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -518,18 +518,29 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 
 				relevantNamespacedCloudProfiles := make(map[string]*gardencorev1beta1.NamespacedCloudProfile)
 
-				wg.Add(len(namespacedCloudProfileList))
-
+				// First pass: identify relevant NamespacedCloudProfiles (referencing this CloudProfile and not being deleted).
 				for _, ncp := range namespacedCloudProfileList {
 					if ncp.DeletionTimestamp != nil ||
 						ncp.Spec.Parent.Name != cloudProfile.Name ||
 						ncp.Spec.Parent.Kind != v1beta1constants.CloudProfileReferenceKindCloudProfile {
-						wg.Done()
 						continue
 					}
-
 					ncpNamespacedName := types.NamespacedName{Name: ncp.Name, Namespace: ncp.Namespace}
 					relevantNamespacedCloudProfiles[ncpNamespacedName.String()] = ncp
+				}
+
+				// Allow reverting to a legacy CloudProfile: if all relevant NamespacedCloudProfiles
+				// reference no capability other than 'architecture' (the legacy architecture(s) fields on
+				// machineImages/machineTypes still cover that case), then capability removals on the parent
+				// CloudProfile must not be blocked, regardless of which capabilities are being removed.
+				if len(removedCapabilities) > 0 && namespacedCloudProfilesUseOnlyArchitectureCapability(relevantNamespacedCloudProfiles) {
+					removedCapabilities = nil
+				}
+
+				wg.Add(len(relevantNamespacedCloudProfiles))
+
+				for _, ncp := range relevantNamespacedCloudProfiles {
+					ncpNamespacedName := types.NamespacedName{Name: ncp.Name, Namespace: ncp.Namespace}
 
 					go func(nscpfl *gardencorev1beta1.NamespacedCloudProfile) {
 						defer wg.Done()
@@ -541,6 +552,8 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 								}
 							}
 						}
+
+						capabilityViolations := map[string]sets.Set[string]{}
 
 						for _, machineImage := range nscpfl.Spec.MachineImages {
 							if machineImageDiff.RemovedImages.Has(machineImage.Name) {
@@ -556,10 +569,19 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 									}
 								}
 							}
-							checkMachineImageForRemovedCapabilities(machineImage, removedCapabilities, nscpfl, cloudProfile, channel)
+							collectMachineImageCapabilityViolations(machineImage, removedCapabilities, capabilityViolations)
 						}
 						for _, machineType := range nscpfl.Spec.MachineTypes {
-							checkMachineTypeForRemovedCapabilities(machineType, removedCapabilities, nscpfl, cloudProfile, channel)
+							collectMachineTypeCapabilityViolations(machineType, removedCapabilities, capabilityViolations)
+						}
+
+						// Emit one aggregated error per removed capability per NamespacedCloudProfile,
+						for _, removedCapability := range removedCapabilities {
+							values, ok := capabilityViolations[removedCapability.Name]
+							if !ok || values.Len() == 0 {
+								continue
+							}
+							channel <- fmt.Errorf("unable to delete MachineCapability %q with values %v from CloudProfile %q - capability values are still in use by NamespacedCloudProfile '%s/%s'", removedCapability.Name, sets.List(values), cloudProfile.Name, nscpfl.Namespace, nscpfl.Name)
 						}
 					}(ncp)
 				}
@@ -725,32 +747,68 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 	return nil
 }
 
-func checkMachineTypeForRemovedCapabilities(machineType gardencorev1beta1.MachineType, removedCapabilities []core.CapabilityDefinition, nscpfl *gardencorev1beta1.NamespacedCloudProfile, cloudProfile *core.CloudProfile, channel chan error) {
+func collectMachineTypeCapabilityViolations(machineType gardencorev1beta1.MachineType, removedCapabilities []core.CapabilityDefinition, violations map[string]sets.Set[string]) {
 	for _, removedCapability := range removedCapabilities {
 		if capabilityValues, exist := machineType.Capabilities[removedCapability.Name]; exist {
 			for _, capabilityValue := range capabilityValues {
 				if slices.Contains(removedCapability.Values, capabilityValue) {
-					channel <- fmt.Errorf("unable to delete MachineCapability %q with value %q from CloudProfile %q - capability value is still in use by NamespacedCloudProfile '%s/%s'", removedCapability.Name, capabilityValue, cloudProfile.Name, nscpfl.Namespace, nscpfl.Name)
+					if _, ok := violations[removedCapability.Name]; !ok {
+						violations[removedCapability.Name] = sets.New[string]()
+					}
+					violations[removedCapability.Name].Insert(capabilityValue)
 				}
 			}
 		}
 	}
 }
 
-func checkMachineImageForRemovedCapabilities(machineImage gardencorev1beta1.MachineImage, removedCapabilities []core.CapabilityDefinition, nscpfl *gardencorev1beta1.NamespacedCloudProfile, cloudProfile *core.CloudProfile, channel chan error) {
+func collectMachineImageCapabilityViolations(machineImage gardencorev1beta1.MachineImage, removedCapabilities []core.CapabilityDefinition, violations map[string]sets.Set[string]) {
 	for _, imageVersion := range machineImage.Versions {
 		for _, imageFlavor := range imageVersion.CapabilityFlavors {
 			for _, removedCapability := range removedCapabilities {
 				if capabilityValues, exist := imageFlavor.Capabilities[removedCapability.Name]; exist {
 					for _, capabilityValue := range capabilityValues {
 						if slices.Contains(removedCapability.Values, capabilityValue) {
-							channel <- fmt.Errorf("unable to delete MachineCapability %q with value %q from CloudProfile %q - capability value is still in use by NamespacedCloudProfile '%s/%s'", removedCapability.Name, capabilityValue, cloudProfile.Name, nscpfl.Namespace, nscpfl.Name)
+							if _, ok := violations[removedCapability.Name]; !ok {
+								violations[removedCapability.Name] = sets.New[string]()
+							}
+							violations[removedCapability.Name].Insert(capabilityValue)
 						}
 					}
 				}
 			}
 		}
 	}
+}
+
+// namespacedCloudProfilesUseOnlyArchitectureCapability returns true if the only capability key
+// referenced by any machineImage flavor or machineType across all given NamespacedCloudProfiles
+// is 'architecture'. NamespacedCloudProfiles that reference no capabilities at all also satisfy
+// this condition. This is used to allow reverting a parent CloudProfile to its legacy form,
+// in which the legacy architecture(s) fields on machineImages/machineTypes still cover the
+// architecture capability.
+func namespacedCloudProfilesUseOnlyArchitectureCapability(nscpfls map[string]*gardencorev1beta1.NamespacedCloudProfile) bool {
+	for _, nscpfl := range nscpfls {
+		for _, machineImage := range nscpfl.Spec.MachineImages {
+			for _, imageVersion := range machineImage.Versions {
+				for _, imageFlavor := range imageVersion.CapabilityFlavors {
+					for capabilityName := range imageFlavor.Capabilities {
+						if capabilityName != v1beta1constants.ArchitectureName {
+							return false
+						}
+					}
+				}
+			}
+		}
+		for _, machineType := range nscpfl.Spec.MachineTypes {
+			for capabilityName := range machineType.Capabilities {
+				if capabilityName != v1beta1constants.ArchitectureName {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 func (r *ReferenceManager) ensureControllerRegistrationReferences(ctx context.Context, ctrlReg *core.ControllerRegistration) error {
@@ -1522,14 +1580,6 @@ func getRemovedMachineCapabilities(old, new []core.CapabilityDefinition) []core.
 				})
 			}
 		}
-	}
-
-	// To allow reverting to legacy CloudProfiles the special case of removing the architecture Capability
-	// must be allowed, as long as the architecture(s) fields for machineImages and machineTypes is still supported.
-	if len(newCapabilitiesMap) == 0 &&
-		len(removedCapabilities) == 1 &&
-		removedCapabilities[0].Name == v1beta1constants.ArchitectureName {
-		return []core.CapabilityDefinition{}
 	}
 
 	return removedCapabilities

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -539,9 +539,7 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 
 				wg.Add(len(relevantNamespacedCloudProfiles))
 
-				for _, ncp := range relevantNamespacedCloudProfiles {
-					ncpNamespacedName := types.NamespacedName{Name: ncp.Name, Namespace: ncp.Namespace}
-
+				for ncpNamespacedName, ncp := range relevantNamespacedCloudProfiles {
 					go func(nscpfl *gardencorev1beta1.NamespacedCloudProfile) {
 						defer wg.Done()
 
@@ -557,10 +555,10 @@ func (r *ReferenceManager) Validate(ctx context.Context, a admission.Attributes,
 
 						for _, machineImage := range nscpfl.Spec.MachineImages {
 							if machineImageDiff.RemovedImages.Has(machineImage.Name) {
-								channel <- fmt.Errorf("unable to delete MachineImage %q from CloudProfile %q - MachineImage is still in use by NamespacedCloudProfile %q", machineImage.Name, cloudProfile.Name, ncpNamespacedName.String())
+								channel <- fmt.Errorf("unable to delete MachineImage %q from CloudProfile %q - MachineImage is still in use by NamespacedCloudProfile %q", machineImage.Name, cloudProfile.Name, ncpNamespacedName)
 							}
 							if machineImageDiff.AddedImages.Has(machineImage.Name) {
-								channel <- fmt.Errorf("unable to add MachineImage %q to CloudProfile %q - MachineImage is already defined by NamespacedCloudProfile %q", machineImage.Name, cloudProfile.Name, ncpNamespacedName.String())
+								channel <- fmt.Errorf("unable to add MachineImage %q to CloudProfile %q - MachineImage is already defined by NamespacedCloudProfile %q", machineImage.Name, cloudProfile.Name, ncpNamespacedName)
 							}
 							if removedVersions, exists := machineImageDiff.RemovedVersions[machineImage.Name]; exists {
 								for _, imageVersion := range machineImage.Versions {

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -1523,5 +1523,14 @@ func getRemovedMachineCapabilities(old, new []core.CapabilityDefinition) []core.
 			}
 		}
 	}
+
+	// To allow reverting to legacy CloudProfiles the special case of removing the architecture Capability
+	// must be allowed, as long as the architecture(s) fields for machineImages and machineTypes is still supported.
+	if len(newCapabilitiesMap) == 0 &&
+		len(removedCapabilities) == 1 &&
+		removedCapabilities[0].Name == v1beta1constants.ArchitectureName {
+		return []core.CapabilityDefinition{}
+	}
+
 	return removedCapabilities
 }

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -3381,12 +3381,12 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Validate(ctx, attrs, nil)
 				Expect(err).To(HaveOccurred())
 
-				// Should get multiple errors for different capability values being removed
+				// Should get one aggregated error per removed capability for the NamespacedCloudProfile
 				Expect(err.Error()).To(And(
-					ContainSubstring("unable to delete MachineCapability \"architecture\" with value \"arm64\" from CloudProfile"),
-					ContainSubstring("capability value is still in use by NamespacedCloudProfile 'default/namespaced-profile'"),
-					ContainSubstring("unable to delete MachineCapability \"network\" with value \"private\" from CloudProfile"),
-					ContainSubstring("unable to delete MachineCapability \"storage\" with value \"hdd\" from CloudProfile"),
+					ContainSubstring("unable to delete MachineCapability \"architecture\" with values [arm64] from CloudProfile"),
+					ContainSubstring("capability values are still in use by NamespacedCloudProfile 'default/namespaced-profile'"),
+					ContainSubstring("unable to delete MachineCapability \"network\" with values [private] from CloudProfile"),
+					ContainSubstring("unable to delete MachineCapability \"storage\" with values [hdd] from CloudProfile"),
 				))
 			})
 
@@ -3463,8 +3463,8 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Validate(ctx, attrs, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(And(
-					ContainSubstring("unable to delete MachineCapability \"storage\""),
-					ContainSubstring("capability value is still in use by NamespacedCloudProfile 'default/namespaced-profile'"),
+					ContainSubstring("unable to delete MachineCapability \"storage\" with values [hdd ssd] from CloudProfile"),
+					ContainSubstring("capability values are still in use by NamespacedCloudProfile 'default/namespaced-profile'"),
 				))
 			})
 
@@ -3502,11 +3502,15 @@ var _ = Describe("resourcereferencemanager", func() {
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
 
-			It("should allow removing the architecture capability entirely (revert to legacy CloudProfile) even if values are still in use by a NamespacedCloudProfile", func() {
-				// Reduce parent CloudProfile to only have the architecture capability,
-				// simulating the legacy state where 'architecture' is the only capability defined.
+			It("should allow removing capabilities (revert to legacy CloudProfile) when NamespacedCloudProfiles only reference the architecture capability, even if multiple capabilities are removed", func() {
+				// Parent CloudProfile defines architecture and additional capabilities; the additional ones
+				// are not referenced by any NamespacedCloudProfile. Removing all of them must be allowed
+				// because the legacy architecture(s) fields on machineImages/machineTypes still cover the
+				// only capability that is actually in use by NamespacedCloudProfiles.
 				cloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
 					{Name: "architecture", Values: []string{"amd64", "arm64"}},
+					{Name: "network", Values: []string{"public", "private"}},
+					{Name: "storage", Values: []string{"ssd", "hdd"}},
 				}
 				cloudProfile.Spec.MachineImages = []core.MachineImage{
 					{
@@ -3533,7 +3537,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				}
 				oldCloudProfile = cloudProfile.DeepCopy()
 
-				// NamespacedCloudProfile still uses architecture values from the parent.
+				// NamespacedCloudProfile only uses the architecture capability.
 				namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 					{
 						Name: "debian",
@@ -3559,8 +3563,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				}
 				Expect(gardenCoreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Update(namespacedCloudProfile)).To(Succeed())
 
-				// Completely drop the MachineCapabilities section. The legacy
-				// architecture(s) fields on machineImages/machineTypes still cover the architecture.
+				// Drop the entire MachineCapabilities section to revert to a legacy CloudProfile.
 				cloudProfile.Spec.MachineCapabilities = nil
 
 				attrs := admission.NewAttributesRecord(cloudProfile, oldCloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("cloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -3501,6 +3501,72 @@ var _ = Describe("resourcereferencemanager", func() {
 
 				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
 			})
+
+			It("should allow removing the architecture capability entirely (revert to legacy CloudProfile) even if values are still in use by a NamespacedCloudProfile", func() {
+				// Reduce parent CloudProfile to only have the architecture capability,
+				// simulating the legacy state where 'architecture' is the only capability defined.
+				cloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
+					{Name: "architecture", Values: []string{"amd64", "arm64"}},
+				}
+				cloudProfile.Spec.MachineImages = []core.MachineImage{
+					{
+						Name: "ubuntu",
+						Versions: []core.MachineImageVersion{
+							{
+								ExpirableVersion: core.ExpirableVersion{Version: "20.04"},
+								CapabilityFlavors: []core.MachineImageFlavor{
+									{Capabilities: core.Capabilities{
+										"architecture": []string{"amd64"},
+									}},
+								},
+							},
+						},
+					},
+				}
+				cloudProfile.Spec.MachineTypes = []core.MachineType{
+					{
+						Name: "m5.large",
+						Capabilities: core.Capabilities{
+							"architecture": []string{"amd64"},
+						},
+					},
+				}
+				oldCloudProfile = cloudProfile.DeepCopy()
+
+				// NamespacedCloudProfile still uses architecture values from the parent.
+				namespacedCloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
+					{
+						Name: "debian",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "11"},
+								CapabilityFlavors: []gardencorev1beta1.MachineImageFlavor{
+									{Capabilities: gardencorev1beta1.Capabilities{
+										"architecture": []string{"arm64"},
+									}},
+								},
+							},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{
+					{
+						Name: "t3.micro",
+						Capabilities: gardencorev1beta1.Capabilities{
+							"architecture": []string{"arm64"},
+						},
+					},
+				}
+				Expect(gardenCoreInformerFactory.Core().V1beta1().NamespacedCloudProfiles().Informer().GetStore().Update(namespacedCloudProfile)).To(Succeed())
+
+				// Completely drop the MachineCapabilities section. The legacy
+				// architecture(s) fields on machineImages/machineTypes still cover the architecture.
+				cloudProfile.Spec.MachineCapabilities = nil
+
+				attrs := admission.NewAttributesRecord(cloudProfile, oldCloudProfile, core.Kind("CloudProfile").WithVersion("version"), "", cloudProfile.Name, core.Resource("cloudprofiles").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, defaultUserInfo)
+
+				Expect(admissionHandler.Validate(ctx, attrs, nil)).To(Succeed())
+			})
 		})
 
 		Context("NamespacedCloudProfile - Extending Kubernetes versions", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/kind bug

**What this PR does / why we need it**:

Replacing a `CloudProfile` with its legacy form (no `MachineCapabilities`, relying on the legacy `architecture(s)` fields on `machineImages`/`machineTypes`) was rejected by the resource-reference-manager admission plugin even when no `NamespacedCloudProfile` actually depended on a non-architecture capability. This PR:

- Skips capability-removal validation entirely when every relevant `NamespacedCloudProfile` references only the `architecture` capability (or no capabilities at all).
- Aggregates rejection errors to one message per `(removedCapability, NamespacedCloudProfile)` instead of one per `(flavor, value)` occurrence — collapsing the previous duplicate-heavy output.

**Which issue(s) this PR fixes**:
Part of: ☂️ #11301 

**Special notes for your reviewer**:

- The legacy-revert allowance is broader than a strict "only architecture removed" check: it permits any combination of capability removals as long as no `NamespacedCloudProfile` references a non-architecture capability.
- Validation for non-capability concerns (Kubernetes versions, machine images, limits, shoots) is unchanged.

**Release note**:
```bugfix operator
Replacing a `CloudProfile` with its legacy form by removing `MachineCapabilities` is now allowed when no `NamespacedCloudProfile` references a capability other than `architecture`. Errors reported when capability removal is rejected are now aggregated to one message per capability per `NamespacedCloudProfile`.
```
