### PR TITLE
Pass `seedName` to `allowIfGardenletIsNotYetBootstrapped`

### DIFF
--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler.go
@@ -433,7 +433,7 @@ func (h *Handler) admitSecret(ctx context.Context, seedName string, request admi
 		case gardenletbootstraputil.KindManagedSeed:
 			return h.allowIfManagedSeedIsNotYetBootstrapped(ctx, seedName, namespace, name)
 		case gardenletbootstraputil.KindGardenlet:
-			return h.allowIfGardenletIsNotYetBootstrapped(ctx, namespace, name)
+			return h.allowIfGardenletIsNotYetBootstrapped(ctx, seedName, namespace, name)
 		default:
 			return admission.Errored(http.StatusBadRequest, fmt.Errorf("unknown kind %q found in bootstrap token secret description %q", kind, secret.Data[bootstraptokenapi.BootstrapTokenDescriptionKey]))
 		}
@@ -614,7 +614,11 @@ func (h *Handler) allowIfManagedSeedIsNotYetBootstrapped(ctx context.Context, se
 	return admission.Errored(http.StatusBadRequest, fmt.Errorf("managed seed %s/%s is already bootstrapped", managedSeed.Namespace, managedSeed.Name))
 }
 
-func (h *Handler) allowIfGardenletIsNotYetBootstrapped(ctx context.Context, gardenletNamespace, gardenletName string) admission.Response {
+func (h *Handler) allowIfGardenletIsNotYetBootstrapped(ctx context.Context, seedName, gardenletNamespace, gardenletName string) admission.Response {
+	if gardenletName != seedName || gardenletNamespace != v1beta1constants.GardenNamespace {
+		return admission.Errored(http.StatusForbidden, fmt.Errorf("gardenlet %s/%s does not belong to seed %q", gardenletNamespace, gardenletName, seedName))
+	}
+
 	gardenlet := &seedmanagementv1alpha1.Gardenlet{}
 	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: gardenletNamespace, Name: gardenletName}, gardenlet); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
+++ b/pkg/admissioncontroller/webhook/admission/seedrestriction/handler_test.go
@@ -1659,8 +1659,8 @@ var _ = Describe("handler", func() {
 							secret    *corev1.Secret
 							gardenlet *seedmanagementv1alpha1.Gardenlet
 
-							gardenletNamespace = "glet1ns"
-							gardenletName      = "glet1name"
+							gardenletNamespace = "garden"
+							gardenletName      = "seed"
 						)
 
 						BeforeEach(func() {
@@ -1887,6 +1887,42 @@ var _ = Describe("handler", func() {
 							})).To(Succeed())
 
 							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+						})
+
+						It("should forbid if the gardenlet name does not match the requesting seed", func() {
+							foreignName := "other-seed"
+							secret.Data["description"] = []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.Gardenlet resource " + gardenletNamespace + "/" + foreignName + ".")
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("gardenlet %s/%s does not belong to seed %q", gardenletNamespace, foreignName, seedName),
+									},
+								},
+							}))
+						})
+
+						It("should forbid if the gardenlet namespace is not the garden namespace", func() {
+							foreignNamespace := "kube-system"
+							secret.Data["description"] = []byte("A bootstrap token for the Gardenlet for seedmanagement.gardener.cloud/v1alpha1.Gardenlet resource " + foreignNamespace + "/" + gardenletName + ".")
+							objData, err := runtime.Encode(encoder, secret)
+							Expect(err).NotTo(HaveOccurred())
+							request.Object.Raw = objData
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("gardenlet %s/%s does not belong to seed %q", foreignNamespace, gardenletName, seedName),
+									},
+								},
+							}))
 						})
 					})
 


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind bug

**What this PR does / why we need it**:
The `KindGardenlet` branch of `admitSecret` was missing a check that the
`Gardenlet` resource named in the bootstrap token description belongs to the
requesting seed. Threads `seedName` into `allowIfGardenletIsNotYetBootstrapped`
and enforces `gardenletName == seedName` and `gardenletNamespace == GardenNamespace`.

**Release note**:
```bugfix operator
The `admission-controller`'s seed-restriction webhook now performs additional authorization checks when gardenlets request bootstrap tokens.
```