### PR TITLE
 feat: remove the Vali datasource from Plutono when RemoveVali FG is enabled

### DIFF
--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -403,7 +403,9 @@ datasources:
 `
 	}
 
-	if !p.values.OnlyDeployDataSourcesAndDashboards && !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+	if !p.values.OnlyDeployDataSourcesAndDashboards &&
+		(!features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend) ||
+			!features.DefaultFeatureGate.Enabled(features.RemoveVali)) {
 		datasource += `- name: vali
   type: vali
   access: proxy

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -403,16 +403,14 @@ datasources:
 `
 	}
 
-	if !p.values.OnlyDeployDataSourcesAndDashboards {
-		if !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
-			datasource += `- name: vali
+	if !p.values.OnlyDeployDataSourcesAndDashboards && !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+		datasource += `- name: vali
   type: vali
   access: proxy
   url: http://logging.` + p.namespace + `.svc:` + strconv.Itoa(valiconstants.ValiPort) + `
   jsonData:
     maxLines: ` + maxLine + `
 `
-		}
 	}
 
 	return datasource

--- a/pkg/component/observability/plutono/plutono.go
+++ b/pkg/component/observability/plutono/plutono.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/pkg/component"
 	valiconstants "github.com/gardener/gardener/pkg/component/observability/logging/vali/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -403,13 +404,15 @@ datasources:
 	}
 
 	if !p.values.OnlyDeployDataSourcesAndDashboards {
-		datasource += `- name: vali
+		if !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+			datasource += `- name: vali
   type: vali
   access: proxy
   url: http://logging.` + p.namespace + `.svc:` + strconv.Itoa(valiconstants.ValiPort) + `
   jsonData:
     maxLines: ` + maxLine + `
 `
+		}
 	}
 
 	return datasource

--- a/pkg/component/observability/plutono/plutono_suite_test.go
+++ b/pkg/component/observability/plutono/plutono_suite_test.go
@@ -24,6 +24,7 @@ func TestPlutono(t *testing.T) {
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.GenerateRandomString, secretsutils.FakeGenerateRandomString))
 	utilruntime.Must(features.DefaultFeatureGate.Add(features.GetFeatures(
+		features.VictoriaLogsBackend,
 		features.RemoveVali,
 	)))
 })

--- a/pkg/component/observability/plutono/plutono_suite_test.go
+++ b/pkg/component/observability/plutono/plutono_suite_test.go
@@ -9,7 +9,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
+	"github.com/gardener/gardener/pkg/features"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
@@ -21,4 +23,7 @@ func TestPlutono(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretsutils.GenerateRandomString, secretsutils.FakeGenerateRandomString))
+	utilruntime.Must(features.DefaultFeatureGate.Add(features.GetFeatures(
+		features.RemoveVali,
+	)))
 })

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	comp "github.com/gardener/gardener/pkg/component"
 	. "github.com/gardener/gardener/pkg/component/observability/plutono"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -234,13 +235,15 @@ metadata:
 `
 				}
 				if !values.OnlyDeployDataSourcesAndDashboards {
-					configMapData += `    - name: vali
+					if !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+						configMapData += `    - name: vali
       type: vali
       access: proxy
       url: http://logging.` + namespace + `.svc:3100
       jsonData:
         maxLines: ` + maxLine
 
+					}
 				}
 				configMapData = strings.TrimSuffix(configMapData, "\n")
 				var dataSourcesKeySuffix string
@@ -778,6 +781,28 @@ status: {}
 
 				It("should successfully deploy all resources", func() {
 					checkDeployedResources("plutono-dashboards", 24)
+				})
+
+				Context("w/ RemoveVali feature gate disabled", func() {
+					BeforeEach(func() {
+						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.RemoveVali, false))
+					})
+
+					It("should include the vali datasource in the datasources ConfigMap", func() {
+						Expect(manifests).To(ContainElement(dataSourceConfigMapYAMLFor(values)))
+						Expect(manifests).To(ContainElement(ContainSubstring("- name: vali")))
+					})
+				})
+
+				Context("w/ RemoveVali feature gate enabled", func() {
+					BeforeEach(func() {
+						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.RemoveVali, true))
+					})
+
+					It("should omit the vali datasource from the datasources ConfigMap", func() {
+						Expect(manifests).To(ContainElement(dataSourceConfigMapYAMLFor(values)))
+						Expect(manifests).NotTo(ContainElement(ContainSubstring("- name: vali")))
+					})
 				})
 
 				Context("w/ enabled vpa", func() {

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -234,16 +234,14 @@ metadata:
         timeInterval: 1m
 `
 				}
-				if !values.OnlyDeployDataSourcesAndDashboards {
-					if !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
-						configMapData += `    - name: vali
+				if !values.OnlyDeployDataSourcesAndDashboards && !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+					configMapData += `    - name: vali
       type: vali
       access: proxy
       url: http://logging.` + namespace + `.svc:3100
       jsonData:
         maxLines: ` + maxLine
 
-					}
 				}
 				configMapData = strings.TrimSuffix(configMapData, "\n")
 				var dataSourcesKeySuffix string

--- a/pkg/component/observability/plutono/plutono_test.go
+++ b/pkg/component/observability/plutono/plutono_test.go
@@ -234,7 +234,9 @@ metadata:
         timeInterval: 1m
 `
 				}
-				if !values.OnlyDeployDataSourcesAndDashboards && !features.DefaultFeatureGate.Enabled(features.RemoveVali) {
+				if !values.OnlyDeployDataSourcesAndDashboards &&
+					(!features.DefaultFeatureGate.Enabled(features.VictoriaLogsBackend) ||
+						!features.DefaultFeatureGate.Enabled(features.RemoveVali)) {
 					configMapData += `    - name: vali
       type: vali
       access: proxy
@@ -781,25 +783,27 @@ status: {}
 					checkDeployedResources("plutono-dashboards", 24)
 				})
 
-				Context("w/ RemoveVali feature gate disabled", func() {
+				Context("w/ Vali is removed", func() {
 					BeforeEach(func() {
-						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.RemoveVali, false))
-					})
-
-					It("should include the vali datasource in the datasources ConfigMap", func() {
-						Expect(manifests).To(ContainElement(dataSourceConfigMapYAMLFor(values)))
-						Expect(manifests).To(ContainElement(ContainSubstring("- name: vali")))
-					})
-				})
-
-				Context("w/ RemoveVali feature gate enabled", func() {
-					BeforeEach(func() {
+						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VictoriaLogsBackend, true))
 						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.RemoveVali, true))
 					})
 
 					It("should omit the vali datasource from the datasources ConfigMap", func() {
 						Expect(manifests).To(ContainElement(dataSourceConfigMapYAMLFor(values)))
 						Expect(manifests).NotTo(ContainElement(ContainSubstring("- name: vali")))
+					})
+				})
+
+				Context("w/ Vali is not removed", func() {
+					BeforeEach(func() {
+						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.VictoriaLogsBackend, true))
+						DeferCleanup(test.WithFeatureGate(features.DefaultFeatureGate, features.RemoveVali, false))
+					})
+
+					It("should include the vali datasource in the datasources ConfigMap", func() {
+						Expect(manifests).To(ContainElement(dataSourceConfigMapYAMLFor(values)))
+						Expect(manifests).To(ContainElement(ContainSubstring("- name: vali")))
 					})
 				})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Remove redundant Vali datasource from Plutono, when RemoveVali feature gate is set to true.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Vali datasource is remove from Plutono, when RemoveVali feature gate is set to true.
```
