### PR TITLE
Introduce composite version marker for golangci-lint and its plugin

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -159,7 +159,10 @@ $(GOIMPORTS): $(call tool_version_file,$(GOIMPORTS),$(GOIMPORTS_VERSION))
 $(GOIMPORTSREVISER): $(call tool_version_file,$(GOIMPORTSREVISER),$(GOIMPORTSREVISER_VERSION))
 	$(call go_tool_copy,$(GOIMPORTSREVISER))
 
-$(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION))
+# Include LOGCHECK_VERSION in golangci-lint's marker so any input that invalidates the bundled logcheck plugin also
+# invalidates golangci-lint, forcing both to be (re)built from the same module graph and avoiding plugin-vs-host
+# x/tools/go/analysis mismatches.
+$(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERSION)-$(LOGCHECK_VERSION))
 	$(call go_tool_copy,$(GOLANGCI_LINT))
 
 $(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
@@ -206,16 +209,14 @@ $(KUSTOMIZE): $(call tool_version_file,$(KUSTOMIZE),$(KUSTOMIZE_VERSION))
 	tar zxvf - -C $(abspath $(TOOLS_BIN_DIR))
 	touch $(KUSTOMIZE) && chmod +x $(KUSTOMIZE)
 
-# Build logcheck with the same toolchain as golangci-lint (required for plugin loading). The recipe also re-copies
-# golangci-lint via go_tool_copy so the locally-built plugin and host both come from the current main go.mod.
-# Without this, a stale /gardenertools golangci-lint would risk an x/tools/go/analysis version mismatch.
+# Build logcheck with the same toolchain as golangci-lint (required for plugin loading). Depending on $(GOLANGCI_LINT)
+# ensures the host binary is (re)built from the current main go.mod before the plugin is — see also the composite
+# marker on $(GOLANGCI_LINT), which guarantees both invalidate together.
 ifeq ($(IS_GARDENER),true)
-$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION))
-	$(call go_tool_copy,$(GOLANGCI_LINT))
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
 	cd $(GARDENER_HACK_DIR)/tools/logcheck; GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(abspath $(LOGCHECK)) -buildmode=plugin ./plugin
 else
-$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION))
-	$(call go_tool_copy,$(GOLANGCI_LINT))
+$(LOGCHECK): $(call tool_version_file,$(LOGCHECK),$(LOGCHECK_VERSION)) $(GOLANGCI_LINT)
 	GOTOOLCHAIN=$(shell go version -m -json $(GOLANGCI_LINT) | jq -r .GoVersion) CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
 endif
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing delivery
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/gardener/ci-infra/pull/6486

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
