### PR TITLE
Fix `gardenadm` release binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,14 @@ on:
         description: |
           the mode to use. either `snapshot` or `release`. Will affect effective version, as well
           as target-oci-registry.
+      commit-objects-artefact:
+        type: string
+        description: |
+          the github-artifact-name containing a captured commit as output by the `capture-commit`
+          action. The default value will import the commit emitted by the `prepare` workflow
+          (which will result in the build to see the to-be-released commit, with correct
+          commit-digest).
+        default: release-commit-objects # exported from prepare.yaml
   pull_request:
     branches:
       - master
@@ -182,6 +190,7 @@ jobs:
     permissions:
       contents: read
     needs:
+      - prepare
       - tests
       - sast-lint
     strategy:
@@ -217,6 +226,12 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+      - name: import-release-commit
+        if: ${{ inputs.commit-objects-artefact != '' }}
+        uses: gardener/cc-utils/.github/actions/import-commit@v1
+        with:
+          commit-objects-artefact: ${{ inputs.commit-objects-artefact }}
+          after-import: rebase
       - name: build-garden-adm
         shell: bash
         run: |


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
Fixes `gardenadm` binaries attached to a GitHub release. Currently, they are built before the `VERSION` is bumped to a non-dev version, leading to a `gardenadm version: gardenadm version v1.145.0-dev` output.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @LucaBernstein

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `gardenadm version` output for binaries attached to GitHub releases has been fixed. Earlier, the `-dev` version of the corresponding release was printed.
```
