### PR TITLE
Wrap `prepareGardenerResources` in a retry

### DIFF
--- a/pkg/gardenadm/cmd/connect/connect.go
+++ b/pkg/gardenadm/cmd/connect/connect.go
@@ -111,8 +111,11 @@ func run(ctx context.Context, opts *Options) error {
 				},
 			})
 			prepareResources = g.Add(flow.Task{
-				Name:         "Preparing Gardener resources in garden cluster",
-				Fn:           func(ctx context.Context) error { return prepareGardenerResources(ctx, b) },
+				Name: "Preparing Gardener resources in garden cluster",
+				// Retry to tolerate transient unavailability of admission webhooks (e.g. gardener-extension-admission-calico)
+				// whose Service endpoints can briefly TCP-reset right after extension reconciliation. The task is idempotent:
+				// all create-calls already swallow AlreadyExists, and the Shoot status patch only runs after a successful Create.
+				Fn:           flow.TaskFn(func(ctx context.Context) error { return prepareGardenerResources(ctx, b) }).RetryUntilTimeout(2*time.Second, 2*time.Minute),
 				Dependencies: flow.NewTaskIDs(retrieveShortLivedKubeconfig),
 			})
 			deployGardenlet = g.Add(flow.Task{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Wrap `prepareGardenerResources` in a retry, mirroring the pattern from the `init` flow to try to fix the calico admission race.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/cc @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
