### PR TITLE
nodeagent: unblock GNA from self-restarting due to failed systemd services

### DIFF
--- a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
+++ b/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go
@@ -239,6 +239,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed calculating the OSC changes: %w", err)
 	}
 
+	// Strip the gardener-node-agent unit from Units.Commands and route its restart through the
+	// MustRestartNodeAgent flag. This keeps the self-restart out of executeUnitCommands, where
+	// a failing third-party unit could otherwise return an error and block it.
+	if slices.ContainsFunc(oscChanges.Units.Commands, func(c unitCommand) bool {
+		return c.Name == nodeagentconfigv1alpha1.UnitName
+	}) {
+		if err := oscChanges.setMustRestartNodeAgent(true); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed setting MustRestartNodeAgent: %w", err)
+		}
+		if err := oscChanges.completedUnitCommand(nodeagentconfigv1alpha1.UnitName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed clearing node-agent unit from commands list: %w", err)
+		}
+	}
+
 	// If the node-agent has restarted after OS update, we need to persist the change in oscChanges.
 	if osc.Spec.InPlaceUpdates != nil {
 		if osVersionUpToDate, err := IsOsVersionUpToDate(osVersion, osc); err != nil {
@@ -304,6 +318,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed reloading systemd daemon: %w", err)
 	}
 
+	// Restart the node-agent before executeUnitCommands. A failing third-party unit there would
+	// otherwise return an error and prevent the restart from happening. The remaining steps
+	// (executeUnitCommands, waitForRegistries, removeDeletedFiles, in-place update) resume in
+	// the next reconcile pass from the persisted [operatingSystemConfigChanges] file.
+	if oscChanges.MustRestartNodeAgent && !r.SkipWritingStateFiles {
+		return r.restartNodeAgent(oscChanges, log)
+	}
+
 	log.Info("Executing unit commands (start/stop)", "unitCommands", len(oscChanges.Units.Commands))
 	if err := r.executeUnitCommands(ctx, log, node, oscChanges); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed executing unit commands: %w", err)
@@ -313,12 +335,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if err := r.completeKubeletInPlaceUpdate(ctx, log, oscChanges, node); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed completing kubelet in-place update: %w", err)
 		}
-	}
-
-	// We restart the gardener-node-agent before removing the old files, so that the previous
-	// config is deleted only after there is no gardener-node-agent that is still using it.
-	if oscChanges.MustRestartNodeAgent {
-		return r.restartNodeAgent(oscChanges, log)
 	}
 
 	// After the node is prepared, we can wait for the registries to be configured.
@@ -357,7 +373,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	if oscChanges.MustRestartNodeAgent {
+	// Second restart site: catches MustRestartNodeAgent set by the CA-rotation path inside
+	// performInPlaceUpdate, which can only flip the flag after the new kubeconfig is on disk.
+	if oscChanges.MustRestartNodeAgent && !r.SkipWritingStateFiles {
 		return r.restartNodeAgent(oscChanges, log)
 	}
 
@@ -752,16 +770,7 @@ func (r *Reconciler) executeUnitCommands(ctx context.Context, log logr.Logger, n
 
 	var containerdChanged bool
 	for _, unit := range slices.Clone(oscChanges.Units.Commands) {
-		switch unit.Name {
-		case nodeagentconfigv1alpha1.UnitName:
-			if err := oscChanges.setMustRestartNodeAgent(true); err != nil {
-				return err
-			}
-			if err := oscChanges.completedUnitCommand(unit.Name); err != nil {
-				return err
-			}
-			continue
-		case v1beta1constants.OperatingSystemConfigUnitNameContainerDService:
+		if unit.Name == v1beta1constants.OperatingSystemConfigUnitNameContainerDService {
 			containerdChanged = true
 		}
 

--- a/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/test/integration/nodeagent/operatingsystemconfig/operatingsystemconfig_test.go
@@ -886,6 +886,65 @@ units: {}
 		Eventually(cancelFunc.called).Should(BeTrue())
 	})
 
+	It("should still restart the node-agent when a third-party unit fails to start", func() {
+		// Regression guard: when an OSC update both changes the node-agent config and adds a
+		// third-party unit that fails to start, the self-restart must still happen. Without the
+		// fix, executeUnitCommands returns the failure and the reconcile bails out before the
+		// restart, leaving the node-agent running with the old config.
+		By("Wait until last-applied OSC file is persisted")
+		Eventually(func() error {
+			_, err := fakeFS.ReadFile("/var/lib/gardener-node-agent/last-applied-osc.yaml")
+			return err
+		}).Should(Succeed())
+
+		fakeDBus.Actions = nil
+
+		By("Inject a failure for the upcoming restart of a third-party unit")
+		failingUnit := extensionsv1alpha1.Unit{
+			Name:    "failing-third-party.service",
+			Enable:  new(true),
+			Command: new(extensionsv1alpha1.CommandRestart),
+			Content: new("#failing"),
+		}
+		fakeDBus.InjectRestartFailure(fmt.Errorf("simulated failure: dependent state not ready"), failingUnit.Name)
+
+		By("Update Operating System Config with both the node-agent unit and the failing unit")
+		operatingSystemConfig.Spec.Units = append(operatingSystemConfig.Spec.Units, gnaUnit, failingUnit)
+
+		var err error
+		oscRaw, err = runtime.Encode(codec, operatingSystemConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Update Secret containing the operating system config")
+		patch := client.MergeFrom(oscSecret.DeepCopy())
+		oscSecret.Annotations["checksum/data-script"] = utils.ComputeSHA256Hex(oscRaw)
+		oscSecret.Data["osc.yaml"] = oscRaw
+		Expect(testClient.Patch(ctx, oscSecret, patch)).To(Succeed())
+
+		By("Wait for the manager cache to observe the updated secret")
+		Eventually(func(g Gomega) []byte {
+			updatedSecret := &corev1.Secret{}
+			g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(oscSecret), updatedSecret)).To(Succeed())
+			return updatedSecret.Data["osc.yaml"]
+		}).Should(Equal(oscSecret.Data["osc.yaml"]))
+
+		By("Expect that cancel func is called despite the failing third-party unit")
+		Eventually(func() bool { return cancelFunc.called }).Should(BeTrue())
+
+		By("Assert that the node-agent self-restart path was taken")
+		// The persisted changes file is used to detect that the node-agent unit is
+		// stripped from Units.Commands, and MustRestartNodeAgent is back to false
+		// (cleared by restartNodeAgent before signalling the cancel).
+		Eventually(func(g Gomega) string {
+			content, err := fakeFS.ReadFile("/var/lib/gardener-node-agent/last-computed-osc-changes.yaml")
+			g.Expect(err).NotTo(HaveOccurred())
+			return string(content)
+		}).Should(And(
+			ContainSubstring("mustRestartNodeAgent: false"),
+			Not(ContainSubstring("name: "+gnaUnit.Name)),
+		))
+	})
+
 	Context("when CRI is not containerd", func() {
 		BeforeEach(func() {
 			operatingSystemConfig.Spec.CRIConfig = nil


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind bug

**What this PR does / why we need it**:

As of today any Gardener component which causes a configuration change to the node agent, coupled with a broken systemd service can cause a deadlock in the `gardener-node-agent` itself, preventing it from self-restarting with the new configuration.

This issue can be triggered by any component, which brings for example a new systemd unit, a file, or a token secret sync item. In these cases the configuration of the GNA is updated, which is supposed to lead to a self-restart of the GNA itself, so that controllers like `token` can now act on newly added sync secrets, OSC on newly added files/systemd units, etc.

However, in situations where a systemd service expects a token or file to be provided by GNA itself leads to a deadlock situation, where the GNA fails to start the service, and then enters a retry-reconcile loop, which will never result in a self-restart of the GNA.

And since the tokens to be synced are part of the **new** GNA configuration, which is loaded at startup this token is never synced, leaving the systemd service failing, and never reaching a state where it starts up.

The only mitigation at this point is a manual restart of the `gardener-node-agent` systemd service, so that the new configuration is reloaded.

In order to prevent these situations this PR unblocks the GNA self-restart by decoupling the (already existing) special handling of the systemd `gardener-node-agent.service` from the rest of the systemd service. 

That way, whenever a restart of GNA is required it is handled in advance, in order to ensure that the GNA always runs with the latest configuration, after persisting any OSC changes on disk first.

The current deadlock can be seen in this snippet here:

https://github.com/gardener/gardener/blob/52830c40ce388755f6cd32a9b5dab0d148bcf56a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go#L307-L322

And the (already existing) special handling of `gardener-node-agent.service` here as well:

https://github.com/gardener/gardener/blob/52830c40ce388755f6cd32a9b5dab0d148bcf56a/pkg/nodeagent/controller/operatingsystemconfig/reconciler.go#L725-L764

Related issues and PRs:

- #15033
- #15028

cc: @iypetrov , @plkokanov , @ialidzhikov , @rfranzke 

**Which issue(s) this PR fixes**:
Fixes #15028

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Unblock gardener-node-agent self-restart by decoupling it from the rest of the systemd services
```
