### PR TITLE
add two panel for node reboot related info

### DIFF
--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1198,7 +1198,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot history for node $Node: bars show reboot events detected in each 10-minute window (left axis), line shows node uptime since last boot (right axis). Legend shows total reboot count and current uptime.",
+      "description": "Reboot history for node $Node: bars show reboot events (detected after node rejoins cluster; each reboot shown once per 10-minute interval) on the left axis, line shows node uptime since last boot on the right axis.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1220,7 +1220,7 @@
         "max": false,
         "min": false,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": true,
@@ -1254,7 +1254,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "changes(node_boot_time_seconds{node=~\"$Node\"}[10m])",
+          "expr": "changes(node_boot_time_seconds{node=~\"$Node\"}[10m:10m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1198,7 +1198,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot history for node $Node: bars show reboot events (detected after node rejoins cluster; one bar per scrape interval where a reboot is detected) on the left axis, line shows node uptime since last boot on the right axis.",
+      "description": "Reboot history for node $Node: line shows reboot events (detected after node rejoins cluster) on the left axis, line shows node uptime since last boot on the right axis.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1237,9 +1237,9 @@
       "seriesOverrides": [
         {
           "alias": "Reboots",
-          "bars": true,
+          "bars": false,
           "color": "#F2495C",
-          "lines": false,
+          "lines": true,
           "yaxis": 1
         },
         {
@@ -1254,9 +1254,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(\n  last_over_time(node_boot_time_seconds{node=~\"$Node\"}[1h])\n  !=\n  last_over_time(node_boot_time_seconds{node=~\"$Node\"}[1h] offset 1m)\n) > bool 0",
+          "expr": "changes(node_boot_time_seconds{node=~\"$Node\"}[$__rate_interval])",
           "format": "time_series",
-          "interval": "",
+          "interval": "1m",
           "intervalFactor": 1,
           "legendFormat": "Reboots",
           "refId": "A"
@@ -1607,7 +1607,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1198,7 +1198,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot history for node $Node: bars show reboot events (detected after node rejoins cluster; each reboot shown once per 10-minute interval) on the left axis, line shows node uptime since last boot on the right axis.",
+      "description": "Reboot history for node $Node: bars show reboot events (detected after node rejoins cluster; one bar per scrape interval where a reboot is detected) on the left axis, line shows node uptime since last boot on the right axis.",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1254,7 +1254,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "changes(node_boot_time_seconds{node=~\"$Node\"}[10m:10m])",
+          "expr": "(\n  last_over_time(node_boot_time_seconds{node=~\"$Node\"}[1h])\n  !=\n  last_over_time(node_boot_time_seconds{node=~\"$Node\"}[1h] offset 1m)\n) > bool 0",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1193,13 +1193,133 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Reboot history for node $Node: bars show reboot events detected in each 10-minute window (left axis), line shows node uptime since last boot (right axis). Legend shows total reboot count and current uptime.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "hiddenSeries": false,
+      "id": 85,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.43",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Reboots",
+          "bars": true,
+          "color": "#F2495C",
+          "lines": false,
+          "yaxis": 1
+        },
+        {
+          "alias": "Uptime",
+          "bars": false,
+          "lines": true,
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(node_boot_time_seconds{node=~\"$Node\"}[10m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Reboots",
+          "refId": "A"
+        },
+        {
+          "expr": "time() - node_boot_time_seconds{node=~\"$Node\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Uptime",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Node Reboot Count, History and Uptime ($Node)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Reboots",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "s",
+          "label": "Uptime",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 58
       },
       "id": 76,
       "panels": [

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-details-dashboard.json
@@ -1607,7 +1607,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -1189,7 +1189,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot events per node over time (detected after node rejoins cluster; each reboot shown once per 10-minute interval). Filtered by selected worker group(s).",
+      "description": "Reboot events per node over time (detected after node rejoins cluster; one bar per scrape interval where a reboot is detected). Filtered by selected worker group(s).",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1232,7 +1232,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "changes(\n  (\n      node_boot_time_seconds\n    + on (node) group_left (label_worker_gardener_cloud_pool)\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )[10m:10m]\n)",
+          "expr": "(\n  last_over_time(node_boot_time_seconds[1h])\n  + on (node) group_left (label_worker_gardener_cloud_pool)\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n)\n!=\n(\n  last_over_time(node_boot_time_seconds[1h] offset 1m)\n  + on (node) group_left (label_worker_gardener_cloud_pool)\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -1189,7 +1189,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot events detected per node over time. Each bar indicates a reboot was detected in that 10-minute window. Filtered by selected worker group(s).",
+      "description": "Reboot events per node over time (detected after node rejoins cluster; each reboot shown once per 10-minute interval). Filtered by selected worker group(s).",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1212,7 +1212,7 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "total": true,
+        "total": false,
         "values": true
       },
       "lines": false,
@@ -1232,7 +1232,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "changes(\n  (\n      node_boot_time_seconds\n    + on (node) group_left (label_worker_gardener_cloud_pool)\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )[10m:]\n)",
+          "expr": "changes(\n  (\n      node_boot_time_seconds\n    + on (node) group_left (label_worker_gardener_cloud_pool)\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )[10m:10m]\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -1185,11 +1185,11 @@
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Reboot events per node over time (detected after node rejoins cluster; one bar per scrape interval where a reboot is detected). Filtered by selected worker group(s).",
+      "description": "Reboot events per node over time (detected after node rejoins cluster). Filtered by selected worker group(s).",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -1215,7 +1215,7 @@
         "total": false,
         "values": true
       },
-      "lines": false,
+      "lines": true,
       "linewidth": 1,
       "nullPointMode": "null as zero",
       "options": {
@@ -1232,9 +1232,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(\n  last_over_time(node_boot_time_seconds[1h])\n  + on (node) group_left (label_worker_gardener_cloud_pool)\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n)\n!=\n(\n  last_over_time(node_boot_time_seconds[1h] offset 1m)\n  + on (node) group_left (label_worker_gardener_cloud_pool)\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n)",
+          "expr": "changes(node_boot_time_seconds[$__rate_interval])\n* on (node) group_left (label_worker_gardener_cloud_pool)\n  kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}",
           "format": "time_series",
-          "interval": "",
+          "interval": "1m",
           "intervalFactor": 1,
           "legendFormat": "{{node}}",
           "refId": "A"
@@ -1444,7 +1444,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -1184,13 +1184,112 @@
       "type": "table-old"
     },
     {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Reboot events detected per node over time. Each bar indicates a reboot was detected in that 10-minute window. Filtered by selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.25",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "changes(\n  (\n      node_boot_time_seconds\n    + on (node) group_left (label_worker_gardener_cloud_pool)\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )[10m:]\n)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Node Reboot Events in Worker Group(s) $worker_group",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "Reboots",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 48
       },
       "id": 16,
       "panels": [

--- a/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
+++ b/pkg/component/observability/plutono/dashboards/shoot/owners/worker/node-pool-dashboard.json
@@ -1212,6 +1212,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "max",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -1444,7 +1446,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
  /area monitoring

**What this PR does / why we need it**:

add two panels for node reboot , one is for reboot count + uptime and one is for reboot events across all nodes

<img width="1611" height="295" alt="image" src="https://github.com/user-attachments/assets/4fc5b2e0-6eb7-4a49-8dde-faff8e0d8de8" />
<img width="1624" height="322" alt="image" src="https://github.com/user-attachments/assets/8e7ee3fb-1f28-4827-bdff-1a7e9d7d992a" />


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
add two panels for node reboot , one is for reboot count + uptime and one is for reboot events across all nodes
```
