### PR TITLE
Revert "provider-local: run machine pods with AppArmor/seccomp unconfined (#15082)"

### DIFF
--- a/pkg/provider-local/machine-provider/node/Dockerfile
+++ b/pkg/provider-local/machine-provider/node/Dockerfile
@@ -11,12 +11,7 @@ RUN rm -f /etc/systemd/system/kubelet.service && \
 # kubelets) get their own cgroup namespace. Without this, nested kubelets see the host's cgroup
 # hierarchy and fail to manage cgroups properly. This is the same adjustment that kind.sh performs
 # at cluster creation time for KinD nodes.
-#
-# Also run containers unconfined (no seccomp, no AppArmor) so that processes started by the
-# machine node's containerd (e.g. the cilium-cli host-netns DaemonSet used for encryption tests)
-# are not restricted. Without this, the runtime default seccomp profile and the host's AppArmor
-# profile are inherited by nested containers.
-RUN jq '.linux.namespaces += [{"type": "cgroup"}] | .linux.seccomp = {} | .process.apparmorProfile = "unconfined"' /etc/containerd/cri-base.json > /tmp/cri-base.json && \
+RUN jq '.linux.namespaces += [{"type": "cgroup"}]' /etc/containerd/cri-base.json > /tmp/cri-base.json && \
     mv /tmp/cri-base.json /etc/containerd/cri-base.json
 
 # copy containerd hosts configurations for local registry mirrors


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Reverts #15082 which broke `make gind-up` on Mac.

Setting `process.apparmorProfile = "unconfined"` in `cri-base.json` causes runc to fail with `unable to apply apparmor profile` on kernels without AppArmor loaded. Docker Desktop on Mac does not have the AppArmor kernel module, so every container that the nested containerd inside `gind-machine-0` tries to start fails immediately. This prevents the kube-apiserver static pod from ever starting, causing `gardenadm init` to time out with an EOF error when trying to connect to the control plane.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A proper follow-up fix will add a conditional in `init-machine-state.sh` to strip `apparmorProfile` from `cri-base.json` at container start time when AppArmor is not loaded on the kernel — preserving the CI behavior on Linux while fixing Mac.

**Release note**:
```bugfix developer
Revert gind-machine containerd configuration change that broke `make gind-up` on Mac by setting an AppArmor profile in `cri-base.json` on kernels without AppArmor support.
```