### PR TITLE
Reserve the `gardener-` capability-name prefix in CloudProfile admission

### DIFF
--- a/docs/operations/cloudprofile_capabilities.md
+++ b/docs/operations/cloudprofile_capabilities.md
@@ -64,6 +64,7 @@ spec:
 Rules enforced by `CloudProfile` admission:
 
 - Names must be unique within `spec.machineCapabilities`.
+- Capability names starting with `gardener-` are reserved for Gardener only and must not be used.
 - Each capability must declare at least one value, and values must be unique within that capability.
 - Only capability names registered in `spec.machineCapabilities` may be used on `machineTypes[*].capabilities` or `machineImages[*].versions[*].capabilityFlavors[*]`. 
 - Using an unregistered name/value is rejected with `Unsupported value`.

--- a/pkg/api/core/validation/cloudprofile.go
+++ b/pkg/api/core/validation/cloudprofile.go
@@ -532,6 +532,12 @@ func HasDecreasedMaxNodesTotal(newMaxNodesTotal, oldMaxNodesTotal *int32) bool {
 	return newMaxNodesTotal != nil && oldMaxNodesTotal != nil && *newMaxNodesTotal < *oldMaxNodesTotal
 }
 
+// gardenerReservedCapabilityPrefix is the capability-name prefix reserved for Gardener
+// core. Operator-supplied capabilities in `CloudProfile.spec.machineCapabilities` must
+// not use this prefix; the namespace is reserved so that future Gardener features can
+// introduce capability names without colliding with operator-defined ones.
+const gardenerReservedCapabilityPrefix = "gardener-"
+
 func validateCapabilityDefinitions(capabilityDefinitions []core.CapabilityDefinition, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -548,6 +554,9 @@ func validateCapabilityDefinitions(capabilityDefinitions []core.CapabilityDefini
 		capabilityDefinitionFieldPath := fldPath.Index(idx)
 		if _, exists := capabilityMap[capability.Name]; exists {
 			allErrs = append(allErrs, field.Duplicate(capabilityDefinitionFieldPath.Child("name"), capability.Name))
+		}
+		if strings.HasPrefix(capability.Name, gardenerReservedCapabilityPrefix) {
+			allErrs = append(allErrs, field.Forbidden(capabilityDefinitionFieldPath.Child("name"), fmt.Sprintf("the %q prefix is reserved for Gardener-core capabilities", gardenerReservedCapabilityPrefix)))
 		}
 		capabilityMap[capability.Name] = capability.Values
 	}

--- a/pkg/api/core/validation/cloudprofile_test.go
+++ b/pkg/api/core/validation/cloudprofile_test.go
@@ -2234,6 +2234,25 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					))
 				})
 
+				It("should reject capability names using the reserved gardener- prefix", func() {
+					cloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors = []core.MachineImageFlavor{
+						{Capabilities: core.Capabilities{"architecture": []string{"amd64"}}},
+					}
+					cloudProfile.Spec.MachineTypes[0].Capabilities = core.Capabilities{
+						"architecture": []string{"amd64"},
+					}
+					cloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
+						{Name: "architecture", Values: []string{"amd64"}},
+						{Name: "gardener-update-type", Values: []string{"rolling", "in-place"}},
+					}
+
+					Expect(ValidateCloudProfile(cloudProfile)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.machineCapabilities[1].name"),
+						"Detail": ContainSubstring(`"gardener-" prefix is reserved`),
+					}))))
+				})
+
 				It("should fail to validate capabilities with keys or values not passing qualified name check", func() {
 					cloudProfile.Spec.MachineCapabilities = []core.CapabilityDefinition{
 						{Name: "architecture", Values: []string{"amd64"}},


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind api-change

**What this PR does / why we need it**:

Reserves the `gardener-` prefix for Gardener-core capability names in `CloudProfile.spec.machineCapabilities`. CloudProfile admission now rejects any operator-supplied capability whose name starts with `gardener-`.

Any future Gardener-core feature that needs to introduce capability names owned by Gardener can claim names under this prefix without risking collision with operator-defined ones. Locking the namespace ahead of any concrete consumer ensures operators don't accidentally register capabilities whose semantics would later conflict with Gardener-core's definition.


**Special notes for your reviewer**:
This PR was inspired by the discussion on [GEP-0053:Worker Capability Requirements for Machine Image Selection](https://github.com/gardener/enhancements/pull/53#discussion_r3441009187).

The GEP is not yet approved, but reserving a gardener controlled namespace gets harder over time once more operators adopt machine capabilities. That is why I propose to reserve the `-gardener` prefix nevertheless. If it will not be used, no harm is done.

**Release note**:
```breaking operator
CloudProfile admission now rejects capability names starting with `gardener-` in `spec.machineCapabilities`. The prefix is reserved for capability names owned by Gardener core.
```
