### PR TITLE
feat(terminal): add RBAC for shoot resources

### DIFF
--- a/pkg/component/gardener/dashboard/terminal/rbac.go
+++ b/pkg/component/gardener/dashboard/terminal/rbac.go
@@ -62,6 +62,11 @@ func (t *terminal) clusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{gardencorev1beta1.GroupName},
+				Resources: []string{"shoots"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{gardencorev1beta1.GroupName},
 				Resources: []string{"shoots/adminkubeconfig"},
 				Verbs:     []string{"create"},
 			},

--- a/pkg/component/gardener/dashboard/terminal/terminal_test.go
+++ b/pkg/component/gardener/dashboard/terminal/terminal_test.go
@@ -518,6 +518,11 @@ server:
 				},
 				{
 					APIGroups: []string{"core.gardener.cloud"},
+					Resources: []string{"shoots"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"core.gardener.cloud"},
 					Resources: []string{"shoots/adminkubeconfig"},
 					Verbs:     []string{"create"},
 				},


### PR DESCRIPTION
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

The terminal-controller-manager needs read access to `Shoot` resources for the skip-hibernated-shoots feature ([gardener/terminal-controller-manager#512](https://github.com/gardener/terminal-controller-manager/pull/512)).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```other operator
The `gardener-operator` now grants the terminal-controller-manager read access to `Shoot` resources.
```