### PR TITLE
[GEP-28] Make `Seed` field optional in `Cluster` extension API

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1216,7 +1216,8 @@ ClusterSpec is the spec for a Cluster resource.
 </em>
 </td>
 <td>
-<p>Seed is a raw extension field that contains the seed resource referenced by the shoot that<br />has to be reconciled.</p>
+<em>(Optional)</em>
+<p>Seed is a raw extension field that contains the seed resource referenced by the shoot that<br />has to be reconciled. It is not set for self-hosted shoots (see GEP-28).</p>
 </td>
 </tr>
 <tr>

--- a/docs/extensions/cluster.md
+++ b/docs/extensions/cluster.md
@@ -41,6 +41,10 @@ The resource is written by Gardener before it starts the reconciliation flow of 
 
 :warning: All Gardener components use the `core.gardener.cloud/v1beta1` version, i.e., the `Cluster` resource will contain the objects in this version.
 
+> [!NOTE]
+> The `.spec.seed` field is optional and not set for self-hosted shoots (see [GEP-28](../proposals/28-self-hosted-shoot-clusters.md)).
+> Extension controllers must tolerate its absence and not assume that a `Seed` resource is always present in the `Cluster`.
+
 ## Important Information that Should Be Taken into Account
 
 There are some fields in the `Shoot` specification that might be interesting to take into account.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
@@ -53,7 +53,7 @@ spec:
               seed:
                 description: |-
                   Seed is a raw extension field that contains the seed resource referenced by the shoot that
-                  has to be reconciled.
+                  has to be reconciled. It is not set for self-hosted shoots (see GEP-28).
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               shoot:
@@ -63,7 +63,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - cloudProfile
-            - seed
             - shoot
             type: object
         required:

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -636,7 +636,7 @@ func clusterObject(cluster *extensionscontroller.Cluster) *extensionsv1alpha1.Cl
 			CloudProfile: runtime.RawExtension{
 				Raw: encode(cluster.CloudProfile),
 			},
-			Seed: runtime.RawExtension{
+			Seed: &runtime.RawExtension{
 				Raw: encode(cluster.Seed),
 			},
 			Shoot: runtime.RawExtension{

--- a/pkg/apis/extensions/v1alpha1/types_cluster.go
+++ b/pkg/apis/extensions/v1alpha1/types_cluster.go
@@ -47,10 +47,11 @@ type ClusterSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	CloudProfile runtime.RawExtension `json:"cloudProfile"`
 	// Seed is a raw extension field that contains the seed resource referenced by the shoot that
-	// has to be reconciled.
+	// has to be reconciled. It is not set for self-hosted shoots (see GEP-28).
+	// +optional
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Seed runtime.RawExtension `json:"seed"`
+	Seed *runtime.RawExtension `json:"seed,omitempty"`
 	// Shoot is a raw extension field that contains the shoot resource that has to be reconciled.
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -516,7 +516,11 @@ func (in *ClusterList) DeepCopyObject() runtime.Object {
 func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 	*out = *in
 	in.CloudProfile.DeepCopyInto(&out.CloudProfile)
-	in.Seed.DeepCopyInto(&out.Seed)
+	if in.Seed != nil {
+		in, out := &in.Seed, &out.Seed
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Shoot.DeepCopyInto(&out.Shoot)
 	return
 }

--- a/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
+++ b/pkg/component/extensions/crds/assets/crd-extensions.gardener.cloud_clusters.yaml
@@ -55,7 +55,7 @@ spec:
               seed:
                 description: |-
                   Seed is a raw extension field that contains the seed resource referenced by the shoot that
-                  has to be reconciled.
+                  has to be reconciled. It is not set for self-hosted shoots (see GEP-28).
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               shoot:
@@ -65,7 +65,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - cloudProfile
-            - seed
             - shoot
             type: object
         required:

--- a/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/component/networking/nodelocaldns/nodelocaldns_test.go
@@ -279,7 +279,7 @@ var _ = Describe("NodeLocalDNS", func() {
 				Shoot: runtime.RawExtension{
 					Object: shoot,
 				},
-				Seed: runtime.RawExtension{
+				Seed: &runtime.RawExtension{
 					Object: &gardencorev1beta1.Seed{},
 				},
 				CloudProfile: runtime.RawExtension{

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -73,7 +73,7 @@ func SyncClusterResourceToSeed(
 			cluster.Spec.CloudProfile = runtime.RawExtension{Object: cloudProfileObj}
 		}
 		if seedObj != nil {
-			cluster.Spec.Seed = runtime.RawExtension{Object: seedObj}
+			cluster.Spec.Seed = &runtime.RawExtension{Object: seedObj}
 		}
 		if shootObj != nil {
 			cluster.Spec.Shoot = runtime.RawExtension{Object: shootObj}
@@ -138,7 +138,7 @@ func SeedFromCluster(cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Se
 		seed    = &gardencorev1beta1.Seed{}
 	)
 
-	if cluster.Spec.Seed.Raw == nil {
+	if cluster.Spec.Seed == nil || cluster.Spec.Seed.Raw == nil {
 		return nil, nil
 	}
 	if _, _, err := decoder.Decode(cluster.Spec.Seed.Raw, nil, seed); err != nil {

--- a/pkg/extensions/cluster_test.go
+++ b/pkg/extensions/cluster_test.go
@@ -112,7 +112,17 @@ var _ = Describe("Cluster", func() {
 			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
 
 			Expect(cluster.Spec.CloudProfile.Raw).NotTo(BeNil())
+			Expect(cluster.Spec.Seed).NotTo(BeNil())
 			Expect(cluster.Spec.Seed.Raw).NotTo(BeNil())
+			Expect(cluster.Spec.Shoot.Raw).NotTo(BeNil())
+		})
+
+		It("should sync cloudprofile and shoot to cluster without seed", func() {
+			Expect(SyncClusterResourceToSeed(ctx, fakeSeedClient, cluster.Name, expectedShoot, expectedCloudProfile, nil)).To(Succeed())
+			Expect(fakeSeedClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+
+			Expect(cluster.Spec.CloudProfile.Raw).NotTo(BeNil())
+			Expect(cluster.Spec.Seed).To(BeNil())
 			Expect(cluster.Spec.Shoot.Raw).NotTo(BeNil())
 		})
 	})
@@ -159,7 +169,7 @@ var _ = Describe("Cluster", func() {
 					CloudProfile: runtime.RawExtension{
 						Object: expectedCloudProfile,
 					},
-					Seed: runtime.RawExtension{
+					Seed: &runtime.RawExtension{
 						Object: expectedSeed,
 					},
 					Shoot: runtime.RawExtension{
@@ -257,7 +267,7 @@ var _ = Describe("Cluster", func() {
 					Name: "foo",
 				},
 				Spec: extensionsv1alpha1.ClusterSpec{
-					Seed: runtime.RawExtension{
+					Seed: &runtime.RawExtension{
 						Raw: encode(expectedSeed),
 					},
 				},
@@ -281,6 +291,14 @@ var _ = Describe("Cluster", func() {
 
 		It("should return nil because the seed is not in raw format in the cluster", func() {
 			cluster.Spec.Seed.Raw = nil
+
+			seed, err := SeedFromCluster(cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(seed).To(BeNil())
+		})
+
+		It("should return nil because the seed is absent from the cluster", func() {
+			cluster.Spec.Seed = nil
 
 			seed, err := SeedFromCluster(cluster)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/provider-local/controller/networkpolicy/reconciler.go
+++ b/pkg/provider-local/controller/networkpolicy/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		},
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 	}
-	if len(cluster.Seed.Spec.Provider.Zones) > 1 {
+	if cluster.Seed != nil && len(cluster.Seed.Spec.Provider.Zones) > 1 {
 		for _, zone := range cluster.Seed.Spec.Provider.Zones {
 			networkPolicyAllowToIstioIngressGateway.Spec.Egress[0].To = append(networkPolicyAllowToIstioIngressGateway.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
 				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-ingress--" + zone}},

--- a/pkg/provider-local/webhook/networkpolicy/mutator.go
+++ b/pkg/provider-local/webhook/networkpolicy/mutator.go
@@ -33,7 +33,7 @@ func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
 		return err
 	}
 
-	if cluster.Seed.Spec.Networks.Nodes == nil {
+	if cluster.Seed == nil || cluster.Seed.Spec.Networks.Nodes == nil {
 		return nil
 	}
 

--- a/test/integration/extensions/controller/backupbucket/backupbucket_test.go
+++ b/test/integration/extensions/controller/backupbucket/backupbucket_test.go
@@ -73,7 +73,7 @@ func prepareAndRunTest(ignoreOperationAnnotation bool) {
 		},
 		Spec: extensionsv1alpha1.ClusterSpec{
 			CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
-			Seed:         runtime.RawExtension{Raw: []byte("{}")},
+			Seed:         &runtime.RawExtension{Raw: []byte("{}")},
 			Shoot:        runtime.RawExtension{Raw: []byte("{}")},
 		},
 	}

--- a/test/integration/extensions/controller/backupentry/backupentry_test.go
+++ b/test/integration/extensions/controller/backupentry/backupentry_test.go
@@ -83,7 +83,7 @@ var _ = Describe("BackupEntry", func() {
 			},
 			Spec: extensionsv1alpha1.ClusterSpec{
 				CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
-				Seed:         runtime.RawExtension{Raw: []byte("{}")},
+				Seed:         &runtime.RawExtension{Raw: []byte("{}")},
 				Shoot:        runtime.RawExtension{Raw: []byte("{}")},
 			},
 		}

--- a/test/integration/extensions/webhook/certificates/certificates_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Certificates tests", func() {
 			},
 			Spec: extensionsv1alpha1.ClusterSpec{
 				CloudProfile: runtime.RawExtension{Object: &gardencorev1beta1.CloudProfile{}},
-				Seed:         runtime.RawExtension{Object: &gardencorev1beta1.Seed{}},
+				Seed:         &runtime.RawExtension{Object: &gardencorev1beta1.Seed{}},
 				Shoot:        runtime.RawExtension{Object: &gardencorev1beta1.Shoot{}},
 			},
 		}

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
@@ -147,7 +147,7 @@ var _ = BeforeSuite(func() {
 		},
 		Spec: extensionsv1alpha1.ClusterSpec{
 			CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
-			Seed:         runtime.RawExtension{Raw: []byte("{}")},
+			Seed:         &runtime.RawExtension{Raw: []byte("{}")},
 			Shoot:        runtime.RawExtension{Raw: []byte("{}")},
 		},
 	}

--- a/test/integration/gardenlet/backupentry/backupentry_test.go
+++ b/test/integration/gardenlet/backupentry/backupentry_test.go
@@ -273,7 +273,7 @@ var _ = Describe("BackupEntry controller tests", func() {
 				Shoot: runtime.RawExtension{
 					Object: shoot,
 				},
-				Seed: runtime.RawExtension{
+				Seed: &runtime.RawExtension{
 					Object: seed,
 				},
 				CloudProfile: runtime.RawExtension{

--- a/test/integration/gardenlet/bastion/bastion_test.go
+++ b/test/integration/gardenlet/bastion/bastion_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Bastion controller tests", func() {
 						},
 					},
 				},
-				Seed: runtime.RawExtension{
+				Seed: &runtime.RawExtension{
 					Object: seed,
 				},
 				CloudProfile: runtime.RawExtension{

--- a/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
+++ b/test/integration/gardenlet/networkpolicy/networkpolicy_test.go
@@ -101,7 +101,7 @@ var _ = Describe("NetworkPolicy controller tests", func() {
 		cluster = &extensionsv1alpha1.Cluster{
 			Spec: extensionsv1alpha1.ClusterSpec{
 				CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
-				Seed:         runtime.RawExtension{Raw: []byte("{}")},
+				Seed:         &runtime.RawExtension{Raw: []byte("{}")},
 				Shoot: runtime.RawExtension{Object: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Networking: &gardencorev1beta1.Networking{

--- a/test/integration/gardenlet/seed/seed/seed_test.go
+++ b/test/integration/gardenlet/seed/seed/seed_test.go
@@ -983,7 +983,7 @@ var _ = Describe("Seed controller tests", func() {
 						},
 						Spec: extensionsv1alpha1.ClusterSpec{
 							CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
-							Seed:         runtime.RawExtension{Raw: []byte("{}")},
+							Seed:         &runtime.RawExtension{Raw: []byte("{}")},
 							Shoot:        runtime.RawExtension{Raw: shootRaw},
 						},
 					}

--- a/test/integration/gardenlet/shoot/care/care_test.go
+++ b/test/integration/gardenlet/shoot/care/care_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Shoot Care controller tests", func() {
 			},
 			Spec: extensionsv1alpha1.ClusterSpec{
 				Shoot:        runtime.RawExtension{Object: shoot},
-				Seed:         runtime.RawExtension{Object: seed},
+				Seed:         &runtime.RawExtension{Object: seed},
 				CloudProfile: runtime.RawExtension{Object: &gardencorev1beta1.CloudProfile{}},
 			},
 		}
@@ -632,7 +632,7 @@ var _ = Describe("Shoot Care controller tests (self-hosted shoot)", func() {
 			},
 			Spec: extensionsv1alpha1.ClusterSpec{
 				Shoot:        runtime.RawExtension{Object: shoot},
-				Seed:         runtime.RawExtension{Object: &gardencorev1beta1.Seed{}},
+				Seed:         &runtime.RawExtension{Object: &gardencorev1beta1.Seed{}},
 				CloudProfile: runtime.RawExtension{Object: &gardencorev1beta1.CloudProfile{}},
 			},
 		}

--- a/test/integration/gardenlet/shoot/status/status_test.go
+++ b/test/integration/gardenlet/shoot/status/status_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Shoot Status controller tests", func() {
 				Shoot: runtime.RawExtension{
 					Object: shoot,
 				},
-				Seed: runtime.RawExtension{
+				Seed: &runtime.RawExtension{
 					Object: &gardencorev1beta1.Seed{},
 				},
 				CloudProfile: runtime.RawExtension{

--- a/test/testmachinery/shoots/logging/utils.go
+++ b/test/testmachinery/shoots/logging/utils.go
@@ -154,7 +154,7 @@ func getCluster(number int) *extensionsv1alpha1.Cluster {
 			CloudProfile: runtime.RawExtension{
 				Raw: encode(&gardencorev1beta1.CloudProfile{}),
 			},
-			Seed: runtime.RawExtension{
+			Seed: &runtime.RawExtension{
 				Raw: encode(&gardencorev1beta1.Seed{}),
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source control-plane
/kind api-change

**What this PR does / why we need it**:
For self-hosted shoots (GEP-28), there is no `Seed` to embed in the `extensions.gardener.cloud/v1alpha1.Cluster` resource. This PR makes the field optional: `ClusterSpec.Seed` is now `*runtime.RawExtension` (matching the convention used by other optional raw-extension fields in this API package such as `BackupBucketProviderStatus` or `InfrastructureProviderStatus`), and `seed` is dropped from the CRD `required` list.

`SeedFromCluster` already returns `(nil, nil)` for an absent seed, so most consumers need no change. The two `provider-local` network policy sites that dereferenced `cluster.Seed` directly now nil-guard.

> [!IMPORTANT]
> This is a breaking change for extension authors who construct `ClusterSpec` literals or read `.Spec.Seed.Raw` directly. The migration is mechanical — switch to `&runtime.RawExtension{…}` and add a nil-check or rely on the `SeedFromCluster` helper.

**Which issue(s) this PR fixes**:
Part of #2906

**Release note**:
```breaking developer
The `.spec.seed` field in `extensions.gardener.cloud/v1alpha1.Cluster` is now optional and represented as a pointer (`*runtime.RawExtension`). Extension authors must tolerate its absence and may need to adapt code that constructs `ClusterSpec` literals or reads `.Spec.Seed.Raw` directly.
```
