### PR TITLE
Support private registries for Shoot worker nodes

### DIFF
--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -127,7 +127,7 @@ spec:
 
 ## CA Bundle for Private Registries
 
-If the registry used in the image vector overwrite is backed by a custom PKI (i.e., it presents a TLS certificate that is not trusted by the default system roots), you can supply the CA bundle alongside the image overrides in the same file:
+If the registry used in the image vector overwrite is backed by a custom CA (i.e., it presents a TLS certificate that is not trusted by the default system roots), you can supply the CA bundle alongside the image overrides in the same file:
 
 ```yaml
 images:
@@ -137,7 +137,7 @@ images:
 caBundle:
   inline: |
     -----BEGIN CERTIFICATE-----
-    <base64-encoded DER certificate>
+    <certificate data>
     -----END CERTIFICATE-----
 ```
 
@@ -199,6 +199,6 @@ images:
 caBundle:
   inline: |
     -----BEGIN CERTIFICATE-----
-    <base64-encoded DER certificate>
+    <certificate data>
     -----END CERTIFICATE-----
 ```

--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -173,3 +173,18 @@ The respective component is responsible for using the overwritten images instead
 Some Gardener components might also deploy [packaged Helm charts](https://helm.sh/docs/helm/helm_package/) which are pulled from an OCI repository.
 The concepts are the very same as for the container images.
 The only difference is that the environment variable for overwriting this chart image vector is called `IMAGEVECTOR_OVERWRITE_CHARTS`.
+
+If the chart OCI registry uses a custom CA, you can supply it via `caBundle.inline` in the same override file.
+Gardener will automatically include this CA in the TLS trust store whenever it pulls an OCI Helm chart.
+
+```yaml
+images:
+- name: my-chart
+  repository: my-private-registry.example.com/charts/my-chart
+  tag: "1.2.3"
+caBundle:
+  inline: |
+    -----BEGIN CERTIFICATE-----
+    <base64-encoded DER certificate>
+    -----END CERTIFICATE-----
+```

--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -68,7 +68,8 @@ In these cases, you might want to overwrite certain images, e.g., point the `pau
 
 :warning: If you specify an image that does not fit to the resource manifest, then the reconciliations might fail.
 
-In order to overwrite the images, you must provide a similar file to the Gardener component:
+In order to overwrite the images, you must provide a similar file to the Gardener component.
+If your registry requires a custom CA, you can also supply a `caBundle` in the same file (see [CA Bundle for Private Registries](#ca-bundle-for-private-registries)):
 
 ```yaml
 images:
@@ -123,6 +124,28 @@ spec:
         configMap:
           name: gardenlet-images-overwrite
 ```
+
+## CA Bundle for Private Registries
+
+If the registry used in the image vector overwrite is backed by a custom PKI (i.e., it presents a TLS certificate that is not trusted by the default system roots), you can supply the CA bundle alongside the image overrides in the same file:
+
+```yaml
+images:
+- name: pause-container
+  repository: my-private-registry.example.com/pause
+  tag: "3.5"
+caBundle:
+  inline: |
+    -----BEGIN CERTIFICATE-----
+    <base64-encoded DER certificate>
+    -----END CERTIFICATE-----
+```
+
+The `caBundle.inline` field accepts a PEM-encoded CA certificate bundle.
+If set for `gardenlet`, it will distribute the CA certificate bundle to the worker nodes of every shoot managed by this seed, so that containerd on those nodes trusts the registry when pulling images.
+
+> [!NOTE]
+> The certificate must be a CA certificate and must not be expired. Gardener validates both conditions when loading the image vector overwrite file.
 
 ## Image Vectors for Dependent Components
 

--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -144,6 +144,15 @@ caBundle:
 The `caBundle.inline` field accepts a PEM-encoded CA certificate bundle.
 If set for `gardenlet`, it will distribute the CA certificate bundle to the worker nodes of every shoot managed by this seed, so that containerd on those nodes trusts the registry when pulling images.
 
+> [!IMPORTANT]
+> Only the **gardenlet**'s image vector `caBundle` is distributed to shoot worker nodes.
+> Setting `caBundle` in the `gardener-operator`'s image vector override does not install the CA on any nodes.
+> For the runtime/soil cluster itself, custom CAs must be installed on nodes by other means (e.g., via the cloud provider's node configuration API).
+
+If extensions deployed by gardenlet use container images from a private registry with a custom CA, that CA must also be included in the gardenlet's image vector `caBundle`.
+This is the only mechanism for installing custom CAs on shoot worker nodes — the `caBundleSecretRef` on an `Extension` or `ControllerDeployment` only covers TLS for pulling the Helm chart archive and does not affect containerd's trust store on the nodes.
+In practice this means operators should consolidate all private registry CAs (both their own and those required by extensions) into the gardenlet's `IMAGEVECTOR_OVERWRITE` `caBundle`.
+
 > [!NOTE]
 > The certificate must be a CA certificate and must not be expired. Gardener validates both conditions when loading the image vector overwrite file.
 
@@ -176,6 +185,11 @@ The only difference is that the environment variable for overwriting this chart 
 
 If the chart OCI registry uses a custom CA, you can supply it via `caBundle.inline` in the same override file.
 Gardener will automatically include this CA in the TLS trust store whenever it pulls an OCI Helm chart.
+
+> [!IMPORTANT]
+> The `caBundle` here (like `caBundleSecretRef` on an `Extension` or `ControllerDeployment`) only secures the TLS connection used to pull the chart archive from the OCI registry.
+> It does **not** install that CA on shoot worker nodes.
+> Container images referenced inside those Helm charts will only be trusted by containerd if the CA is also present in the gardenlet's `IMAGEVECTOR_OVERWRITE` `caBundle` (see [CA Bundle for Private Registries](#ca-bundle-for-private-registries)).
 
 ```yaml
 images:

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -215,6 +215,11 @@ spec:
 
 If your OCI registry uses a custom or self-signed TLS certificate, you can provide a CA bundle. For registries requiring authentication, you can reference a pull secret.
 
+> [!NOTE]
+> If you configure a `caBundle` in the Charts image vector override (`IMAGEVECTOR_OVERWRITE_CHARTS`), Gardener automatically includes that CA in the TLS trust store for every OCI Helm chart pull.
+> This means you do not need to repeat the same CA secret for every `Extension` that uses the same private registry.
+> See [Helm Chart Image Vector](image_vector.md#helm-chart-image-vector) for details.
+
 ```yaml
 apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension

--- a/docs/extensions/registration.md
+++ b/docs/extensions/registration.md
@@ -261,6 +261,11 @@ data:
   bundle.crt: <base64-encoded-ca-bundle>
 ```
 
+> [!NOTE]
+> If you configure a `caBundle` in the Charts image vector override (`IMAGEVECTOR_OVERWRITE_CHARTS`), Gardener automatically includes that CA in the TLS trust store for every OCI Helm chart pull.
+> This means you do not need to repeat the same CA secret for every `Extension` or `ControllerDeployment` that uses the same private registry.
+> See [Helm Chart Image Vector](../deployment/image_vector.md#helm-chart-image-vector) for details.
+
 The downloaded chart is cached in memory. It is recommended to always specify a digest, because if it is not specified, the manifest is fetched in every reconciliation to compare the digest with the local cache.
 
 ### Helm Values

--- a/imagevector/imagevector.go
+++ b/imagevector/imagevector.go
@@ -20,23 +20,25 @@ var (
 	//go:embed containers.yaml
 	containersYAML        string
 	containersImageVector imagevector.ImageVector
+	containersCABundle    *imagevector.CABundle
 
 	//go:embed charts.yaml
 	chartsYAML        string
 	chartsImageVector imagevector.ImageVector
+	chartsCABundle    *imagevector.CABundle
 )
 
 func init() {
 	var err error
 
-	containersImageVector, err = imagevector.Read([]byte(containersYAML))
+	containersImageVector, containersCABundle, err = imagevector.Read([]byte(containersYAML))
 	runtime.Must(err)
-	containersImageVector, err = imagevector.WithEnvOverride(containersImageVector, imagevector.OverrideEnv)
+	containersImageVector, containersCABundle, err = imagevector.WithEnvOverride(containersImageVector, containersCABundle, imagevector.OverrideEnv)
 	runtime.Must(err)
 
-	chartsImageVector, err = imagevector.Read([]byte(chartsYAML))
+	chartsImageVector, chartsCABundle, err = imagevector.Read([]byte(chartsYAML))
 	runtime.Must(err)
-	chartsImageVector, err = imagevector.WithEnvOverride(chartsImageVector, imagevector.OverrideChartsEnv)
+	chartsImageVector, chartsCABundle, err = imagevector.WithEnvOverride(chartsImageVector, chartsCABundle, imagevector.OverrideChartsEnv)
 	runtime.Must(err)
 }
 
@@ -48,4 +50,14 @@ func Containers() imagevector.ImageVector {
 // Charts is the image vector that contains all the needed Helm chart images.
 func Charts() imagevector.ImageVector {
 	return chartsImageVector
+}
+
+// ContainersCABundle returns the CA bundle defined in the container image vector.
+func ContainersCABundle() *imagevector.CABundle {
+	return containersCABundle
+}
+
+// ChartsCABundle returns the CA bundle defined in the chart image vector.
+func ChartsCABundle() *imagevector.CABundle {
+	return chartsCABundle
 }

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -16,6 +16,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -33,19 +34,20 @@ func Config(
 	nodeAgentImage string,
 	config *nodeagentconfigv1alpha1.NodeAgentConfiguration,
 	clusterCABundle []byte,
+	registryCAEnabled bool,
 ) (
 	[]extensionsv1alpha1.Unit,
 	[]extensionsv1alpha1.File,
 	error,
 ) {
-	initScript, err := generateInitScript(nodeAgentImage)
+	initScript, err := generateInitScript(nodeAgentImage, registryCAEnabled, config.APIServer.Server)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed generating init script: %w", err)
 	}
 
 	var (
 		nodeInitUnits = []extensionsv1alpha1.Unit{
-			generateInitScriptUnit(nodeagentconfigv1alpha1.InitUnitName, "gardener-node-agent", PathInitScript),
+			generateInitScriptUnit(nodeagentconfigv1alpha1.InitUnitName, "gardener-node-agent", PathInitScript, registryCAEnabled),
 		}
 
 		nodeInitFiles = []extensionsv1alpha1.File{
@@ -92,6 +94,14 @@ func Config(
 		}
 	)
 
+	if registryCAEnabled {
+		updateCACertsScriptFile, err := rootcertificates.UpdateLocalCACertificatesScriptFile()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed generating update-ca-certificates script file: %w", err)
+		}
+		nodeInitFiles = append(nodeInitFiles, updateCACertsScriptFile)
+	}
+
 	// The gardener-node-init script above will bootstrap the gardener-node-agent. This means that the unit file for
 	// the gardener-node-agent unit will be written and eventually started (whilst gardener-node-init disables and stops
 	// itself). Hence, the files for gardener-node-agent (component configuration and kubeconfig) must be present on the
@@ -121,28 +131,51 @@ func init() {
 	initScriptTpl = template.Must(template.New("init-script").Parse(initScriptTplContent))
 }
 
-func generateInitScript(nodeAgentImage string) ([]byte, error) {
+func generateInitScript(nodeAgentImage string, registryCAEnabled bool, apiServerURL string) ([]byte, error) {
 	var initScript bytes.Buffer
-	if err := initScriptTpl.Execute(&initScript, map[string]any{
+
+	data := map[string]any{
 		"image":           nodeAgentImage,
 		"binaryName":      "gardener-node-agent",
 		"binaryDirectory": nodeagentconfigv1alpha1.BinaryDir,
 		"configDir":       nodeagentconfigv1alpha1.BaseDir,
-	}); err != nil {
+	}
+
+	if registryCAEnabled {
+		data["registryCAEnabled"] = registryCAEnabled
+		data["localCACertsDir"] = rootcertificates.PathLocalSSLCerts
+		data["registryCAFilePath"] = rootcertificates.PathLocalSSLRegistryCACerts
+		data["pkiTrustAnchorsDir"] = rootcertificates.PathPKITrustAnchors
+		data["registryCAFilePathPKI"] = rootcertificates.PathPKITrustAnchorsRegistryCACerts
+		data["bootstrapTokenFilePath"] = nodeagentconfigv1alpha1.BootstrapTokenFilePath
+		data["clusterCAFilePath"] = nodeagentconfigv1alpha1.ClusterCAFilePath
+		data["apiServerURL"] = apiServerURL
+		data["updateCACertificatesScript"] = rootcertificates.PathUpdateLocalCACertificates
+	}
+
+	if err := initScriptTpl.Execute(&initScript, data); err != nil {
 		return nil, err
 	}
 
 	return initScript.Bytes(), nil
 }
 
-func generateInitScriptUnit(unitName, binaryName, filePath string) extensionsv1alpha1.Unit {
+func generateInitScriptUnit(unitName, binaryName, filePath string, registryCAEnabled bool) extensionsv1alpha1.Unit {
+	// When a custom registry CA is configured, the init script restarts containerd after updating the
+	// system CA store so that the running daemon picks up the new certificate. Using Wants instead of
+	// Requires ensures that this temporary stop of containerd does not cause systemd to also stop the
+	// init service itself due to the dependency which would cause an infinite loop.
+	containerdDep := "Requires=containerd.service"
+	if registryCAEnabled {
+		containerdDep = "Wants=containerd.service"
+	}
 	return extensionsv1alpha1.Unit{
 		Name:    unitName,
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
 Description=Downloads the ` + binaryName + ` binary from the container registry and bootstraps it.
-Requires=containerd.service
+` + containerdDep + `
 After=containerd.service
 After=network-online.target
 Wants=network-online.target

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/utils"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 // PathInitScript is the path to the init script.
@@ -151,6 +152,7 @@ func generateInitScript(nodeAgentImage string, registryCAEnabled bool, apiServer
 		data["clusterCAFilePath"] = nodeagentconfigv1alpha1.ClusterCAFilePath
 		data["apiServerURL"] = apiServerURL
 		data["updateCACertificatesScript"] = rootcertificates.PathUpdateLocalCACertificates
+		data["registryCABundleKey"] = secretsutils.DataKeyCertificateBundle
 	}
 
 	if err := initScriptTpl.Execute(&initScript, data); err != nil {

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -20,6 +20,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/nodeinit"
 	nodeagentcomponent "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
+	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -43,7 +44,7 @@ var _ = Describe("Init", func() {
 
 		When("kubelet data volume is not configured", func() {
 			It("should return the expected units and files", func() {
-				units, files, err := Config(worker, image, config, caBundle)
+				units, files, err := Config(worker, image, config, caBundle, false)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(units).To(ConsistOf(extensionsv1alpha1.Unit{
@@ -173,6 +174,181 @@ exec "/opt/bin/gardener-node-agent" bootstrap --config-dir="/var/lib/gardener-no
 			})
 		})
 
+		Context("registry CA", func() {
+			When("registryCA is enabled", func() {
+				It("should use Wants=containerd.service in the unit", func() {
+					units, _, err := Config(worker, image, config, caBundle, true)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(units).To(ConsistOf(extensionsv1alpha1.Unit{
+						Name:    nodeagentconfigv1alpha1.InitUnitName,
+						Command: new(extensionsv1alpha1.CommandStart),
+						Enable:  new(true),
+						Content: new(`[Unit]
+Description=Downloads the gardener-node-agent binary from the container registry and bootstraps it.
+Wants=containerd.service
+After=containerd.service
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=0
+EnvironmentFile=/etc/environment
+ExecStart=/var/lib/gardener-node-agent/init.sh
+StandardOutput=journal+console
+StandardError=journal+console
+[Install]
+WantedBy=multi-user.target`),
+						FilePaths: []string{"/var/lib/gardener-node-agent/init.sh"},
+					}))
+				})
+
+				It("should embed the CA fetch block in the init script and include the update-ca-certificates script file", func() {
+					_, files, err := Config(worker, image, config, caBundle, true)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(files).To(ContainElement(extensionsv1alpha1.File{
+						Path:        "/var/lib/gardener-node-agent/init.sh",
+						Permissions: new(uint32(0755)),
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+image="` + image + `"
+
+echo "> Prepare temporary directory for image pull and mount"
+tmp_dir="$(mktemp -d)"
+unmount() {
+  ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"
+}
+trap unmount EXIT
+
+CA_B64=$(curl -f \
+  --cacert "/var/lib/gardener-node-agent/cluster-ca.crt" \
+  --header "Authorization: Bearer $(cat "/var/lib/gardener-node-agent/credentials/bootstrap-token" 2>/dev/null)" \
+  "` + apiServerURL + `/api/v1/namespaces/kube-system/configmaps/registry-ca-bundle" \
+  | sed -n 's/.*"ca\.b64"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [ -n "$CA_B64" ]; then
+  mkdir -p "/var/lib/ca-certificates-local" "/etc/pki/trust/anchors"
+  printf '%s' "$CA_B64" | base64 -d | tee "/var/lib/ca-certificates-local/registry-ca.crt" > "/etc/pki/trust/anchors/registry-ca.pem"
+  /var/lib/ssl/update-local-ca-certificates.sh
+  systemctl restart containerd
+  echo "> Registry CA configured"
+fi
+
+echo "> Pull gardener-node-agent image and mount it to the temporary directory"
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1 | sed 's/[a-zA-Z]//g')
+CTR_EXTRA_ARGS=""
+if [ "$CTR_MAJOR" -gt 1 ]; then
+    CTR_EXTRA_ARGS="--skip-metadata"
+fi
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "$image"
+ctr images mount "$image" "$tmp_dir"
+
+echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
+mkdir -p "/opt/bin"
+cp -f "$tmp_dir/gardener-node-agent" "/opt/bin" || cp -f "$tmp_dir/ko-app/gardener-node-agent" "/opt/bin"
+chmod +x "/opt/bin/gardener-node-agent"
+
+echo "> Bootstrap gardener-node-agent"
+exec "/opt/bin/gardener-node-agent" bootstrap --config-dir="/var/lib/gardener-node-agent"
+`)),
+							},
+						},
+					}))
+
+					updateCACertsFile, err := rootcertificates.UpdateLocalCACertificatesScriptFile()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(files).To(ContainElement(updateCACertsFile))
+				})
+			})
+
+			When("registryCA is disabled", func() {
+				It("should use Requires=containerd.service in the unit", func() {
+					units, _, err := Config(worker, image, config, caBundle, false)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(units).To(ConsistOf(extensionsv1alpha1.Unit{
+						Name:    nodeagentconfigv1alpha1.InitUnitName,
+						Command: new(extensionsv1alpha1.CommandStart),
+						Enable:  new(true),
+						Content: new(`[Unit]
+Description=Downloads the gardener-node-agent binary from the container registry and bootstraps it.
+Requires=containerd.service
+After=containerd.service
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=0
+EnvironmentFile=/etc/environment
+ExecStart=/var/lib/gardener-node-agent/init.sh
+StandardOutput=journal+console
+StandardError=journal+console
+[Install]
+WantedBy=multi-user.target`),
+						FilePaths: []string{"/var/lib/gardener-node-agent/init.sh"},
+					}))
+				})
+
+				It("should not embed the CA fetch block in the init script", func() {
+					_, files, err := Config(worker, image, config, caBundle, false)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(files).To(ContainElement(extensionsv1alpha1.File{
+						Path:        "/var/lib/gardener-node-agent/init.sh",
+						Permissions: new(uint32(0755)),
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data: utils.EncodeBase64([]byte(`#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+image="` + image + `"
+
+echo "> Prepare temporary directory for image pull and mount"
+tmp_dir="$(mktemp -d)"
+unmount() {
+  ctr images unmount "$tmp_dir" && rm -rf "$tmp_dir"
+}
+trap unmount EXIT
+
+echo "> Pull gardener-node-agent image and mount it to the temporary directory"
+CTR_MAJOR=$(ctr version | grep Version | tail -n1 | awk '{print $2}' | cut -d '.' -f 1 | sed 's/[a-zA-Z]//g')
+CTR_EXTRA_ARGS=""
+if [ "$CTR_MAJOR" -gt 1 ]; then
+    CTR_EXTRA_ARGS="--skip-metadata"
+fi
+ctr images pull $CTR_EXTRA_ARGS --hosts-dir "/etc/containerd/certs.d" "$image"
+ctr images mount "$image" "$tmp_dir"
+
+echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
+mkdir -p "/opt/bin"
+cp -f "$tmp_dir/gardener-node-agent" "/opt/bin" || cp -f "$tmp_dir/ko-app/gardener-node-agent" "/opt/bin"
+chmod +x "/opt/bin/gardener-node-agent"
+
+echo "> Bootstrap gardener-node-agent"
+exec "/opt/bin/gardener-node-agent" bootstrap --config-dir="/var/lib/gardener-node-agent"
+`)),
+							},
+						},
+					}))
+				})
+			})
+		})
+
 		When("kubelet data volume is configured", func() {
 			BeforeEach(func() {
 				worker.KubeletDataVolumeName = new("kubelet-data-vol")
@@ -185,14 +361,14 @@ exec "/opt/bin/gardener-node-agent" bootstrap --config-dir="/var/lib/gardener-no
 			It("should return an error when the data volume cannot be found", func() {
 				*worker.KubeletDataVolumeName = "not-found"
 
-				units, files, err := Config(worker, image, config, caBundle)
+				units, files, err := Config(worker, image, config, caBundle, false)
 				Expect(err).To(MatchError(ContainSubstring("failed finding data volume for kubelet in worker with name")))
 				Expect(units).To(BeNil())
 				Expect(files).To(BeNil())
 			})
 
 			It("should correctly configure the bootstrap configuration", func() {
-				_, files, err := Config(worker, image, config, caBundle)
+				_, files, err := Config(worker, image, config, caBundle, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(files).To(ContainElement(extensionsv1alpha1.File{
 					Path:        fmt.Sprintf("/var/lib/gardener-node-agent/config-%s.yaml", version.Get().GitVersion),
@@ -225,7 +401,7 @@ server: {}
 			})
 
 			It("should ensure the size of the configuration is not exceeding a certain limit", func() {
-				units, files, err := Config(worker, image, config, caBundle)
+				units, files, err := Config(worker, image, config, caBundle, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				writeFilesToDiskScript, err := operatingsystemconfig.FilesToDiskScript(context.Background(), nil, "", files)

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -234,7 +234,7 @@ CA_B64=$(curl -f \
   --cacert "/var/lib/gardener-node-agent/cluster-ca.crt" \
   --header "Authorization: Bearer $(cat "/var/lib/gardener-node-agent/credentials/bootstrap-token" 2>/dev/null)" \
   "` + apiServerURL + `/api/v1/namespaces/kube-system/configmaps/registry-ca-bundle" \
-  | sed -n 's/.*"ca\.b64"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  | sed -n 's/.*"bundle.crt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 if [ -n "$CA_B64" ]; then
   mkdir -p "/var/lib/ca-certificates-local" "/etc/pki/trust/anchors"
   printf '%s' "$CA_B64" | base64 -d | tee "/var/lib/ca-certificates-local/registry-ca.crt" > "/etc/pki/trust/anchors/registry-ca.pem"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -27,7 +27,7 @@ CA_B64=$(curl -f \
   --cacert "{{ .clusterCAFilePath }}" \
   --header "Authorization: Bearer $(cat "{{ .bootstrapTokenFilePath }}" 2>/dev/null)" \
   "{{ .apiServerURL }}/api/v1/namespaces/kube-system/configmaps/registry-ca-bundle" \
-  | sed -n 's/.*"ca\.b64"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  | sed -n 's/.*"{{ .registryCABundleKey }}"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 if [ -n "$CA_B64" ]; then
   mkdir -p "{{ .localCACertsDir }}" "{{ .pkiTrustAnchorsDir }}"
   printf '%s' "$CA_B64" | base64 -d | tee "{{ .registryCAFilePath }}" > "{{ .registryCAFilePathPKI }}"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -21,6 +21,22 @@ unmount() {
 }
 trap unmount EXIT
 
+{{- if .registryCAEnabled }}
+
+CA_B64=$(curl -f \
+  --cacert "{{ .clusterCAFilePath }}" \
+  --header "Authorization: Bearer $(cat "{{ .bootstrapTokenFilePath }}" 2>/dev/null)" \
+  "{{ .apiServerURL }}/api/v1/namespaces/kube-system/configmaps/registry-ca-bundle" \
+  | sed -n 's/.*"ca\.b64"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [ -n "$CA_B64" ]; then
+  mkdir -p "{{ .localCACertsDir }}" "{{ .pkiTrustAnchorsDir }}"
+  printf '%s' "$CA_B64" | base64 -d | tee "{{ .registryCAFilePath }}" > "{{ .registryCAFilePathPKI }}"
+  {{ .updateCACertificatesScript }}
+  systemctl restart containerd
+  echo "> Registry CA configured"
+fi
+{{- end }}
+
 echo "> Pull {{ .binaryName }} image and mount it to the temporary directory"
 {{- /*
 ctr v2 pulls manifests for all platforms of a multi-arch image by default. Mirror registries

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -113,6 +113,8 @@ type InitValues struct {
 type OriginalValues struct {
 	// CABundle is the bundle of certificate authorities that will be added as root certificates.
 	CABundle string
+	// RegistryCABundle is the bundle of certificate authorities for the private container registry.
+	RegistryCABundle *string
 	// ClusterDNSAddresses are the addresses for in-cluster DNS.
 	ClusterDNSAddresses []string
 	// ClusterDomain is the Kubernetes cluster domain.
@@ -602,6 +604,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		key:                                     oscKey,
 		apiServerURL:                            apiServerURL,
 		caBundle:                                caBundle,
+		registryCABundle:                        o.values.RegistryCABundle,
 		clusterCASecretName:                     clusterCASecret.Name,
 		clusterCABundle:                         clusterCASecret.Data[secretsutils.DataKeyCertificateBundle],
 		clusterDNSAddresses:                     o.values.ClusterDNSAddresses,
@@ -674,6 +677,7 @@ type deployer struct {
 
 	// original values
 	caBundle                                    string
+	registryCABundle                            *string
 	clusterCASecretName                         string
 	clusterCABundle                             []byte
 	clusterDNSAddresses                         []string
@@ -720,6 +724,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	componentsContext := components.Context{
 		Key:                                     d.key,
 		CABundle:                                d.caBundle,
+		RegistryCABundle:                        d.registryCABundle,
 		ClusterDNSAddresses:                     d.clusterDNSAddresses,
 		ClusterDomain:                           d.clusterDomain,
 		CRIName:                                 d.criName,
@@ -751,6 +756,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			d.images[imagevector.ContainerImageNameGardenerNodeAgent].String(),
 			nodeagent.ComponentConfig(d.key, d.kubernetesVersion, d.apiServerURL, nil),
 			d.clusterCABundle,
+			d.registryCABundle != nil,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -97,7 +97,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			openTelemetryCollectorLogShipperEnabled = false
 
 			//nolint:unparam
-			initConfigFn = func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration, _ []byte) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
+			initConfigFn = func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration, _ []byte, _ bool) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 				return []extensionsv1alpha1.Unit{
 						{Name: worker.Name},
 						{
@@ -201,6 +201,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						CAFile: nodeagentconfigv1alpha1.ClusterCAFilePath,
 					}},
 					[]byte(caBundle),
+					values.RegistryCABundle != nil,
 				)
 				componentsContext := components.Context{
 					Key:                 key,
@@ -603,8 +604,8 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			It("should exclude the bootstrap token file if purpose is not provision", func() {
 				bootstrapTokenFile := extensionsv1alpha1.File{Path: "/var/lib/gardener-node-agent/credentials/bootstrap-token"}
-				initConfigFnWithBootstrapToken := func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration, clusterCABundle []byte) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-					units, files, err := initConfigFn(worker, nodeAgentImage, config, clusterCABundle)
+				initConfigFnWithBootstrapToken := func(worker gardencorev1beta1.Worker, nodeAgentImage string, config *nodeagentconfigv1alpha1.NodeAgentConfiguration, clusterCABundle []byte, registryCAEnabled bool) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
+					units, files, err := initConfigFn(worker, nodeAgentImage, config, clusterCABundle, registryCAEnabled)
 					return units, append(files, bootstrapTokenFile), err
 				}
 

--- a/pkg/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/components.go
@@ -25,6 +25,7 @@ type Component interface {
 type Context struct {
 	Key                                     string
 	CABundle                                string
+	RegistryCABundle                        *string
 	ClusterDNSAddresses                     []string
 	ClusterDomain                           string
 	CRIName                                 extensionsv1alpha1.CRIName

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -21,10 +21,18 @@ import (
 
 const (
 	// PathLocalSSLRootCerts is the path to the Gardener CAs. It can be used as trigger for other components to reload the CAs.
-	PathLocalSSLRootCerts = pathLocalSSLCerts + "/ROOTcerts.crt"
+	PathLocalSSLRootCerts = PathLocalSSLCerts + "/ROOTcerts.crt"
+	// PathLocalSSLCerts is the directory for local CA certificates.
+	PathLocalSSLCerts = "/var/lib/ca-certificates-local"
+	// PathLocalSSLRegistryCACerts is the path to the registry CA certificate written during node init and OSC reconciliation.
+	PathLocalSSLRegistryCACerts = PathLocalSSLCerts + "/registry-ca.crt"
+	// PathPKITrustAnchors is the directory for PKI trust anchor certificates (RedHat/SUSE systems).
+	PathPKITrustAnchors = "/etc/pki/trust/anchors"
+	// PathPKITrustAnchorsRegistryCACerts is the path to the registry CA certificate in the PKI trust anchors (RedHat/SUSE systems).
+	PathPKITrustAnchorsRegistryCACerts = PathPKITrustAnchors + "/registry-ca.pem"
 
-	pathLocalSSLCerts             = "/var/lib/ca-certificates-local"
-	pathUpdateLocalCaCertificates = "/var/lib/ssl/update-local-ca-certificates.sh"
+	// PathUpdateLocalCACertificates is the path to the script that updates the local CA certificates.
+	PathUpdateLocalCACertificates = "/var/lib/ssl/update-local-ca-certificates.sh"
 )
 
 var (
@@ -55,13 +63,14 @@ func (component) Name() string {
 }
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
-	updateLocalCaCertificatesScriptFile, err := updateLocalCACertificatesScriptFile()
+	updateLocalCaCertificatesScriptFile, err := UpdateLocalCACertificatesScriptFile()
 	if err != nil {
 		return nil, nil, err
 	}
 
 	const pathEtcSSLCerts = "/etc/ssl/certs"
-	var caBundleBase64 = utils.EncodeBase64([]byte(ctx.CABundle))
+
+	caBundleBase64 := utils.EncodeBase64([]byte(ctx.CABundle))
 
 	updateCACertsFiles := []extensionsv1alpha1.File{
 		updateLocalCaCertificatesScriptFile,
@@ -78,7 +87,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		},
 		// This file contains Gardener CAs for Redhat/SUSE OS
 		{
-			Path:        "/etc/pki/trust/anchors/ROOTcerts.pem",
+			Path:        PathPKITrustAnchors + "/ROOTcerts.pem",
 			Permissions: new(uint32(0644)),
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
@@ -87,6 +96,31 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 				},
 			},
 		},
+	}
+
+	if ctx.RegistryCABundle != nil {
+		updateCACertsFiles = append(updateCACertsFiles,
+			extensionsv1alpha1.File{
+				Path:        PathLocalSSLRegistryCACerts,
+				Permissions: new(uint32(0644)),
+				Content: extensionsv1alpha1.FileContent{
+					Inline: &extensionsv1alpha1.FileContentInline{
+						Encoding: "b64",
+						Data:     utils.EncodeBase64([]byte(*ctx.RegistryCABundle)),
+					},
+				},
+			},
+			extensionsv1alpha1.File{
+				Path:        PathPKITrustAnchorsRegistryCACerts,
+				Permissions: new(uint32(0644)),
+				Content: extensionsv1alpha1.FileContent{
+					Inline: &extensionsv1alpha1.FileContentInline{
+						Encoding: "b64",
+						Data:     utils.EncodeBase64([]byte(*ctx.RegistryCABundle)),
+					},
+				},
+			},
+		)
 	}
 
 	updateCACertsUnit := extensionsv1alpha1.Unit{
@@ -100,10 +134,10 @@ Wants=systemd-tmpfiles-setup.service clean-ca-certificates.service
 After=systemd-tmpfiles-setup.service clean-ca-certificates.service
 Before=sysinit.target ` + v1beta1constants.OperatingSystemConfigUnitNameKubeletService + `
 ConditionPathIsReadWrite=` + pathEtcSSLCerts + `
-ConditionPathIsReadWrite=` + pathLocalSSLCerts + `
+ConditionPathIsReadWrite=` + PathLocalSSLCerts + `
 [Service]
 Type=oneshot
-ExecStart=` + pathUpdateLocalCaCertificates + `
+ExecStart=` + PathUpdateLocalCACertificates + `
 [Install]
 WantedBy=multi-user.target`),
 		FilePaths: extensionsv1alpha1helper.FilePathsFrom(updateCACertsFiles),
@@ -112,16 +146,17 @@ WantedBy=multi-user.target`),
 	return []extensionsv1alpha1.Unit{updateCACertsUnit}, updateCACertsFiles, nil
 }
 
-func updateLocalCACertificatesScriptFile() (extensionsv1alpha1.File, error) {
+// UpdateLocalCACertificatesScriptFile returns the file for the update-local-ca-certificates script.
+func UpdateLocalCACertificatesScriptFile() (extensionsv1alpha1.File, error) {
 	var script bytes.Buffer
 	if err := tplUpdateLocalCaCertificates.Execute(&script, map[string]any{
-		"pathLocalSSLCerts": pathLocalSSLCerts,
+		"pathLocalSSLCerts": PathLocalSSLCerts,
 	}); err != nil {
 		return extensionsv1alpha1.File{}, err
 	}
 
 	return extensionsv1alpha1.File{
-		Path:        pathUpdateLocalCaCertificates,
+		Path:        PathUpdateLocalCACertificates,
 		Permissions: new(uint32(0744)),
 		Content: extensionsv1alpha1.FileContent{
 			Inline: &extensionsv1alpha1.FileContentInline{

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component.go
@@ -20,17 +20,16 @@ import (
 )
 
 const (
-	// PathLocalSSLRootCerts is the path to the Gardener CAs. It can be used as trigger for other components to reload the CAs.
-	PathLocalSSLRootCerts = PathLocalSSLCerts + "/ROOTcerts.crt"
 	// PathLocalSSLCerts is the directory for local CA certificates.
 	PathLocalSSLCerts = "/var/lib/ca-certificates-local"
+	// PathLocalSSLRootCerts is the path to the Gardener CAs. It can be used as trigger for other components to reload the CAs.
+	PathLocalSSLRootCerts = PathLocalSSLCerts + "/ROOTcerts.crt"
 	// PathLocalSSLRegistryCACerts is the path to the registry CA certificate written during node init and OSC reconciliation.
 	PathLocalSSLRegistryCACerts = PathLocalSSLCerts + "/registry-ca.crt"
 	// PathPKITrustAnchors is the directory for PKI trust anchor certificates (RedHat/SUSE systems).
 	PathPKITrustAnchors = "/etc/pki/trust/anchors"
 	// PathPKITrustAnchorsRegistryCACerts is the path to the registry CA certificate in the PKI trust anchors (RedHat/SUSE systems).
 	PathPKITrustAnchorsRegistryCACerts = PathPKITrustAnchors + "/registry-ca.pem"
-
 	// PathUpdateLocalCACertificates is the path to the script that updates the local CA certificates.
 	PathUpdateLocalCACertificates = "/var/lib/ssl/update-local-ca-certificates.sh"
 )

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -72,26 +72,19 @@ set -o nounset
 set -o pipefail
 
 if [[ -f "/etc/debian_version" ]]; then
-    # Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
-    # See https://github.com/gardenlinux/gardenlinux/issues/1490
     mkdir -p "/var/lib/ca-certificates-local"
     if [[ -d "/usr/local/share/ca-certificates" && -n "$(ls -A '/usr/local/share/ca-certificates')" ]]; then
         cp -af /usr/local/share/ca-certificates/* "/var/lib/ca-certificates-local"
     fi
-    # localcertsdir is supported on Debian based OS only
     /usr/sbin/update-ca-certificates --fresh --localcertsdir "/var/lib/ca-certificates-local"
-    exit
-fi
-
-if grep -q flatcar "/etc/os-release"; then
-    # Flatcar needs the file in /etc/ssl/certs/ with .pem file extension
-    cp "/var/lib/ca-certificates-local/ROOTcerts.crt" /etc/ssl/certs/ROOTcerts.pem
-    # Flatcar does not support --fresh
+elif grep -q flatcar "/etc/os-release"; then
+    for f in "/var/lib/ca-certificates-local"/*.crt; do
+        [ -f "$f" ] && cp "$f" "/etc/ssl/certs/$(basename "${f%.crt}").pem"
+    done
     /usr/sbin/update-ca-certificates
-    exit
+else
+    /usr/sbin/update-ca-certificates --fresh
 fi
-
-/usr/sbin/update-ca-certificates --fresh
 `)),
 						},
 					},

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -20,8 +20,10 @@ var _ = Describe("Component", func() {
 			component components.Component
 			ctx       components.Context
 
-			caBundle       = "some-non-base64-encoded-ca-bundle"
-			caBundleBase64 = utils.EncodeBase64([]byte(caBundle))
+			caBundle            = "some-non-base64-encoded-ca-bundle"
+			caBundleBase64      = utils.EncodeBase64([]byte(caBundle))
+			registryCABundle    = "registry-ca"
+			registryCABundleB64 = utils.EncodeBase64([]byte(registryCABundle))
 		)
 
 		BeforeEach(func() {
@@ -113,6 +115,43 @@ fi
 
 			Expect(units).To(ConsistOf(updateCACertsUnit))
 			Expect(files).To(ConsistOf(updateCACertsFiles))
+		})
+
+		When("RegistryCABundle is set", func() {
+			BeforeEach(func() {
+				ctx.RegistryCABundle = &registryCABundle
+			})
+
+			It("should include the registry CA as a separate file and not merge it into ROOTcerts.crt", func() {
+				units, files, err := component.Config(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(units).To(HaveLen(1))
+				Expect(units[0].FilePaths).To(ContainElement(PathLocalSSLRegistryCACerts))
+
+				Expect(files).To(ContainElements(
+					extensionsv1alpha1.File{
+						Path:        "/var/lib/ca-certificates-local/ROOTcerts.crt",
+						Permissions: new(uint32(0644)),
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data:     caBundleBase64,
+							},
+						},
+					},
+					extensionsv1alpha1.File{
+						Path:        PathLocalSSLRegistryCACerts,
+						Permissions: new(uint32(0644)),
+						Content: extensionsv1alpha1.FileContent{
+							Inline: &extensionsv1alpha1.FileContentInline{
+								Encoding: "b64",
+								Data:     registryCABundleB64,
+							},
+						},
+					},
+				))
+			})
 		})
 	})
 })

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
@@ -5,23 +5,21 @@ set -o nounset
 set -o pipefail
 
 if [[ -f "/etc/debian_version" ]]; then
-    # Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
-    # See https://github.com/gardenlinux/gardenlinux/issues/1490
+    {{- /* Copy certificates from default "localcertsdir" because /usr is mounted read-only in Garden Linux.
+    See https://github.com/gardenlinux/gardenlinux/issues/1490 */}}
     mkdir -p "{{ .pathLocalSSLCerts }}"
     if [[ -d "/usr/local/share/ca-certificates" && -n "$(ls -A '/usr/local/share/ca-certificates')" ]]; then
         cp -af /usr/local/share/ca-certificates/* "{{ .pathLocalSSLCerts }}"
     fi
-    # localcertsdir is supported on Debian based OS only
+    {{- /* localcertsdir is supported on Debian based OS only */}}
     /usr/sbin/update-ca-certificates --fresh --localcertsdir "{{ .pathLocalSSLCerts }}"
-    exit
-fi
-
-if grep -q flatcar "/etc/os-release"; then
-    # Flatcar needs the file in /etc/ssl/certs/ with .pem file extension
-    cp "{{ .pathLocalSSLCerts }}/ROOTcerts.crt" /etc/ssl/certs/ROOTcerts.pem
-    # Flatcar does not support --fresh
+elif grep -q flatcar "/etc/os-release"; then
+    {{- /* Flatcar needs the files in /etc/ssl/certs/ with .pem file extension */}}
+    for f in "{{ .pathLocalSSLCerts }}"/*.crt; do
+        [ -f "$f" ] && cp "$f" "/etc/ssl/certs/$(basename "${f%.crt}").pem"
+    done
+    {{- /* Flatcar does not support --fresh */}}
     /usr/sbin/update-ca-certificates
-    exit
+else
+    /usr/sbin/update-ca-certificates --fresh
 fi
-
-/usr/sbin/update-ca-certificates --fresh

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -6,6 +6,7 @@ package system
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"slices"
@@ -75,6 +76,10 @@ type Values struct {
 	NodeNetworkCIDRs []net.IPNet
 	// EgressCIDRs are the egress CIDRs of the cluster, actual presence of this field depends on the implementation of the provider extension.
 	EgressCIDRs []net.IPNet
+	// RegistryCABundle is the PEM-encoded CA bundle for the container image registry. When non-nil,
+	// the system component creates a ConfigMap and RBAC in kube-public so that bootstrap tokens can
+	// fetch the CA before pulling the gardener-node-agent image.
+	RegistryCABundle *string
 }
 
 // New creates a new instance of DeployWaiter for shoot system resources.
@@ -329,6 +334,31 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 
 	if err := registry.Add(s.selfHostedShootResources()...); err != nil {
 		return nil, err
+	}
+
+	if !s.values.IsWorkerless && s.values.RegistryCABundle != nil {
+		const name = "registry-ca-bundle"
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceSystem},
+			Data:       map[string]string{"ca.b64": base64.StdEncoding.EncodeToString([]byte(*s.values.RegistryCABundle))},
+		}
+		role := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceSystem},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{name},
+				Verbs:         []string{"get"},
+			}},
+		}
+		roleBinding := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceSystem},
+			Subjects:   []rbacv1.Subject{{Kind: rbacv1.GroupKind, Name: "system:bootstrappers", APIGroup: rbacv1.GroupName}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: name},
+		}
+		if err := registry.Add(configMap, role, roleBinding); err != nil {
+			return nil, err
+		}
 	}
 
 	return registry.SerializedObjects()

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -32,6 +32,7 @@ import (
 	nodelocaldnsconstants "github.com/gardener/gardener/pkg/component/networking/nodelocaldns/constants"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	netutils "github.com/gardener/gardener/pkg/utils/net"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
@@ -340,7 +341,7 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 		const name = "registry-ca-bundle"
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceSystem},
-			Data:       map[string]string{"ca.b64": base64.StdEncoding.EncodeToString([]byte(*s.values.RegistryCABundle))},
+			Data:       map[string]string{secretsutils.DataKeyCertificateBundle: base64.StdEncoding.EncodeToString([]byte(*s.values.RegistryCABundle))},
 		}
 		role := &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceSystem},

--- a/pkg/component/shoot/system/system.go
+++ b/pkg/component/shoot/system/system.go
@@ -78,7 +78,7 @@ type Values struct {
 	// EgressCIDRs are the egress CIDRs of the cluster, actual presence of this field depends on the implementation of the provider extension.
 	EgressCIDRs []net.IPNet
 	// RegistryCABundle is the PEM-encoded CA bundle for the container image registry. When non-nil,
-	// the system component creates a ConfigMap and RBAC in kube-public so that bootstrap tokens can
+	// the system component creates a ConfigMap and RBAC in kube-system namespace so that bootstrap tokens can
 	// fetch the CA before pulling the gardener-node-agent image.
 	RegistryCABundle *string
 }

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -6,6 +6,7 @@ package system_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 
 	"github.com/Masterminds/semver/v3"
@@ -622,6 +623,74 @@ var _ = Describe("ShootSystem", func() {
 						expectedClusterRole,
 						expectedClusterRoleBinding,
 					))
+				})
+			})
+		})
+
+		Context("registry-ca-bundle resources", func() {
+			var (
+				registryCABundle = "-----BEGIN CERTIFICATE-----\nfake-ca\n-----END CERTIFICATE-----\n"
+
+				expectedConfigMap = func(caBundle string) *corev1.ConfigMap {
+					return &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{Name: "registry-ca-bundle", Namespace: "kube-system"},
+						Data:       map[string]string{"ca.b64": base64.StdEncoding.EncodeToString([]byte(caBundle))},
+					}
+				}
+				expectedRole = &rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: "registry-ca-bundle", Namespace: "kube-system"},
+					Rules: []rbacv1.PolicyRule{{
+						APIGroups:     []string{""},
+						Resources:     []string{"configmaps"},
+						ResourceNames: []string{"registry-ca-bundle"},
+						Verbs:         []string{"get"},
+					}},
+				}
+				expectedRoleBinding = &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "registry-ca-bundle", Namespace: "kube-system"},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "system:bootstrappers", APIGroup: "rbac.authorization.k8s.io"}},
+					RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "registry-ca-bundle"},
+				}
+			)
+
+			When("RegistryCABundle is set and cluster has workers", func() {
+				BeforeEach(func() {
+					values.RegistryCABundle = &registryCABundle
+				})
+
+				It("should deploy the ConfigMap, Role, and RoleBinding in kube-system", func() {
+					Expect(managedResource).To(contain(
+						expectedConfigMap(registryCABundle),
+						expectedRole,
+						expectedRoleBinding,
+					))
+				})
+			})
+
+			When("RegistryCABundle is nil", func() {
+				It("should not deploy any registry-ca-bundle resources", func() {
+					manifests, err := test.ExtractManifestsFromManagedResourceData(managedResourceSecret.Data)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, manifest := range manifests {
+						Expect(manifest).NotTo(ContainSubstring("registry-ca-bundle"))
+					}
+				})
+			})
+
+			When("shoot is workerless and RegistryCABundle is set", func() {
+				BeforeEach(func() {
+					values.IsWorkerless = true
+					values.RegistryCABundle = &registryCABundle
+				})
+
+				It("should not deploy any registry-ca-bundle resources", func() {
+					manifests, err := test.ExtractManifestsFromManagedResourceData(managedResourceSecret.Data)
+					Expect(err).NotTo(HaveOccurred())
+
+					for _, manifest := range manifests {
+						Expect(manifest).NotTo(ContainSubstring("registry-ca-bundle"))
+					}
 				})
 			})
 		})

--- a/pkg/component/shoot/system/system_test.go
+++ b/pkg/component/shoot/system/system_test.go
@@ -634,7 +634,7 @@ var _ = Describe("ShootSystem", func() {
 				expectedConfigMap = func(caBundle string) *corev1.ConfigMap {
 					return &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "registry-ca-bundle", Namespace: "kube-system"},
-						Data:       map[string]string{"ca.b64": base64.StdEncoding.EncodeToString([]byte(caBundle))},
+						Data:       map[string]string{"bundle.crt": base64.StdEncoding.EncodeToString([]byte(caBundle))},
 					}
 				}
 				expectedRole = &rbacv1.Role{

--- a/pkg/gardenadm/botanist/botanist.go
+++ b/pkg/gardenadm/botanist/botanist.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/gardener/gardener/imagevector"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
@@ -171,13 +172,19 @@ func NewGardenadmBotanistWithoutResources(log logr.Logger) (*GardenadmBotanist, 
 		return nil, fmt.Errorf("failed fetching hostname: %w", err)
 	}
 
-	return &GardenadmBotanist{
+	b := &GardenadmBotanist{
 		Botanist: &botanistpkg.Botanist{Operation: newOperation(log, newFakeGardenClient(), newFakeSeedClientSet(""))},
 
 		HostName: hostName,
 		DBus:     dbus.New(log),
 		FS:       afero.Afero{Fs: NewFs()},
-	}, nil
+	}
+
+	if caBundle := imagevector.ContainersCABundle(); caBundle != nil && caBundle.Inline != nil {
+		b.RegistryCABundle = caBundle.Inline
+	}
+
+	return b, nil
 }
 
 func newOperation(log logr.Logger, gardenClient client.Client, clientSet kubernetes.Interface) *operation.Operation {
@@ -233,6 +240,10 @@ func newBotanist(
 		if err != nil {
 			return nil, fmt.Errorf("failed creating seed object: %w", err)
 		}
+	}
+
+	if caBundle := imagevector.ContainersCABundle(); caBundle != nil && caBundle.Inline != nil {
+		o.RegistryCABundle = caBundle.Inline
 	}
 
 	return botanistpkg.New(ctx, o)

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -146,7 +146,7 @@ func (b *GardenadmBotanist) generateGardenerNodeInitOperatingSystemConfig(secret
 		image.String(),
 		nodeagentcomponent.ComponentConfig(secretName, b.Shoot.KubernetesVersion, controlPlaneAddress, nil),
 		caBundle,
-		false,
+		b.RegistryCABundle != nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing units and files for gardener-node-init: %w", err)

--- a/pkg/gardenadm/botanist/operatingsystemconfig.go
+++ b/pkg/gardenadm/botanist/operatingsystemconfig.go
@@ -146,6 +146,7 @@ func (b *GardenadmBotanist) generateGardenerNodeInitOperatingSystemConfig(secret
 		image.String(),
 		nodeagentcomponent.ComponentConfig(secretName, b.Shoot.KubernetesVersion, controlPlaneAddress, nil),
 		caBundle,
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed computing units and files for gardener-node-init: %w", err)

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler.go
@@ -27,6 +27,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/gardener/gardener/imagevector"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/apis/config/gardenlet/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -466,6 +467,10 @@ func (r *Reconciler) initializeOperation(
 	op, err := opBuilder.WithShoot(shootObj).Build(ctx, r.GardenClient, r.SeedClientSet, r.ShootClientMap, shoot)
 	if err != nil {
 		return nil, err
+	}
+
+	if containersCABundle := imagevector.ContainersCABundle(); containersCABundle != nil && containersCABundle.Inline != nil {
+		op.RegistryCABundle = containersCABundle.Inline
 	}
 
 	// Only set UID once the operation was initialized successfully.

--- a/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go
@@ -863,7 +863,7 @@ func (r *Reconciler) setupReconcileHostedShootFlow(b *botanistpkg.Botanist, flow
 			Name:         "Configuring shoot worker pools",
 			Fn:           flow.TaskFn(b.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			SkipIf:       b.Shoot.IsWorkerless,
-			Dependencies: flow.NewTaskIDs(deployMachineControllerManager),
+			Dependencies: flow.NewTaskIDs(deployMachineControllerManager, deployShootSystemResources),
 		})
 		waitUntilWorkerStatusUpdate = g.Add(flow.Task{
 			Name: "Waiting until worker resource status is updated with latest machine deployments",

--- a/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
+++ b/pkg/gardenlet/operation/botanist/operatingsystemconfig.go
@@ -108,6 +108,7 @@ func (b *Botanist) OperatingSystemConfigValues() (*operatingsystemconfig.Values,
 			PrimaryIPFamily:                         b.Shoot.GetInfo().Spec.Networking.IPFamilies[0],
 			KubeProxyConfig:                         b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy,
 			Region:                                  region,
+			RegistryCABundle:                        b.RegistryCABundle,
 		},
 	}, nil
 }

--- a/pkg/gardenlet/operation/botanist/shootsystem.go
+++ b/pkg/gardenlet/operation/botanist/shootsystem.go
@@ -35,6 +35,10 @@ func (b *Botanist) DefaultShootSystem() shootsystem.Interface {
 		EncryptedResources:    append(sets.List(gardenerutils.DefaultResourcesForEncryption()), b.Shoot.ResourcesToEncrypt...),
 	}
 
+	if !b.Shoot.IsWorkerless {
+		values.RegistryCABundle = b.RegistryCABundle
+	}
+
 	return shootsystem.New(b.SeedClientSet.Client(), b.Shoot.ControlPlaneNamespace, values)
 }
 

--- a/pkg/gardenlet/operation/types.go
+++ b/pkg/gardenlet/operation/types.go
@@ -65,4 +65,6 @@ type Operation struct {
 
 	// ControlPlaneWildcardCert is a wildcard TLS certificate which is issued for the seed's ingress domain.
 	ControlPlaneWildcardCert *corev1.Secret
+	// RegistryCABundle is the PEM-encoded CA bundle for the private container registry, if configured.
+	RegistryCABundle *string
 }

--- a/pkg/provider-local/imagevector/imagevector.go
+++ b/pkg/provider-local/imagevector/imagevector.go
@@ -22,10 +22,10 @@ var (
 func init() {
 	var err error
 
-	imageVector, err = imagevector.Read([]byte(imagesYAML))
+	imageVector, _, err = imagevector.Read([]byte(imagesYAML))
 	runtime.Must(err)
 
-	imageVector, err = imagevector.WithEnvOverride(imageVector, imagevector.OverrideEnv)
+	imageVector, _, err = imagevector.WithEnvOverride(imageVector, nil, imagevector.OverrideEnv)
 	runtime.Must(err)
 }
 

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -28,28 +28,32 @@ const (
 	SHA256TagPrefix = "sha256:"
 )
 
-// Read reads an ImageVector from the given io.Reader.
-func Read(buf []byte) (ImageVector, error) {
+// Read reads an ImageVector from the given bytes. It also returns the optional global CABundle.
+func Read(buf []byte) (ImageVector, *CABundle, error) {
 	vector := struct {
-		Images ImageVector `json:"images" yaml:"images"`
+		Images   ImageVector `json:"images" yaml:"images"`
+		CABundle *CABundle   `json:"caBundle,omitempty" yaml:"caBundle,omitempty"`
 	}{}
 
 	if err := yaml.Unmarshal(buf, &vector); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if errs := ValidateImageVector(vector.Images, field.NewPath("images")); len(errs) > 0 {
-		return nil, errs.ToAggregate()
+		return nil, nil, errs.ToAggregate()
+	}
+	if errs := ValidateCABundle(vector.CABundle, field.NewPath("caBundle")); len(errs) > 0 {
+		return nil, nil, errs.ToAggregate()
 	}
 
-	return vector.Images, nil
+	return vector.Images, vector.CABundle, nil
 }
 
 // ReadFile reads an ImageVector from the file with the given name.
-func ReadFile(name string) (ImageVector, error) {
+func ReadFile(name string) (ImageVector, *CABundle, error) {
 	buf, err := os.ReadFile(name) // #nosec: G304,G703 -- ImageVectorOverwrite is a feature. In reality files can be read from the Pod's file system only.
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return Read(buf)
@@ -145,11 +149,11 @@ func computeKey(source *ImageSource) imageSourceKey {
 	}
 }
 
-// Merge merges the given ImageVectors into one.
+// MergeImageVectors merges the given ImageVectors into one.
 //
 // Images of ImageVectors that are later in the given sequence with the same name override
 // previous images.
-func Merge(vectors ...ImageVector) ImageVector {
+func MergeImageVectors(vectors ...ImageVector) ImageVector {
 	var (
 		out        ImageVector
 		keyToIndex = make(map[imageSourceKey]int)
@@ -172,21 +176,29 @@ func Merge(vectors ...ImageVector) ImageVector {
 	return out
 }
 
+// MergeCABundle merges two CABundle sources. The override takes precedence over the base.
+func MergeCABundle(caBundle, overrideCABundle *CABundle) *CABundle {
+	if overrideCABundle != nil {
+		return overrideCABundle
+	}
+	return caBundle
+}
+
 // WithEnvOverride checks if an environment variable with the provided key is set.
 // If yes, it reads the ImageVector at the value of the variable and merges it with the given one.
-// Otherwise, it returns the unmodified ImageVector.
-func WithEnvOverride(vector ImageVector, env string) (ImageVector, error) {
+// Otherwise, it returns the unmodified ImageVector and caBundle.
+func WithEnvOverride(vector ImageVector, caBundle *CABundle, env string) (ImageVector, *CABundle, error) {
 	overwritePath := os.Getenv(env)
 	if len(overwritePath) == 0 {
-		return vector, nil
+		return vector, caBundle, nil
 	}
 
-	override, err := ReadFile(overwritePath)
+	overrideImageVector, overrideCABundle, err := ReadFile(overwritePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return Merge(vector, override), nil
+	return MergeImageVectors(vector, overrideImageVector), MergeCABundle(caBundle, overrideCABundle), nil
 }
 
 // String implements Stringer.

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -5,6 +5,7 @@
 package imagevector_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/onsi/gomega/types"
 
 	. "github.com/gardener/gardener/pkg/utils/imagevector"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -298,13 +300,13 @@ images:
 
 		Describe("#Read", func() {
 			It("should successfully read a JSON image vector", func() {
-				vector, err := Read([]byte(image1Src1VectorJSON))
+				vector, _, err := Read([]byte(image1Src1VectorJSON))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(image1Src1Vector))
 			})
 
 			It("should successfully read a YAML image vector", func() {
-				vector, err := Read([]byte(image1Src1VectorYAML))
+				vector, _, err := Read([]byte(image1Src1VectorYAML))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(image1Src1Vector))
 			})
@@ -315,15 +317,15 @@ images:
 				tmpFile, cleanup := withTempFile("imagevector", []byte(image1Src1VectorJSON))
 				defer cleanup()
 
-				vector, err := ReadFile(tmpFile.Name())
+				vector, _, err := ReadFile(tmpFile.Name())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(vector).To(Equal(image1Src1Vector))
 			})
 		})
 
-		DescribeTable("#Merge",
+		DescribeTable("#MergeImageVectors",
 			func(v1, v2, expected ImageVector) {
-				Expect(Merge(v1, v2)).To(Equal(expected))
+				Expect(MergeImageVectors(v1, v2)).To(Equal(expected))
 			},
 
 			Entry("no override", ImageVector{image1Src1}, ImageVector{image1Src2}, ImageVector{image1Src1, image1Src2}),
@@ -346,13 +348,65 @@ images:
 				defer cleanup()
 				defer test.WithEnvVar(OverrideEnv, file.Name())()
 
-				Expect(WithEnvOverride(vector, "IMAGEVECTOR_OVERWRITE")).To(Equal(ImageVector{image1Src1, image2Src1}))
+				resultVector, _, err := WithEnvOverride(vector, nil, "IMAGEVECTOR_OVERWRITE")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resultVector).To(Equal(ImageVector{image1Src1, image2Src1}))
 			})
 
 			It("should keep the vector as-is if the env variable is not set", func() {
-				Expect(WithEnvOverride(image1Src1Vector, "IMAGEVECTOR_OVERWRITE")).To(Equal(image1Src1Vector))
+				resultVector, _, err := WithEnvOverride(image1Src1Vector, nil, "IMAGEVECTOR_OVERWRITE")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resultVector).To(Equal(image1Src1Vector))
 			})
 		})
+
+		Describe("#Read with caBundle", func() {
+			It("should read a vector without caBundle", func() {
+				_, caBundle, err := Read([]byte(image1Src1VectorYAML))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundle).To(BeNil())
+			})
+
+			It("should read a vector with an inline caBundle", func() {
+				ca, err := (&secretsutils.CertificateSecretConfig{
+					Name:       "test-ca",
+					CommonName: "TestCA",
+					CertType:   secretsutils.CACert,
+				}).GenerateCertificate()
+				Expect(err).NotTo(HaveOccurred())
+				certPEM := string(ca.SecretData()[secretsutils.DataKeyCertificateCA])
+
+				certPEMJSON, err := json.Marshal(certPEM)
+				Expect(err).NotTo(HaveOccurred())
+				vectorWithCA := fmt.Sprintf(`{"images":[{"name":"test","repository":"registry.example.com/test","tag":"v1.0"}],"caBundle":{"inline":%s}}`, string(certPEMJSON))
+				_, caBundle, err := Read([]byte(vectorWithCA))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundle).NotTo(BeNil())
+				Expect(caBundle.Inline).To(Equal(&certPEM))
+			})
+		})
+
+		DescribeTable("#MergeCABundle",
+			func(base, override, expected *CABundle) {
+				Expect(MergeCABundle(base, override)).To(Equal(expected))
+			},
+			Entry("both nil returns nil", nil, nil, nil),
+			Entry("override wins over base",
+				&CABundle{Inline: new("base")},
+				&CABundle{Inline: new("override")},
+				&CABundle{Inline: new("override")},
+			),
+			Entry("nil override keeps base",
+				&CABundle{Inline: new("base")},
+				nil,
+				&CABundle{Inline: new("base")},
+			),
+			Entry("nil base with override returns override",
+				nil,
+				&CABundle{Inline: new("override")},
+				&CABundle{Inline: new("override")},
+			),
+		)
 
 		DescribeTable("#FindImage",
 			func(vec ImageVector, name string, opts []FindOptionFunc, imageMatcher, errorMatcher types.GomegaMatcher) {

--- a/pkg/utils/imagevector/imagevector_validation.go
+++ b/pkg/utils/imagevector/imagevector_validation.go
@@ -5,8 +5,12 @@
 package imagevector
 
 import (
+	"time"
+
 	"github.com/Masterminds/semver/v3"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // ValidateImageVector validates the given ImageVector.
@@ -81,6 +85,23 @@ func validateImageSource(imageSource *ImageSource, fldPath *field.Path) field.Er
 	return allErrs
 }
 
+// ValidateCABundle validates the given CABundle.
+func ValidateCABundle(source *CABundle, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if source == nil || source.Inline == nil {
+		return allErrs
+	}
+
+	if cert, err := utils.DecodeCertificate([]byte(*source.Inline)); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("inline"), *source.Inline, "not a valid PEM-encoded certificate"))
+	} else if time.Now().After(cert.NotAfter) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("inline"), *source.Inline, "certificate has expired"))
+	}
+
+	return allErrs
+}
+
 func validateComponentImageVector(componentImageVector *ComponentImageVector, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -90,9 +111,8 @@ func validateComponentImageVector(componentImageVector *ComponentImageVector, fl
 	}
 
 	// Read (and validate) imageVectorOverwrite as image vector
-	imageVector, err := Read([]byte(componentImageVector.ImageVectorOverwrite))
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("imageVectorOverwrite"), imageVector, err.Error()))
+	if _, _, err := Read([]byte(componentImageVector.ImageVectorOverwrite)); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("imageVectorOverwrite"), componentImageVector.ImageVectorOverwrite, err.Error()))
 	}
 
 	return allErrs

--- a/pkg/utils/imagevector/imagevector_validation_test.go
+++ b/pkg/utils/imagevector/imagevector_validation_test.go
@@ -5,13 +5,18 @@
 package imagevector_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	testclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/yaml"
 
 	. "github.com/gardener/gardener/pkg/utils/imagevector"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("validation", func() {
@@ -138,6 +143,65 @@ var _ = Describe("validation", func() {
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("components[].imageVectorOverwrite"),
+				})),
+			))
+		})
+	})
+
+	Describe("#ValidateCABundle", func() {
+		var (
+			fldPath      *field.Path
+			validCertPEM string
+		)
+
+		BeforeEach(func() {
+			fldPath = field.NewPath("caBundle")
+
+			ca, err := (&secretsutils.CertificateSecretConfig{
+				Name:       "test-ca",
+				CommonName: "TestCA",
+				CertType:   secretsutils.CACert,
+			}).GenerateCertificate()
+			Expect(err).NotTo(HaveOccurred())
+			validCertPEM = string(ca.SecretData()[secretsutils.DataKeyCertificateCA])
+		})
+
+		It("should allow nil", func() {
+			Expect(ValidateCABundle(nil, fldPath)).To(BeEmpty())
+			Expect(ValidateCABundle(&CABundle{Inline: nil}, fldPath)).To(BeEmpty())
+		})
+
+		It("should allow a valid CABundle", func() {
+			Expect(ValidateCABundle(&CABundle{Inline: &validCertPEM}, fldPath)).To(BeEmpty())
+		})
+
+		It("should forbid non-PEM inline", func() {
+			inline := "not-a-certificate"
+			errs := ValidateCABundle(&CABundle{Inline: &inline}, fldPath)
+			Expect(errs).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("caBundle.inline"),
+				"Detail": ContainSubstring("not a valid PEM-encoded certificate"),
+			}))))
+		})
+
+		It("should fail when inline certificate is already expired", func() {
+			DeferCleanup(test.WithVar(&secretsutils.Clock, testclock.NewFakeClock(time.Now().Add(-8*24*time.Hour))))
+
+			cert, err := (&secretsutils.CertificateSecretConfig{
+				Name:       "test",
+				CommonName: "test",
+				CertType:   secretsutils.CACert,
+				Validity:   new(24 * time.Hour),
+			}).GenerateCertificate()
+			Expect(err).NotTo(HaveOccurred())
+			expired := string(cert.CertificatePEM)
+
+			Expect(ValidateCABundle(&CABundle{Inline: &expired}, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("caBundle.inline"),
+					"Detail": Equal("certificate has expired"),
 				})),
 			))
 		})

--- a/pkg/utils/imagevector/types.go
+++ b/pkg/utils/imagevector/types.go
@@ -4,6 +4,14 @@
 
 package imagevector
 
+// CABundle specifies a bundle of CA certificates that should be used when pulling images from
+// a registry.
+type CABundle struct {
+	// Inline contains the CA bundle in plain text (PEM-encoded certificates).
+	// +optional
+	Inline *string `json:"inline,omitempty" yaml:"inline,omitempty"`
+}
+
 // ImageSource contains the repository and the tag of a Docker container image. If the respective
 // image is only valid for a specific Kubernetes runtime version, then it must also contain the
 // 'runtimeVersion' field describing for which versions it can be used. Similarly, if it is only

--- a/pkg/utils/oci/helmregistry.go
+++ b/pkg/utils/oci/helmregistry.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener/imagevector"
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -31,6 +32,9 @@ const (
 
 	localRegistryPattern = "registry.local.gardener.cloud:"
 )
+
+// chartsCABundleFunc is an alias for imagevector.ChartsCABundle. Exposed for testing purposes.
+var chartsCABundleFunc = imagevector.ChartsCABundle
 
 type secretNamespace struct{}
 
@@ -83,6 +87,7 @@ func (r *HelmRegistry) Pull(ctx context.Context, oci *gardencorev1.OCIRepository
 	}
 
 	// Configure custom transport with CA bundle if provided
+	var caCertPool *x509.CertPool
 	if oci.CABundleSecretRef != nil {
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: secretNamespace, Name: oci.CABundleSecretRef.Name}}
 		if err := r.client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
@@ -96,11 +101,22 @@ func (r *HelmRegistry) Pull(ctx context.Context, oci *gardencorev1.OCIRepository
 			return nil, fmt.Errorf("CA bundle secret %s has empty data for key %s", client.ObjectKeyFromObject(secret), secretsutils.DataKeyCertificateBundle)
 		}
 
-		caCertPool := x509.NewCertPool()
+		caCertPool = x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(caBundle) {
 			return nil, errors.New("failed to append CA certificates from bundle")
 		}
+	}
 
+	if chartsCABundle := chartsCABundleFunc(); chartsCABundle != nil && chartsCABundle.Inline != nil {
+		if caCertPool == nil {
+			caCertPool = x509.NewCertPool()
+		}
+		if !caCertPool.AppendCertsFromPEM([]byte(*chartsCABundle.Inline)) {
+			return nil, errors.New("failed to append CA certificates from charts image vector bundle")
+		}
+	}
+
+	if caCertPool != nil {
 		transport := remote.DefaultTransport.(*http.Transport).Clone()
 		transport.TLSClientConfig = &tls.Config{
 			RootCAs:    caCertPool,

--- a/pkg/utils/oci/helmregistry_test.go
+++ b/pkg/utils/oci/helmregistry_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net"
 
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -16,17 +17,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	gardencorev1 "github.com/gardener/gardener/pkg/apis/core/v1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
+	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("helmregistry", func() {
 	var (
-		hr  *HelmRegistry
-		rc  *recordingCache
-		ctx context.Context
+		fakeClient client.Client
+		hr         *HelmRegistry
+		rc         *recordingCache
+		ctx        context.Context
 
 		caBundleSecretName = "test-ca-bundle"
 		caBundleSecret     *corev1.Secret
@@ -55,7 +61,7 @@ var _ = Describe("helmregistry", func() {
 			},
 		}
 
-		fakeClient := fake.NewClientBuilder().WithObjects(caBundleSecret, pullSecret).Build()
+		fakeClient = fake.NewClientBuilder().WithObjects(caBundleSecret, pullSecret).Build()
 		hr = &HelmRegistry{cache: rc, client: fakeClient}
 		authProvider.receivedAuthorization = "" // Reset before test
 	})
@@ -194,10 +200,9 @@ var _ = Describe("helmregistry", func() {
 				"bundle.crt": []byte("invalid-pem-data"),
 			},
 		}
-		fakeClient := fake.NewClientBuilder().WithObjects(invalidCABundleSecret).Build()
-		invalidHr := &HelmRegistry{cache: rc, client: fakeClient}
+		Expect(fakeClient.Create(ctx, invalidCABundleSecret)).To(Succeed())
 
-		_, err := invalidHr.Pull(ctx, &gardencorev1.OCIRepository{
+		_, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
 			Repository:        new(registryAddress + "/charts/example"),
 			Tag:               new("0.1.0"),
 			CABundleSecretRef: &corev1.LocalObjectReference{Name: "invalid-ca-bundle"},
@@ -224,6 +229,104 @@ var _ = Describe("helmregistry", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).NotTo(BeEmpty())
 		Expect(authProvider.receivedAuthorization).To(Equal(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte("foo:bar")))))
+	})
+
+	It("should include ChartsCABundle certs in the TLS cert pool", func() {
+		wrongCA, err := (&secretsutils.CertificateSecretConfig{
+			Name:        "wrong-ca",
+			CommonName:  "WrongCA",
+			CertType:    secretsutils.CACert,
+			IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		}).GenerateCertificate()
+		Expect(err).NotTo(HaveOccurred())
+		wrongCAData := wrongCA.SecretData()
+
+		wrongCASecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-ca-bundle",
+				Namespace: v1beta1constants.GardenNamespace,
+			},
+			Data: map[string][]byte{
+				secretsutils.DataKeyCertificateBundle: wrongCAData[secretsutils.DataKeyCertificateCA],
+			},
+		}
+
+		Expect(fakeClient.Create(ctx, wrongCASecret)).To(Succeed())
+
+		inline := string(testCACert)
+		DeferCleanup(test.WithVar(&chartsCABundleFunc, func() *imagevectorutils.CABundle {
+			return &imagevectorutils.CABundle{Inline: &inline}
+		}))
+
+		out, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
+			Repository:        new(registryAddress + "/charts/example"),
+			Tag:               new("0.1.0"),
+			CABundleSecretRef: &corev1.LocalObjectReference{Name: "wrong-ca-bundle"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(BeEmpty())
+	})
+
+	It("should not break the pull when ChartsCABundle contains a wrong CA alongside the correct secret CA", func() {
+		wrongCA, err := (&secretsutils.CertificateSecretConfig{
+			Name:        "wrong-ca",
+			CommonName:  "WrongCA",
+			CertType:    secretsutils.CACert,
+			IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		}).GenerateCertificate()
+		Expect(err).NotTo(HaveOccurred())
+		wrongCAData := wrongCA.SecretData()
+
+		DeferCleanup(test.WithVar(&chartsCABundleFunc, func() *imagevectorutils.CABundle {
+			return &imagevectorutils.CABundle{Inline: new(string(wrongCAData[secretsutils.DataKeyCertificateCA]))}
+		}))
+
+		out, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
+			Repository:        new(registryAddress + "/charts/example"),
+			Tag:               new("0.1.0"),
+			CABundleSecretRef: &corev1.LocalObjectReference{Name: caBundleSecretName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(BeEmpty())
+	})
+
+	It("should not fail when ChartsCABundle.Inline is nil", func() {
+		DeferCleanup(test.WithVar(&chartsCABundleFunc, func() *imagevectorutils.CABundle {
+			return &imagevectorutils.CABundle{}
+		}))
+
+		out, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
+			Repository:        new(registryAddress + "/charts/example"),
+			Tag:               new("0.1.0"),
+			CABundleSecretRef: &corev1.LocalObjectReference{Name: caBundleSecretName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(BeEmpty())
+	})
+
+	It("should pull chart using ChartsCABundle as the sole CA (no caBundleSecretRef)", func() {
+		DeferCleanup(test.WithVar(&chartsCABundleFunc, func() *imagevectorutils.CABundle {
+			return &imagevectorutils.CABundle{Inline: new(string(testCACert))}
+		}))
+
+		out, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
+			Repository: new(registryAddress + "/charts/example"),
+			Tag:        new("0.1.0"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(BeEmpty())
+	})
+
+	It("should return error when ChartsCABundle contains invalid PEM", func() {
+		DeferCleanup(test.WithVar(&chartsCABundleFunc, func() *imagevectorutils.CABundle {
+			return &imagevectorutils.CABundle{Inline: new("invalid-pem-data")}
+		}))
+
+		_, err := hr.Pull(ctx, &gardencorev1.OCIRepository{
+			Repository: new(registryAddress + "/charts/example"),
+			Tag:        new("0.1.0"),
+		})
+		Expect(err).To(MatchError("failed to append CA certificates from charts image vector bundle"))
 	})
 })
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Gardener already supports distributing custom CA bundles to shoot worker nodes via the shoot spec. However, that mechanism runs as part of the operating system config applied by `gardener-node-agent`: meaning the CA is only trusted after the node-agent is already running. But if the gardener-node-agent image itself is hosted in a private registry that requires a custom CA, containerd cannot pull the image in the first place, and node bootstrapping never gets off the ground.

This PR introduces a caBundle field in the image vector overwrite file (IMAGEVECTOR_OVERWRITE). When gardenlet loads its image vector overwrite with a `caBundle`, it:

- Publishes a `registry-ca-bundle` ConfigMap and its RBAC into the `kube-system` namespace of every shoot managed by that seed, via the `shoot-core-system` ManagedResource.
- Extends the node-init script to fetch the CA and install it into node before containerd pulling the gardener-node-agent image, unblocking the initial pull.
- Adds the CA bundle to the `rootcertificates` operatingsystemconfig component so all worker nodes continue to trust the registry after bootstrapping.

The same caBundle field is supported in `IMAGEVECTOR_OVERWRITE_CHARTS` in both `gardenlet` and `gardener-operator` to secure TLS when pulling OCI Helm chart archives from a private registry.

Operators who also use extensions with images from private registries should consolidate all required CAs into the gardenlet's `IMAGEVECTOR_OVERWRITE` caBundle, as this is the only mechanism for installing custom CAs on shoot worker nodes.

See [image vector documentation](https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md#ca-bundle-for-private-registries) for details.

**Which issue(s) this PR fixes**:
Fixes #13751

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Operators can now configure a custom registry CA bundle by adding a `caBundle.inline` field (PEM-encoded) to the gardenlet image vector overwrite file (`IMAGEVECTOR_OVERWRITE`). Gardenlet distributes this CA to the worker nodes of all its shoots, enabling containerd to trust private registries. The same `caBundle` field is supported in `IMAGEVECTOR_OVERWRITE_CHARTS` for both gardenlet and gardener-operator to secure OCI Helm chart pulls from private registries. See [image vector documentation](https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md#ca-bundle-for-private-registries) for details.
```
```breaking dependency
The `github.com/gardener/gardener/pkg/utils/imagevector` functions `Read`, `ReadFile`, and `WithEnvOverride` now return an additional `*CABundle` value. Additionally, the `WithEnvOverride` function accepts a new `caBundle *CABundle` parameter. Extensions using these functions must update on their side accordingly.
```