### PR TITLE
Fix `gardenlet` bootstrap script

### DIFF
--- a/hack/usage/rebootstrap-gardenlet.sh
+++ b/hack/usage/rebootstrap-gardenlet.sh
@@ -63,7 +63,7 @@ EOF
 
 function generate_random_string() {
   local length=$1
-  LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c "$length"
+  LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c "$length" || true
 }
 
 function validate_requirements() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Fixes an issue with the `hack/usage/rebootstrap-gardenlet.sh` script, when the bootstrap token content is automatically created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
With `pipefail` being set in the script, it fails early since `head -c` causes a disgraceful exit of `tr`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The helper script `hack/usage/rebootstrap-gardenlet.sh` was fixed to handle cases where the bootstrap token content is automatically generated.
```
