### PR TITLE
Enable server-side TLS for gardener-dashboard backend

### DIFF
--- a/pkg/component/gardener/dashboard/config/config.go
+++ b/pkg/component/gardener/dashboard/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	APIServerURL       string  `yaml:"apiServerUrl"`
 	APIServerCAData    *string `yaml:"apiServerCaData,omitempty"`
 	MaxRequestBodySize string  `yaml:"maxRequestBodySize"`
+	TLS                TLS     `yaml:"tls"`
 
 	ReadinessProbe          ReadinessProbe         `yaml:"readinessProbe"`
 	UnreachableSeeds        UnreachableSeeds       `yaml:"unreachableSeeds"`
@@ -25,6 +26,12 @@ type Config struct {
 	OIDC                    *OIDC                  `yaml:"oidc,omitempty"`
 	GitHub                  *GitHub                `yaml:"gitHub,omitempty"`
 	Frontend                map[string]any         `yaml:"frontend,omitempty"`
+}
+
+// TLS is the dashboard server TLS configuration.
+type TLS struct {
+	CertFile       string `yaml:"certFile"`
+	PrivateKeyFile string `yaml:"privateKeyFile"`
 }
 
 // ReadinessProbe is the readiness probe configuration.

--- a/pkg/component/gardener/dashboard/configmap.go
+++ b/pkg/component/gardener/dashboard/configmap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/gardener/dashboard/config"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 const (
@@ -57,12 +58,16 @@ func (g *gardenerDashboard) configMap(ctx context.Context) (*corev1.ConfigMap, e
 
 	var (
 		cfg = &config.Config{
-			Port:                    portServer,
-			LogFormat:               "text",
-			LogLevel:                g.values.LogLevel,
-			APIServerURL:            "https://" + g.values.APIServerURL,
-			APIServerCAData:         g.values.APIServerCABundle,
-			MaxRequestBodySize:      "500kb",
+			Port:               portServer,
+			LogFormat:          "text",
+			LogLevel:           g.values.LogLevel,
+			APIServerURL:       "https://" + g.values.APIServerURL,
+			APIServerCAData:    g.values.APIServerCABundle,
+			MaxRequestBodySize: "500kb",
+			TLS: config.TLS{
+				CertFile:       volumeMountPathTLS + "/" + secretsutils.DataKeyCertificate,
+				PrivateKeyFile: volumeMountPathTLS + "/" + secretsutils.DataKeyPrivateKey,
+			},
 			ReadinessProbe:          config.ReadinessProbe{PeriodSeconds: readinessProbePeriodSeconds},
 			UnreachableSeeds:        config.UnreachableSeeds{MatchLabels: map[string]string{v1beta1constants.LabelSeedNetwork: v1beta1constants.LabelSeedNetworkPrivate}},
 			WebsocketAllowedOrigins: websocketAllowedOrigins,

--- a/pkg/component/gardener/dashboard/dashboard.go
+++ b/pkg/component/gardener/dashboard/dashboard.go
@@ -140,6 +140,16 @@ func (g *gardenerDashboard) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	serverCert, err := g.reconcileServerCert(ctx)
+	if err != nil {
+		return err
+	}
+
+	secretCARuntime, found := g.secretsManager.Get(operatorv1alpha1.SecretNameCARuntime)
+	if !found {
+		return fmt.Errorf("secret %q not found", operatorv1alpha1.SecretNameCARuntime)
+	}
+
 	sessionSecretPrevious, _ := g.secretsManager.Get("gardener-dashboard-session-secret", secretsmanager.Old)
 
 	configMap, err := g.configMap(ctx)
@@ -147,13 +157,13 @@ func (g *gardenerDashboard) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	deployment, err := g.deployment(ctx, secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name, sessionSecret.Name, sessionSecretPrevious, configMap.Name)
+	deployment, err := g.deployment(ctx, secretGenericTokenKubeconfig.Name, virtualGardenAccessSecret.Secret.Name, sessionSecret.Name, sessionSecretPrevious, serverCert.Name, configMap.Name)
 	if err != nil {
 		return err
 	}
 
 	if g.values.Ingress.Enabled {
-		istioResources, err := g.istioResources(ctx)
+		istioResources, err := g.istioResources(ctx, secretCARuntime)
 		if err != nil {
 			return err
 		}

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -96,6 +96,7 @@ var _ = Describe("GardenerDashboard", func() {
 		virtualService            *istionetworkingv1beta1.VirtualService
 		destinationRule           *istionetworkingv1beta1.DestinationRule
 		tlsSecret                 *corev1.Secret
+		tlsCASecret               *corev1.Secret
 		serviceMonitor            *monitoringv1.ServiceMonitor
 
 		clusterRole                      *rbacv1.ClusterRole
@@ -211,6 +212,9 @@ logFormat: text
 logLevel: ` + logLevel + `
 apiServerUrl: https://` + apiServerURL + `
 maxRequestBodySize: 500kb
+tls:
+  certFile: /etc/gardener-dashboard/secrets/tls/tls.crt
+  privateKeyFile: /etc/gardener-dashboard/secrets/tls/tls.key
 readinessProbe:
   periodSeconds: 10
 unreachableSeeds:
@@ -414,7 +418,7 @@ frontend:
 									},
 									Ports: []corev1.ContainerPort{
 										{
-											Name:          "http",
+											Name:          "https",
 											ContainerPort: 8080,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -427,7 +431,7 @@ frontend:
 									LivenessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
 											TCPSocket: &corev1.TCPSocketAction{
-												Port: intstr.FromString("http"),
+												Port: intstr.FromString("https"),
 											},
 										},
 										InitialDelaySeconds: 15,
@@ -440,8 +444,8 @@ frontend:
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/healthz",
-												Port:   intstr.FromString("http"),
-												Scheme: "HTTP",
+												Port:   intstr.FromString("https"),
+												Scheme: "HTTPS",
 											},
 										},
 										InitialDelaySeconds: 5,
@@ -467,6 +471,11 @@ frontend:
 											Name:      "gardener-dashboard-login-config",
 											MountPath: "/app/public/login-config.json",
 											SubPath:   "login-config.json",
+										},
+										{
+											Name:      "gardener-dashboard-tls",
+											MountPath: "/etc/gardener-dashboard/secrets/tls",
+											ReadOnly:  true,
 										},
 									},
 								},
@@ -506,6 +515,15 @@ frontend:
 												Key:  "login-config.json",
 												Path: "login-config.json",
 											}},
+										},
+									},
+								},
+								{
+									Name: "gardener-dashboard-tls",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName:  "gardener-dashboard-server",
+											DefaultMode: ptr.To[int32](0640),
 										},
 									},
 								},
@@ -602,7 +620,7 @@ frontend:
 				Selector: GetLabels(),
 				Ports: []corev1.ServicePort{
 					{
-						Name:       "http",
+						Name:       "https",
 						Port:       8080,
 						Protocol:   corev1.ProtocolTCP,
 						TargetPort: intstr.FromInt32(8080),
@@ -751,7 +769,11 @@ frontend:
 						},
 					},
 					OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{},
-					Tls:              &istioapinetworkingv1beta1.ClientTLSSettings{},
+					Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
+						Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
+						CredentialName: "some-namespace-gardener-dashboard-tls-ca",
+						Sni:            "gardener-dashboard.some-namespace.svc.cluster.local",
+					},
 				},
 			},
 		}
@@ -763,6 +785,19 @@ frontend:
 					"app":  "gardener",
 					"role": "dashboard",
 				},
+			},
+		}
+		tlsCASecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-namespace-gardener-dashboard-tls-ca",
+				Namespace: "virtual-garden-istio-ingress",
+				Labels: map[string]string{
+					"app":  "gardener",
+					"role": "dashboard",
+				},
+			},
+			Data: map[string][]byte{
+				"cacert": []byte("ca-cert-data"),
 			},
 		}
 		serviceMonitor = &monitoringv1.ServiceMonitor{
@@ -951,6 +986,7 @@ frontend:
 
 		By("Create secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "generic-token-kubeconfig", Namespace: namespace}})).To(Succeed())
+		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-garden-runtime", Namespace: namespace}, Data: map[string][]byte{"bundle.crt": []byte("ca-cert-data")}})).To(Succeed())
 	})
 
 	Describe("#Deploy", func() {
@@ -1046,10 +1082,11 @@ frontend:
 					service,
 					podDisruptionBudget,
 					vpa,
+					tlsSecret,
+					tlsCASecret,
 					gateway,
 					virtualService,
 					destinationRule,
-					tlsSecret,
 					serviceMonitor,
 				}
 				expectedVirtualObjects = []client.Object{

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -523,7 +523,7 @@ frontend:
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "gardener-dashboard-server",
-											DefaultMode: new(0640),
+											DefaultMode: new(int32(0640)),
 										},
 									},
 								},

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -523,7 +523,7 @@ frontend:
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
 											SecretName:  "gardener-dashboard-server",
-											DefaultMode: ptr.To[int32](0640),
+											DefaultMode: new(0640),
 										},
 									},
 								},

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -31,7 +32,7 @@ const (
 	dataKeySessionSecret         = "sessionSecret"
 	dataKeySessionSecretPrevious = "sessionSecretPrevious"
 
-	portNameServer  = "http"
+	portNameServer  = "https"
 	portNameMetrics = "metrics"
 
 	portServer  = 8080
@@ -49,6 +50,7 @@ const (
 	volumeMountPathSessionPrevious = "/etc/gardener-dashboard/secrets/session/sessionSecretPrevious"
 	volumeMountPathOIDC            = "/etc/gardener-dashboard/secrets/oidc"
 	volumeMountPathGithub          = "/etc/gardener-dashboard/secrets/github"
+	volumeMountPathTLS             = "/etc/gardener-dashboard/secrets/tls"
 
 	volumeNameConfig          = "gardener-dashboard-config"
 	volumeNameLoginConfig     = "gardener-dashboard-login-config"
@@ -57,6 +59,7 @@ const (
 	volumeNameSessionPrevious = "gardener-dashboard-sessionsecret-previous"
 	volumeNameOIDC            = "gardener-dashboard-oidc"
 	volumeNameGithub          = "gardener-dashboard-github"
+	volumeNameTLS             = "gardener-dashboard-tls"
 )
 
 func (g *gardenerDashboard) deployment(
@@ -65,6 +68,7 @@ func (g *gardenerDashboard) deployment(
 	secretNameVirtualGardenAccess string,
 	secretNameSession string,
 	secretSessionPrevious *corev1.Secret,
+	secretNameServerCert string,
 	configMapName string,
 ) (
 	*appsv1.Deployment,
@@ -178,7 +182,7 @@ func (g *gardenerDashboard) deployment(
 									HTTPGet: &corev1.HTTPGetAction{
 										Path:   "/healthz",
 										Port:   intstr.FromString(portNameServer),
-										Scheme: corev1.URISchemeHTTP,
+										Scheme: corev1.URISchemeHTTPS,
 									},
 								},
 								InitialDelaySeconds: 5,
@@ -204,6 +208,11 @@ func (g *gardenerDashboard) deployment(
 									Name:      volumeNameLoginConfig,
 									MountPath: volumeMountPathLoginConfig,
 									SubPath:   dataKeyLoginConfig,
+								},
+								{
+									Name:      volumeNameTLS,
+									MountPath: volumeMountPathTLS,
+									ReadOnly:  true,
 								},
 							},
 						},
@@ -243,6 +252,15 @@ func (g *gardenerDashboard) deployment(
 										Key:  dataKeyLoginConfig,
 										Path: dataKeyLoginConfig,
 									}},
+								},
+							},
+						},
+						{
+							Name: volumeNameTLS,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName:  secretNameServerCert,
+									DefaultMode: ptr.To[int32](0640),
 								},
 							},
 						},

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -260,7 +260,7 @@ func (g *gardenerDashboard) deployment(
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameServerCert,
-									DefaultMode: new(0640),
+									DefaultMode: new(int32(0640)),
 								},
 							},
 						},

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -260,7 +260,7 @@ func (g *gardenerDashboard) deployment(
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName:  secretNameServerCert,
-									DefaultMode: ptr.To[int32](0640),
+									DefaultMode: new(0640),
 								},
 							},
 						},

--- a/pkg/component/gardener/dashboard/ingress.go
+++ b/pkg/component/gardener/dashboard/ingress.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +25,7 @@ import (
 
 const istioIngressGatewayNamespace = operatorv1alpha1.VirtualGardenNamePrefix + v1beta1constants.DefaultSNIIngressNamespace
 
-func (g *gardenerDashboard) istioResources(ctx context.Context) ([]client.Object, error) {
+func (g *gardenerDashboard) istioResources(ctx context.Context, secretCARuntime *corev1.Secret) ([]client.Object, error) {
 	var (
 		gatewayName   = deploymentName
 		tlsSecretName = ptr.Deref(g.values.Ingress.TLSSecretName, "")
@@ -37,7 +38,7 @@ func (g *gardenerDashboard) istioResources(ctx context.Context) ([]client.Object
 			CommonName:                  deploymentName,
 			DNSNames:                    g.values.Ingress.Domains,
 			CertType:                    secretsutils.ServerCert,
-			Validity:                    new(v1beta1constants.IngressTLSCertificateValidity),
+			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
 			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(operatorv1alpha1.SecretNameCAGardener))
 		if err != nil {
@@ -88,10 +89,31 @@ func (g *gardenerDashboard) istioResources(ctx context.Context) ([]client.Object
 		return nil, fmt.Errorf("failed to create virtual service resource: %w", err)
 	}
 
+	tlsCASecretInIstioNamespace := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s-tls-ca", g.namespace, deploymentName),
+			Namespace: istioIngressGatewayNamespace,
+			Labels:    GetLabels(),
+		},
+		Data: map[string][]byte{
+			"cacert": secretCARuntime.Data[secretsutils.DataKeyCertificateBundle],
+		},
+	}
+
 	destinationRule := &istionetworkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: gatewayName, Namespace: g.namespace}}
-	if err := istio.DestinationRuleWithLocalityPreference(destinationRule, GetLabels(), []string{istioIngressGatewayNamespace}, destinationHost)(); err != nil {
+	if err := istio.DestinationRuleWithLocalityPreferenceAndTLS(
+		destinationRule,
+		GetLabels(),
+		[]string{istioIngressGatewayNamespace},
+		destinationHost,
+		&istioapinetworkingv1beta1.ClientTLSSettings{
+			Mode:           istioapinetworkingv1beta1.ClientTLSSettings_SIMPLE,
+			CredentialName: tlsCASecretInIstioNamespace.Name,
+			Sni:            destinationHost,
+		},
+	)(); err != nil {
 		return nil, fmt.Errorf("failed to create destination rule resource: %w", err)
 	}
 
-	return []client.Object{tlsSecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
+	return []client.Object{tlsSecretInIstioNamespace, tlsCASecretInIstioNamespace, gateway, virtualService, destinationRule}, nil
 }

--- a/pkg/component/gardener/dashboard/ingress.go
+++ b/pkg/component/gardener/dashboard/ingress.go
@@ -38,7 +38,7 @@ func (g *gardenerDashboard) istioResources(ctx context.Context, secretCARuntime 
 			CommonName:                  deploymentName,
 			DNSNames:                    g.values.Ingress.Domains,
 			CertType:                    secretsutils.ServerCert,
-			Validity:                    ptr.To(v1beta1constants.IngressTLSCertificateValidity),
+			Validity:                    new(v1beta1constants.IngressTLSCertificateValidity),
 			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(operatorv1alpha1.SecretNameCAGardener))
 		if err != nil {

--- a/pkg/component/gardener/dashboard/secrets.go
+++ b/pkg/component/gardener/dashboard/secrets.go
@@ -10,7 +10,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 )
@@ -26,4 +28,14 @@ func (g *gardenerDashboard) reconcileSessionSecret(ctx context.Context) (*corev1
 		Username:       "admin",
 		PasswordLength: 32,
 	}, secretsmanager.Rotate(secretsmanager.KeepOld), secretsmanager.Validity(30*24*time.Hour), secretsmanager.IgnoreOldSecretsAfter(24*time.Hour))
+}
+
+func (g *gardenerDashboard) reconcileServerCert(ctx context.Context) (*corev1.Secret, error) {
+	return g.secretsManager.Generate(ctx, &secretsutils.CertificateSecretConfig{
+		Name:                        deploymentName + "-server",
+		CommonName:                  deploymentName,
+		DNSNames:                    kubernetesutils.DNSNamesForService(serviceName, g.namespace),
+		CertType:                    secretsutils.ServerCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(operatorv1alpha1.SecretNameCARuntime, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhacement

**What this PR does / why we need it**:
This change configures the gardener-operator managed dashboard backend to serve HTTPS by default. It generates and mounts a runtime-CA-signed serving certificate, renders the new `tls.certFile` / `tls.privateKeyFile` dashboard config, switches probes and service naming to HTTPS, and configures Istio upstream TLS with the corresponding CA trust.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold
Until Gardener Dashboard 1.85 has been released which includes required Dashboard changes: https://github.com/gardener/dashboard/pull/3014

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
