### PR TITLE
Add Bobi-Wan to the gardener-reviewers-logging group

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -38,6 +38,7 @@ aliases:
   - shreyas-s-rao
   - unmarshall
   gardener-reviewers-logging: # This group is primarily responsible for logging topics.
+  - Bobi-Wan
   - iypetrov
   - nickytd
   - rrhubenov


### PR DESCRIPTION
**How to categorize this PR?**

/area open-source
/kind task

**What this PR does / why we need it**:

This adds @Bobi-Wan to the `gardener-reviewers-logging` group.

**Special notes for your reviewer**:

/cc @Bobi-Wan @ScheererJ @nickytd 

**Release note**:

```other operator
NONE
```
