### PR TITLE
Add logcheck tool to build process and define versioning mechanism to bundle in `golang-test` image and don't rebuild if not necessary in ci

### DIFF
--- a/.github/workflows/golang-test-build-test.yaml
+++ b/.github/workflows/golang-test-build-test.yaml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/golang-test-images.yaml
       - hack/tools/image/**
       - hack/tools.mk
+      - hack/tools/logcheck/**
       - go.mod
 
 jobs:

--- a/.github/workflows/golang-test-build.yaml
+++ b/.github/workflows/golang-test-build.yaml
@@ -9,6 +9,7 @@ on:
       - .github/workflows/golang-test-images.yaml
       - hack/tools/image/**
       - hack/tools.mk
+      - hack/tools/logcheck/**
       - go.mod
 
 jobs:

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -89,11 +89,7 @@ GO_ADD_LICENSE_VERSION     ?= $(call version_gomod,github.com/google/addlicense)
 CONTROLLER_RUNTIME_VERSION ?= $(call version_gomod,sigs.k8s.io/controller-runtime)
 K8S_VERSION                ?= $(subst v0,v1,$(call version_gomod,k8s.io/api))
 
-# logcheck is built from sources in this repo, so its "version" is a hash of the analyzer sources, the main module's
-# go.mod (which determines the toolchain), and the golangci-lint version (which determines the host x/tools version
-# the plugin must match). This way, the marker file invalidates whenever any input that could change the plugin's
-# build inputs changes, triggering a rebuild — and stays stable otherwise, so the bundled .so from /gardenertools is
-# reused as-is.
+# Hash of analyzer sources + golangci-lint version + main go.mod toolchain. Invalidates iff the bundled plugin would no longer match the bundled golangci-lint.
 LOGCHECK_VERSION           ?= $(shell { find $(GARDENER_HACK_DIR)/tools/logcheck -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) | LC_ALL=C sort | xargs shasum -a 256; echo $(GOLANGCI_LINT_VERSION); grep -E '^(go|toolchain) ' go.mod; } | shasum -a 256 | cut -c1-12)
 
 # default dir for importing tool binaries
@@ -210,15 +206,9 @@ $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 	tar zxvf - -C $(abspath $(TOOLS_BIN_DIR))
 	touch $(KUSTOMIZE) && chmod +x $(KUSTOMIZE)
 
-# Explicitly specify the toolchain version to ensure logcheck is compiled with the same go version as golangci-lint,
-# i.e., the go toolchain version of the main module (required for loading golangci-lint plugins).
-# The marker file (see LOGCHECK_VERSION) tracks the analyzer sources plus the inputs that determine the plugin's
-# embedded x/tools/go/analysis version, so the rebuild fires exactly when the bundled /gardenertools plugin would
-# no longer be compatible with the (also bundled) golangci-lint binary.
-# Whenever logcheck.so is (re)built, also force golangci-lint to be (re)built from the current main go.mod via
-# go_tool_copy: the imported /gardenertools binary may have been built against an older go.mod, so reusing it
-# would risk the same `plugin was built with a different version of package golang.org/x/tools/go/analysis`
-# failure that this rule guards against. Rebuilding both from the same module graph keeps them compatible.
+# Build logcheck with the same toolchain as golangci-lint (required for plugin loading). The recipe also re-copies
+# golangci-lint via go_tool_copy so the locally-built plugin and host both come from the current main go.mod.
+# Without this, a stale /gardenertools golangci-lint would risk an x/tools/go/analysis version mismatch.
 ifeq ($(IS_GARDENER),true)
 $(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION))
 	$(call go_tool_copy,$(GOLANGCI_LINT))

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -215,11 +215,17 @@ $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 # The marker file (see LOGCHECK_VERSION) tracks the analyzer sources plus the inputs that determine the plugin's
 # embedded x/tools/go/analysis version, so the rebuild fires exactly when the bundled /gardenertools plugin would
 # no longer be compatible with the (also bundled) golangci-lint binary.
+# Whenever logcheck.so is (re)built, also force golangci-lint to be (re)built from the current main go.mod via
+# go_tool_copy: the imported /gardenertools binary may have been built against an older go.mod, so reusing it
+# would risk the same `plugin was built with a different version of package golang.org/x/tools/go/analysis`
+# failure that this rule guards against. Rebuilding both from the same module graph keeps them compatible.
 ifeq ($(IS_GARDENER),true)
-$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION))
+	$(call go_tool_copy,$(GOLANGCI_LINT))
 	cd $(GARDENER_HACK_DIR)/tools/logcheck; GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
 else
-$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION))
+	$(call go_tool_copy,$(GOLANGCI_LINT))
 	GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
 endif
 

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -38,7 +38,8 @@ IMPORT_BOSS                := $(TOOLS_BIN_DIR)/import-boss
 KIND                       := $(TOOLS_BIN_DIR)/kind
 KUBECTL                    := $(TOOLS_BIN_DIR)/kubectl
 KUSTOMIZE                  := $(TOOLS_BIN_DIR)/kustomize
-LOGCHECK                   := $(TOOLS_BIN_DIR)/logcheck.so # plugin binary
+# plugin binary loaded by golangci-lint
+LOGCHECK                   := $(TOOLS_BIN_DIR)/logcheck.so
 MOCKGEN                    := $(TOOLS_BIN_DIR)/mockgen
 OPENAPI_GEN                := $(TOOLS_BIN_DIR)/openapi-gen
 PROMTOOL                   := $(TOOLS_BIN_DIR)/promtool
@@ -88,6 +89,13 @@ GO_ADD_LICENSE_VERSION     ?= $(call version_gomod,github.com/google/addlicense)
 CONTROLLER_RUNTIME_VERSION ?= $(call version_gomod,sigs.k8s.io/controller-runtime)
 K8S_VERSION                ?= $(subst v0,v1,$(call version_gomod,k8s.io/api))
 
+# logcheck is built from sources in this repo, so its "version" is a hash of the analyzer sources, the main module's
+# go.mod (which determines the toolchain), and the golangci-lint version (which determines the host x/tools version
+# the plugin must match). This way, the marker file invalidates whenever any input that could change the plugin's
+# build inputs changes, triggering a rebuild — and stays stable otherwise, so the bundled .so from /gardenertools is
+# reused as-is.
+LOGCHECK_VERSION           ?= $(shell { find $(GARDENER_HACK_DIR)/tools/logcheck -type f \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' \) | LC_ALL=C sort | xargs shasum -a 256; echo $(GOLANGCI_LINT_VERSION); grep -E '^(go|toolchain) ' go.mod; } | shasum -a 256 | cut -c1-12)
+
 # default dir for importing tool binaries
 TOOLS_BIN_SOURCE_DIR ?= /gardenertools
 
@@ -134,7 +142,7 @@ ifeq ($(shell if [ -d $(TOOLS_BIN_SOURCE_DIR) ]; then echo "found"; fi),found)
 endif
 
 .PHONY: create-tools-bin
-create-tools-bin: $(CONTROLLER_GEN) $(CRD_REF_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GOLANGCI_LINT) $(GOSEC) $(GO_ADD_LICENSE) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(KUSTOMIZE) $(TYPOS) $(GOBUILDCACHE)
+create-tools-bin: $(CONTROLLER_GEN) $(CRD_REF_DOCS) $(GINKGO) $(GOIMPORTS) $(GOIMPORTSREVISER) $(GOLANGCI_LINT) $(GOSEC) $(GO_ADD_LICENSE) $(GO_TO_PROTOBUF) $(HELM) $(IMPORT_BOSS) $(KIND) $(KUBECTL) $(LOGCHECK) $(MOCKGEN) $(OPENAPI_GEN) $(PROMTOOL) $(PROTOC) $(PROTOC_GEN_GOGO) $(SETUP_ENVTEST) $(SKAFFOLD) $(YQ) $(KUSTOMIZE) $(TYPOS) $(GOBUILDCACHE)
 
 #########################################
 # Tools                                 #
@@ -204,11 +212,14 @@ $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 
 # Explicitly specify the toolchain version to ensure logcheck is compiled with the same go version as golangci-lint,
 # i.e., the go toolchain version of the main module (required for loading golangci-lint plugins).
+# The marker file (see LOGCHECK_VERSION) tracks the analyzer sources plus the inputs that determine the plugin's
+# embedded x/tools/go/analysis version, so the rebuild fires exactly when the bundled /gardenertools plugin would
+# no longer be compatible with the (also bundled) golangci-lint binary.
 ifeq ($(IS_GARDENER),true)
-$(LOGCHECK): $(GARDENER_HACK_DIR)/tools/logcheck/go.* $(shell find $(GARDENER_HACK_DIR)/tools/logcheck -type f -name '*.go') $(GOLANGCI_LINT)
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
 	cd $(GARDENER_HACK_DIR)/tools/logcheck; GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
 else
-$(LOGCHECK): go.mod $(GOLANGCI_LINT)
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
 	GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
 endif
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area test dev-productivity
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/gardener/ci-infra/pull/6472

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
