### PR TITLE
fix(release): disambiguate gardenadm assets by OCM resource type

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,35 +42,41 @@ jobs:
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: darwin
             architecture: amd64
         - name: gardenadm-darwin-arm64
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: darwin
             architecture: arm64
         - name: gardenadm-linux-amd64
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: linux
             architecture: amd64
         - name: gardenadm-linux-arm64
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: linux
             architecture: arm64
         - name: gardenadm-windows-amd64
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: windows
             architecture: amd64
         - name: gardenadm-windows-arm64
           type: ocm-resource
           id:
             name: gardenadm
+            type: executable
             os: windows
             architecture: arm64


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area delivery
/kind bug

**What this PR does / why we need it**:
The release workflow crashed with "is ambiguous (more than one matching OCM-Resource)" for gardenadm on linux/amd64 and linux/arm64.

The oci-ocm workflow generates SBOM resources (spdx, cyclonedx) for each OCI image platform. These share the same name, os, and architecture in their OCM identity as the actual binary resources — so Asset.matches(), which does a subset check, matched both the binary and the SBOM resources.

Darwin and Windows were unaffected because no OCI images (and thus no SBOMs) are built for those platforms.

Fix: add type: executable to each asset's id in the release workflow, so the matcher also checks resource.type and filters out the SBOM resources.

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
