### PR TITLE
Visualize ignored MRs for `Seed` and  `Garden` resource

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -382,6 +382,10 @@ A `ManagedResource` is considered "healthy" if the conditions `ResourcesApplied=
 If all `ManagedResource`s are healthy, then the `SeedSystemComponentsHealthy` condition of the `Seed` will be set to `True`.
 Otherwise, it will be set to `False`.
 
+Additionally, it maintains the `SeedHasIgnoredManagedResources` condition, which is set to `False` when at least one `ManagedResource` in the seed's namespaces is annotated with `resources.gardener.cloud/ignore=true`.
+The names of the affected resources are listed in the condition message.
+Operators should remove the annotation once manual intervention is complete to restore reconciliation and clear the condition.
+
 If at least one `ManagedResource` is unhealthy and there is threshold configuration for the conditions (in `.controllers.seedCare.conditionThresholds`), then the status of the `SeedSystemComponentsHealthy` condition will be set:
 
 - to `Progressing` if it was `True` before.
@@ -394,9 +398,10 @@ Only if the unhealthiness persists for at least the configured threshold duratio
 In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
 The following table explains which `ManagedResource`s are considered for which condition type:
 
-| Condition Type                | `ManagedResource`s are considered when |
-|-------------------------------|----------------------------------------|
-| `SeedSystemComponentsHealthy` | `.spec.class` is set                   |
+| Condition Type                  | `ManagedResource`s are considered when                              |
+|---------------------------------|---------------------------------------------------------------------|
+| `SeedSystemComponentsHealthy`  | `.spec.class` is set                                                |
+| `SeedHasIgnoredManagedResources`| any `ManagedResource` annotated with `resources.gardener.cloud/ignore=true` |
 
 #### ["Lease" Reconciler](../../pkg/gardenlet/controller/seed/lease)
 

--- a/docs/concepts/operator.md
+++ b/docs/concepts/operator.md
@@ -520,7 +520,7 @@ data:
 
 #### [`Care` Reconciler](../../pkg/operator/controller/garden/care)
 
-This reconciler performs four "care" actions related to `Garden`s.
+This reconciler performs five "care" actions related to `Garden`s.
 
 It maintains the following conditions:
 
@@ -528,6 +528,7 @@ It maintains the following conditions:
 - `RuntimeComponentsHealthy`: The conditions of the `ManagedResource`s applied to the runtime cluster are checked (e.g., `ResourcesApplied`).
 - `VirtualComponentsHealthy`: The virtual components are considered healthy when the respective `Deployment`s (for example `virtual-garden-kube-apiserver`,`virtual-garden-kube-controller-manager`), and `Etcd`s (for example `virtual-garden-etcd-main`) exist and are healthy. Additionally, the conditions of the `ManagedResource`s applied to the virtual cluster are checked (e.g., `ResourcesApplied`).
 - `ObservabilityComponentsHealthy`: This condition is considered healthy when the respective `Deployment`s (for example `plutono`) and `StatefulSet`s (for example `prometheus`, `vali`) exist and are healthy.
+- `GardenHasIgnoredManagedResources`: This condition is set to `False` when at least one `ManagedResource` in the garden's namespaces is annotated with `resources.gardener.cloud/ignore=true`, meaning its reconciliation has been disabled. The names of the affected resources are listed in the condition message. Operators should remove the annotation once manual intervention is complete.
 
 If all checks for a certain condition are succeeded, then its `status` will be set to `True`.
 Otherwise, it will be set to `False` or `Progressing`.
@@ -544,11 +545,12 @@ Only if the unhealthiness persists for at least the configured threshold duratio
 In order to compute the condition statuses, this reconciler considers `ManagedResource`s (in the `garden` and `istio-system` namespace) and their status, see [this document](resource-manager.md#conditions) for more information.
 The following table explains which `ManagedResource`s are considered for which condition type:
 
-| Condition Type                   | `ManagedResource`s are considered when                                                                               |
-|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `RuntimeComponentsHealthy`       | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `RuntimeComponentsHealthy` |
-| `VirtualComponentsHealthy`       | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
-| `ObservabilityComponentsHealthy` | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |
+| Condition Type                    | `ManagedResource`s are considered when                                                                               |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `RuntimeComponentsHealthy`        | `.spec.class=seed` and `care.gardener.cloud/condition-type` label either unset, or set to `RuntimeComponentsHealthy` |
+| `VirtualComponentsHealthy`        | `.spec.class` unset or `care.gardener.cloud/condition-type` label set to `VirtualComponentsHealthy`                  |
+| `ObservabilityComponentsHealthy`  | `care.gardener.cloud/condition-type` label set to `ObservabilityComponentsHealthy`                                   |
+| `GardenHasIgnoredManagedResources`| any `ManagedResource` annotated with `resources.gardener.cloud/ignore=true`                                          |
 
 #### [`Reference` Reconciler](../../pkg/operator/controller/garden/reference)
 

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -540,6 +540,9 @@ const (
 	SeedSystemComponentsHealthy ConditionType = "SeedSystemComponentsHealthy"
 	// SeedEmergencyStopShootReconciliations is a constant for a condition type indicating disabled shoot reconciliations.
 	SeedEmergencyStopShootReconciliations ConditionType = "EmergencyStopShootReconciliations"
+	// SeedHasIgnoredManagedResources is a constant for a condition type indicating that one or more ManagedResources
+	// in the seed's namespaces have been annotated with resources.gardener.cloud/ignore=true.
+	SeedHasIgnoredManagedResources ConditionType = "SeedHasIgnoredManagedResources"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/apis/operator/v1alpha1/types_garden.go
+++ b/pkg/apis/operator/v1alpha1/types_garden.go
@@ -935,6 +935,9 @@ const (
 	VirtualGardenAPIServerAvailable gardencorev1beta1.ConditionType = "VirtualGardenAPIServerAvailable"
 	// ObservabilityComponentsHealthy is a constant for a condition type indicating the health of observability components.
 	ObservabilityComponentsHealthy gardencorev1beta1.ConditionType = v1beta1constants.ObservabilityComponentsHealthy
+	// GardenHasIgnoredManagedResources is a constant for a condition type indicating that one or more ManagedResources
+	// have been annotated with resources.gardener.cloud/ignore=true.
+	GardenHasIgnoredManagedResources gardencorev1beta1.ConditionType = "GardenHasIgnoredManagedResources"
 )
 
 // AvailableOperationAnnotations is the set of available operation annotations for Garden resources.

--- a/pkg/gardenlet/controller/seed/care/health.go
+++ b/pkg/gardenlet/controller/seed/care/health.go
@@ -7,8 +7,11 @@ package care
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,6 +73,7 @@ func (h *health) Check(
 	if newEmergencyStopShootReconciliations := h.checkEmergencyStopShootReconciliations(conditions.emergencyStopShootReconciliations); newEmergencyStopShootReconciliations != nil {
 		checkedConditions = append(checkedConditions, v1beta1helper.NewConditionOrError(h.clock, conditions.emergencyStopShootReconciliations, newEmergencyStopShootReconciliations, nil))
 	}
+	checkedConditions = append(checkedConditions, v1beta1helper.NewConditionOrError(h.clock, conditions.hasIgnoredManagedResources, h.checkIfManagedResourcesAreIgnored(conditions.hasIgnoredManagedResources, managedResources), nil))
 	return checkedConditions
 }
 
@@ -129,10 +133,32 @@ func (h *health) checkEmergencyStopShootReconciliations(condition gardencorev1be
 	))
 }
 
+func (h *health) checkIfManagedResourcesAreIgnored(condition gardencorev1beta1.Condition, managedResources []resourcesv1alpha1.ManagedResource) *gardencorev1beta1.Condition {
+	ignoredNames := sets.New[string]()
+	for _, mr := range managedResources {
+		if value, ok := mr.GetAnnotations()[resourcesv1alpha1.Ignore]; ok {
+			if truthy, _ := strconv.ParseBool(value); truthy {
+				ignoredNames.Insert(mr.Name)
+			}
+		}
+	}
+	if ignoredNames.Len() > 0 {
+		cond := v1beta1helper.UpdatedConditionWithClock(h.clock, condition,
+			gardencorev1beta1.ConditionFalse, "ManagedResourcesIgnored",
+			fmt.Sprintf("Some ManagedResources have been annotated with %s=true: %s",
+				resourcesv1alpha1.Ignore, strings.Join(sets.List(ignoredNames), ", ")))
+		return &cond
+	}
+	cond := v1beta1helper.UpdatedConditionWithClock(h.clock, condition,
+		gardencorev1beta1.ConditionTrue, "NoManagedResourcesIgnored", "No ManagedResources are annotated to be ignored.")
+	return &cond
+}
+
 // SeedConditions contains all seed related conditions of the seed status subresource.
 type SeedConditions struct {
 	systemComponentsHealthy           gardencorev1beta1.Condition
 	emergencyStopShootReconciliations gardencorev1beta1.Condition
+	hasIgnoredManagedResources        gardencorev1beta1.Condition
 }
 
 // ConvertToSlice returns the seed conditions as a slice.
@@ -140,6 +166,7 @@ func (s SeedConditions) ConvertToSlice() []gardencorev1beta1.Condition {
 	return []gardencorev1beta1.Condition{
 		s.systemComponentsHealthy,
 		s.emergencyStopShootReconciliations,
+		s.hasIgnoredManagedResources,
 	}
 }
 
@@ -148,6 +175,7 @@ func (s SeedConditions) ConditionTypes() []gardencorev1beta1.ConditionType {
 	return []gardencorev1beta1.ConditionType{
 		s.systemComponentsHealthy.Type,
 		s.emergencyStopShootReconciliations.Type,
+		s.hasIgnoredManagedResources.Type,
 	}
 }
 
@@ -157,5 +185,6 @@ func NewSeedConditions(clock clock.Clock, status gardencorev1beta1.SeedStatus) S
 	return SeedConditions{
 		systemComponentsHealthy:           v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, gardencorev1beta1.SeedSystemComponentsHealthy),
 		emergencyStopShootReconciliations: v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, gardencorev1beta1.SeedEmergencyStopShootReconciliations),
+		hasIgnoredManagedResources:        v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, gardencorev1beta1.SeedHasIgnoredManagedResources),
 	}
 }

--- a/pkg/gardenlet/controller/seed/care/health_test.go
+++ b/pkg/gardenlet/controller/seed/care/health_test.go
@@ -364,6 +364,7 @@ var _ = Describe("Seed health", func() {
 				Expect(conditions.ConvertToSlice()).To(ConsistOf(
 					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedSystemComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedEmergencyStopShootReconciliations, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedHasIgnoredManagedResources, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 
@@ -379,6 +380,7 @@ var _ = Describe("Seed health", func() {
 				Expect(conditions.ConvertToSlice()).To(HaveExactElements(
 					OfType("SeedSystemComponentsHealthy"),
 					OfType("EmergencyStopShootReconciliations"),
+					beConditionOfTypeWithStatusReasonAndMessage(gardencorev1beta1.SeedHasIgnoredManagedResources, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 		})
@@ -390,6 +392,7 @@ var _ = Describe("Seed health", func() {
 				Expect(conditions.ConvertToSlice()).To(HaveExactElements(
 					OfType("SeedSystemComponentsHealthy"),
 					OfType("EmergencyStopShootReconciliations"),
+					OfType("SeedHasIgnoredManagedResources"),
 				))
 			})
 		})
@@ -401,6 +404,88 @@ var _ = Describe("Seed health", func() {
 				Expect(conditions.ConditionTypes()).To(HaveExactElements(
 					gardencorev1beta1.ConditionType("SeedSystemComponentsHealthy"),
 					gardencorev1beta1.ConditionType("EmergencyStopShootReconciliations"),
+					gardencorev1beta1.ConditionType("SeedHasIgnoredManagedResources"),
+				))
+			})
+		})
+
+		Describe("#checkIfManagedResourcesAreIgnored", func() {
+			var (
+				healthCheck HealthCheck
+				conditions  SeedConditions
+			)
+
+			JustBeforeEach(func() {
+				healthCheck = NewHealth(seed, c, fakeClock, nil, checker.NewHealthChecker(log, c, fakeClock))
+				conditions = NewSeedConditions(fakeClock, gardencorev1beta1.SeedStatus{})
+			})
+
+			It("should set condition to True when no ManagedResources exist", func() {
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(gardencorev1beta1.SeedHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason("NoManagedResourcesIgnored"),
+				))
+			})
+
+			It("should set condition to True when a ManagedResource has ignore=false", func() {
+				mr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: v1beta1constants.GardenNamespace,
+						Annotations: map[string]string{
+							resourcesv1alpha1.Ignore: "false",
+						},
+					},
+				}
+				Expect(c.Create(ctx, mr)).To(Succeed())
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(gardencorev1beta1.SeedHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason("NoManagedResourcesIgnored"),
+				))
+			})
+
+			It("should set condition to False when a ManagedResource has ignore=true", func() {
+				mr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: v1beta1constants.GardenNamespace,
+						Annotations: map[string]string{
+							resourcesv1alpha1.Ignore: "true",
+						},
+					},
+				}
+				Expect(c.Create(ctx, mr)).To(Succeed())
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(gardencorev1beta1.SeedHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason("ManagedResourcesIgnored"),
+					WithMessageSubstrings("foo"),
+				))
+			})
+
+			It("should list multiple ignored ManagedResources sorted alphabetically", func() {
+				for _, name := range []string{"foo", "bar", "baz"} {
+					mr := &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: v1beta1constants.GardenNamespace,
+							Annotations: map[string]string{
+								resourcesv1alpha1.Ignore: "true",
+							},
+						},
+					}
+					Expect(c.Create(ctx, mr)).To(Succeed())
+				}
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(gardencorev1beta1.SeedHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason("ManagedResourcesIgnored"),
+					WithMessageSubstrings("bar, baz, foo"),
 				))
 			})
 		})

--- a/pkg/gardenlet/controller/seed/care/reconciler_test.go
+++ b/pkg/gardenlet/controller/seed/care/reconciler_test.go
@@ -224,6 +224,8 @@ var _ = Describe("Seed Care Control", func() {
 						"Status":  BeEquivalentTo("True"),
 						"Reason":  Equal("EmergencyStopShootReconciliations"),
 						"Message": Equal("Reconciliations of Shoots managed by this Seed cluster are currently disabled by annotation."),
+					}), MatchFields(IgnoreExtras, Fields{
+						"Type": BeEquivalentTo("SeedHasIgnoredManagedResources"),
 					}),
 				))
 			})
@@ -243,9 +245,13 @@ var _ = Describe("Seed Care Control", func() {
 
 				updatedSeed := &gardencorev1beta1.Seed{}
 				Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(seed), updatedSeed)).To(Succeed())
-				Expect(updatedSeed.Status.Conditions).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
-					"Type": BeEquivalentTo("SeedSystemComponentsHealthy"),
-				})))
+				Expect(updatedSeed.Status.Conditions).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Type": BeEquivalentTo("SeedSystemComponentsHealthy"),
+					}), MatchFields(IgnoreExtras, Fields{
+						"Type": BeEquivalentTo("SeedHasIgnoredManagedResources"),
+					}),
+				))
 			})
 		})
 	})

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -223,10 +223,10 @@ func (h *health) checkIfManagedResourcesAreIgnored(condition gardencorev1beta1.C
 
 // GardenConditions contains all conditions of the garden status subresource.
 type GardenConditions struct {
-	virtualGardenAPIServerAvailable gardencorev1beta1.Condition
-	runtimeComponentsHealthy        gardencorev1beta1.Condition
-	virtualComponentsHealthy        gardencorev1beta1.Condition
-	observabilityComponentsHealthy  gardencorev1beta1.Condition
+	virtualGardenAPIServerAvailable  gardencorev1beta1.Condition
+	runtimeComponentsHealthy         gardencorev1beta1.Condition
+	virtualComponentsHealthy         gardencorev1beta1.Condition
+	observabilityComponentsHealthy   gardencorev1beta1.Condition
 	gardenHasIgnoredManagedResources gardencorev1beta1.Condition
 }
 

--- a/pkg/operator/controller/garden/care/health.go
+++ b/pkg/operator/controller/garden/care/health.go
@@ -7,6 +7,8 @@ package care
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -98,6 +100,13 @@ func (h *health) Check(ctx context.Context, conditions GardenConditions) []garde
 			return nil
 		})
 	}
+
+	taskFns = append(taskFns, func(_ context.Context) error {
+		conditions.gardenHasIgnoredManagedResources = v1beta1helper.NewConditionOrError(
+			h.clock, conditions.gardenHasIgnoredManagedResources,
+			h.checkIfManagedResourcesAreIgnored(conditions.gardenHasIgnoredManagedResources, managedResources), nil)
+		return nil
+	})
 
 	_ = flow.Parallel(taskFns...)(ctx)
 
@@ -191,12 +200,34 @@ func (h *health) checkObservabilityComponents(ctx context.Context, condition gar
 	return new(v1beta1helper.UpdatedConditionWithClock(h.clock, condition, gardencorev1beta1.ConditionTrue, "ObservabilityComponentsRunning", "All observability components are healthy."))
 }
 
+func (h *health) checkIfManagedResourcesAreIgnored(condition gardencorev1beta1.Condition, managedResources []resourcesv1alpha1.ManagedResource) *gardencorev1beta1.Condition {
+	ignoredNames := sets.New[string]()
+	for _, mr := range managedResources {
+		if value, ok := mr.GetAnnotations()[resourcesv1alpha1.Ignore]; ok {
+			if truthy, _ := strconv.ParseBool(value); truthy {
+				ignoredNames.Insert(mr.Name)
+			}
+		}
+	}
+	if ignoredNames.Len() > 0 {
+		cond := v1beta1helper.UpdatedConditionWithClock(h.clock, condition,
+			gardencorev1beta1.ConditionFalse, "ManagedResourcesIgnored",
+			fmt.Sprintf("Some ManagedResources have been annotated with %s=true: %s",
+				resourcesv1alpha1.Ignore, strings.Join(sets.List(ignoredNames), ", ")))
+		return &cond
+	}
+	cond := v1beta1helper.UpdatedConditionWithClock(h.clock, condition,
+		gardencorev1beta1.ConditionTrue, "NoManagedResourcesIgnored", "No ManagedResources are annotated to be ignored.")
+	return &cond
+}
+
 // GardenConditions contains all conditions of the garden status subresource.
 type GardenConditions struct {
 	virtualGardenAPIServerAvailable gardencorev1beta1.Condition
 	runtimeComponentsHealthy        gardencorev1beta1.Condition
 	virtualComponentsHealthy        gardencorev1beta1.Condition
 	observabilityComponentsHealthy  gardencorev1beta1.Condition
+	gardenHasIgnoredManagedResources gardencorev1beta1.Condition
 }
 
 // ConvertToSlice returns the garden conditions as a slice.
@@ -206,6 +237,7 @@ func (g GardenConditions) ConvertToSlice() []gardencorev1beta1.Condition {
 		g.runtimeComponentsHealthy,
 		g.virtualComponentsHealthy,
 		g.observabilityComponentsHealthy,
+		g.gardenHasIgnoredManagedResources,
 	}
 }
 
@@ -216,6 +248,7 @@ func (g GardenConditions) ConditionTypes() []gardencorev1beta1.ConditionType {
 		g.runtimeComponentsHealthy.Type,
 		g.virtualComponentsHealthy.Type,
 		g.observabilityComponentsHealthy.Type,
+		g.gardenHasIgnoredManagedResources.Type,
 	}
 }
 
@@ -223,9 +256,10 @@ func (g GardenConditions) ConditionTypes() []gardencorev1beta1.ConditionType {
 // All conditions are retrieved from the given 'status' or newly initialized.
 func NewGardenConditions(clock clock.Clock, status operatorv1alpha1.GardenStatus) GardenConditions {
 	return GardenConditions{
-		virtualGardenAPIServerAvailable: v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.VirtualGardenAPIServerAvailable),
-		runtimeComponentsHealthy:        v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.RuntimeComponentsHealthy),
-		virtualComponentsHealthy:        v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.VirtualComponentsHealthy),
-		observabilityComponentsHealthy:  v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.ObservabilityComponentsHealthy),
+		virtualGardenAPIServerAvailable:  v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.VirtualGardenAPIServerAvailable),
+		runtimeComponentsHealthy:         v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.RuntimeComponentsHealthy),
+		virtualComponentsHealthy:         v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.VirtualComponentsHealthy),
+		observabilityComponentsHealthy:   v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.ObservabilityComponentsHealthy),
+		gardenHasIgnoredManagedResources: v1beta1helper.GetOrInitConditionWithClock(clock, status.Conditions, operatorv1alpha1.GardenHasIgnoredManagedResources),
 	}
 }

--- a/pkg/operator/controller/garden/care/health_test.go
+++ b/pkg/operator/controller/garden/care/health_test.go
@@ -711,6 +711,7 @@ var _ = Describe("Garden health", func() {
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.VirtualComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.VirtualGardenAPIServerAvailable, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.ObservabilityComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.GardenHasIgnoredManagedResources, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 
@@ -727,6 +728,7 @@ var _ = Describe("Garden health", func() {
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.RuntimeComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.VirtualComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.ObservabilityComponentsHealthy, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
+					beConditionOfTypeWithStatusReasonAndMessage(operatorv1alpha1.GardenHasIgnoredManagedResources, "Unknown", "ConditionInitialized", "The condition has been initialized but its semantic check has not been performed yet."),
 				))
 			})
 		})
@@ -740,6 +742,7 @@ var _ = Describe("Garden health", func() {
 					OfType("RuntimeComponentsHealthy"),
 					OfType("VirtualComponentsHealthy"),
 					OfType("ObservabilityComponentsHealthy"),
+					OfType("GardenHasIgnoredManagedResources"),
 				))
 			})
 		})
@@ -753,6 +756,88 @@ var _ = Describe("Garden health", func() {
 					gardencorev1beta1.ConditionType("RuntimeComponentsHealthy"),
 					gardencorev1beta1.ConditionType("VirtualComponentsHealthy"),
 					gardencorev1beta1.ConditionType("ObservabilityComponentsHealthy"),
+					gardencorev1beta1.ConditionType("GardenHasIgnoredManagedResources"),
+				))
+			})
+		})
+
+		Describe("#checkIfManagedResourcesAreIgnored", func() {
+			var (
+				healthCheck HealthCheck
+				conditions  GardenConditions
+			)
+
+			JustBeforeEach(func() {
+				healthCheck = NewHealth(garden, runtimeClient, nil, fakeClock, nil, gardenNamespace, healthchecker.NewHealthChecker(log, runtimeClient, fakeClock))
+				conditions = NewGardenConditions(fakeClock, operatorv1alpha1.GardenStatus{})
+			})
+
+			It("should set condition to True when no ManagedResources exist", func() {
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(operatorv1alpha1.GardenHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason("NoManagedResourcesIgnored"),
+				))
+			})
+
+			It("should set condition to True when a ManagedResource has ignore=false", func() {
+				mr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: gardenNamespace,
+						Annotations: map[string]string{
+							resourcesv1alpha1.Ignore: "false",
+						},
+					},
+				}
+				Expect(runtimeClient.Create(ctx, mr)).To(Succeed())
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(operatorv1alpha1.GardenHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionTrue),
+					WithReason("NoManagedResourcesIgnored"),
+				))
+			})
+
+			It("should set condition to False when a ManagedResource has ignore=true", func() {
+				mr := &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: gardenNamespace,
+						Annotations: map[string]string{
+							resourcesv1alpha1.Ignore: "true",
+						},
+					},
+				}
+				Expect(runtimeClient.Create(ctx, mr)).To(Succeed())
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(operatorv1alpha1.GardenHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason("ManagedResourcesIgnored"),
+					WithMessageSubstrings("foo"),
+				))
+			})
+
+			It("should list multiple ignored ManagedResources sorted alphabetically", func() {
+				for _, name := range []string{"foo", "bar", "baz"} {
+					mr := &resourcesv1alpha1.ManagedResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: gardenNamespace,
+							Annotations: map[string]string{
+								resourcesv1alpha1.Ignore: "true",
+							},
+						},
+					}
+					Expect(runtimeClient.Create(ctx, mr)).To(Succeed())
+				}
+
+				Expect(healthCheck.Check(ctx, conditions)).To(ContainCondition(
+					OfType(operatorv1alpha1.GardenHasIgnoredManagedResources),
+					WithStatus(gardencorev1beta1.ConditionFalse),
+					WithReason("ManagedResourcesIgnored"),
+					WithMessageSubstrings("bar, baz, foo"),
 				))
 			})
 		})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
  The `gardenlet` and `gardener-operator` now expose dedicated conditions that surface any `ManagedResource` annotated with `resources.gardener.cloud/ignore=true` in the `seed's` or `garden's` control-plane namespaces.

  - `SeedHasIgnoredManagedResources` is added to `Seed.status.conditions` by the gardenlet's seed care controller.
  - `GardenHasIgnoredManagedResources` is added to `Garden.status.conditions` by the gardener-operator's garden care controller.

  When at least one `ManagedResource` carries the ignore annotation the condition is set to `False` with reason `ManagedResourcesIgnored` and a message listing the affected resource names (sorted alphabetically). When
  no `ManagedResource` is ignored the condition is `True` with reason `NoManagedResourcesIgnored`.

  This makes it immediately visible to operators that one or more resources have had reconciliation disabled, reducing the risk of diverging state going unnoticed after manual intervention.
  
**Which issue(s) this PR fixes**:
This PR is a continuation of https://github.com/gardener/gardener/pull/15023. In this PR we are adapting the `Seed` and `Garden` resources. 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       feature|
- target_group:   operator|
-->
```other operator
`SeedHasIgnoredManagedResources` and `GardenHasIgnoredManagedResources` conditions are now reported on `Seed` and `Garden` resources respectively, surfacing any `ManagedResource` annotated with
  `resources.gardener.cloud/ignore=true` to alert operators of disabled reconciliation.
```
