### PR TITLE
Changes the etcd defrag schedule format to run the etcd defrag once a day in maintenance window.

### DIFF
--- a/pkg/gardenlet/operation/botanist/etcd.go
+++ b/pkg/gardenlet/operation/botanist/etcd.go
@@ -17,7 +17,6 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/utils/timewindow"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
 	"github.com/gardener/gardener/pkg/component/shared"
@@ -42,7 +41,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		TopologyAwareRoutingEnabled: b.Shoot.TopologyAwareRoutingEnabled,
 	}
 
-	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.GetInfo(), b.ManagedSeed, class)
+	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.GetInfo())
 	if err != nil {
 		return nil, err
 	}
@@ -251,12 +250,8 @@ func determineBackupSchedule(shoot *gardencorev1beta1.Shoot) (string, error) {
 	)
 }
 
-func determineDefragmentationSchedule(shoot *gardencorev1beta1.Shoot, managedSeed *seedmanagementv1alpha1.ManagedSeed, class etcd.Class) (string, error) {
-	scheduleFormat := "%d %d */3 * *"
-	if managedSeed != nil && class == etcd.ClassImportant {
-		// defrag important etcds of ManagedSeeds daily in the maintenance window
-		scheduleFormat = "%d %d * * *"
-	}
+func determineDefragmentationSchedule(shoot *gardencorev1beta1.Shoot) (string, error) {
+	scheduleFormat := "%d %d * * *"
 
 	return timewindow.DetermineSchedule(
 		scheduleFormat,

--- a/pkg/gardenlet/operation/botanist/etcd_test.go
+++ b/pkg/gardenlet/operation/botanist/etcd_test.go
@@ -32,7 +32,6 @@ import (
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/component/etcd/etcd"
@@ -110,7 +109,7 @@ var _ = Describe("Etcd", func() {
 				expectedReplicas:                  PointTo(Equal(int32(1))),
 				expectedETCDMainStorageCapacity:   Equal("25Gi"),
 				expectedETCDEventsStorageCapacity: Equal("10Gi"),
-				expectedDefragmentationSchedule:   Equal(new("34 12 */3 * *")),
+				expectedDefragmentationSchedule:   Equal(new("34 12 * * *")),
 				expectedMaintenanceTimeWindow:     Equal(maintenanceTimeWindow),
 				expectedHighAvailabilityEnabled:   Equal(v1beta1helper.IsHAControlPlaneConfigured(botanist.Shoot.GetInfo())),
 			}
@@ -142,36 +141,6 @@ var _ = Describe("Etcd", func() {
 					})
 				}
 			}
-		})
-
-		Context("with ManagedSeed", func() {
-			BeforeEach(func() {
-				botanist.ManagedSeed = &seedmanagementv1alpha1.ManagedSeed{}
-				validator.expectedDefragmentationSchedule = Equal(new("34 12 * * *"))
-			})
-
-			It("should successfully create an etcd interface (normal class)", func() {
-
-				oldNewEtcd := NewEtcd
-				defer func() { NewEtcd = oldNewEtcd }()
-				NewEtcd = validator.NewEtcd
-
-				etcd, err := botanist.DefaultEtcd(role, class)
-				Expect(etcd).NotTo(BeNil())
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should successfully create an etcd interface (important class)", func() {
-				class := etcd.ClassImportant
-
-				oldNewEtcd := NewEtcd
-				defer func() { NewEtcd = oldNewEtcd }()
-				NewEtcd = validator.NewEtcd
-
-				etcd, err := botanist.DefaultEtcd(role, class)
-				Expect(etcd).NotTo(BeNil())
-				Expect(err).NotTo(HaveOccurred())
-			})
 		})
 
 		Context("with minAllowed configuration", func() {


### PR DESCRIPTION
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR changes the etcd defrag schedule format to run the etcd defrag once a day in maintenance window for all seeds/shoots.
Defragmentation is first run on all etcd-followers then on etcd-leader, so it shouldn't cause any downtime. Please refer to this [doc](https://github.com/gardener/etcd-backup-restore/blob/master/docs/operations/leader_election.md#defragmentation) for more information on this.

**Which issue(s) this PR fixes**:
Fixes #15124 

**Special notes for your reviewer**:
cc @shreyas-s-rao @dguendisch @Shreyas-s14 @ashwani2k 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user operator
The etcd defragmentation schedule has been changed from once every 3 days to once daily, within the shoot's maintenance window. For HA clusters, defragmentation runs in a rolling fashion across etcd members, so there is no downtime.
```
