### PR TITLE
Use newly introduced API submodule of `cert-management`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/elliotchance/orderedmap/v3 v3.1.0
 	github.com/fatih/color v1.19.0
 	github.com/fluent/fluent-operator/v3 v3.7.0
-	github.com/gardener/cert-management v0.23.0
+	github.com/gardener/cert-management/pkg/apis v0.25.0
 	github.com/gardener/dependency-watchdog v1.8.0
 	github.com/gardener/etcd-druid/api v0.36.4
 	github.com/gardener/machine-controller-manager v0.61.3
@@ -94,6 +94,12 @@ require (
 require github.com/gardener/gardener/pkg/apis v1.144.2 // overwritten by replace directive below
 
 replace github.com/gardener/gardener/pkg/apis => ./pkg/apis
+
+// TODO(MartinWeindel) drop this line as soon as `github.com/gardener/dependency-watchdog` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
+exclude github.com/gardener/cert-management v0.22.0
+
+// TODO(MartinWeindel) drop this line as soon as `github.com/gardener/terminal-controller-manager` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
+exclude github.com/gardener/cert-management v0.23.0
 
 tool github.com/joelanford/go-apidiff
 
@@ -190,6 +196,8 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
+	github.com/go-openapi/testify/enable/yaml/v2 v2.5.0 // indirect
+	github.com/go-openapi/testify/v2 v2.5.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobuffalo/flect v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gardener/cert-management/pkg/apis v0.25.0
 	github.com/gardener/dependency-watchdog v1.8.0
 	github.com/gardener/etcd-druid/api v0.36.4
+	github.com/gardener/gardener/pkg/apis v0.0.0
 	github.com/gardener/machine-controller-manager v0.61.3
 	github.com/gardener/pvc-autoscaler v0.2.0
 	github.com/gardener/terminal-controller-manager v0.37.0
@@ -91,8 +92,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-require github.com/gardener/gardener/pkg/apis v1.144.2 // overwritten by replace directive below
-
 replace github.com/gardener/gardener/pkg/apis => ./pkg/apis
 
 // TODO(MartinWeindel) drop this line as soon as `github.com/gardener/dependency-watchdog` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
@@ -100,6 +99,12 @@ exclude github.com/gardener/cert-management v0.22.0
 
 // TODO(MartinWeindel) drop this line as soon as `github.com/gardener/terminal-controller-manager` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
 exclude github.com/gardener/cert-management v0.23.0
+
+// TODO(MartinWeindel) drop this line as soon as `github.com/gardener/dependency-watchdog` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
+exclude github.com/gardener/gardener/pkg/apis v1.143.0
+
+// TODO(MartinWeindel) drop this line as soon as `github.com/gardener/terminal-controller-manager` has been updated and does not have an indirect dependency to `github.com/gardener/cert-management` anymore
+exclude github.com/gardener/gardener/pkg/apis v1.144.2
 
 tool github.com/joelanford/go-apidiff
 

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gardener/cert-management v0.23.0 h1:kD88XcPn6C4zLc8EYtrHyb+/45Iyaozhb+HEM44MKz0=
-github.com/gardener/cert-management v0.23.0/go.mod h1:Mehn8XY+iAkm8XOBbNGHmbMft8fP9ZEJFWzWSonPkfc=
+github.com/gardener/cert-management/pkg/apis v0.25.0 h1:+BSRLH1LwNTXujZmUguEIAuB078Cn5qZgSf5FnfhBFs=
+github.com/gardener/cert-management/pkg/apis v0.25.0/go.mod h1:aj0PW4fBbZMLfC9hoJWzpePGkt+9KAji86r8ADkWts0=
 github.com/gardener/dependency-watchdog v1.8.0 h1:+3FE8sR1V6YM9JsGqX7m9oUjhr1wXhedQo29r6fsC+I=
 github.com/gardener/dependency-watchdog v1.8.0/go.mod h1:jRIyBZ4ySWy+EdQjfLm/N+90vBPdWJ7khiBN7CGQs18=
 github.com/gardener/etcd-druid/api v0.36.4 h1:o/17ciPrbh/w+igKMUuglW7N9XLjoMh7AvRKTzsBEVs=


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Switches the `cert-management` dependency from the full module to its newly introduced lightweight API submodule (`github.com/gardener/cert-management/pkg/apis`). This mirrors the pattern already used for `etcd-druid/api` and Gardener's own `pkg/apis` — consumers pull in only the CRD/API types rather  than the entire controller module and its transitive dependencies.

### Changes
  
**`go.mod` / `go.sum`**

- **Replaced** `github.com/gardener/cert-management v0.23.0` → `github.com/gardener/cert-management/pkg/apis v0.25.0`.
- **Added four `exclude` directives** as temporary workarounds to prevent older monolithic `cert-management` versions from being pulled in transitively:
    - `exclude github.com/gardener/cert-management v0.22.0` — via `dependency-watchdog`
    - `exclude github.com/gardener/gardener/pkg/apis v1.143.0` — via `dependency-watchdog`
    - `exclude github.com/gardener/cert-management v0.23.0` — via `terminal-controller-manager` 
    - `exclude github.com/gardener/gardener/pkg/apis v1.144.2` — via `terminal-controller-manager`
    
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
related to https://github.com/gardener/gardener/pull/14971#pullrequestreview-4577215466

### Follow-ups
  
- Drop the four `exclude` directives once `dependency-watchdog` and `terminal-controller-manager` no longer indirectly depend on the old monolithic `cert-management` module (by consuming a future gardener/gardener version).
 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `cert-management` module dependency is switched from the full module (`github.com/gardener/cert-management`) to its newly introduced lightweight API submodule (`github.com/gardener/cert-management/pkg/apis`).
```
