### PR TITLE
chore: Add Kubernetes 1.36 to the list of supported Kubernetes versions

### DIFF
--- a/docs/usage/shoot-operations/supported_k8s_versions.md
+++ b/docs/usage/shoot-operations/supported_k8s_versions.md
@@ -12,6 +12,7 @@ Currently, Gardener supports the following Kubernetes versions:
 | [`v1.33`](https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/) | [`v1.122.0`](https://github.com/gardener/gardener/releases/tag/v1.122.0) | `2025-06-27`  | `2026-08-27`    |
 | [`v1.34`](https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/) | [`v1.132.0`](https://github.com/gardener/gardener/releases/tag/v1.132.0) | `2025-11-13`  | `2027-01-13`    |
 | [`v1.35`](https://kubernetes.io/blog/2025/12/17/kubernetes-v1-35-release/) | [`v1.136.0`](https://github.com/gardener/gardener/releases/tag/v1.136.0) | `2026-02-14`  | `2027-04-14`    |
+| [`v1.36`](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/) | [`v1.145.0`](https://github.com/gardener/gardener/releases/tag/v1.145.0) | `2026-06-19`  | `2027-08-19`    |
 
 > [!NOTE]  
 > Gardener supports Kubernetes versions for at least 14 months after their initial support date.

--- a/supported-kubernetes-versions.yaml
+++ b/supported-kubernetes-versions.yaml
@@ -15,3 +15,7 @@ versions:
   addedIn: "1.136.0"
   startDate: 2026-02-14
   endDate: 2027-04-14
+- version: "1.36"
+  addedIn: "1.145.0"
+  startDate: 2026-06-19
+  endDate: 2027-08-19


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
After the release of [v1.145.0](https://github.com/gardener/gardener/releases/tag/v1.145.0), we can now add Kubernetes 1.36.0 to the list of the supported Kubernetes versions in the docs.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/14924
Part of https://github.com/gardener/gardener/issues/14653

**Special notes for your reviewer**:
I followed the instructions in https://github.com/gardener/gardener/blob/085602fb79e35cf36ecb24e7be35bd321546670e/docs/development/new-kubernetes-version.md?plain=1#L208-L209.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
