### PR TITLE
Update kindest/node image to v1.36.1

### DIFF
--- a/dev-setup/kind/cluster/components/node/kustomization.yaml
+++ b/dev-setup/kind/cluster/components/node/kustomization.yaml
@@ -7,7 +7,7 @@ patches:
       path: /nodes/-
       value:
         role: worker
-        image: kindest/node:v1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab
+        image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
         labels:
           topology.kubernetes.io/zone: "0"
         extraPortMappings: []
@@ -42,21 +42,8 @@ patches:
     - op: replace
       path: /nodes/0/kubeadmConfigPatches/0
       value: |
-        # TODO(ialidzhikov): Use the kubeadm.k8s.io/v1beta4 API when kind supports it (ref https://github.com/kubernetes-sigs/kind/pull/3675).
-        # Currently kind accepts kubeadm.k8s.io/v1beta3 only.
-        apiVersion: kubeadm.k8s.io/v1beta3
+        apiVersion: kubeadm.k8s.io/v1beta4
         kind: ClusterConfiguration
-        apiServer:
-          extraArgs:
-            # TODO(DobromirNPeev): Remove once kind uses a Kubernetes version 1.36+.
-            # The MutatingAdmissionPolicy feature gate is promoted to GA and enabled by default in Kubernetes 1.36.
-            feature-gates: "MutatingAdmissionPolicy=true"
-            runtime-config: "admissionregistration.k8s.io/v1beta1=true"
-        controllerManager:
-          extraArgs:
-            # TODO(LucaBernstein): Remove once kind uses a Kubernetes version that includes the fix for
-            # https://github.com/kubernetes/kubernetes/issues/137409 (MaxUnavailableStatefulSet deadlock).
-            feature-gates: "MaxUnavailableStatefulSet=false"
   target:
     group: kind.x-k8s.io
     kind: Cluster

--- a/dev-setup/kind/cluster/components/node/kustomization.yaml
+++ b/dev-setup/kind/cluster/components/node/kustomization.yaml
@@ -19,8 +19,6 @@ patches:
           - hostPath: ${DOCKER_SOCKET}
             containerPath: /var/run/docker.sock
         kubeadmConfigPatches:
-          - "" # empty patch to allow adding kubeadm config patches for the control plane node only, see next patch below
-               # if we'd just append to kubeadmConfigPatches, we would end up with duplication in case this node component is added multiple times (for multi-node kind clusters)
           - |
             apiVersion: kubelet.config.k8s.io/v1beta1
             kind: KubeletConfiguration
@@ -39,11 +37,6 @@ patches:
     - op: replace
       path: /nodes/0/role
       value: control-plane
-    - op: replace
-      path: /nodes/0/kubeadmConfigPatches/0
-      value: |
-        apiVersion: kubeadm.k8s.io/v1beta4
-        kind: ClusterConfiguration
   target:
     group: kind.x-k8s.io
     kind: Cluster

--- a/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
+++ b/dev-setup/kind/node-status-capacity/mutatingadmissionpolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: node-status-capacity
@@ -28,7 +28,7 @@ spec:
           }
         }
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: node-status-capacity

--- a/pkg/provider-local/machine-provider/node/Dockerfile
+++ b/pkg/provider-local/machine-provider/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
+FROM kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends wget apparmor apparmor-utils jq openssh-server sudo logrotate


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source usability
/kind enhancement

**What this PR does / why we need it**:

Updates the kindest/node image used in the local setup and provider-local node Dockerfile from `v1.35.5` to `v1.36.1`.

**Which issue(s) this PR fixes**:
Part of #14653 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Update kindest/node image to `v1.36.1` (kind v0.32.0). 
```
